### PR TITLE
Fixes #70 by ensuring the proper HTTP verbs are used

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/RouteListRoutingRules.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RouteListRoutingRules.java
@@ -211,12 +211,12 @@ class RouteListRoutingRules implements Routing.Rules<RouteListRoutingRules> {
 
     @Override
     public RouteListRoutingRules put(PathMatcher pathMatcher, Handler... requestHandlers) {
-        return addSingle(Http.Method.GET, pathMatcher, requestHandlers);
+        return addSingle(Http.Method.PUT, pathMatcher, requestHandlers);
     }
 
     @Override
     public RouteListRoutingRules post(Handler... requestHandlers) {
-        return addSingle(Http.Method.PUT, requestHandlers);
+        return addSingle(Http.Method.POST, requestHandlers);
     }
 
     @Override


### PR DESCRIPTION
See `RouteListRoutingRules.java` and issue #70.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>