### PR TITLE
Pre matching security

### DIFF
--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/FeatureConfig.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/FeatureConfig.java
@@ -26,39 +26,48 @@ import java.util.List;
 class FeatureConfig {
     private final boolean debug;
     private final boolean authorizeAnnotatedOnly;
-    private final boolean usePrematching;
+    private final boolean usePrematchingAtn;
+    private final boolean usePrematchingAtz;
     private final List<QueryParamHandler> queryParamHandlers = new LinkedList<>();
 
     FeatureConfig() {
-        this.authorizeAnnotatedOnly = false;
         this.debug = false;
-        this.usePrematching = false;
+        this.authorizeAnnotatedOnly = false;
+        this.usePrematchingAtn = false;
+        this.usePrematchingAtz = false;
     }
 
-    FeatureConfig(boolean authorizeAnnotatedOnly,
-                  List<QueryParamHandler> queryParamHandlers,
-                  boolean debug,
-                  boolean usePrematching) {
-        this.authorizeAnnotatedOnly = authorizeAnnotatedOnly;
-        this.queryParamHandlers.addAll(queryParamHandlers);
-        this.debug = debug;
-        this.usePrematching = usePrematching;
+    FeatureConfig(SecurityFeature.Builder builder) {
+        this.debug = builder.isDebug();
+        this.authorizeAnnotatedOnly = builder.isAuthorizeAnnotatedOnly();
+        this.usePrematchingAtz = builder.isPrematchingAuthorization();
+        if (this.usePrematchingAtz) {
+            this.usePrematchingAtn = true;
+        } else {
+            this.usePrematchingAtn = builder.isPrematchingAuthentication();
+        }
+
+        this.queryParamHandlers.addAll(builder.getQueryParamHandlers());
     }
 
-    public boolean shouldAuthorizeAnnotatedOnly() {
+    boolean shouldAuthorizeAnnotatedOnly() {
         return authorizeAnnotatedOnly;
     }
 
-    public List<QueryParamHandler> getQueryParamHandlers() {
+    List<QueryParamHandler> getQueryParamHandlers() {
         return Collections.unmodifiableList(queryParamHandlers);
     }
 
-    public boolean isDebug() {
+    boolean isDebug() {
         return debug;
     }
 
-    public boolean shouldUsePrematching() {
-        return usePrematching;
+    public boolean shouldUsePrematchingAuthentication() {
+        return usePrematchingAtn;
+    }
+
+    public boolean shouldUsePrematchingAuthorization() {
+        return usePrematchingAtz;
     }
 
     @Override

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/FeatureConfig.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/FeatureConfig.java
@@ -26,19 +26,23 @@ import java.util.List;
 class FeatureConfig {
     private final boolean debug;
     private final boolean authorizeAnnotatedOnly;
+    private final boolean usePrematching;
     private final List<QueryParamHandler> queryParamHandlers = new LinkedList<>();
 
     FeatureConfig() {
         this.authorizeAnnotatedOnly = false;
         this.debug = false;
+        this.usePrematching = false;
     }
 
     FeatureConfig(boolean authorizeAnnotatedOnly,
                   List<QueryParamHandler> queryParamHandlers,
-                  boolean debug) {
+                  boolean debug,
+                  boolean usePrematching) {
         this.authorizeAnnotatedOnly = authorizeAnnotatedOnly;
         this.queryParamHandlers.addAll(queryParamHandlers);
         this.debug = debug;
+        this.usePrematching = usePrematching;
     }
 
     public boolean shouldAuthorizeAnnotatedOnly() {
@@ -51,6 +55,10 @@ class FeatureConfig {
 
     public boolean isDebug() {
         return debug;
+    }
+
+    public boolean shouldUsePrematching() {
+        return usePrematching;
     }
 
     @Override

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityDefinition.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityDefinition.java
@@ -104,6 +104,14 @@ class SecurityDefinition {
         this.auditErrorSeverity = checkDefault(auditErrorSeverity, audited.errorSeverity(), Audited.DEFAULT_ERROR_SEVERITY);
     }
 
+    void requiresAuthentication(boolean atn) {
+        this.requiresAuthentication = atn;
+    }
+
+    void setRequiresAuthorization(boolean atz) {
+        this.requiresAuthorization = atz;
+    }
+
     private <T> T checkDefault(T currentValue, T annotValue, T defaultValue) {
         if (null == currentValue) {
             return annotValue;

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilter.java
@@ -19,15 +19,11 @@ package io.helidon.security.jersey;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
@@ -48,17 +44,9 @@ import javax.ws.rs.core.UriInfo;
 
 import io.helidon.common.CollectionsHelper;
 import io.helidon.common.OptionalHelper;
-import io.helidon.common.reactive.Flow;
 import io.helidon.security.AuditEvent;
-import io.helidon.security.AuthenticationResponse;
-import io.helidon.security.AuthorizationResponse;
-import io.helidon.security.EndpointConfig;
-import io.helidon.security.Entity;
 import io.helidon.security.Security;
-import io.helidon.security.SecurityClientBuilder;
 import io.helidon.security.SecurityContext;
-import io.helidon.security.SecurityEnvironment;
-import io.helidon.security.SecurityResponse;
 import io.helidon.security.annot.Audited;
 import io.helidon.security.annot.Authenticated;
 import io.helidon.security.annot.Authorized;
@@ -73,25 +61,17 @@ import org.glassfish.jersey.server.ServerConfig;
 import org.glassfish.jersey.server.model.Invocable;
 import org.glassfish.jersey.server.model.ResourceMethod;
 
-import static io.helidon.security.EndpointConfig.AnnotationScope.APPLICATION;
-import static io.helidon.security.EndpointConfig.AnnotationScope.CLASS;
-import static io.helidon.security.EndpointConfig.AnnotationScope.METHOD;
-
 /**
  * A filter that handles authentication and authorization.
  */
 @Priority(Priorities.AUTHENTICATION)
 @ConstrainedTo(RuntimeType.SERVER)
 public class SecurityFilter extends SecurityFilterCommon implements ContainerRequestFilter, ContainerResponseFilter {
-    private static final String PROP_FILTER_CONTEXT = "io.helidon.security.jersey.FilterContext";
 
     private static final Logger LOGGER = Logger.getLogger(SecurityFilter.class.getName());
 
     private final Map<Class<?>, SecurityDefinition> resourceClassSecurity = new ConcurrentHashMap<>();
     private final Map<Method, SecurityDefinition> resourceMethodSecurity = new ConcurrentHashMap<>();
-
-    @Context
-    private FeatureConfig featureConfig;
 
     @Context
     private ServerConfig serverConfig;
@@ -123,8 +103,8 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
                    UriInfo uriInfo,
                    SecurityContext securityContext) {
 
-        super(security);
-        this.featureConfig = featureConfig;
+        super(security, featureConfig);
+
         this.serverConfig = serverConfig;
         this.resourceInfo = resourceInfo;
         this.uriInfo = uriInfo;
@@ -143,105 +123,43 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
 
     @Override
     public void filter(ContainerRequestContext request) {
-        if (featureConfig.shouldUsePrematching()) {
+        if (featureConfig().shouldUsePrematchingAuthentication() && featureConfig().shouldUsePrematchingAuthorization()) {
             return;
         }
-        handleSecurity(request);
+        // only filter when not pre-matching (see SecurityPreMatchingFilter)
+        doFilter(request, securityContext);
     }
 
-    private void handleSecurity(ContainerRequestContext request) {
-        Span securitySpan = startSecuritySpan(securityContext);
+    @Override
+    protected void processSecurity(ContainerRequestContext request,
+                                   FilterContext filterContext,
+                                   Span securitySpan,
+                                   SecurityContext securityContext) {
 
-        FilterContext context = initRequestFiltering(request);
-
-        if (context.isShouldFinish()) {
-            // 404
-            finishSpan(securitySpan, CollectionsHelper.listOf());
-            return;
-        }
-
-        // The following two lines are not possible in JAX-RS or Jersey - we would have to touch
-        // underlying web server's request...
-        //.addAttribute("userIp", req.remoteAddress())
-        //.addAttribute("userPort", req.remotePort())
-        URI requestUri = request.getUriInfo().getRequestUri();
-        String query = requestUri.getQuery();
-        String origRequest;
-        if ((null == query) || query.isEmpty()) {
-            origRequest = requestUri.getPath();
-        } else {
-            origRequest = requestUri.getPath() + "?" + query;
-        }
-        Map<String, List<String>> allHeaders = new HashMap<>(context.getHeaders());
-        allHeaders.put(Security.HEADER_ORIG_URI, CollectionsHelper.listOf(origRequest));
-
-        SecurityEnvironment env = SecurityEnvironment.builder(security.getServerTime())
-                .path(context.getResourcePath())
-                .targetUri(context.getTargetUri())
-                .method(context.getMethod())
-                .headers(allHeaders)
-                .addAttribute("resourceType", context.getResourceName())
-                .build();
-
-        EndpointConfig ec = EndpointConfig.builder()
-                .annotations(APPLICATION, context.getMethodSecurity().getApplicationScope())
-                .annotations(CLASS, context.getMethodSecurity().getResourceScope())
-                .annotations(METHOD, context.getMethodSecurity().getOperationScope())
-                .build();
-
-        try {
-            securityContext.setEnv(env);
-            securityContext.setEndpointConfig(ec);
-            doFilter(request, context, securitySpan, securityContext);
-        } finally {
-            if (context.isTraceSuccess()) {
-                finishSpan(securitySpan, CollectionsHelper.listOf());
-            } else {
-                // failed
-                HttpUtil.traceError(securitySpan, null, "aborted");
+        // if we use pre-matching authentication, skip this step
+        if (!featureConfig().shouldUsePrematchingAuthentication()) {
+            /*
+             * Authentication
+             */
+            authenticate(filterContext, securitySpan, securityContext);
+            LOGGER.finest(() -> "Filter after authentication. Should finish: " + filterContext.isShouldFinish());
+            // authentication failed
+            if (filterContext.isShouldFinish()) {
+                return;
             }
-        }
-    }
 
-    private void doFilter(ContainerRequestContext request,
-                          FilterContext filterContext,
-                          Span securitySpan, SecurityContext securityContext) {
-        request.setProperty(PROP_FILTER_CONTEXT, filterContext);
-
-        // security not configured or 404
-        if (filterContext.isShouldFinish()) {
-            LOGGER.finest(() -> "Filter aborting, not configured security or 404");
-            return;
+            filterContext.clearTrace();
         }
 
-        //context is needed even if authn/authz fails - for auditing
-        request.setSecurityContext(new JerseySecurityContext(securityContext,
-                                                             filterContext.getMethodSecurity(),
-                                                             "https".equals(filterContext.getTargetUri().getScheme())));
+        // for the sake of consistency, check this again
+        if (!featureConfig().shouldUsePrematchingAuthorization()) {
+            /*
+             * Authorization
+             */
+            authorize(filterContext, securitySpan, securityContext);
 
-
-        /*
-         * Authentication
-         */
-        authenticate(filterContext, securitySpan, securityContext);
-
-        LOGGER.finest(() -> "Filter after authentication. Should finish: " + filterContext.isShouldFinish());
-
-        // authentication failed
-        if (filterContext.isShouldFinish()) {
-            return;
+            LOGGER.finest(() -> "Filter completed (after authorization)");
         }
-
-        filterContext.setTraceSuccess(true);
-        filterContext.setTraceDescription(null);
-        filterContext.setTraceThrowable(null);
-
-        /*
-         * Authorization
-         */
-        authorize(filterContext, securitySpan, securityContext);
-
-        LOGGER.finest(() -> "Filter completed (after authorization)");
     }
 
     @Override
@@ -264,7 +182,7 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
 
         if (fc.isExplicitAtz() && !securityContext.atzChecked()) {
             // authorization should have been explicit, yet it was not checked - this is a programmer error
-            if (featureConfig.isDebug()) {
+            if (featureConfig().isDebug()) {
                 responseContext.setEntity("Authorization was marked as explicit, yet it was never called in method");
             } else {
                 responseContext.setEntity("");
@@ -307,13 +225,13 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
                 securityContext.audit(auditEvent);
             }
 
-            if (!fc.isShouldFinish() && (fc.getResponseMessage().filterFunction != null)) {
+            if (!fc.isShouldFinish() && (fc.getResponseMessage().filterFunction() != null)) {
                 OutputStream originalStream = responseContext.getEntityStream();
 
                 OutputStreamPublisher outputStreamPublisher = new OutputStreamPublisher();
                 responseContext.setEntityStream(outputStreamPublisher);
 
-                fc.getResponseMessage().filterFunction
+                fc.getResponseMessage().filterFunction()
                         .apply(outputStreamPublisher)
                         .subscribe(new SubscriberOutputStream(originalStream, outputStreamPublisher::signalCloseComplete));
             }
@@ -326,101 +244,8 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
         }
     }
 
-    private void finishSpan(Span span, List<String> logs) {
-        if (null == span) {
-            return;
-        }
-        logs.forEach(span::log);
-        span.finish();
-    }
-
-
-
-    private void authorize(FilterContext context, Span securitySpan, SecurityContext securityContext) {
-        if (context.getMethodSecurity().isAtzExplicit()) {
-            // authorization is explicitly done by user, we MUST skip it here
-            context.setExplicitAtz(true);
-            return;
-        }
-        Span atzSpan = startNewSpan(securitySpan.context(), "security:atz");
-
-        try {
-            //now authorize (also authorize anonymous requests, as we may have a path-based authorization that allows public
-            // access
-            if (context.getMethodSecurity().requiresAuthorization()) {
-                SecurityClientBuilder<AuthorizationResponse> clientBuilder = securityContext.atzClientBuilder()
-                        .tracingSpan(atzSpan)
-                        .explicitProvider(context.getMethodSecurity().getAuthorizer());
-
-                processAuthorization(context, clientBuilder);
-            }
-        } finally {
-            if (!context.isTraceSuccess()) {
-                HttpUtil.traceError(atzSpan, context.getTraceThrowable(), context.getTraceDescription());
-            } else {
-                finishSpan(atzSpan, CollectionsHelper.listOf());
-            }
-        }
-    }
-
-    private void authenticate(FilterContext context, Span securitySpan, SecurityContext securityContext) {
-        Span atnSpan = startNewSpan(securitySpan.context(), "security:atn");
-
-        try {
-            if (context.getMethodSecurity().requiresAuthentication()) {
-                //authenticate request
-                SecurityClientBuilder<AuthenticationResponse> clientBuilder = securityContext
-                        .atnClientBuilder()
-                        .optional(context.getMethodSecurity().authenticationOptional())
-                        .requestMessage(toRequestMessage(context))
-                        .responseMessage(context.getResponseMessage())
-                        .tracingSpan(atnSpan);
-
-                clientBuilder.explicitProvider(context.getMethodSecurity().getAuthenticator());
-                processAuthentication(context, clientBuilder, context.getMethodSecurity());
-            }
-        } finally {
-            if (context.isTraceSuccess()) {
-                List<String> logs = new LinkedList<>();
-                securityContext.getUser()
-                        .ifPresent(user -> logs.add("security.user: " + user.getPrincipal().getName()));
-                securityContext.getService()
-                        .ifPresent(service -> logs.add("security.service: " + service.getPrincipal().getName()));
-
-                finishSpan(atnSpan, logs);
-            } else {
-                HttpUtil.traceError(atnSpan, context.getTraceThrowable(), context.getTraceDescription());
-            }
-        }
-    }
-
-    private SecurityDefinition securityForClass(Class<?> theClass, SecurityDefinition parent) {
-        Authenticated atn = theClass.getAnnotation(Authenticated.class);
-        Authorized atz = theClass.getAnnotation(Authorized.class);
-        Audited audited = theClass.getAnnotation(Audited.class);
-
-        // as sometimes we may want to prevent calls to authorization provider unless
-        // explicitly invoked by developer
-        SecurityDefinition definition = (
-                (null == parent)
-                        ? new SecurityDefinition(featureConfig.shouldAuthorizeAnnotatedOnly())
-                        : parent.copyMe());
-        definition.add(atn);
-        definition.add(atz);
-        definition.add(audited);
-
-        //this is specific jersey implementation - if parent is null, this is application scope, otherwise resource scope
-        Map<Class<? extends Annotation>, List<Annotation>> customAnnotsMap = (
-                (null == parent)
-                        ? definition.getApplicationScope()
-                        : definition.getResourceScope());
-
-        addCustomAnnotations(customAnnotsMap, theClass);
-
-        return definition;
-    }
-
-    private FilterContext initRequestFiltering(ContainerRequestContext requestContext) {
+    @Override
+    protected FilterContext initRequestFiltering(ContainerRequestContext requestContext) {
         FilterContext context = new FilterContext();
 
         Method definitionMethod = getDefinitionMethod(requestContext);
@@ -441,164 +266,41 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
         context.setJerseyRequest((ContainerRequest) requestContext);
 
         // now extract headers
-        featureConfig.getQueryParamHandlers()
+        featureConfig().getQueryParamHandlers()
                 .forEach(handler -> handler.extract(uriInfo, context.getHeaders()));
 
         return context;
     }
 
-    private void processAuthorization(FilterContext context,
-                                      SecurityClientBuilder<AuthorizationResponse> clientBuilder) {
-        // now fully synchronous
-        AuthorizationResponse response = clientBuilder.get();
-        SecurityResponse.SecurityStatus responseStatus = response.getStatus();
-
-        switch (responseStatus) {
-        case SUCCESS:
-            //everything is fine, we can continue with processing
-            return;
-        case FAILURE_FINISH:
-            context.setTraceSuccess(false);
-            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-            context.setTraceThrowable(response.getThrowable().orElse(null));
-            context.setShouldFinish(true);
-            int status = response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode());
-            abortRequest(context, response, status, CollectionsHelper.mapOf());
-            return;
-        case SUCCESS_FINISH:
-            context.setShouldFinish(true);
-            status = response.getStatusCode().orElse(Response.Status.OK.getStatusCode());
-            abortRequest(context, response, status, CollectionsHelper.mapOf());
-            return;
-        case FAILURE:
-            context.setTraceSuccess(false);
-            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-            context.setTraceThrowable(response.getThrowable().orElse(null));
-            context.setShouldFinish(true);
-            abortRequest(context,
-                         response,
-                         response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode()),
-                         CollectionsHelper.mapOf());
-            return;
-        case ABSTAIN:
-            context.setTraceSuccess(false);
-            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-            context.setShouldFinish(true);
-            abortRequest(context,
-                         response,
-                         response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode()),
-                         CollectionsHelper.mapOf());
-            return;
-        default:
-            context.setTraceSuccess(false);
-            context.setTraceDescription(response.getDescription().orElse("UNKNOWN_RESPONSE: " + responseStatus));
-            context.setShouldFinish(true);
-            SecurityException throwable = new SecurityException("Invalid SecurityStatus returned: " + responseStatus);
-            context.setTraceThrowable(throwable);
-            throw throwable;
-        }
+    @Override
+    protected Logger logger() {
+        return LOGGER;
     }
 
-    void processAuthentication(FilterContext context,
-                                       SecurityClientBuilder<AuthenticationResponse> clientBuilder,
-                                       SecurityDefinition methodSecurity) {
+    private SecurityDefinition securityForClass(Class<?> theClass, SecurityDefinition parent) {
+        Authenticated atn = theClass.getAnnotation(Authenticated.class);
+        Authorized atz = theClass.getAnnotation(Authorized.class);
+        Audited audited = theClass.getAnnotation(Audited.class);
 
-        AuthenticationResponse response = clientBuilder.get();
+        // as sometimes we may want to prevent calls to authorization provider unless
+        // explicitly invoked by developer
+        SecurityDefinition definition = (
+                (null == parent)
+                        ? new SecurityDefinition(featureConfig().shouldAuthorizeAnnotatedOnly())
+                        : parent.copyMe());
+        definition.add(atn);
+        definition.add(atz);
+        definition.add(audited);
 
-        SecurityResponse.SecurityStatus responseStatus = response.getStatus();
+        //this is specific jersey implementation - if parent is null, this is application scope, otherwise resource scope
+        Map<Class<? extends Annotation>, List<Annotation>> customAnnotsMap = (
+                (null == parent)
+                        ? definition.getApplicationScope()
+                        : definition.getResourceScope());
 
-        switch (responseStatus) {
-        case SUCCESS:
-            //everything is fine, we can continue with processing
-            return;
-        case FAILURE_FINISH:
-            if (methodSecurity.authenticationOptional()) {
-                LOGGER.finest("Authentication failed, but was optional, so assuming anonymous");
-            } else {
-                context.setTraceSuccess(false);
-                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-                context.setTraceThrowable(response.getThrowable().orElse(null));
-                context.setShouldFinish(true);
+        addCustomAnnotations(customAnnotsMap, theClass);
 
-                int status = response.getStatusCode().orElse(Response.Status.UNAUTHORIZED.getStatusCode());
-                abortRequest(context, response, status, CollectionsHelper.mapOf());
-            }
-
-            return;
-        case SUCCESS_FINISH:
-            context.setShouldFinish(true);
-
-            int status = response.getStatusCode().orElse(Response.Status.OK.getStatusCode());
-            abortRequest(context, response, status, CollectionsHelper.mapOf());
-
-            return;
-        case ABSTAIN:
-            if (methodSecurity.authenticationOptional()) {
-                LOGGER.finest("Authentication failed, but was optional, so assuming anonymous");
-            } else {
-                context.setTraceSuccess(false);
-                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-                context.setShouldFinish(true);
-                abortRequest(context,
-                             response,
-                             Response.Status.UNAUTHORIZED.getStatusCode(),
-                             CollectionsHelper.mapOf());
-            }
-            return;
-        case FAILURE:
-            if (methodSecurity.authenticationOptional()) {
-                LOGGER.finest("Authentication failed, but was optional, so assuming anonymous");
-            } else {
-                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
-                context.setTraceThrowable(response.getThrowable().orElse(null));
-                context.setTraceSuccess(false);
-                abortRequest(context,
-                             response,
-                             Response.Status.UNAUTHORIZED.getStatusCode(),
-                             CollectionsHelper.mapOf());
-                context.setShouldFinish(true);
-            }
-            return;
-        default:
-            context.setTraceSuccess(false);
-            context.setTraceDescription(response.getDescription().orElse("UNKNOWN_RESPONSE: " + responseStatus));
-            context.setShouldFinish(true);
-            SecurityException throwable = new SecurityException("Invalid SecurityStatus returned: " + responseStatus);
-            context.setTraceThrowable(throwable);
-            throw throwable;
-        }
-    }
-
-    private void abortRequest(FilterContext context,
-                              SecurityResponse response,
-                              int defaultStatusCode,
-                              Map<String, List<String>> defaultHeaders) {
-
-        int statusCode = response.getStatusCode().orElse(defaultStatusCode);
-        Map<String, List<String>> responseHeaders = response.getResponseHeaders();
-
-        Response.ResponseBuilder responseBuilder = Response.status(statusCode);
-        if (responseHeaders.isEmpty()) {
-            for (Map.Entry<String, List<String>> entry : defaultHeaders.entrySet()) {
-                responseBuilder.header(entry.getKey(), entry.getValue());
-            }
-        } else {
-            updateHeaders(responseHeaders, responseBuilder);
-        }
-
-        if (featureConfig.isDebug()) {
-            response.getDescription().ifPresent(responseBuilder::entity);
-        }
-
-        context.getJerseyRequest().abortWith(responseBuilder.build());
-    }
-
-    private void updateHeaders(Map<String, List<String>> responseHeaders, Response.ResponseBuilder responseBuilder) {
-        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
-            for (String value : entry.getValue()) {
-                responseBuilder.header(entry.getKey(), value);
-            }
-        }
+        return definition;
     }
 
     private SecurityDefinition getMethodSecurity(Method definitionMethod) {
@@ -728,157 +430,4 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
         return application;
     }
 
-    private Entity toRequestMessage(FilterContext context) {
-        switch (context.getMethod().toLowerCase()) {
-        case "get":
-        case "options":
-        case "head":
-        case "delete":
-            return null;
-        default:
-            break;
-        }
-
-        return filterFunction -> {
-            // this is request message (inbound)
-
-            // this will publish bytes coming in from external source (to security provider)
-            Flow.Publisher<ByteBuffer> publisherFromJersey =
-                    new InputStreamPublisher(context.getJerseyRequest().getEntityStream(), 1024);
-
-            SubscriberInputStream subscriberInputStream = new SubscriberInputStream();
-            context.getJerseyRequest().setEntityStream(subscriberInputStream);
-
-            Flow.Publisher<ByteBuffer> publisherToJersey = filterFunction.apply(publisherFromJersey);
-            // this will receive request bytes coming in from security provider (filtered)
-            publisherToJersey.subscribe(subscriberInputStream);
-        };
-    }
-
-    static class FilterContext {
-        private final JerseyResponseEntity responseMessage = new JerseyResponseEntity();
-        private String resourceName;
-        private String resourcePath;
-        private String method;
-        private Map<String, List<String>> headers;
-        private URI targetUri;
-        private ContainerRequest jerseyRequest;
-        private boolean shouldFinish;
-        private SecurityDefinition methodSecurity;
-        private boolean explicitAtz;
-
-        // tracing support
-        private boolean traceSuccess = true;
-        private String traceDescription;
-        private Throwable traceThrowable;
-
-        JerseyResponseEntity getResponseMessage() {
-            return responseMessage;
-        }
-
-        String getResourceName() {
-            return resourceName;
-        }
-
-        void setResourceName(String resourceName) {
-            this.resourceName = resourceName;
-        }
-
-        String getResourcePath() {
-            return resourcePath;
-        }
-
-        void setResourcePath(String resourcePath) {
-            this.resourcePath = resourcePath;
-        }
-
-        String getMethod() {
-            return method;
-        }
-
-        void setMethod(String method) {
-            this.method = method;
-        }
-
-        Map<String, List<String>> getHeaders() {
-            return headers;
-        }
-
-        void setHeaders(Map<String, List<String>> headers) {
-            this.headers = headers;
-        }
-
-        URI getTargetUri() {
-            return targetUri;
-        }
-
-        void setTargetUri(URI targetUri) {
-            this.targetUri = targetUri;
-        }
-
-        ContainerRequest getJerseyRequest() {
-            return jerseyRequest;
-        }
-
-        void setJerseyRequest(ContainerRequest jerseyRequest) {
-            this.jerseyRequest = jerseyRequest;
-        }
-
-        boolean isShouldFinish() {
-            return shouldFinish;
-        }
-
-        void setShouldFinish(boolean shouldFinish) {
-            this.shouldFinish = shouldFinish;
-        }
-
-        SecurityDefinition getMethodSecurity() {
-            return methodSecurity;
-        }
-
-        void setMethodSecurity(SecurityDefinition methodSecurity) {
-            this.methodSecurity = methodSecurity;
-        }
-
-        boolean isExplicitAtz() {
-            return explicitAtz;
-        }
-
-        void setExplicitAtz(boolean explicitAtz) {
-            this.explicitAtz = explicitAtz;
-        }
-
-        boolean isTraceSuccess() {
-            return traceSuccess;
-        }
-
-        void setTraceSuccess(boolean traceSuccess) {
-            this.traceSuccess = traceSuccess;
-        }
-
-        String getTraceDescription() {
-            return traceDescription;
-        }
-
-        void setTraceDescription(String traceDescription) {
-            this.traceDescription = traceDescription;
-        }
-
-        Throwable getTraceThrowable() {
-            return traceThrowable;
-        }
-
-        void setTraceThrowable(Throwable traceThrowable) {
-            this.traceThrowable = traceThrowable;
-        }
-    }
-
-    private static class JerseyResponseEntity implements Entity {
-        private volatile Function<Flow.Publisher<ByteBuffer>, Flow.Publisher<ByteBuffer>> filterFunction;
-
-        @Override
-        public void filter(Function<Flow.Publisher<ByteBuffer>, Flow.Publisher<ByteBuffer>> filterFunction) {
-            this.filterFunction = filterFunction;
-        }
-    }
 }

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilterCommon.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilterCommon.java
@@ -15,30 +15,60 @@
  */
 package io.helidon.security.jersey;
 
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 
 import io.helidon.common.CollectionsHelper;
+import io.helidon.common.reactive.Flow;
+import io.helidon.security.AuthenticationResponse;
+import io.helidon.security.AuthorizationResponse;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.Entity;
 import io.helidon.security.Security;
+import io.helidon.security.SecurityClientBuilder;
 import io.helidon.security.SecurityContext;
+import io.helidon.security.SecurityEnvironment;
+import io.helidon.security.SecurityResponse;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import org.glassfish.jersey.server.ContainerRequest;
+
+import static io.helidon.security.EndpointConfig.AnnotationScope.APPLICATION;
+import static io.helidon.security.EndpointConfig.AnnotationScope.CLASS;
+import static io.helidon.security.EndpointConfig.AnnotationScope.METHOD;
 
 /**
  * Helper class for security filters.
  */
 abstract class SecurityFilterCommon {
-    @Context
-    protected Security security;
+    static final String PROP_FILTER_CONTEXT = "io.helidon.security.jersey.FilterContext";
 
-    public SecurityFilterCommon() {
+    @Context
+    private Security security;
+
+    @Context
+    private FeatureConfig featureConfig;
+
+    SecurityFilterCommon() {
     }
 
     // due to a bug in Jersey @Context in constructor injection is failing
     // this method is needed for unit tests
-    SecurityFilterCommon(Security security) {
+    SecurityFilterCommon(Security security, FeatureConfig featureConfig) {
         this.security = security;
+        this.featureConfig = featureConfig;
     }
 
     protected Span startSecuritySpan(SecurityContext securityContext) {
@@ -47,10 +77,472 @@ abstract class SecurityFilterCommon {
         return securitySpan;
     }
 
-    private Span startNewSpan(SpanContext parentSpan, String name) {
+    protected void finishSpan(Span span, List<String> logs) {
+        if (null == span) {
+            return;
+        }
+        logs.forEach(span::log);
+        span.finish();
+    }
+
+    protected Span startNewSpan(SpanContext parentSpan, String name) {
         Tracer.SpanBuilder spanBuilder = security.getTracer().buildSpan(name);
         spanBuilder.asChildOf(parentSpan);
 
         return spanBuilder.start();
+    }
+
+    protected void doFilter(ContainerRequestContext request, SecurityContext securityContext) {
+        Span securitySpan = startSecuritySpan(securityContext);
+
+        SecurityFilter.FilterContext filterContext = initRequestFiltering(request);
+
+        if (filterContext.isShouldFinish()) {
+            // 404
+            finishSpan(securitySpan, CollectionsHelper.listOf());
+            return;
+        }
+
+        // The following two lines are not possible in JAX-RS or Jersey - we would have to touch
+        // underlying web server's request...
+        //.addAttribute("userIp", req.remoteAddress())
+        //.addAttribute("userPort", req.remotePort())
+        URI requestUri = request.getUriInfo().getRequestUri();
+        String query = requestUri.getQuery();
+        String origRequest;
+        if ((null == query) || query.isEmpty()) {
+            origRequest = requestUri.getPath();
+        } else {
+            origRequest = requestUri.getPath() + "?" + query;
+        }
+        Map<String, List<String>> allHeaders = new HashMap<>(filterContext.getHeaders());
+        allHeaders.put(Security.HEADER_ORIG_URI, CollectionsHelper.listOf(origRequest));
+
+        SecurityEnvironment env = SecurityEnvironment.builder(security.getServerTime())
+                .path(filterContext.getResourcePath())
+                .targetUri(filterContext.getTargetUri())
+                .method(filterContext.getMethod())
+                .headers(allHeaders)
+                .addAttribute("resourceType", filterContext.getResourceName())
+                .build();
+
+        EndpointConfig ec = EndpointConfig.builder()
+                .annotations(APPLICATION, filterContext.getMethodSecurity().getApplicationScope())
+                .annotations(CLASS, filterContext.getMethodSecurity().getResourceScope())
+                .annotations(METHOD, filterContext.getMethodSecurity().getOperationScope())
+                .build();
+
+        try {
+            securityContext.setEnv(env);
+            securityContext.setEndpointConfig(ec);
+
+            request.setProperty(PROP_FILTER_CONTEXT, filterContext);
+            //context is needed even if authn/authz fails - for auditing
+            request.setSecurityContext(new JerseySecurityContext(securityContext,
+                                                                 filterContext.getMethodSecurity(),
+                                                                 "https".equals(filterContext.getTargetUri().getScheme())));
+
+            processSecurity(request, filterContext, securitySpan, securityContext);
+        } finally {
+            if (filterContext.isTraceSuccess()) {
+                finishSpan(securitySpan, CollectionsHelper.listOf());
+            } else {
+                // failed
+                HttpUtil.traceError(securitySpan, null, "aborted");
+            }
+        }
+    }
+
+    protected void authenticate(SecurityFilter.FilterContext context, Span securitySpan, SecurityContext securityContext) {
+        Span atnSpan = startNewSpan(securitySpan.context(), "security:atn");
+
+        try {
+            if (context.getMethodSecurity().requiresAuthentication()) {
+                //authenticate request
+                SecurityClientBuilder<AuthenticationResponse> clientBuilder = securityContext
+                        .atnClientBuilder()
+                        .optional(context.getMethodSecurity().authenticationOptional())
+                        .requestMessage(toRequestMessage(context))
+                        .responseMessage(context.getResponseMessage())
+                        .tracingSpan(atnSpan);
+
+                clientBuilder.explicitProvider(context.getMethodSecurity().getAuthenticator());
+                processAuthentication(context, clientBuilder, context.getMethodSecurity());
+            }
+        } finally {
+            if (context.isTraceSuccess()) {
+                List<String> logs = new LinkedList<>();
+                securityContext.getUser()
+                        .ifPresent(user -> logs.add("security.user: " + user.getPrincipal().getName()));
+                securityContext.getService()
+                        .ifPresent(service -> logs.add("security.service: " + service.getPrincipal().getName()));
+
+                finishSpan(atnSpan, logs);
+            } else {
+                HttpUtil.traceError(atnSpan, context.getTraceThrowable(), context.getTraceDescription());
+            }
+        }
+    }
+
+    protected Entity toRequestMessage(SecurityFilter.FilterContext context) {
+        switch (context.getMethod().toLowerCase()) {
+        case "get":
+        case "options":
+        case "head":
+        case "delete":
+            return null;
+        default:
+            break;
+        }
+
+        return filterFunction -> {
+            // this is request message (inbound)
+
+            // this will publish bytes coming in from external source (to security provider)
+            Flow.Publisher<ByteBuffer> publisherFromJersey =
+                    new InputStreamPublisher(context.getJerseyRequest().getEntityStream(), 1024);
+
+            SubscriberInputStream subscriberInputStream = new SubscriberInputStream();
+            context.getJerseyRequest().setEntityStream(subscriberInputStream);
+
+            Flow.Publisher<ByteBuffer> publisherToJersey = filterFunction.apply(publisherFromJersey);
+            // this will receive request bytes coming in from security provider (filtered)
+            publisherToJersey.subscribe(subscriberInputStream);
+        };
+    }
+
+    protected void processAuthentication(SecurityFilter.FilterContext context,
+                                         SecurityClientBuilder<AuthenticationResponse> clientBuilder,
+                                         SecurityDefinition methodSecurity) {
+
+        AuthenticationResponse response = clientBuilder.get();
+
+        SecurityResponse.SecurityStatus responseStatus = response.getStatus();
+
+        switch (responseStatus) {
+        case SUCCESS:
+            //everything is fine, we can continue with processing
+            return;
+        case FAILURE_FINISH:
+            if (methodSecurity.authenticationOptional()) {
+                logger().finest("Authentication failed, but was optional, so assuming anonymous");
+            } else {
+                context.setTraceSuccess(false);
+                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+                context.setTraceThrowable(response.getThrowable().orElse(null));
+                context.setShouldFinish(true);
+
+                int status = response.getStatusCode().orElse(Response.Status.UNAUTHORIZED.getStatusCode());
+                abortRequest(context, response, status, CollectionsHelper.mapOf());
+            }
+
+            return;
+        case SUCCESS_FINISH:
+            context.setShouldFinish(true);
+
+            int status = response.getStatusCode().orElse(Response.Status.OK.getStatusCode());
+            abortRequest(context, response, status, CollectionsHelper.mapOf());
+
+            return;
+        case ABSTAIN:
+            if (methodSecurity.authenticationOptional()) {
+                logger().finest("Authentication failed, but was optional, so assuming anonymous");
+            } else {
+                context.setTraceSuccess(false);
+                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+                context.setShouldFinish(true);
+                abortRequest(context,
+                             response,
+                             Response.Status.UNAUTHORIZED.getStatusCode(),
+                             CollectionsHelper.mapOf());
+            }
+            return;
+        case FAILURE:
+            if (methodSecurity.authenticationOptional()) {
+                logger().finest("Authentication failed, but was optional, so assuming anonymous");
+            } else {
+                context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+                context.setTraceThrowable(response.getThrowable().orElse(null));
+                context.setTraceSuccess(false);
+                abortRequest(context,
+                             response,
+                             Response.Status.UNAUTHORIZED.getStatusCode(),
+                             CollectionsHelper.mapOf());
+                context.setShouldFinish(true);
+            }
+            return;
+        default:
+            context.setTraceSuccess(false);
+            context.setTraceDescription(response.getDescription().orElse("UNKNOWN_RESPONSE: " + responseStatus));
+            context.setShouldFinish(true);
+            SecurityException throwable = new SecurityException("Invalid SecurityStatus returned: " + responseStatus);
+            context.setTraceThrowable(throwable);
+            throw throwable;
+        }
+    }
+
+    protected abstract Logger logger();
+
+    protected void authorize(SecurityFilter.FilterContext context, Span securitySpan, SecurityContext securityContext) {
+        if (context.getMethodSecurity().isAtzExplicit()) {
+            // authorization is explicitly done by user, we MUST skip it here
+            context.setExplicitAtz(true);
+            return;
+        }
+        Span atzSpan = startNewSpan(securitySpan.context(), "security:atz");
+
+        try {
+            //now authorize (also authorize anonymous requests, as we may have a path-based authorization that allows public
+            // access
+            if (context.getMethodSecurity().requiresAuthorization()) {
+                SecurityClientBuilder<AuthorizationResponse> clientBuilder = securityContext.atzClientBuilder()
+                        .tracingSpan(atzSpan)
+                        .explicitProvider(context.getMethodSecurity().getAuthorizer());
+
+                processAuthorization(context, clientBuilder);
+            }
+        } finally {
+            if (!context.isTraceSuccess()) {
+                HttpUtil.traceError(atzSpan, context.getTraceThrowable(), context.getTraceDescription());
+            } else {
+                finishSpan(atzSpan, CollectionsHelper.listOf());
+            }
+        }
+    }
+
+    protected void processAuthorization(SecurityFilter.FilterContext context,
+                                        SecurityClientBuilder<AuthorizationResponse> clientBuilder) {
+        // now fully synchronous
+        AuthorizationResponse response = clientBuilder.get();
+        SecurityResponse.SecurityStatus responseStatus = response.getStatus();
+
+        switch (responseStatus) {
+        case SUCCESS:
+            //everything is fine, we can continue with processing
+            return;
+        case FAILURE_FINISH:
+            context.setTraceSuccess(false);
+            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+            context.setTraceThrowable(response.getThrowable().orElse(null));
+            context.setShouldFinish(true);
+            int status = response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode());
+            abortRequest(context, response, status, CollectionsHelper.mapOf());
+            return;
+        case SUCCESS_FINISH:
+            context.setShouldFinish(true);
+            status = response.getStatusCode().orElse(Response.Status.OK.getStatusCode());
+            abortRequest(context, response, status, CollectionsHelper.mapOf());
+            return;
+        case FAILURE:
+            context.setTraceSuccess(false);
+            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+            context.setTraceThrowable(response.getThrowable().orElse(null));
+            context.setShouldFinish(true);
+            abortRequest(context,
+                         response,
+                         response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode()),
+                         CollectionsHelper.mapOf());
+            return;
+        case ABSTAIN:
+            context.setTraceSuccess(false);
+            context.setTraceDescription(response.getDescription().orElse(responseStatus.toString()));
+            context.setShouldFinish(true);
+            abortRequest(context,
+                         response,
+                         response.getStatusCode().orElse(Response.Status.FORBIDDEN.getStatusCode()),
+                         CollectionsHelper.mapOf());
+            return;
+        default:
+            context.setTraceSuccess(false);
+            context.setTraceDescription(response.getDescription().orElse("UNKNOWN_RESPONSE: " + responseStatus));
+            context.setShouldFinish(true);
+            SecurityException throwable = new SecurityException("Invalid SecurityStatus returned: " + responseStatus);
+            context.setTraceThrowable(throwable);
+            throw throwable;
+        }
+    }
+
+    protected void abortRequest(SecurityFilter.FilterContext context,
+                                SecurityResponse response,
+                                int defaultStatusCode,
+                                Map<String, List<String>> defaultHeaders) {
+
+        int statusCode = response.getStatusCode().orElse(defaultStatusCode);
+        Map<String, List<String>> responseHeaders = response.getResponseHeaders();
+
+        Response.ResponseBuilder responseBuilder = Response.status(statusCode);
+        if (responseHeaders.isEmpty()) {
+            for (Map.Entry<String, List<String>> entry : defaultHeaders.entrySet()) {
+                responseBuilder.header(entry.getKey(), entry.getValue());
+            }
+        } else {
+            updateHeaders(responseHeaders, responseBuilder);
+        }
+
+        if (featureConfig.isDebug()) {
+            response.getDescription().ifPresent(responseBuilder::entity);
+        }
+
+        context.getJerseyRequest().abortWith(responseBuilder.build());
+    }
+
+    protected void updateHeaders(Map<String, List<String>> responseHeaders, Response.ResponseBuilder responseBuilder) {
+        for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
+            for (String value : entry.getValue()) {
+                responseBuilder.header(entry.getKey(), value);
+            }
+        }
+    }
+
+    protected Security security() {
+        return security;
+    }
+
+    protected FeatureConfig featureConfig() {
+        return featureConfig;
+    }
+
+    protected abstract void processSecurity(ContainerRequestContext request,
+                                            SecurityFilter.FilterContext context,
+                                            Span securitySpan,
+                                            SecurityContext securityContext);
+
+    protected abstract SecurityFilter.FilterContext initRequestFiltering(ContainerRequestContext requestContext);
+
+    static class FilterContext {
+        private final JerseyResponseEntity responseMessage = new JerseyResponseEntity();
+        private String resourceName;
+        private String resourcePath;
+        private String method;
+        private Map<String, List<String>> headers;
+        private URI targetUri;
+        private ContainerRequest jerseyRequest;
+        private boolean shouldFinish;
+        private SecurityDefinition methodSecurity;
+        private boolean explicitAtz;
+
+        // tracing support
+        private boolean traceSuccess = true;
+        private String traceDescription;
+        private Throwable traceThrowable;
+
+        JerseyResponseEntity getResponseMessage() {
+            return responseMessage;
+        }
+
+        String getResourceName() {
+            return resourceName;
+        }
+
+        void setResourceName(String resourceName) {
+            this.resourceName = resourceName;
+        }
+
+        String getResourcePath() {
+            return resourcePath;
+        }
+
+        void setResourcePath(String resourcePath) {
+            this.resourcePath = resourcePath;
+        }
+
+        String getMethod() {
+            return method;
+        }
+
+        void setMethod(String method) {
+            this.method = method;
+        }
+
+        Map<String, List<String>> getHeaders() {
+            return headers;
+        }
+
+        void setHeaders(Map<String, List<String>> headers) {
+            this.headers = headers;
+        }
+
+        URI getTargetUri() {
+            return targetUri;
+        }
+
+        void setTargetUri(URI targetUri) {
+            this.targetUri = targetUri;
+        }
+
+        ContainerRequest getJerseyRequest() {
+            return jerseyRequest;
+        }
+
+        void setJerseyRequest(ContainerRequest jerseyRequest) {
+            this.jerseyRequest = jerseyRequest;
+        }
+
+        boolean isShouldFinish() {
+            return shouldFinish;
+        }
+
+        void setShouldFinish(boolean shouldFinish) {
+            this.shouldFinish = shouldFinish;
+        }
+
+        SecurityDefinition getMethodSecurity() {
+            return methodSecurity;
+        }
+
+        void setMethodSecurity(SecurityDefinition methodSecurity) {
+            this.methodSecurity = methodSecurity;
+        }
+
+        boolean isExplicitAtz() {
+            return explicitAtz;
+        }
+
+        void setExplicitAtz(boolean explicitAtz) {
+            this.explicitAtz = explicitAtz;
+        }
+
+        boolean isTraceSuccess() {
+            return traceSuccess;
+        }
+
+        void setTraceSuccess(boolean traceSuccess) {
+            this.traceSuccess = traceSuccess;
+        }
+
+        String getTraceDescription() {
+            return traceDescription;
+        }
+
+        void setTraceDescription(String traceDescription) {
+            this.traceDescription = traceDescription;
+        }
+
+        Throwable getTraceThrowable() {
+            return traceThrowable;
+        }
+
+        void setTraceThrowable(Throwable traceThrowable) {
+            this.traceThrowable = traceThrowable;
+        }
+
+        void clearTrace() {
+            setTraceSuccess(true);
+            setTraceDescription(null);
+            setTraceThrowable(null);
+        }
+    }
+
+    protected static class JerseyResponseEntity implements Entity {
+        private volatile Function<Flow.Publisher<ByteBuffer>, Flow.Publisher<ByteBuffer>> filterFunction;
+
+        @Override
+        public void filter(Function<Flow.Publisher<ByteBuffer>, Flow.Publisher<ByteBuffer>> filterFunction) {
+            this.filterFunction = filterFunction;
+        }
+
+        protected Function<Flow.Publisher<ByteBuffer>, Flow.Publisher<ByteBuffer>> filterFunction() {
+            return filterFunction;
+        }
     }
 }

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilterCommon.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityFilterCommon.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.security.jersey;
+
+import javax.ws.rs.core.Context;
+
+import io.helidon.common.CollectionsHelper;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityContext;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+/**
+ * Helper class for security filters.
+ */
+abstract class SecurityFilterCommon {
+    @Context
+    protected Security security;
+
+    public SecurityFilterCommon() {
+    }
+
+    // due to a bug in Jersey @Context in constructor injection is failing
+    // this method is needed for unit tests
+    SecurityFilterCommon(Security security) {
+        this.security = security;
+    }
+
+    protected Span startSecuritySpan(SecurityContext securityContext) {
+        Span securitySpan = startNewSpan(securityContext.getTracingSpan(), "security");
+        securitySpan.log(CollectionsHelper.mapOf("securityId", securityContext.getId()));
+        return securitySpan;
+    }
+
+    private Span startNewSpan(SpanContext parentSpan, String name) {
+        Tracer.SpanBuilder spanBuilder = security.getTracer().buildSpan(name);
+        spanBuilder.asChildOf(parentSpan);
+
+        return spanBuilder.start();
+    }
+}

--- a/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityPreMatchingFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/jersey/SecurityPreMatchingFilter.java
@@ -18,6 +18,7 @@ package io.helidon.security.jersey;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import javax.annotation.Priority;
 import javax.inject.Provider;
@@ -29,6 +30,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.UriInfo;
 
 import io.helidon.security.SecurityContext;
 
@@ -36,6 +38,7 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.util.collection.Ref;
+import org.glassfish.jersey.server.ContainerRequest;
 
 /**
  * Security context must be created before resource method is matched, so it is available for injection into resource classes.
@@ -44,6 +47,8 @@ import org.glassfish.jersey.internal.util.collection.Ref;
 @Priority(Priorities.AUTHENTICATION)
 @ConstrainedTo(RuntimeType.SERVER)
 class SecurityPreMatchingFilter extends SecurityFilterCommon implements ContainerRequestFilter {
+    private static final Logger LOGGER = Logger.getLogger(SecurityPreMatchingFilter.class.getName());
+
     static final String PROP_CLOSE_PARENT_SPAN = "io.helidon.security.jersey.SecurityFilter.closeParent";
     static final String PROP_PARENT_SPAN = "io.helidon.security.jersey.SecurityFilter.parentSpan";
 
@@ -60,7 +65,9 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
     private ExecutorService executorService;
 
     @Context
-    private FeatureConfig featureConfig;
+    private UriInfo uriInfo;
+
+
 
     @Override
     public void filter(ContainerRequestContext request) {
@@ -69,7 +76,7 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
 
         if (null == requestSpanContext) {
             closeParentSpan = true;
-            Span requestSpan = security.getTracer().buildSpan("security-parent").start();
+            Span requestSpan = security().getTracer().buildSpan("security-parent").start();
             request.setProperty(PROP_PARENT_SPAN, requestSpan);
             requestSpanContext = requestSpan.context();
         }
@@ -77,7 +84,7 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
         request.setProperty(PROP_CLOSE_PARENT_SPAN, closeParentSpan);
 
         // create a new security context
-        SecurityContext securityContext = security
+        SecurityContext securityContext = security()
                 .contextBuilder(Integer.toString(CONTEXT_COUNTER.incrementAndGet(), Character.MAX_RADIX))
                 .tracingSpan(requestSpanContext)
                 .executorService(executorService)
@@ -86,13 +93,64 @@ class SecurityPreMatchingFilter extends SecurityFilterCommon implements Containe
         injectionManager.<Ref<SecurityContext>>getInstance((new GenericType<Ref<SecurityContext>>() { }).getType())
                 .set(securityContext);
 
-        if (featureConfig.shouldUsePrematching()) {
-            handleSecurity(request, securityContext);
+        if (featureConfig().shouldUsePrematchingAuthentication()) {
+            doFilter(request, securityContext);
         }
     }
 
-    private void handleSecurity(ContainerRequestContext request, SecurityContext securityContext) {
-        Span securitySpan = startSecuritySpan(securityContext);
-        FilterCon
+    @Override
+    protected void processSecurity(ContainerRequestContext request,
+                                   SecurityFilter.FilterContext filterContext,
+                                   Span securitySpan,
+                                   SecurityContext securityContext) {
+
+        // when I reach this point, I am sure we should at least authenticate in prematching filter
+        authenticate(filterContext, securitySpan, securityContext);
+
+        LOGGER.finest(() -> "Filter after authentication. Should finish: " + filterContext.isShouldFinish());
+
+        // authentication failed
+        if (filterContext.isShouldFinish()) {
+            return;
+        }
+
+        filterContext.clearTrace();
+
+        if (featureConfig().shouldUsePrematchingAuthorization()) {
+            LOGGER.finest(() -> "Using pre-matching authorization");
+            authorize(filterContext, securitySpan, securityContext);
+        }
+
+        LOGGER.finest(() -> "Filter completed (after authorization)");
+    }
+
+    @Override
+    protected SecurityFilter.FilterContext initRequestFiltering(ContainerRequestContext requestContext) {
+        SecurityFilter.FilterContext context = new SecurityFilter.FilterContext();
+
+        // this is a pre-matching filter, so no method or class security
+
+        SecurityDefinition methodDef = new SecurityDefinition(false);
+        methodDef.requiresAuthentication(true);
+        methodDef.setRequiresAuthorization(featureConfig().shouldUsePrematchingAuthorization());
+        context.setMethodSecurity(methodDef);
+        context.setResourceName("jax-rs");
+        context.setMethod(requestContext.getMethod());
+        context.setHeaders(HttpUtil.toSimpleMap(requestContext.getHeaders()));
+        context.setTargetUri(requestContext.getUriInfo().getRequestUri());
+        context.setResourcePath(context.getTargetUri().getPath());
+
+        context.setJerseyRequest((ContainerRequest) requestContext);
+
+        // now extract headers
+        featureConfig().getQueryParamHandlers()
+                .forEach(handler -> handler.extract(uriInfo, context.getHeaders()));
+
+        return context;
+    }
+
+    @Override
+    protected Logger logger() {
+        return LOGGER;
     }
 }

--- a/security/integration/jersey/src/test/java/io/helidon/security/jersey/OptionalSecurityTest.java
+++ b/security/integration/jersey/src/test/java/io/helidon/security/jersey/OptionalSecurityTest.java
@@ -76,7 +76,7 @@ class OptionalSecurityTest {
                 .addAuthenticationProvider(OptionalSecurityTest::authenticate)
                 .build();
 
-        featureConfig = new FeatureConfig(false, CollectionsHelper.listOf(), false);
+        featureConfig = new FeatureConfig();
 
         serverConfig = ResourceConfig.forApplication(getApplication());
 

--- a/security/integration/jersey/src/test/java/io/helidon/security/jersey/PreMatchingBindingTest.java
+++ b/security/integration/jersey/src/test/java/io/helidon/security/jersey/PreMatchingBindingTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.jersey;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.security.Principal;
+import io.helidon.security.Security;
+import io.helidon.security.SecurityContext;
+import io.helidon.security.Subject;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.jersey.JerseySupport;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test that Jersey binding works.
+ */
+public class PreMatchingBindingTest {
+    private static Client client;
+    private static WebServer server;
+    private static WebTarget baseTarget;
+
+    @BeforeAll
+    public static void initClass() throws Throwable {
+        Config config = Config.builder()
+                .sources(ConfigSources.classpath("pre-matching.yaml"))
+                .build();
+
+        server = Routing.builder()
+                .register(JerseySupport.builder()
+                                  .register(MyResource.class)
+                                  .register(new SecurityFeature(Security.fromConfig(config)))
+                                  .register(new ExceptionMapper<Exception>() {
+                                      @Override
+                                      public Response toResponse(Exception exception) {
+                                          exception.printStackTrace();
+                                          return Response.serverError().build();
+                                      }
+                                  })
+                                  .build())
+                .build()
+                .createServer();
+        CountDownLatch cdl = new CountDownLatch(1);
+        AtomicReference<Throwable> th = new AtomicReference<>();
+        server.start().whenComplete((webServer, throwable) -> {
+            th.set(throwable);
+            cdl.countDown();
+        });
+
+        cdl.await();
+
+        if (th.get() != null) {
+            throw th.get();
+        }
+
+        client = ClientBuilder.newClient();
+        URI baseUri = UriBuilder.fromUri("http://localhost/").port(server.port()).build();
+        baseTarget = client.target(baseUri);
+    }
+
+    @AfterAll
+    public static void destroyClass() throws InterruptedException {
+        client.close();
+
+        CountDownLatch cdl = new CountDownLatch(1);
+        server.shutdown().whenComplete((webServer, throwable) -> cdl.countDown());
+        cdl.await();
+    }
+
+    @Test
+    public void testPublic() {
+        Response response = baseTarget
+                .path("/")
+                .request()
+                .get();
+
+        // this must be forbidden, as we use a pre-matching filter
+        assertThat(response.getStatus(), is(401));
+    }
+
+    @Test
+    public void testAuthenticated() {
+        Response response = baseTarget
+                .path("/")
+                .request()
+                .header("x-user", "jack")
+                .get();
+
+        assertThat(response.getStatus(), is(200));
+
+        String entity = response.readEntity(String.class);
+        assertThat(entity, is("hello jack"));
+    }
+
+    @Test
+    public void testDeny() {
+        //this should fail
+        try {
+            baseTarget
+                    .path("/deny")
+                    .request()
+                    // we must authenticate, as we use a pre-matching filter
+                    .header("x-user", "jack")
+                    .get(String.class);
+            fail("The deny path should have been forbidden by authorization provider");
+        } catch (ForbiddenException ignored) {
+            //this is expected
+        }
+    }
+
+    @Path("/")
+    public static class MyResource {
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getIt(@Context SecurityContext context) {
+            return "hello" +
+                    context.getUser()
+                            .map(Subject::getPrincipal)
+                            .map(Principal::getName)
+                            .map(name -> " " + name)
+                            .orElse("");
+        }
+
+        @GET
+        @Path("deny")
+        public String denyIt() {
+            return "shouldNotGet";
+        }
+    }
+}
+

--- a/security/integration/jersey/src/test/resources/pre-matching.yaml
+++ b/security/integration/jersey/src/test/resources/pre-matching.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+security:
+  providers:
+  # Security provider - basic authentication (supports roles) - default
+  - name: "TestProvider"
+    class: "io.helidon.security.jersey.BindingTestProvider"
+  jersey:
+    use-prematching-filter: true
+    defaults:
+      # query parameters will be extracted from request
+      # and sent to authentication and authorization providers
+      # as headers. These will NOT be available to application
+      # as headers.
+      query-params:
+      - name: "basicAuth"
+        header: "x-user"

--- a/security/integration/jersey/src/test/resources/pre-matching.yaml
+++ b/security/integration/jersey/src/test/resources/pre-matching.yaml
@@ -20,7 +20,8 @@ security:
   - name: "TestProvider"
     class: "io.helidon.security.jersey.BindingTestProvider"
   jersey:
-    use-prematching-filter: true
+    prematching-authentication: true
+    prematching-authorization: true
     defaults:
       # query parameters will be extracted from request
       # and sent to authentication and authorization providers

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -315,6 +315,7 @@ public final class Security {
      * <li>environment</li>
      * </ul>
      *
+     * @param child the name of the child node to retrieve from config
      * @return a child node of security configuration
      * @throws IllegalArgumentException in case you request child in one of the forbidden trees
      */


### PR DESCRIPTION
User can now configure Jersey integration to use pre-matching filter for securing requests.
This is to prevent access to APIs that are using sub-resource locators in Jersey.