### PR TITLE
Fixed test to register data in histograms at the same time to avoid p…

### DIFF
--- a/microprofile/metrics/metrics-se/src/main/java/io/helidon/metrics/HelidonHistogram.java
+++ b/microprofile/metrics/metrics-se/src/main/java/io/helidon/metrics/HelidonHistogram.java
@@ -142,6 +142,17 @@ final class HelidonHistogram extends MetricImpl implements Histogram {
         prometheusQuantile(sb, tags, units, nameUnits, "0.999", snap::get999thPercentile);
     }
 
+    /**
+     * Returns underlying delegate. For testing purposes only.
+     *
+     * @return Underlying delegate.
+     */
+    HistogramImpl getDelegate() {
+        return delegate instanceof HistogramImpl ? (HistogramImpl) delegate
+                : delegate instanceof HelidonHistogram ? ((HelidonHistogram) delegate).getDelegate()
+                : null;
+    }
+
     @Override
     public void jsonData(JsonObjectBuilder builder) {
         JsonObjectBuilder myBuilder = Json.createObjectBuilder();
@@ -162,7 +173,7 @@ final class HelidonHistogram extends MetricImpl implements Histogram {
         builder.add(getName(), myBuilder.build());
     }
 
-    private static final class HistogramImpl implements Histogram {
+    static final class HistogramImpl implements Histogram {
         private final LongAdder counter = new LongAdder();
         private final ExponentiallyDecayingReservoir reservoir;
 
@@ -178,6 +189,11 @@ final class HelidonHistogram extends MetricImpl implements Histogram {
         public void update(long value) {
             counter.increment();
             reservoir.update(value);
+        }
+
+        public void update(long value, long timestamp) {
+            counter.increment();
+            reservoir.update(value, timestamp);
         }
 
         @Override

--- a/microprofile/metrics/metrics-se/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
+++ b/microprofile/metrics/metrics-se/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
@@ -17,6 +17,7 @@
 package io.helidon.metrics;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -84,7 +85,7 @@ class HelidonHistogramTest {
     private static HelidonHistogram delegatingHistoLong;
 
     @BeforeAll
-    static void initClass() {
+    static void initClass() throws Exception {
         meta = new Metadata("file_sizes",
                             "theDisplayName",
                             "Users file size",
@@ -96,14 +97,16 @@ class HelidonHistogramTest {
         histoLong = HelidonHistogram.create("application", meta);
         delegatingHistoLong = HelidonHistogram.create("application", meta, HelidonHistogram.create("ignored", meta));
 
+        long now = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+
         for (int dato : SAMPLE_INT_DATA) {
-            histoInt.update(dato);
-            delegatingHistoInt.update(dato);
+            histoInt.getDelegate().update(dato, now);
+            delegatingHistoInt.getDelegate().update(dato, now);
         }
 
         for (long dato : SAMPLE_LONG_DATA) {
-            histoLong.update(dato);
-            delegatingHistoLong.update(dato);
+            histoLong.getDelegate().update(dato, now);
+            delegatingHistoLong.getDelegate().update(dato, now);
         }
     }
 

--- a/microprofile/metrics/metrics-se/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
+++ b/microprofile/metrics/metrics-se/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
@@ -85,7 +85,7 @@ class HelidonHistogramTest {
     private static HelidonHistogram delegatingHistoLong;
 
     @BeforeAll
-    static void initClass() throws Exception {
+    static void initClass() {
         meta = new Metadata("file_sizes",
                             "theDisplayName",
                             "Users file size",


### PR DESCRIPTION
Fixed test to register data in histograms at the same time to avoid problems with slow runs. See issue 

https://github.com/oracle/helidon/issues/44

for more information.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>