### PR TITLE
Support for create method for config.as(Class).

### DIFF
--- a/config/config/src/main/java/io/helidon/config/ConfigMapperManager.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigMapperManager.java
@@ -45,6 +45,7 @@ class ConfigMapperManager {
     private static final String METHOD_BUILDER = "builder";
     private static final String METHOD_BUILD = "build";
     private static final String METHOD_PARSE = "parse";
+    private static final String METHOD_CREATE = "create";
 
     private static final Map<Class<?>, Class<?>> REPLACED_TYPES = new HashMap<>();
 
@@ -174,6 +175,11 @@ class ConfigMapperManager {
         if (!configMapper.isPresent()) {
             configMapper = findStaticMethod(type, METHOD_FROM, String.class)
                     .map(methodHandle -> new StringMethodHandleConfigMapper<>(type, "from(String) method", methodHandle));
+        }
+        //create(Config) method
+        if (!configMapper.isPresent()) {
+            configMapper = findStaticMethod(type, METHOD_CREATE, Config.class)
+                    .map(methodHandle -> new ConfigMethodHandleConfigMapper<>(type, "create(Config) method", methodHandle));
         }
         //parse(String) method
         if (!configMapper.isPresent()) {

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -65,6 +65,11 @@
             <version>${version.lib.microprofile-health-api}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
"create" method is quite often used in our project as a shortcut to create a new instance without a Builder (e.g. when we have sensible defaults and when we load the instance fully from config).
It would be great to have support for this also in Config itself.