### PR TITLE
Fix for jigsaw service loading problem with webserver.

### DIFF
--- a/common/common/src/main/java/io/helidon/common/SpiHelper.java
+++ b/common/common/src/main/java/io/helidon/common/SpiHelper.java
@@ -33,7 +33,10 @@ public final class SpiHelper {
      * @param <T>     service type
      * @return the loaded service
      * @throws IllegalStateException if none implementation found
+     * @deprecated Use direct access to {@link ServiceLoader} or have such a helper in your module, as from jigsaw this is not
+     * allowed
      */
+    @Deprecated
     public static <T> T loadSpi(Class<T> service) {
         ServiceLoader<T> servers = ServiceLoader.load(service);
         Iterator<T> serversIt = servers.iterator();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -17,12 +17,13 @@
 package io.helidon.webserver;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
-import io.helidon.common.SpiHelper;
 import io.helidon.common.http.ContextualRegistry;
 import io.helidon.webserver.spi.WebServerFactory;
 
@@ -311,7 +312,7 @@ public interface WebServer {
                 throw new IllegalStateException("No server socket configuration found for named routings: " + unpairedRoutings);
             }
 
-            WebServer result = SpiHelper.loadSpi(WebServerFactory.class)
+            WebServer result = loadFactory()
                                     .newWebServer(configuration == null
                                                           ? ServerBasicConfig.DEFAULT_CONFIGURATION
                                                           : configuration,
@@ -320,6 +321,15 @@ public interface WebServer {
                 ((RequestRouting) defaultRouting).fireNewWebServer(result);
             }
             return result;
+        }
+
+        private WebServerFactory loadFactory() {
+            Iterator<WebServerFactory> implementations = ServiceLoader.load(WebServerFactory.class).iterator();
+            if (implementations.hasNext()) {
+                return implementations.next();
+            }
+
+            throw new IllegalStateException("No implementation found for SPI: " + WebServerFactory.class.getName());
         }
     }
 }


### PR DESCRIPTION
Service loading must be done from the module that uses the service in module system. Delegating to a class in common module broke this.
Fixed this, deprecated common SpiHelper method and moved webserver loading to the same module.