### PR TITLE
Experimental support for HTTP/2

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -164,7 +164,12 @@
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|@see| \* |@link|imp|@todo|@version"/>
         </module>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
+
+        <!-- Some Netty interfaces need this -->
+        <module name="ParameterNumber">
+            <property name="ignoreOverriddenMethods" value="true"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
 
         <!-- Several variable declaration on one line: int i, p; -->
         <module name="MultipleVariableDeclarations"/>

--- a/examples/helidon-quickstart-se/src/main/resources/application.yaml
+++ b/examples/helidon-quickstart-se/src/main/resources/application.yaml
@@ -21,5 +21,6 @@ server:
   port: 8080
   host: 0.0.0.0
 #  experimental:
-#    enable-http2: true
-#    http2-max-content-length: 16384
+#    http2:
+#      enable: true
+#      max-content-length: 16384

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -147,12 +147,6 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-netty</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -605,6 +605,11 @@
                 <artifactId>netty-codec-http</artifactId>
                 <version>${version.lib.netty}</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${version.lib.netty}</version>
+            </dependency>
 
             <!-- Config related -->
             <dependency>

--- a/webserver/netty/pom.xml
+++ b/webserver/netty/pom.xml
@@ -155,5 +155,9 @@
             <artifactId>javax.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/netty/src/main/java/io/helidon/webserver/netty/HelidonConnectionHandler.java
+++ b/webserver/netty/src/main/java/io/helidon/webserver/netty/HelidonConnectionHandler.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
+
+import static io.netty.handler.logging.LogLevel.INFO;
+
+/**
+ * Class HelidonConnectionHandler.
+ */
+class HelidonConnectionHandler extends HttpToHttp2ConnectionHandler implements Http2FrameListener {
+
+    private static final int MAX_CONTENT_LENGTH = 64 * 1024;
+
+    private final InboundHttp2ToHttpAdapter inboundAdapter;
+
+    HelidonConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                             Http2Settings initialSettings) {
+        super(decoder, encoder, initialSettings, true);
+        inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(decoder.connection())
+                .maxContentLength(MAX_CONTENT_LENGTH)
+                .propagateSettings(true)
+                .validateHttpHeaders(true)
+                .build();
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
+            HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = (HttpServerUpgradeHandler.UpgradeEvent) evt;
+
+            // Map initial request headers to HTTP2
+            FullHttpRequest request = upgradeEvent.upgradeRequest();
+            Http2Headers headers = new DefaultHttp2Headers()
+                    .method(HttpMethod.GET.asciiName())
+                    .path(request.uri())
+                    .scheme(HttpScheme.HTTP.name());
+            CharSequence host = request.headers().get(HttpHeaderNames.HOST);
+            if (host != null) {
+                headers.authority(host);
+            }
+
+            // Process mapped headers
+            onHeadersRead(ctx, 1, headers, 0, true);
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+
+    @Override
+    public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                          boolean endOfStream) throws Http2Exception {
+        return inboundAdapter.onDataRead(ctx, streamId, data, padding, endOfStream);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                              boolean endOfStream) throws Http2Exception {
+        inboundAdapter.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                              short weight, boolean exclusive, int padding, boolean endOfStream)
+            throws Http2Exception {
+        inboundAdapter.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding,
+                endOfStream);
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
+        inboundAdapter.onRstStreamRead(ctx, streamId, errorCode);
+    }
+
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                  Http2Headers headers, int padding) throws Http2Exception {
+        inboundAdapter.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+    }
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+        inboundAdapter.onSettingsRead(ctx, settings);
+    }
+
+    @Override
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                               boolean exclusive) throws Http2Exception {
+        inboundAdapter.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+    }
+
+    @Override
+    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+        inboundAdapter.onSettingsAckRead(ctx);
+    }
+
+    @Override
+    public void onPingRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
+        inboundAdapter.onPingRead(ctx, data);
+    }
+
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
+        inboundAdapter.onPingAckRead(ctx, data);
+    }
+
+    @Override
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                             ByteBuf debugData) throws Http2Exception {
+        inboundAdapter.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
+    }
+
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
+            throws Http2Exception {
+        inboundAdapter.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+    }
+
+    @Override
+    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                               ByteBuf payload) throws Http2Exception {
+        inboundAdapter.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+    }
+
+    static final class HelidonHttp2ConnectionHandlerBuilder extends
+            AbstractHttp2ConnectionHandlerBuilder<HelidonConnectionHandler, HelidonHttp2ConnectionHandlerBuilder> {
+
+        private static final Http2FrameLogger logger = new Http2FrameLogger(INFO, HelidonConnectionHandler.class);
+
+        HelidonHttp2ConnectionHandlerBuilder() {
+            frameLogger(logger);
+        }
+
+        @Override
+        public HelidonConnectionHandler build() {
+            return super.build();
+        }
+
+        @Override
+        protected HelidonConnectionHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                                 Http2Settings initialSettings) {
+            HelidonConnectionHandler handler = new HelidonConnectionHandler(decoder, encoder, initialSettings);
+            frameListener(handler);
+            return handler;
+        }
+    }
+}
+

--- a/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
+++ b/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
@@ -16,20 +16,50 @@
 
 package io.helidon.webserver.netty;
 
+import javax.net.ssl.SSLEngine;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.net.ssl.SSLEngine;
-
 import io.helidon.webserver.Routing;
-
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameListener;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.Http2Stream;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.AsciiString;
+
+import static io.netty.handler.logging.LogLevel.INFO;
 
 /**
  * The HttpInitializer.
@@ -58,8 +88,8 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         });
     }
 
-    @Override
-    public void initChannel(SocketChannel ch) {
+    // @Override
+    public void initChannel_old(SocketChannel ch) {
         ChannelPipeline p = ch.pipeline();
 
         SSLEngine sslEngine = null;
@@ -78,5 +108,211 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         p.addLast(new ForwardingHandler(routing, webServer, sslEngine, queues));
 
         ch.eventLoop().execute(this::clearQueues);
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        final ChannelPipeline p = ch.pipeline();
+
+        SSLEngine sslEngine = null;
+        if (sslContext != null) {
+            SslHandler sslHandler = sslContext.newHandler(ch.alloc());
+            sslEngine = sslHandler.engine();
+            p.addLast(sslHandler);
+        }
+
+        final HttpServerCodec sourceCodec = new HttpServerCodec();
+        final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory);
+        final HelidonConnectionHandler helidonHandler = new HelidonHttp2ConnectionHandlerBuilder().build();
+        final CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
+                new CleartextHttp2ServerUpgradeHandler(sourceCodec, upgradeHandler, helidonHandler);
+
+        p.addLast(new HelidonEventLogger());
+        p.addLast(cleartextHttp2ServerUpgradeHandler);
+        p.addLast(new ForwardingHandler(routing, webServer, sslEngine, queues));
+    }
+
+    private static final HttpServerUpgradeHandler.UpgradeCodecFactory upgradeCodecFactory =
+            protocol -> {
+                if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+                    return new Http2ServerUpgradeCodec(new HelidonHttp2ConnectionHandlerBuilder().build());
+                } else {
+                    return null;
+                }
+            };
+
+    private static class HelidonEventLogger extends ChannelInboundHandlerAdapter {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            System.out.println("Event Triggered: " + evt);
+            ctx.fireUserEventTriggered(evt);
+        }
+    }
+
+    private static class HelidonConnectionHandler extends Http2ConnectionHandler implements Http2FrameListener {
+
+        private final InboundHttp2ToHttpAdapter inboundAdapter;
+
+        HelidonConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                 Http2Settings initialSettings) {
+            super(decoder, encoder, initialSettings);
+            inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(decoder.connection())
+                    .maxContentLength(64 * 1024)
+                    .propagateSettings(true)
+                    .validateHttpHeaders(true)
+                    .build();
+        }
+
+        private static Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
+            CharSequence host = request.headers().get(HttpHeaderNames.HOST);
+            Http2Headers http2Headers = new DefaultHttp2Headers()
+                    .method(HttpMethod.GET.asciiName())
+                    .path(request.uri())
+                    .scheme(HttpScheme.HTTP.name());
+            if (host != null) {
+                http2Headers.authority(host);
+            }
+            return http2Headers;
+        }
+
+        /**
+         * Handles the cleartext HTTP upgrade event. If an upgrade occurred, sends a simple response via HTTP/2
+         * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
+         */
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
+                HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
+                        (HttpServerUpgradeHandler.UpgradeEvent) evt;
+                onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
+            }
+            super.userEventTriggered(ctx, evt);
+        }
+
+        public void onStreamRemoved(Http2Stream stream) {
+            inboundAdapter.onStreamRemoved(stream);
+        }
+
+        @Override
+        public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                              boolean endOfStream) throws Http2Exception {
+            return inboundAdapter.onDataRead(ctx, streamId, data, padding, endOfStream);
+        }
+
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                                  boolean endOfStream) throws Http2Exception {
+            inboundAdapter.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+        }
+
+        @Override
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                                  short weight, boolean exclusive, int padding, boolean endOfStream)
+                throws Http2Exception {
+            inboundAdapter.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding,
+                    endOfStream);
+        }
+
+        @Override
+        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
+            inboundAdapter.onRstStreamRead(ctx, streamId, errorCode);
+        }
+
+        @Override
+        public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                      Http2Headers headers, int padding) throws Http2Exception {
+            inboundAdapter.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+        }
+
+        @Override
+        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+            inboundAdapter.onSettingsRead(ctx, settings);
+        }
+
+        @Override
+        public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                                   boolean exclusive) throws Http2Exception {
+            inboundAdapter.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+        }
+
+        @Override
+        public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+            inboundAdapter.onSettingsAckRead(ctx);
+        }
+
+        @Override
+        public void onPingRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
+            inboundAdapter.onPingRead(ctx, data);
+        }
+
+        @Override
+        public void onPingAckRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
+            inboundAdapter.onPingAckRead(ctx, data);
+        }
+
+        @Override
+        public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                                 ByteBuf debugData) throws Http2Exception {
+            inboundAdapter.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
+        }
+
+        @Override
+        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
+                throws Http2Exception {
+            inboundAdapter.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+        }
+
+        @Override
+        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                                   ByteBuf payload) throws Http2Exception {
+            inboundAdapter.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+        }
+
+        public void onStreamAdded(Http2Stream stream) {
+            inboundAdapter.onStreamAdded(stream);
+        }
+
+        public void onStreamActive(Http2Stream stream) {
+            inboundAdapter.onStreamActive(stream);
+        }
+
+        public void onStreamHalfClosed(Http2Stream stream) {
+            inboundAdapter.onStreamHalfClosed(stream);
+        }
+
+        public void onStreamClosed(Http2Stream stream) {
+            inboundAdapter.onStreamClosed(stream);
+        }
+
+        public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
+            inboundAdapter.onGoAwaySent(lastStreamId, errorCode, debugData);
+        }
+
+        public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+            inboundAdapter.onGoAwayReceived(lastStreamId, errorCode, debugData);
+        }
+    }
+
+    private static final class HelidonHttp2ConnectionHandlerBuilder
+            extends AbstractHttp2ConnectionHandlerBuilder<HelidonConnectionHandler, HelidonHttp2ConnectionHandlerBuilder> {
+
+        private static final Http2FrameLogger logger = new Http2FrameLogger(INFO, HelidonConnectionHandler.class);
+
+        HelidonHttp2ConnectionHandlerBuilder() {
+            frameLogger(logger);
+        }
+
+        @Override
+        public HelidonConnectionHandler build() {
+            return super.build();
+        }
+
+        @Override
+        protected HelidonConnectionHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                                 Http2Settings initialSettings) {
+            HelidonConnectionHandler handler = new HelidonConnectionHandler(decoder, encoder, initialSettings);
+            frameListener(handler);
+            return handler;
+        }
     }
 }

--- a/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
+++ b/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
@@ -19,52 +19,29 @@ package io.helidon.webserver.netty;
 import javax.net.ssl.SSLEngine;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Logger;
 
 import io.helidon.webserver.Routing;
-import io.netty.buffer.ByteBuf;
+import io.helidon.webserver.netty.HelidonConnectionHandler.HelidonHttp2ConnectionHandlerBuilder;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
-import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler;
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2CodecUtil;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
-import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2Flags;
-import io.netty.handler.codec.http2.Http2FrameListener;
-import io.netty.handler.codec.http2.Http2FrameLogger;
-import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
-import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.codec.http2.Http2Stream;
-import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
-import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
-import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
-import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
-
-import static io.netty.handler.logging.LogLevel.INFO;
 
 /**
  * The HttpInitializer.
  */
 class HttpInitializer extends ChannelInitializer<SocketChannel> {
+    private static final Logger LOGGER = Logger.getLogger(HttpInitializer.class.getName());
 
     private final SslContext sslContext;
     private final NettyWebServer webServer;
@@ -88,28 +65,6 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         });
     }
 
-    // @Override
-    public void initChannel_old(SocketChannel ch) {
-        ChannelPipeline p = ch.pipeline();
-
-        SSLEngine sslEngine = null;
-        if (sslContext != null) {
-            SslHandler sslHandler = sslContext.newHandler(ch.alloc());
-            sslEngine = sslHandler.engine();
-            p.addLast(sslHandler);
-        }
-
-        p.addLast(new HttpRequestDecoder());
-        // Uncomment the following line if you don't want to handle HttpChunks.
-        //        p.addLast(new HttpObjectAggregator(1048576));
-        p.addLast(new HttpResponseEncoder());
-        // Remove the following line if you don't want automatic content compression.
-        //p.addLast(new HttpContentCompressor());
-        p.addLast(new ForwardingHandler(routing, webServer, sslEngine, queues));
-
-        ch.eventLoop().execute(this::clearQueues);
-    }
-
     @Override
     public void initChannel(SocketChannel ch) {
         final ChannelPipeline p = ch.pipeline();
@@ -121,10 +76,10 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
             p.addLast(sslHandler);
         }
 
-        final HttpServerCodec sourceCodec = new HttpServerCodec();
-        final HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory);
-        final HelidonConnectionHandler helidonHandler = new HelidonHttp2ConnectionHandlerBuilder().build();
-        final CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
+        HttpServerCodec sourceCodec = new HttpServerCodec();
+        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory);
+        HelidonConnectionHandler helidonHandler = new HelidonHttp2ConnectionHandlerBuilder().build();
+        CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
                 new CleartextHttp2ServerUpgradeHandler(sourceCodec, upgradeHandler, helidonHandler);
 
         p.addLast(cleartextHttp2ServerUpgradeHandler);
@@ -141,178 +96,11 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
                 }
             };
 
-    private static class HelidonEventLogger extends ChannelInboundHandlerAdapter {
+    private static final class HelidonEventLogger extends ChannelInboundHandlerAdapter {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-            System.out.println("Event Triggered: " + evt);
+            LOGGER.info("Event Triggered: " + evt);
             ctx.fireUserEventTriggered(evt);
-        }
-    }
-
-    private static class HelidonConnectionHandler extends HttpToHttp2ConnectionHandler implements Http2FrameListener {
-
-        private final InboundHttp2ToHttpAdapter inboundAdapter;
-
-        HelidonConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
-                                 Http2Settings initialSettings) {
-            super(decoder, encoder, initialSettings, true);
-            inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(decoder.connection())
-                    .maxContentLength(64 * 1024)
-                    .propagateSettings(true)
-                    .validateHttpHeaders(true)
-                    .build();
-        }
-
-        private static Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
-            CharSequence host = request.headers().get(HttpHeaderNames.HOST);
-            Http2Headers http2Headers = new DefaultHttp2Headers()
-                    .method(HttpMethod.GET.asciiName())
-                    .path(request.uri())
-                    .scheme(HttpScheme.HTTP.name());
-            if (host != null) {
-                http2Headers.authority(host);
-            }
-            return http2Headers;
-        }
-
-        /**
-         * Handles the cleartext HTTP upgrade event. If an upgrade occurred, sends a simple response via HTTP/2
-         * on stream 1 (the stream specifically reserved for cleartext HTTP upgrade).
-         */
-        @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-            if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
-                HttpServerUpgradeHandler.UpgradeEvent upgradeEvent =
-                        (HttpServerUpgradeHandler.UpgradeEvent) evt;
-                onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
-            }
-            super.userEventTriggered(ctx, evt);
-        }
-
-        public void onStreamRemoved(Http2Stream stream) {
-            inboundAdapter.onStreamRemoved(stream);
-        }
-
-        @Override
-        public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-                              boolean endOfStream) throws Http2Exception {
-            return inboundAdapter.onDataRead(ctx, streamId, data, padding, endOfStream);
-        }
-
-        @Override
-        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-                                  boolean endOfStream) throws Http2Exception {
-            inboundAdapter.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
-        }
-
-        @Override
-        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
-                                  short weight, boolean exclusive, int padding, boolean endOfStream)
-                throws Http2Exception {
-            inboundAdapter.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding,
-                    endOfStream);
-        }
-
-        @Override
-        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-            inboundAdapter.onRstStreamRead(ctx, streamId, errorCode);
-        }
-
-        @Override
-        public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                      Http2Headers headers, int padding) throws Http2Exception {
-            inboundAdapter.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
-        }
-
-        @Override
-        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
-            inboundAdapter.onSettingsRead(ctx, settings);
-        }
-
-        @Override
-        public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
-                                   boolean exclusive) throws Http2Exception {
-            inboundAdapter.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
-        }
-
-        @Override
-        public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-            inboundAdapter.onSettingsAckRead(ctx);
-        }
-
-        @Override
-        public void onPingRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
-            inboundAdapter.onPingRead(ctx, data);
-        }
-
-        @Override
-        public void onPingAckRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
-            inboundAdapter.onPingAckRead(ctx, data);
-        }
-
-        @Override
-        public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-                                 ByteBuf debugData) throws Http2Exception {
-            inboundAdapter.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
-        }
-
-        @Override
-        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
-                throws Http2Exception {
-            inboundAdapter.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
-        }
-
-        @Override
-        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-                                   ByteBuf payload) throws Http2Exception {
-            inboundAdapter.onUnknownFrame(ctx, frameType, streamId, flags, payload);
-        }
-
-        public void onStreamAdded(Http2Stream stream) {
-            inboundAdapter.onStreamAdded(stream);
-        }
-
-        public void onStreamActive(Http2Stream stream) {
-            inboundAdapter.onStreamActive(stream);
-        }
-
-        public void onStreamHalfClosed(Http2Stream stream) {
-            inboundAdapter.onStreamHalfClosed(stream);
-        }
-
-        public void onStreamClosed(Http2Stream stream) {
-            inboundAdapter.onStreamClosed(stream);
-        }
-
-        public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
-            inboundAdapter.onGoAwaySent(lastStreamId, errorCode, debugData);
-        }
-
-        public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
-            inboundAdapter.onGoAwayReceived(lastStreamId, errorCode, debugData);
-        }
-    }
-
-    private static final class HelidonHttp2ConnectionHandlerBuilder
-            extends AbstractHttp2ConnectionHandlerBuilder<HelidonConnectionHandler, HelidonHttp2ConnectionHandlerBuilder> {
-
-        private static final Http2FrameLogger logger = new Http2FrameLogger(INFO, HelidonConnectionHandler.class);
-
-        HelidonHttp2ConnectionHandlerBuilder() {
-            frameLogger(logger);
-        }
-
-        @Override
-        public HelidonConnectionHandler build() {
-            return super.build();
-        }
-
-        @Override
-        protected HelidonConnectionHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
-                                                 Http2Settings initialSettings) {
-            HelidonConnectionHandler handler = new HelidonConnectionHandler(decoder, encoder, initialSettings);
-            frameListener(handler);
-            return handler;
         }
     }
 }

--- a/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
+++ b/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
@@ -127,8 +127,8 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         final CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
                 new CleartextHttp2ServerUpgradeHandler(sourceCodec, upgradeHandler, helidonHandler);
 
-        p.addLast(new HelidonEventLogger());
         p.addLast(cleartextHttp2ServerUpgradeHandler);
+        p.addLast(new HelidonEventLogger());
         p.addLast(new ForwardingHandler(routing, webServer, sslEngine, queues));
     }
 
@@ -149,13 +149,13 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         }
     }
 
-    private static class HelidonConnectionHandler extends Http2ConnectionHandler implements Http2FrameListener {
+    private static class HelidonConnectionHandler extends HttpToHttp2ConnectionHandler implements Http2FrameListener {
 
         private final InboundHttp2ToHttpAdapter inboundAdapter;
 
         HelidonConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                  Http2Settings initialSettings) {
-            super(decoder, encoder, initialSettings);
+            super(decoder, encoder, initialSettings, true);
             inboundAdapter = new InboundHttp2ToHttpAdapterBuilder(decoder.connection())
                     .maxContentLength(64 * 1024)
                     .propagateSettings(true)

--- a/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
+++ b/webserver/netty/src/main/java/io/helidon/webserver/netty/HttpInitializer.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.netty;
 
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
@@ -23,6 +24,7 @@ import java.util.logging.Logger;
 import javax.net.ssl.SSLEngine;
 
 import io.helidon.webserver.ExperimentalConfiguration;
+import io.helidon.webserver.Http2Configuration;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.netty.HelidonConnectionHandler.HelidonHttp2ConnectionHandlerBuilder;
 
@@ -83,10 +85,11 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
 
         // Set up HTTP/2 pipeline if feature is enabled
         ExperimentalConfiguration experimental = webServer.configuration().experimental();
-        if (experimental.enableHttp2()) {
+        if (experimental != null && experimental.http2() != null && experimental.http2().enable()) {
+            Http2Configuration http2Config = experimental.http2();
             HttpServerCodec sourceCodec = new HttpServerCodec();
             HelidonConnectionHandler helidonHandler = new HelidonHttp2ConnectionHandlerBuilder()
-                    .maxContentLength(experimental.http2MaxContentLength()).build();
+                    .maxContentLength(http2Config.maxContentLength()).build();
             HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec,
                     protocol -> AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)
                             ? new Http2ServerUpgradeCodec(helidonHandler) : null);

--- a/webserver/netty/src/main/java9/module-info.java
+++ b/webserver/netty/src/main/java9/module-info.java
@@ -31,6 +31,7 @@ module io.helidon.webserver.netty {
     requires io.netty.transport;
     requires io.netty.common;
     requires io.netty.buffer;
+    requires io.netty.codec.http2;
 
     provides io.helidon.webserver.spi.WebServerFactory with io.helidon.webserver.netty.Factory;
 }

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -98,5 +98,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExperimentalConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExperimentalConfiguration.java
@@ -22,58 +22,33 @@ package io.helidon.webserver;
 public interface ExperimentalConfiguration {
 
     /**
-     * Default value for max content length.
-     */
-    int DEFAULT_MAX_CONTENT_LENGTH = 64 * 1024;
-
-    /**
-     * Config property to enable HTTP/2 support.
+     * Config property to set HTTP/2 configuration.
      *
-     * @return Value of property.
+     * @return HTTP/2 configuration.
      */
-    boolean enableHttp2();
-
-    /**
-     * Default HTTP/2 content length. Streaming is currently not supported for HTTP/2,
-     * so this is largest payload acceptable.
-     *
-     * @return Max HTTP/2 buffer size.
-     */
-    int http2MaxContentLength();
+    Http2Configuration http2();
 
     /**
      * Builder for {@link ExperimentalConfiguration}.
      */
     final class Builder implements io.helidon.common.Builder<ExperimentalConfiguration> {
 
-        private boolean enableHttp2 = false;
-        private int http2MaxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
+        private Http2Configuration http2;
 
         /**
-         * Sets value to enable HTTP/2 support.
+         * Sets value for HTTP/2 configuration.
          *
-         * @param enableHttp2 New value.
-         * @return
+         * @param http2 HTTP/2 configuration.
+         * @return The builder.
          */
-        public Builder enableHttp2(boolean enableHttp2) {
-            this.enableHttp2 = enableHttp2;
-            return this;
-        }
-
-        /**
-         * Sets max content length for HTTP/2.
-         *
-         * @param http2MaxContentLength New value for max content length.
-         * @return
-         */
-        public Builder http2MaxContentLength(int http2MaxContentLength) {
-            this.http2MaxContentLength = http2MaxContentLength;
+        public Builder http2(Http2Configuration http2) {
+            this.http2 = http2;
             return this;
         }
 
         @Override
         public ExperimentalConfiguration build() {
-            return new ServerBasicConfig.ExperimentalConfig(enableHttp2, http2MaxContentLength);
+            return () -> http2;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ExperimentalConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ExperimentalConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * Interface ExperimentalConfiguration.
+ */
+public interface ExperimentalConfiguration {
+
+    /**
+     * Default value for max content length.
+     */
+    int DEFAULT_MAX_CONTENT_LENGTH = 64 * 1024;
+
+    /**
+     * Config property to enable HTTP/2 support.
+     *
+     * @return Value of property.
+     */
+    boolean enableHttp2();
+
+    /**
+     * Default HTTP/2 content length. Streaming is currently not supported for HTTP/2,
+     * so this is largest payload acceptable.
+     *
+     * @return Max HTTP/2 buffer size.
+     */
+    int http2MaxContentLength();
+
+    /**
+     * Builder for {@link ExperimentalConfiguration}.
+     */
+    final class Builder implements io.helidon.common.Builder<ExperimentalConfiguration> {
+
+        private boolean enableHttp2 = false;
+        private int http2MaxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
+
+        /**
+         * Sets value to enable HTTP/2 support.
+         *
+         * @param enableHttp2 New value.
+         * @return
+         */
+        public Builder enableHttp2(boolean enableHttp2) {
+            this.enableHttp2 = enableHttp2;
+            return this;
+        }
+
+        /**
+         * Sets max content length for HTTP/2.
+         *
+         * @param http2MaxContentLength New value for max content length.
+         * @return
+         */
+        public Builder http2MaxContentLength(int http2MaxContentLength) {
+            this.http2MaxContentLength = http2MaxContentLength;
+            return this;
+        }
+
+        @Override
+        public ExperimentalConfiguration build() {
+            return new ServerBasicConfig.ExperimentalConfig(enableHttp2, http2MaxContentLength);
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Http2Configuration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Http2Configuration.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * Interface Http2Configuration.
+ */
+public interface Http2Configuration {
+
+    /**
+     * Default value for max content length.
+     */
+    int DEFAULT_MAX_CONTENT_LENGTH = 64 * 1024;
+
+    /**
+     * Config property to enable HTTP/2 support.
+     *
+     * @return Value of property.
+     */
+    boolean enable();
+
+    /**
+     * Default HTTP/2 content length. Streaming is currently not supported for HTTP/2,
+     * so this is largest payload acceptable.
+     *
+     * @return Max HTTP/2 buffer size.
+     */
+    int maxContentLength();
+
+    /**
+     * Builder for {@link Http2Configuration}.
+     */
+    final class Builder implements io.helidon.common.Builder<Http2Configuration> {
+
+        private boolean enableHttp2 = false;
+        private int http2MaxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
+
+        /**
+         * Sets value to enable HTTP/2 support.
+         *
+         * @param enableHttp2 New value.
+         * @return
+         */
+        public Builder enable(boolean enableHttp2) {
+            this.enableHttp2 = enableHttp2;
+            return this;
+        }
+
+        /**
+         * Sets max content length for HTTP/2.
+         *
+         * @param http2MaxContentLength New value for max content length.
+         * @return
+         */
+        public Builder maxContentLength(int http2MaxContentLength) {
+            this.http2MaxContentLength = http2MaxContentLength;
+            return this;
+        }
+
+        @Override
+        public Http2Configuration build() {
+            return new Http2Configuration() {
+                @Override
+                public boolean enable() {
+                    return enableHttp2;
+                }
+
+                @Override
+                public int maxContentLength() {
+                    return http2MaxContentLength;
+                }
+            };
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -37,6 +37,7 @@ class ServerBasicConfig implements ServerConfiguration {
     private final int workers;
     private final Tracer tracer;
     private final Map<String, SocketConfiguration> socketConfigs;
+    private final ExperimentalConfiguration experimental;
 
     /**
      * Creates new instance.
@@ -49,7 +50,8 @@ class ServerBasicConfig implements ServerConfiguration {
     ServerBasicConfig(SocketConfiguration socketConfig,
                       int workers,
                       Tracer tracer,
-                      Map<String, SocketConfiguration> socketConfigs) {
+                      Map<String, SocketConfiguration> socketConfigs,
+                      ExperimentalConfiguration experimental) {
         this.socketConfig = socketConfig == null ? new SocketConfig() : socketConfig;
         if (workers <= 0) {
             workers = Runtime.getRuntime().availableProcessors() * 2;
@@ -59,6 +61,8 @@ class ServerBasicConfig implements ServerConfiguration {
         HashMap<String, SocketConfiguration> map = new HashMap<>(socketConfigs);
         map.put(ServerConfiguration.DEFAULT_SOCKET_NAME, this.socketConfig);
         this.socketConfigs = Collections.unmodifiableMap(map);
+        this.experimental = experimental != null ? experimental
+                : new ExperimentalConfiguration.Builder().build();
     }
 
     @Override
@@ -104,6 +108,11 @@ class ServerBasicConfig implements ServerConfiguration {
     @Override
     public Map<String, SocketConfiguration> sockets() {
         return socketConfigs;
+    }
+
+    @Override
+    public ExperimentalConfiguration experimental() {
+        return experimental;
     }
 
     static class SocketConfig implements SocketConfiguration {
@@ -174,6 +183,27 @@ class ServerBasicConfig implements ServerConfiguration {
         @Override
         public SSLContext ssl() {
             return sslContext;
+        }
+    }
+
+    static class ExperimentalConfig implements ExperimentalConfiguration {
+
+        private final boolean enableHttp2;
+        private final int http2MaxContentLength;
+
+        ExperimentalConfig(boolean enableHttp2, int http2MaxContentLength) {
+            this.enableHttp2 = enableHttp2;
+            this.http2MaxContentLength = http2MaxContentLength;
+        }
+
+        @Override
+        public boolean enableHttp2() {
+            return enableHttp2;
+        }
+
+        @Override
+        public int http2MaxContentLength() {
+            return http2MaxContentLength;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -185,25 +185,4 @@ class ServerBasicConfig implements ServerConfiguration {
             return sslContext;
         }
     }
-
-    static class ExperimentalConfig implements ExperimentalConfiguration {
-
-        private final boolean enableHttp2;
-        private final int http2MaxContentLength;
-
-        ExperimentalConfig(boolean enableHttp2, int http2MaxContentLength) {
-            this.enableHttp2 = enableHttp2;
-            this.http2MaxContentLength = http2MaxContentLength;
-        }
-
-        @Override
-        public boolean enableHttp2() {
-            return enableHttp2;
-        }
-
-        @Override
-        public int http2MaxContentLength() {
-            return http2MaxContentLength;
-        }
-    }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -437,13 +437,17 @@ public interface ServerConfiguration extends SocketConfiguration {
             // experimental
             Config experimentalConfig = config.get("experimental");
             if (experimentalConfig.exists()) {
-                Optional<Boolean> enableHttp2 = experimentalConfig.get("enable-http2").asOptional(Boolean.class);
-                Optional<Integer> http2MaxBufferSize = experimentalConfig.get("maxHttp2BufferSize")
-                        .asOptional(Integer.class);
-                ExperimentalConfiguration.Builder builder = new ExperimentalConfiguration.Builder();
-                enableHttp2.ifPresent(builder::enableHttp2);
-                http2MaxBufferSize.ifPresent(builder::http2MaxContentLength);
-                experimental = builder.build();
+                ExperimentalConfiguration.Builder experimentalBuilder = new ExperimentalConfiguration.Builder();
+                Config http2Config = experimentalConfig.get("http2");
+                if (http2Config.exists()) {
+                    Optional<Boolean> enable = http2Config.get("enable").asOptional(Boolean.class);
+                    Optional<Integer> maxContentLength = http2Config.get("maxContentLength").asOptional(Integer.class);
+                    Http2Configuration.Builder http2Builder = new Http2Configuration.Builder();
+                    enable.ifPresent(http2Builder::enable);
+                    maxContentLength.ifPresent(http2Builder::maxContentLength);
+                    experimentalBuilder.http2(http2Builder.build());
+                }
+                experimental = experimentalBuilder.build();
             }
 
             return this;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ExperimentalConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ExperimentalConfigTest.java
@@ -30,28 +30,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ExperimentalConfigTest {
 
     @Test
-    public void configBuilderDefault() {
-        ExperimentalConfiguration config = new ExperimentalConfiguration.Builder().build();
-        assertFalse(config.enableHttp2());
-        assertEquals(ExperimentalConfiguration.DEFAULT_MAX_CONTENT_LENGTH, config.http2MaxContentLength());
+    public void http2BuilderDefaults() {
+        Http2Configuration http2 = new Http2Configuration.Builder().build();
+        assertFalse(http2.enable());
+        assertEquals(Http2Configuration.DEFAULT_MAX_CONTENT_LENGTH, http2.maxContentLength());
     }
 
     @Test
     public void configBuilder() {
-        ExperimentalConfiguration.Builder builder = new ExperimentalConfiguration.Builder();
-        builder.enableHttp2(true);
-        builder.http2MaxContentLength(32 * 1024);
-        ExperimentalConfiguration config = builder.build();
-        assertTrue(config.enableHttp2());
-        assertEquals(32 * 1024, config.http2MaxContentLength());
+        Http2Configuration.Builder builder = new Http2Configuration.Builder();
+        builder.enable(true);
+        builder.maxContentLength(32 * 1024);
+        Http2Configuration http2 = builder.build();
+        assertTrue(http2.enable());
+        assertEquals(32 * 1024, http2.maxContentLength());
+        ExperimentalConfiguration config = new ExperimentalConfiguration.Builder().http2(http2).build();
+        assertEquals(http2, config.http2());
     }
 
     @Test
     public void configResource() {
-        Config experimental = Config.from(ConfigSources.classpath("experimental/application.yaml"))
+        Config http2 = Config.from(ConfigSources.classpath("experimental/application.yaml"))
                 .get("webserver")
-                .get("experimental");
-        assertTrue(experimental.get("enable-http2").as(Boolean.class));
-        assertEquals(64 * 1024, (int) experimental.get("http2-max-content-length").as(Integer.class));
+                .get("experimental")
+                .get("http2");
+        assertTrue(http2.get("enable").as(Boolean.class));
+        assertEquals(16 * 1024, (int) http2.get("max-content-length").as(Integer.class));
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ExperimentalConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ExperimentalConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Class ExperimentalConfigTest.
+ */
+public class ExperimentalConfigTest {
+
+    @Test
+    public void configBuilderDefault() {
+        ExperimentalConfiguration config = new ExperimentalConfiguration.Builder().build();
+        assertFalse(config.enableHttp2());
+        assertEquals(ExperimentalConfiguration.DEFAULT_MAX_CONTENT_LENGTH, config.http2MaxContentLength());
+    }
+
+    @Test
+    public void configBuilder() {
+        ExperimentalConfiguration.Builder builder = new ExperimentalConfiguration.Builder();
+        builder.enableHttp2(true);
+        builder.http2MaxContentLength(32 * 1024);
+        ExperimentalConfiguration config = builder.build();
+        assertTrue(config.enableHttp2());
+        assertEquals(32 * 1024, config.http2MaxContentLength());
+    }
+
+    @Test
+    public void configResource() {
+        Config experimental = Config.from(ConfigSources.classpath("experimental/application.yaml"))
+                .get("webserver")
+                .get("experimental");
+        assertTrue(experimental.get("enable-http2").as(Boolean.class));
+        assertEquals(64 * 1024, (int) experimental.get("http2-max-content-length").as(Integer.class));
+    }
+}

--- a/webserver/webserver/src/test/resources/experimental/application.yaml
+++ b/webserver/webserver/src/test/resources/experimental/application.yaml
@@ -17,5 +17,6 @@
 
 webserver:
   experimental:
-    enable-http2: true
-    http2-max-content-length: 65536
+    http2:
+      enable: true
+      max-content-length: 16384

--- a/webserver/webserver/src/test/resources/experimental/application.yaml
+++ b/webserver/webserver/src/test/resources/experimental/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,8 @@
 # limitations under the License.
 #
 
-app:
-  greeting: "Hello"
 
-server:
-  port: 8080
-  host: 0.0.0.0
-#  experimental:
-#    enable-http2: true
-#    http2-max-content-length: 16384
+webserver:
+  experimental:
+    enable-http2: true
+    http2-max-content-length: 65536


### PR DESCRIPTION
Applications can use a new section under a server's configuration to enable HTTP/2 support. When doing this, application endpoints will support:

1. HTTP/2 via upgrade from HTTP 1.X 
2. HTTP/2 support using previous knowledge
3. HTTP 1.X traffic 

Configuration example:

```
server:
  port: 8080
  host: 0.0.0.0
  experimental:
    enable-http2: true
    http2-max-content-length: 16384
```

