### PR TITLE
Move integrations into a profile

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -47,6 +47,6 @@ inject_credentials
 
 mvn -f ${WS_DIR}/pom.xml \
     clean install \
-    -Pexamples,spotbugs,javadoc,docs,sources,ossrh-releases
+    -Pexamples,integrations,spotbugs,javadoc,docs,sources,ossrh-releases
 
 examples/archetypes/test-archetypes.sh

--- a/etc/scripts/checkstyle.sh
+++ b/etc/scripts/checkstyle.sh
@@ -49,7 +49,7 @@ mvn checkstyle:checkstyle-aggregate \
     -f ${WS_DIR}/pom.xml \
     -Dcheckstyle.output.format=plain \
     -Dcheckstyle.output.file=${RESULT_FILE} \
-    -Pexamples,ossrh-releases > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
+    -Pexamples,integrations,ossrh-releases > ${LOG_FILE} 2>&1 || (cat ${LOG_FILE} ; exit 1)
 
 grep "^\[ERROR\]" ${RESULT_FILE} \
     && die "CHECKSTYLE ERROR" || echo "CHECKSTYLE OK"

--- a/etc/scripts/copyright.sh
+++ b/etc/scripts/copyright.sh
@@ -48,7 +48,7 @@ mvn -q org.glassfish.copyright:glassfish-copyright-maven-plugin:copyright \
         -Dcopyright.exclude=${WS_DIR}/etc/copyright-exclude.txt \
         -Dcopyright.template=${WS_DIR}/etc/copyright.txt \
         -Dcopyright.scm=git \
-        -Pexamples,docs,ossrh-releases > ${RESULT_FILE} || die "Error running the Maven command"
+        -Pexamples,integrations,docs,ossrh-releases > ${RESULT_FILE} || die "Error running the Maven command"
 
 grep -i "copyright" ${RESULT_FILE} \
     && die "COPYRIGHT ERROR" || echo "COPYRIGHT OK"

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -171,7 +171,7 @@ update_version(){
     -DnewVersion="${FULL_VERSION}" \
     -Dproperty=helidon.version \
     -DprocessAllModules=true \
-    -Pexamples,docs
+    -Pexamples,integrations,docs
 
   # Invoke prepare hook
   if [ -n "${PREPARE_HOOKS}" ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,6 @@
         <module>security</module>
         <module>bom</module>
         <module>microprofile</module>
-        <module>integrations</module>
     </modules>
 
     <build>
@@ -985,6 +984,12 @@
             <id>examples</id>
             <modules>
                 <module>examples</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>integrations</id>
+            <modules>
+                <module>integrations</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

This pull request follows a good suggestion by @romain-grecourt and moves the `integrations` Maven module (merged now that #109 is done) into a (disabled by default) Maven profile so we don't have to require the casual user to [work around oci-java-sdk/#25](https://github.com/oracle/oci-java-sdk/issues/25#issuecomment-375246967) and [configure the Oracle Maven repository](https://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm) (which requires an [OTN account](https://www.oracle.com/technetwork/index.html)).