### PR TITLE
Fixes minor error in OCI object storage integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target/
 *.releaseBackup
 atlassian-ide-plugin.xml
 user.txt
+nbactions.xml
 nb-configuration.xml
 node_modules/
 node/

--- a/integrations/cdi/oci-objectstorage-cdi/src/main/java/io/helidon/integrations/cdi/oci/objectstorage/MicroProfileConfigAuthenticationDetailsProvider.java
+++ b/integrations/cdi/oci-objectstorage-cdi/src/main/java/io/helidon/integrations/cdi/oci/objectstorage/MicroProfileConfigAuthenticationDetailsProvider.java
@@ -67,7 +67,8 @@ final class MicroProfileConfigAuthenticationDetailsProvider extends CustomerAuth
       .orElse(null);
     if (privateKey == null || privateKey.trim().isEmpty()) {
       final String pemFormattedPrivateKeyFilePath =
-        this.config.getOptionalValue("oci.auth.keyFile", String.class).orElse("~/.oci/oci_api_key.pem");
+        this.config.getOptionalValue("oci.auth.keyFile", String.class)
+        .orElse(Paths.get(System.getProperty("user.home"), ".oci/oci_api_key.pem").toString());
       assert pemFormattedPrivateKeyFilePath != null;
       try {
         return new BufferedInputStream(Files.newInputStream(Paths.get(pemFormattedPrivateKeyFilePath)));


### PR DESCRIPTION
The user's default private key file was not being located properly.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>