### PR TITLE
WIP: Fixes #125 to work around JDK9 javadoc bug

### DIFF
--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -44,16 +44,28 @@
                             <goal>javadoc-no-fork</goal>
                         </goals>
                         <configuration>
-                            <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
-                            <destDir>classes</destDir>
-                            <doctitle>Helidon ${project.version} API Documentation</doctitle>
-                            <windowtitle>Helidon ${project.version} API</windowtitle>
                             <bottom>
                             <![CDATA[Copyright &#169; 2018,
                                 <a href="http://www.oracle.com">Oracle</a>
                                 and/or its affiliates.
                                 All Rights Reserved. Use is subject to license terms.]]>
                             </bottom>
+                            <dependencySourceExcludes>
+                                <dependencySourceExclude>org.osgi:*</dependencySourceExclude>
+                                <dependencySourceExclude>com.typesafe:config-test-lib_*</dependencySourceExclude>
+                                <dependencySourceExclude>javax.annotation:*</dependencySourceExclude>
+                                <dependencySourceExclude>javax.interceptor:*</dependencySourceExclude>
+                                <dependencySourceExclude>javax.enterprise.concurrent:*</dependencySourceExclude>
+                                <dependencySourceExclude>javax.el:*</dependencySourceExclude>
+                            </dependencySourceExcludes>
+                            <dependencySourceIncludes>
+                                <dependencySourceInclude>io.helidon.*:*</dependencySourceInclude>
+                                <dependencySourceInclude>io.helidon*:*</dependencySourceInclude>
+                            </dependencySourceIncludes>
+                            <destDir>classes</destDir>
+                            <doclint>none</doclint>
+                            <doctitle>Helidon ${project.version} API Documentation</doctitle>
+                            <excludePackageNames>*.internal:*.internal.*:*.config.testing.*</excludePackageNames>
                             <groups>
                                 <group>
                                     <title>Microprofile</title>
@@ -75,13 +87,16 @@
                                     <title>Reactive Web Server API</title>
                                     <packages>io.helidon.webserver*</packages>
                                 </group>
+                                <group>
+                                    <title>Integrations</title>
+                                    <packages>io.helidon.integrations*:io.helidon.service.configuration*</packages>
+                                </group>
                             </groups>
-                            <verbose/>
-                            <maxmemory>256m</maxmemory>
+                            <includeDependencySources>true</includeDependencySources>
+                            <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                             <links>
                                 <link>http://docs.jboss.org/cdi/api/${version.lib.cdi-api}</link>
                                 <link>http://www.reactive-streams.org/reactive-streams-${version.lib.reactivestreams}-javadoc</link>
-                                <link>https://docs.oracle.com/javase/8/docs/api</link>
                                 <link>https://jax-rs.github.io/apidocs/${version.lib.jaxrs-api}</link>
                                 <link>https://jersey.github.io/apidocs/${version.lib.jersey}/jersey</link>
                                 <link>https://static.javadoc.io/com.typesafe/config/${version.lib.typesafe-config}</link>
@@ -94,32 +109,15 @@
                                 <link>https://static.javadoc.io/org.eclipse.microprofile.health/microprofile-health-api/${version.lib.microprofile-health-api}</link>
                                 <link>https://static.javadoc.io/org.eclipse.microprofile.metrics/microprofile-metrics-api/${version.lib.microprofile-metrics-api}</link>
                             </links>
-                            <additionalJOptions combine.children="append">
-                                <!-- javadoc.io requires a user agent -->
-                                <JOption>-J-Dhttp.agent=maven-javadoc-plugin</JOption>
-                            </additionalJOptions>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                            <includeDependencySources>true</includeDependencySources>
-                            <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
-                            <dependencySourceIncludes>
-                                <dependencySourceInclude>io.helidon.*:*</dependencySourceInclude>
-                                <dependencySourceInclude>io.helidon*:*</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                            <dependencySourceExcludes>
-                                <dependencySourceExclude>org.osgi:*</dependencySourceExclude>
-                                <dependencySourceExclude>com.typesafe:config-test-lib_*</dependencySourceExclude>
-                                <dependencySourceExclude>javax.annotation:*</dependencySourceExclude>
-                                <dependencySourceExclude>javax.interceptor:*</dependencySourceExclude>
-                                <dependencySourceExclude>javax.enterprise.concurrent:*</dependencySourceExclude>
-                                <dependencySourceExclude>javax.el:*</dependencySourceExclude>
-                            </dependencySourceExcludes>
-                            <sourceFileIncludes>
-                                <sourceFileInclude>io/helidon/**/*.java</sourceFileInclude>
-                            </sourceFileIncludes>
-                            <excludePackageNames>*.internal:*.internal.*:*.config.testing.*</excludePackageNames>
+                            <maxmemory>256m</maxmemory>
+                            <reportOutputDirectory>${project.build.directory}</reportOutputDirectory>
                             <sourceFileExcludes>
                                 <sourceFileExclude>**/module-info.java</sourceFileExclude>
                             </sourceFileExcludes>
+                            <sourceFileIncludes>
+                                <sourceFileInclude>io/helidon/**/*.java</sourceFileInclude>
+                            </sourceFileIncludes>
+                            <windowtitle>Helidon ${project.version} API</windowtitle>
                         </configuration>
                     </execution>
                 </executions>
@@ -268,6 +266,58 @@
         <dependency>
             <groupId>io.helidon.microprofile</groupId>
             <artifactId>helidon-microprofile-security</artifactId>
+        </dependency>
+
+        <!-- integrations javadocs -->
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-config-source</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-jedis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -998,6 +998,58 @@
             </modules>
         </profile>
         <profile>
+          <id>jdk9-javadoc</id>
+          <!-- https://maven.apache.org/guides/introduction/introduction-to-profiles.html#Details_on_profile_activation -->
+          <!-- AND semantics; see https://issues.apache.org/jira/browse/MNG-4565 -->
+            <activation> 
+              <jdk>[9,10)</jdk>
+              <property>
+                  <name>!jdkToolchainVersion</name>
+              </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <additionalJOptions>
+                                    <!-- https://bugs.openjdk.java.net/browse/JDK-8184969 -->
+                                    <JOption>-Xold</JOption>
+                                </additionalJOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+          <id>jdk9-toolchain-javadoc</id>
+            <activation>
+              <property>
+                <name>jdkToolchainVersion</name>
+                <value>9</value>
+              </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <additionalJOptions combine.children="append">
+                                    <!-- https://bugs.openjdk.java.net/browse/JDK-8184969 -->
+                                    <JOption>-Xold</JOption>
+                                </additionalJOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
             <id>jdk9+</id>
             <activation>
                 <jdk>[9,)</jdk>
@@ -1010,7 +1062,7 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <executions>
-                                <!-- fist pass, compile everything for java9 -->
+                                <!-- first pass, compile everything for java9 -->
                                 <execution>
                                     <id>default-compile</id>
                                     <configuration>
@@ -1353,7 +1405,7 @@
                 </file>
             </activation>
             <properties>
-                <jdkToolchainVersion>${maven.compiler.target}</jdkToolchainVersion>
+                <jdkToolchainVersion>${java.vm.specification.version}</jdkToolchainVersion>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

This pull request works around a [JDK9 `javadoc` bug](https://bugs.openjdk.java.net/browse/JDK-8184969) without affecting other JDK versions.

I've alphabetized the long list of `maven-javadoc-plugin` configuration items in the `javadocs/pom.xml` file, and introduced two very special-purpose `<profile>`s in the root `pom.xml`.

The fix involves adding the `-Xold` option (!) to `javadoc` when (a) it is from JDK 9 (but not JDK 8, and not JDK 10 or greater) sufficiently "early" in the command line.  If the option appears in the wrong place, then `javadoc` will crash.  I accomplish this by adding `-Xold` to the list of `<additionalJOptions>`, even though it is not, strictly speaking, a J option.

After this fix, javadocs contain all links as they should—at least on my machine! 😉 