### PR TITLE
Add health check and metrics to first guide

### DIFF
--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -30,5 +30,7 @@
              as unacceptable blank lines within a package's imports. -->
         <suppress checks="ImportOrder"
             files="examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java"/>
+        <suppress checks="ImportOrder"
+            files="examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java"/>
 </suppressions>
 

--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -25,5 +25,10 @@
     <suppress checks="FileLength"
             files="config/config/src/main/java/io/helidon/config/Config.java"
             lines="1"/>
+
+        <!-- Java comments with AsciiDoc tag:: and end:: in import section incorrectly flagged
+             as unacceptable blank lines within a package's imports. -->
+        <suppress checks="ImportOrder"
+            files="examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java"/>
 </suppressions>
 

--- a/examples/guides/se-restful-webservice/pom.xml
+++ b/examples/guides/se-restful-webservice/pom.xml
@@ -198,6 +198,12 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
 <!-- end::configYamlDependency[] -->
+<!-- tag::metricsDependency[] -->
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-metrics-se</artifactId>
+        </dependency>
+<!-- end::metricsDependency[] -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/examples/guides/se-restful-webservice/pom.xml
+++ b/examples/guides/se-restful-webservice/pom.xml
@@ -193,6 +193,12 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <!-- end::configYamlDependency[] -->
+        <!-- tag::metricsDependency[] -->
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-metrics-se</artifactId>
+        </dependency>
+        <!-- end::metricsDependency[] -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -39,6 +39,13 @@ You'll learn how to use Helidon quickly to create a ReSTful web service that acc
 |`PUT localhost:8080/greet/greeting/Hola` |Changes the greeting used in subsequent responses
 |===
 
+We create the app in three main steps:
+. Write a basic app to respond to the HTTP requests.
+. Add code to perform simple health checks.
+. Add code to record simple metrics.
+
+(See the last section to find out how to get the entire finished code for this example.)
+
 == What You Need
 
 |===
@@ -54,8 +61,7 @@ You'll learn how to use Helidon quickly to create a ReSTful web service that acc
 //|`kubectl` 1.7.4
 //|===
 
-== Write Your Application
-(See the last section to find out how to get the entire finished code for this example.)
+== Create Your Application
 
 === Create a new Maven Project
 You can create your maven project in these ways:
@@ -73,8 +79,7 @@ Make sure your POM contains these sections:
 [source,xml,subs="verbatim,attributes"]
 ----
     <properties>
-include::{pom}[tag=helidonVersion]
-include::{pom}[tag=javaVersions]
+include::{pom}[tags=helidonVersion;javaVersions]
     </properties>
 
     <dependencyManagement>
@@ -88,8 +93,7 @@ For this example add these dependencies:
 [source,xml]
 ----
     <dependencies>
-include::{pom}[tag=webserverBundleDependency]
-include::{pom}[tag=configYamlDependency]
+include::{pom}[tags=webserverBundleDependency;configYamlDependency]
     </dependencies>
 ----
 <1> Incorporates the Helidon web server.
@@ -156,7 +160,7 @@ Create a new Java class `GreetService.java` as follows. Note that along the way
 you or your IDE will be adding these Java `import` statements:
 [source,java]
 ----
-include::{greet-service}[tag=imports]
+include::{greet-service}[tags=importsStart;importsWebServer]
 ----
 
 . Make `GreetService` implement `io.helidon.webserver.Service`.
@@ -165,8 +169,7 @@ the loaded config:
 +
 [source,java]
 ----
-include::{greet-service}[tag=CONFIG]
-include::{greet-service}[tag=greetingDef]
+include::{greet-service}[tags=CONFIG;greetingDef]
 ----
 <1> Loads the config from the (default) `application.yaml` resource you created earlier
 and loads the subtree rooted at the `app` entry into the `CONFIG` field. The
@@ -205,7 +208,7 @@ include::{greet-service}[tag=updateGreeting]
 +
 [source,java]
 ----
-include::{greet-service}[tag=update]
+include::{greet-service}[tags=updateStart;updateGetsAndPuts]
 ----
 <1> Each service overrides `update` to define its routing rules.
 <2> Handle `GET` requests with no extra path using `getDefaultMessage`.
@@ -221,8 +224,7 @@ and makes it aware of your greeting service.
 Along the way you or your IDE will be adding these Java `import` statements:
 [source,java]
 ----
-include::{main-class}[tag=importsStart]
-include::{main-class}[tag=importsEnd]
+include::{main-class}[tags=importsStart;importsWebServer;importsEnd]
 ----
 . Add a field to your main class to hold a reference to a `GreetService` instance.
 +
@@ -235,13 +237,12 @@ include::{main-class}[tag=greetServiceDecl]
 +
 [source,java]
 ----
-include::{main-class}[tag=createRoutingStart]
-include::{main-class}[tag=createRoutingEnd]
+include::{main-class}[tags=createRoutingStart;createRoutingBasic;registerGreetService;createRoutingEnd]
 ----
-<1> Creates and saves the reference to the `GreetService`. (We'll use this again
+<1> Creates and saves the reference to the `GreetService`. (We'll use `greeting` reference again
 later when we add support for health checking.)
 <2> Tells the Helidon web server that you want to use JSON.
-<3> Associates the `/greet` path with your greet service. 
+<3> Associates the greeting service with the `/greet` path. 
 
 . Add the `startServer` method.
 +
@@ -282,7 +283,7 @@ java -jar target/your-jar-name.jar
 Once you have started your app, from another command window run these commands 
 to access its three functions (order is important for the last two):
 |====
-|Commmand |Result
+|Command |Result
 
 a|[source,bash]
 curl -X GET http://localhost:8080/greet
@@ -305,7 +306,7 @@ a|[source,bash]
 {"message":"Hola Jose!"}
 |====
 
-== Add Support for Health Checking
+== Add Health Checks
 A well-behaved microservice reports on its own health.
 Two common approaches for checking health, often used together, are:
 
@@ -360,9 +361,7 @@ to the `Main` class.
 
 Along the way, you or your IDE will need to add 
 [source,java]
-include::{main-class}[tag=importsHealth1]
-include::{main-class}[tag=importsHealth2]
-include::{main-class}[tag=importsHealth3]
+include::{main-class}[tags=importsHealth1;importsHealth2;importsHealth3]
 
 . Add a new `ready` method
 +
@@ -385,7 +384,7 @@ include::{main-class}[tag=alive]
 . Add the new endpoints to the routing
 +
 In the `createRouting` method in `Main.java` insert these lines immediately
-after the two `.register` invocations:
+after the `.register` invocations:
 +
 [source,java]
 ----
@@ -394,7 +393,7 @@ include::{main-class}[tag=createRoutingHealth]
 These link the health-related endpoints your code is exposing to the new methods.
 
 === Rebuild and rerun your service
-Just follow the same steps you did before. Make sure you have stopped any earlier 
+Follow the same steps you did before. Make sure you have stopped any earlier 
 instance of your service to free up the port.
 
 === Try the readiness check
@@ -433,6 +432,159 @@ This time you should see
 {"error":"greeting is not set or is empty"}
 +
 and with the `-i` added to the `curl` command you would see the 500 status returned.
+
+== Add Metrics Support
+As a simple illustration of using metrics, we revise our greeting service to count how many times
+a client sends a request to the app.
+
+. Add the metrics dependency to `pom.xml`
++
+[source,xml]
+----
+include::{pom}[tag=metricsDependency]
+----
+. Enable metrics in `Main.java`
++
+You or your IDE will add this import:
++
+[source,java]
+----
+include::{main-class}[tag=importsMetrics]
+----
+.. Register metrics support in request routing 
++
+In `Main.createRouting`:
+
+... Just before the code instantiates `GreetService` add this:
++
+[source,java]
+----
+include::{main-class}[tag=initMetrics]
+----
+<1> Initializes the metrics infrastructure in Helidon.
+
+... Just after the invocation of `register(JsonSupport.get())`
+add this
++
+[source,java]
+----
+include::{main-class}[tag=registerMetrics]
+----
+<1> Registers the `MetricsSupport` handler with the web server's
+handler chain.
++
+Here is the whole, updated method:
++
+[source,java]
+include::{main-class}[tag=createRoutingFull]
+
+. Revise `GreetService.java` for metrics
++
+You or your IDE will add these imports:
++
+[source,java]
+----
+include::{greet-service}[tags=importsHelidonMetrics;importsMPMetrics]
+----
+
+.. Register a metric in `GreetService.java`
++
+Add these declarations as private fields:
++
+[source,java]
+----
+include::{greet-service}[tags=metricsRegistration;counterRegistration]
+----
+<1> Refers to the application-scoped metrics registry.
+<2> Declares a metric of type `counter`.
+
+.. Create a method to display which method is handling a request.
++
+Add this method:
++
+[source,java]
+----
+include::{greet-service}[tag=displayThread]
+----
+
+.. Create a request handler to update the counter
++
+Add this method:
++
+[source,java]
+----
+include::{greet-service}[tag=counterFilter]
+----
+<1> Shows which method is handling the request.
+<2> Updates the counter metric.
+<3> Lets the next handler process the same request.
+
+.. Register a filter to count requests
++
+To the `update` method add this line immediately before the
+existing `get` invocations.
++
+[source,java]
+----
+include::{greet-service}[tag=updateForCounter]
+----
+<1> Invokes `counterFilter` for _any_ incoming request.
+
+=== Rebuild and rerun your application
+Follow the same steps as before, remembering to stop any instance
+of your application that is still running.
+
+=== Sends some requests
+Use the same `curl` commands from the beginning to send requests to the server:
+
+|====
+|Command |Server Output
+
+a|[source,bash]
+curl -X GET http://localhost:8080/greet
+a|[source,bash]
+Method=counterFilter Thread=nioEventLoopGroup-3-1
+
+a|[source,bash]
+curl -X GET http://localhost:8080/greet/Joe
+a|[source,bash]
+Method=counterFilter Thread=nioEventLoopGroup-3-2
+
+a|[source,bash]
+curl -X PUT http://localhost:8080/greet/greeting/Hola
+a|[source,bash]
+Method=counterFilter Thread=nioEventLoopGroup-3-3
+
+a|[source,bash]
+curl -X GET http://localhost:8080/greet/Jose
+a|[source,bash]
+Method=counterFilter Thread=nioEventLoopGroup-3-4
+|====
+
+=== Retrieve metrics
+Run this `curl` command to retrieve the collected metrics:
+[source,bash]
+----
+curl -X GET http://localhost:8080/metrics
+----
+
+You should see a long JSON result. Note two parts:
+|====
+|Output |Meaning
+
+a|[source,bash]
+"application":{"accessctr":4}
+
+|The counter we added to the app
+
+a|[source,bash]
+"requests.meter":{"count":5, ...
+
+|The total HTTP requests the Helidon web server received (and several values
+reflecting the request arrival rate)
+|====
+The request count is higher because of the access to `/metrics` to retrieve the
+monitoring data.
 
 == (Or, Download the Example Source)
 We think the guide is most useful if you follow along step-by-step, building

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -370,7 +370,7 @@ include::{main-class}[tags=importsHealth1;importsHealth2;importsHealth3]
 include::{main-class}[tag=ready]
 ----
 This method simply returns 200 so the client knows the service is up.
-. Add a new `health` method
+. Add a new `alive` method
 +
 [source,java]
 ----
@@ -583,8 +583,9 @@ a|[source,bash]
 |The total HTTP requests the Helidon web server received (and several values
 reflecting the request arrival rate)
 |====
-The request count is higher because of the access to `/metrics` to retrieve the
-monitoring data.
+The request count is higher because the access to `/metrics` to retrieve the
+monitoring data is _not_ handled by our app's rules and filters but by the 
+metrics infrastructure.
 
 == (Or, Download the Example Source)
 We think the guide is most useful if you follow along step-by-step, building

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -42,7 +42,7 @@ You'll learn how to use Helidon quickly to create a ReSTful web service that acc
 == What You Need
 
 |===
-|About 10 minutes
+|About 15 minutes
 |An IDE or text editor
 |JDK 1.8 or later
 |Maven 3.5 or later
@@ -221,16 +221,27 @@ and makes it aware of your greeting service.
 Along the way you or your IDE will be adding these Java `import` statements:
 [source,java]
 ----
-include::{main-class}[tag=imports]
+include::{main-class}[tag=importsStart]
+include::{main-class}[tag=importsEnd]
 ----
+. Add a field to your main class to hold a reference to a `GreetService` instance.
++
+[source,java]
+----
+include::{main-class}[tag=greetServiceDecl]
+----
+
 . Add a method to your main class to set up routing for your app.
 +
 [source,java]
 ----
-include::{main-class}[tag=createRouting]
+include::{main-class}[tag=createRoutingStart]
+include::{main-class}[tag=createRoutingEnd]
 ----
-<1> Tells the Helidon web server that you want to use JSON.
-<2> Associates the `/greet` path with your greet service. 
+<1> Creates and saves the reference to the `GreetService`. (We'll use this again
+later when we add support for health checking.)
+<2> Tells the Helidon web server that you want to use JSON.
+<3> Associates the `/greet` path with your greet service. 
 
 . Add the `startServer` method.
 +
@@ -293,6 +304,134 @@ curl -X GET http://localhost:8080/greet/Jose
 a|[source,bash]
 {"message":"Hola Jose!"}
 |====
+
+== Add Support for Health Checking
+A key responsibility of a well-behaved microservice is to actually report on its own behavior.
+Two common approaches for checking health, often used together, are:
+
+- readiness - a simple verification that the service has been started, has initialized itself,
+and is ready to respond to requests; and
+- liveness - often a more thorough assessment of if
+and how well the service can do its job.
+
+For example, Kubernetes can ping your service's 
+readiness endpoint after it starts the pod containing the service to determine 
+when the service is ready to accept requests, withholding traffic until the readiness
+endpoint reports success. Kubernetes can use the liveness endpoint to find out if
+the service considers itself able to function, attempting a pod restart if the
+endpoint reports a problem.
+
+In general a liveness check might assess:
+
+- service health - whether the service itself is prepared to respond correctly
+- host health - if the host has sufficient resources (for example, disk space)
+for the service to operate
+- health of other, dependent services - if other services on which this service
+depends are themselves OK.
+
+To do its job our greeting service does not depend on any
+host resources (like disk space) or any other services. So we'll define the 
+health of our greeting service to be OK if the greeting text has been assigned
+_and is not empty_ when trimmed of leading or trailing white space. Otherwise we'll
+consider the service to be unhealthy. Note that in this case the service will
+still respond but its answers might not be what we want. 
+
+Normally we would 
+write our service to make 
+sure that a newly-assigned greeting is non-empty _before_
+accepting it. But omitting that validation lets us create an easy health check
+and we can see it in operation by simply setting the greeting to blank from 
+a `curl` command.
+
+=== Add code to `GreetService.java`
+
+For our simple service, assess health simply by making sure the greeting contains
+something other than blanks.
+
+[source,java]
+----
+include::{greet-service}[tag=checkHealth]
+----
+
+=== Add code to `Main.java`
+
+Now let's add the code to actually implement the readiness and liveness endpoints to
+to the `Main` class.
+
+Along the way, you or your IDE will need to add 
+[source,java]
+include::{main-class}[tag=importsHealth1]
+include::{main-class}[tag=importsHealth2]
+include::{main-class}[tag=importsHealth3]
+
+. Add a new `ready` method
++
+[source,java]
+----
+include::{main-class}[tag=ready]
+----
+This method simply returns 200 so the client knows the service is up.
+. Add a new `health` method
++
+[source,java]
+----
+include::{main-class}[tag=alive]
+----
+<1> Delegates to `GreetService` to evaluate the liveness of the service -- in our case, is the greeting non-empty.
+<2> Replies with a simple 200 for the health case.
+<3> For the unhealthy case prepares a description of the problem...
+<4> ...and replies with a 500.
+
+. Add the new endpoints to the routing
++
+In the `createRouting` method in `Main.java` insert these lines immediately
+after the two `.register` invocations:
++
+[source,java]
+----
+include::{main-class}[tag=createRoutingHealth]
+----
+
+=== Rebuild and rerun your service
+Just follow the same steps you did before. Make sure you have stopped any earlier 
+instance of your service to free up the port.
+
+=== Try the readiness check
+Access the readiness check endpoint:
+[source,bash]
+curl -X GET http://localhost:8080/ready
+
+Our readiness check returns no payload, just the 200 status, so you won't see any data
+displayed. You can add the `-v` verbose option to the `curl` command to see the
+200 status in the response.
+
+=== Try the health check
+. Ping the health check endpoint
++
+Without changing the greeting, ping the health endpoint:
+[source,bash]
+curl -i -X GET http://localhost:8080/alive
++
+The greeting is valid and in that case our health check code simply returns a 200
+with no payload. 
+
+. Set the greeting to a blank
++
+[source,bash]
+curl -X PUT http://localhost:8080/greet/greeting/%20
++
+Our code to update the greeting accepts this and saves it as the new greeting.
+
+. Ping the health check endpoint again with the same command as before
++
+[source,bash]
+curl -i -X GET http://localhost:8080/alive
++
+This time you should see
+[source,bash]
+{"error":"greeting is not set or is empty"}
++
+and if you added `-i` to the `curl` command you would see the 500 status returned.
 
 == (Or, Download the Example Source)
 We think the guide is most useful if you follow along step-by-step, building

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -391,6 +391,7 @@ after the two `.register` invocations:
 ----
 include::{main-class}[tag=createRoutingHealth]
 ----
+These link the health-related endpoints your code is exposing to the new methods.
 
 === Rebuild and rerun your service
 Just follow the same steps you did before. Make sure you have stopped any earlier 
@@ -399,10 +400,10 @@ instance of your service to free up the port.
 === Try the readiness check
 Access the readiness check endpoint:
 [source,bash]
-curl -X GET http://localhost:8080/ready
+curl -i -X GET http://localhost:8080/ready
 
 Our readiness check returns no payload, just the 200 status, so you won't see any data
-displayed. You can add the `-v` verbose option to the `curl` command to see the
+displayed. The `-i` option shows the
 200 status in the response.
 
 === Try the liveness check
@@ -431,7 +432,7 @@ This time you should see
 [source,bash]
 {"error":"greeting is not set or is empty"}
 +
-and if you added `-i` to the `curl` command you would see the 500 status returned.
+and with the `-i` added to the `curl` command you would see the 500 status returned.
 
 == (Or, Download the Example Source)
 We think the guide is most useful if you follow along step-by-step, building

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -306,7 +306,7 @@ a|[source,bash]
 |====
 
 == Add Support for Health Checking
-A key responsibility of a well-behaved microservice is to actually report on its own behavior.
+A well-behaved microservice reports on its own health.
 Two common approaches for checking health, often used together, are:
 
 - readiness - a simple verification that the service has been started, has initialized itself,
@@ -323,24 +323,24 @@ endpoint reports a problem.
 
 In general a liveness check might assess:
 
-- service health - whether the service itself is prepared to respond correctly
+- service health - whether the service itself can do its job correctly
 - host health - if the host has sufficient resources (for example, disk space)
 for the service to operate
 - health of other, dependent services - if other services on which this service
 depends are themselves OK.
 
-To do its job our greeting service does not depend on any
-host resources (like disk space) or any other services. So we'll define the 
-health of our greeting service to be OK if the greeting text has been assigned
-_and is not empty_ when trimmed of leading or trailing white space. Otherwise we'll
-consider the service to be unhealthy. Note that in this case the service will
+Our greeting service does not depend on any
+host resources (like disk space) or any other services. So we choose to define our
+greeting service to be OK if the greeting text has been assigned
+_and is not empty_ when trimmed of leading or trailing white space. Otherwise we
+consider the service to be unhealthy, in which case the service will
 still respond but its answers might not be what we want. 
 
 Normally we would 
 write our service to make 
 sure that a newly-assigned greeting is non-empty _before_
 accepting it. But omitting that validation lets us create an easy health check
-and we can see it in operation by simply setting the greeting to blank from 
+that we can use by simply setting the greeting to blank from 
 a `curl` command.
 
 === Add code to `GreetService.java`

--- a/examples/guides/se-restful-webservice/src/main/docs/index.adoc
+++ b/examples/guides/se-restful-webservice/src/main/docs/index.adoc
@@ -405,7 +405,7 @@ Our readiness check returns no payload, just the 200 status, so you won't see an
 displayed. You can add the `-v` verbose option to the `curl` command to see the
 200 status in the response.
 
-=== Try the health check
+=== Try the liveness check
 . Ping the health check endpoint
 +
 Without changing the greeting, ping the health endpoint:

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -56,7 +56,7 @@ public class GreetService implements Service {
      * The config value for the key {@code greeting}.
      */
     // tag::greetingDef[]
-    private static String greeting = CONFIG.get("greeting").asString("Ciao"); // <2>
+    private String greeting = CONFIG.get("greeting").asString("Ciao"); // <2>
     // end::greetingDef[]
 
     /**
@@ -74,7 +74,7 @@ public class GreetService implements Service {
     // end::update[]
 
     /**
-     * Return a wordly greeting message.
+     * Return a worldly greeting message.
      * @param request the server request
      * @param response the server response
      */
@@ -124,4 +124,17 @@ public class GreetService implements Service {
         response.send(returnObject);
     }
     // end::updateGreeting[]
+
+    /**
+     * Checks the health of the greeting service.
+     * @return a String reporting any problems; null if all is well
+     */
+    // tag::checkHealth[]
+    String checkHealth() {
+        if (greeting == null || greeting.trim().length() == 0) { //<1>
+           return "greeting is not set or is empty";
+        }
+        return null;
+    }
+    // end::checkHealth[]
 }

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -24,9 +24,14 @@ import io.helidon.common.http.Http;
 // end::importsHealth1[]
 // tag::importsStart[]
 import io.helidon.config.Config;
+// end::importsStart[]
+// tag::importsMetrics[]
+import io.helidon.metrics.MetricsSupport;
+// end::importsMetrics[]
+// tag::importsWebServer[]
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerConfiguration;
-// end::importsStart[]
+// end::importsWebServer[]
 // tag::importsHealth2[]
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
@@ -59,13 +64,24 @@ public final class Main {
      *
      * @return the new instance
      */
+    // tag::createRoutingFull[]
     // tag::createRoutingStart[]
     private static Routing createRouting() {
-        greetService = new GreetService(); //<1>
+    // end::createRoutingStart[]
+    // tag::initMetrics[]
+        final MetricsSupport metrics = MetricsSupport.create(); // <1>
+    // end::initMetrics[]
+    // tag::createRoutingBasic[]
+        greetService = new GreetService(); // <1>
         return Routing.builder()
                 .register(JsonSupport.get()) // <2>
+    // end::createRoutingBasic[]
+    // tag::registerMetrics[]
+                .register(metrics) // <1>
+    // end::registerMetrics[]
+    // tag::registerGreetService[]
                 .register("/greet", greetService) // <3>
-    // end::createRoutingStart[]
+    // end::registerGreetService[]
     // tag::createRoutingHealth[]
                 .get("/alive", Main::alive)
                 .get("/ready", Main::ready)
@@ -74,6 +90,7 @@ public final class Main {
                 .build();
     }
     // end::createRoutingEnd[]
+    // end::createRoutingFull[]
 
     /**
      * Application main entry point.

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -67,8 +67,8 @@ public final class Main {
                 .register("/greet", greetService) // <3>
     // end::createRoutingStart[]
     // tag::createRoutingHealth[]
-                .get("/alive", Main::alive) //<1>
-                .get("/ready", Main::ready) //<2>
+                .get("/alive", Main::alive)
+                .get("/ready", Main::ready)
     // end::createRoutingHealth[]
     // tag::createRoutingEnd[]
                 .build();

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -19,18 +19,35 @@ package io.helidon.guides.se.restfulwebservice;
 import java.io.IOException;
 import java.util.logging.LogManager;
 
-// tag::imports[]
+// tag::importsHealth1[]
+import io.helidon.common.http.Http;
+// end::importsHealth1[]
+// tag::importsStart[]
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerConfiguration;
+// end::importsStart[]
+// tag::importsHealth2[]
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+// end::importsHealth2[]
+// tag::importsEnd[]
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.json.JsonSupport;
-// end::imports[]
+// end::importsEnd[]
+// tag::importsHealth3[]
+import javax.json.Json;
+import javax.json.JsonObject;
+// end::importsHealth3[]
 
 /**
  * Simple Hello World rest application.
  */
 public final class Main {
+
+    // tag::greetServiceDecl[]
+    private static GreetService greetService;
+    // end::greetServiceDecl[]
 
     /**
      * Cannot be instantiated.
@@ -42,14 +59,21 @@ public final class Main {
      *
      * @return the new instance
      */
-    // tag::createRouting[]
+    // tag::createRoutingStart[]
     private static Routing createRouting() {
+        greetService = new GreetService(); //<1>
         return Routing.builder()
-                .register(JsonSupport.get()) // <1>
-                .register("/greet", new GreetService()) // <2>
+                .register(JsonSupport.get()) // <2>
+                .register("/greet", greetService) // <3>
+    // end::createRoutingStart[]
+    // tag::createRoutingHealth[]
+                .get("/alive", Main::alive) //<1>
+                .get("/ready", Main::ready) //<2>
+    // end::createRoutingHealth[]
+    // tag::createRoutingEnd[]
                 .build();
     }
-    // end::createRouting[]
+    // end::createRoutingEnd[]
 
     /**
      * Application main entry point.
@@ -96,4 +120,46 @@ public final class Main {
         return server;
     }
     // end::startServer[]
+
+    /**
+     * Responds with a health message.
+     * @param request the server request
+     * @param response the server response
+     */
+    // tag::alive[]
+    private static void alive(final ServerRequest request,
+                        final ServerResponse response) {
+        /*
+         * Return 200 if the greeting is set to something non-null and non-empty;
+         * return 500 (server error) otherwise.
+         */
+        String greetServiceError = greetService.checkHealth(); //<1>
+        if (greetServiceError == null) {
+            response
+                    .status(Http.Status.OK_200) //<2>
+                    .send();
+        } else {
+            JsonObject returnObject = Json.createObjectBuilder() //<3>
+                    .add("error", greetServiceError)
+                    .build();
+            response
+                    .status(Http.Status.INTERNAL_SERVER_ERROR_500) //<4>
+                    .send(returnObject);
+        }
+    }
+    // end::alive[]
+
+    /**
+     * Implements a very simple readiness check.
+     * @param request the server request
+     * @param response the server response
+     */
+    //tag::ready[]
+    private static void ready(final ServerRequest request,
+                       final ServerResponse response) {
+        response
+                .status(Http.Status.OK_200)
+                .send();
+    }
+    //end::ready[]
 }


### PR DESCRIPTION
These changes add, to the Java code and the AsciiDoc, code and discussion for adding the health check (readiness and liveness, in K8s terms) to the example app.

The previous part of the guide should not have changed (with one exception: we now save a reference to the instantiated `GreetService` object so we can use it in creating the routing and also later in the health implementation). Having said that, the source code in the example `.java` files now includes the health check code so the AsciiDoc `includes`s for the initial part of the guide had to change slightly to avoid showing the health-related code at first. So it's possible that I inadvertently messed that up, so reviewers should help me make sure the first part is still correct.

I added the readiness and liveness endpoints in the `Main` class, not the `GreetingService` class (based on the recent slack discussion) and wrote a very quick review of K8s readiness and liveness.

I've marked this PR as WIP temporarily because I want to do a more thorough review myself, but I also want others to take a look as they have time.