### PR TITLE
Update integrations/serviceconfiguration/serviceconfiguration-hikaric…

### DIFF
--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/README.adoc
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/README.adoc
@@ -17,3 +17,19 @@ When your program is running on the Application Container Cloud
 Service platform, Hikari connection pool information will be made
 available to programs using the Helidon Service Configuration
 Framework.
+
+== Using Oracle DB
+
+The JDBC driver for the Oracle DB is only available from the
+https://www.oracle.com/webfolder/application/maven/index.html[Oracle Maven Repository].
+
+This means that you have to configure the repository in order to add the driver
+ to your classpath.
+
+Follow these steps:
+
+- Go to https://www.oracle.com/webfolder/application/maven/index.html and
+ accept the license
+- Create an OTN account
+- Update your settings.xml as documented
+ https://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm#MAVEN9016[here]

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
@@ -51,6 +51,16 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!--

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
@@ -16,53 +16,63 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
+    <name>Helidon ServiceConfiguration HikariCP ACCS</name>
 
-  <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
+    <description>
+        Helidon HikariCP ServiceConfiguration Implementation for Application Container Cloud Service
+    </description>
 
-  <name>Helidon HikariCP ServiceConfiguration Implementation for Application Container Cloud Service</name>
-  <description>${project.name}</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.oracle.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <!--
+        com.oracle:jdbc:odjbc8 requires the maven oracle repository
+    -->
+    <repositories>
+        <repository>
+            <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
 </project>
-


### PR DESCRIPTION
…p-accs/pom.xml, declare the

Oracle Maven Repository in the pom.xml rather than requiring an active profile.
This will reduce the usafe of this repository to this single module rather than the whole build.

Update README.adoc to document the pre-requisite for using the JDBC driver for the Oracle DB.

Fixed #136 