### PR TITLE
Pom alignment in the following modules: integrations, integrations ex…

### DIFF
--- a/examples/guides/pom.xml
+++ b/examples/guides/pom.xml
@@ -18,38 +18,22 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.examples</groupId>
+        <artifactId>helidon-examples-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.guides</groupId>
+    <artifactId>helidon-guides-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon Guides</name>
 
-  <groupId>io.helidon.guides</groupId>
-  <artifactId>helidon-guides-project</artifactId>
-  <version>0.10.5-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  
-  <parent>
-      <groupId>io.helidon.examples</groupId>
-      <artifactId>helidon-examples-project</artifactId>
-      <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <description>
+        Project containing the Helidon Guides documentation and code
+    </description>
 
-  <name>helidon-guides-project</name>
-  <description>Project containing the Helidon Guides documentation and code</description>
-  <url>http://io.helidon</url>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-  </properties>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-  
-  <modules>
-    <module>se-restful-webservice</module>
-  </modules>
+    <modules>
+        <module>se-restful-webservice</module>
+    </modules>
 </project>

--- a/examples/guides/se-restful-webservice/pom.xml
+++ b/examples/guides/se-restful-webservice/pom.xml
@@ -18,34 +18,29 @@
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <artifactId>helidon-guides-project</artifactId>
         <groupId>io.helidon.guides</groupId>
         <version>0.10.5-SNAPSHOT</version>
     </parent>
-
-    <groupId>io.helidon.guides</groupId>
     <artifactId>se-restful-webservice</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <name>se-restful-webservice</name>
+    <name>Helidon Guides SE RESTful Web Service</name>
 
     <properties>
-<!-- tag::helidonVersion[] -->
-        <helidon.version>0.10.5-SNAPSHOT</helidon.version>
-<!-- end::helidonVersion[] -->
+        <!-- tag::helidonVersion[] -->
+        <helidon.version>${project.version}</helidon.version>
+        <!-- end::helidonVersion[] -->
         <!-- Default package. Will be overriden by Maven archetype -->
         <package>io.helidon.examples.quickstart.se</package>
         <mainClass>io.helidon.guides.se.restfulwebservice.Main</mainClass>
-<!-- tag::javaVersions[] -->
+        <!-- tag::javaVersions[] -->
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-<!-- end::javaVersions[] -->
-<!-- tag::libsCopying[] -->
+        <!-- end::javaVersions[] -->
+        <!-- tag::libsCopying[] -->
         <libs.classpath.prefix>libs</libs.classpath.prefix>
         <copied.libs.dir>${project.build.directory}/${libs.classpath.prefix}</copied.libs.dir>
-<!-- end::libsCopying[] -->
+        <!-- end::libsCopying[] -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <argLine>-Dfile.encoding=UTF-8</argLine>
@@ -102,7 +97,7 @@
         </pluginManagement>
 
         <plugins>
-<!-- tag::copyDependencies[] -->
+            <!-- tag::copyDependencies[] -->
             <plugin> <!--3-->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -125,7 +120,7 @@
                     </execution>
                 </executions>
             </plugin>
-<!-- end::copyDependencies[] -->
+            <!-- end::copyDependencies[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -163,15 +158,15 @@
 
     <dependencyManagement>
         <dependencies>
-<!-- tag::depMgt[] -->
-            <dependency>            
+            <!-- tag::depMgt[] -->
+            <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-bom</artifactId>
                 <version>${helidon.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-<!-- end::depMgt[] -->
+            <!-- end::depMgt[] -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
@@ -186,18 +181,18 @@
     </dependencyManagement>
 
     <dependencies>
-<!-- tag::webserverBundleDependency[] -->
+        <!-- tag::webserverBundleDependency[] -->
         <dependency> <!--1-->
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-bundle</artifactId>
         </dependency>
-<!-- end::webserverBundleDependency[] -->
-<!-- tag::configYamlDependency[] -->
+        <!-- end::webserverBundleDependency[] -->
+        <!-- tag::configYamlDependency[] -->
         <dependency> <!--2-->
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
-<!-- end::configYamlDependency[] -->
+        <!-- end::configYamlDependency[] -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -20,220 +20,193 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-examples-datasource-hikaricp</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.examples</groupId>
+        <artifactId>helidon-integrations-examples-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-examples-datasource-hikaricp</artifactId>
+    <name>Helidon Integrations Examples DataSource/HikariCP</name>
 
-  <name>Helidon Integrations: DataSource/HikariCP Example</name>
-  <description>Helidon Integrations DataSource Hikari Connection Pool Example</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.examples</groupId>
-    <artifactId>helidon-integrations-examples-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <properties>
+        <dependenciesDirectory>libs</dependenciesDirectory>
+        <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
+        <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
+    </properties>
 
-  <dependencyManagement>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeScope>test</excludeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
+                            <mainClass>io.helidon.microprofile.server.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/docker</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Dockerfile</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/main/k8s</directory>
+                                    <includes>
+                                        <include>datasource.secrets.template</include>
+                                        <include>app.yaml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
-      <dependency>
-        <groupId>io.helidon.integrations.cdi</groupId>
-        <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.el</groupId>
+                    <artifactId>jboss-el-api_3.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.interceptor</groupId>
+                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Runtime-scoped dependencies. -->
-
-    <dependency>
-      <groupId>com.oracle.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.el</groupId>
-          <artifactId>jboss-el-api_3.0_spec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.interceptor</groupId>
-          <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.helidon.integrations.cdi</groupId>
-      <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.server</groupId>
-      <artifactId>helidon-microprofile-server</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>javax.activation-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <!-- Compile-scoped dependencies. -->
-
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>redis.clients</groupId>
-      <artifactId>jedis</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy all project dependencies to ${project.build.directory}/${dependenciesDirectory} for Docker image construction</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeScope>runtime</includeScope>
-              <excludeScope>test</excludeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
-              <mainClass>io.helidon.microprofile.server.Main</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy Dockerfile and Kubernetes resources</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/docker</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>Dockerfile</include>
-                  </includes>
-                </resource>
-                <resource>
-                  <filtering>true</filtering>
-                  <directory>src/main/k8s</directory>
-                  <includes>
-                    <include>datasource.secrets.template</include>
-                    <include>app.yaml</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <dependenciesDirectory>libs</dependenciesDirectory>
-    <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
-    <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
-  </properties>
-
 </project>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -19,214 +19,188 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-examples-jedis</artifactId>
-  
-  <name>Helidon Integrations Jedis Example</name>
-  <description>${project.name}</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.examples</groupId>
-    <artifactId>helidon-integrations-examples-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.examples</groupId>
+        <artifactId>helidon-integrations-examples-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-examples-jedis</artifactId>
+    <name>Helidon Integrations Examples Jedis</name>
 
-  <dependencyManagement>
+    <properties>
+        <dependenciesDirectory>libs</dependenciesDirectory>
+        <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
+        <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeScope>test</excludeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
+                            <mainClass>io.helidon.microprofile.server.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/docker</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Dockerfile</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/main/k8s</directory>
+                                    <includes>
+                                        <include>jedis.secrets.template</include>
+                                        <include>app.yaml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
-      <dependency>
-        <groupId>io.helidon.integrations.cdi</groupId>
-        <artifactId>helidon-integrations-cdi-jedis</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.el</groupId>
+                    <artifactId>jboss-el-api_3.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.interceptor</groupId>
+                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-jedis</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Runtime-scoped dependencies. -->
-
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.el</groupId>
-          <artifactId>jboss-el-api_3.0_spec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.interceptor</groupId>
-          <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.helidon.integrations.cdi</groupId>
-      <artifactId>helidon-integrations-cdi-jedis</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.server</groupId>
-      <artifactId>helidon-microprofile-server</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>javax.activation-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <!-- Compile-scoped dependencies. -->
-
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>redis.clients</groupId>
-      <artifactId>jedis</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy all project dependencies to ${project.build.directory}/${dependenciesDirectory} for Docker image construction</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeScope>runtime</includeScope>
-              <excludeScope>test</excludeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
-              <mainClass>io.helidon.microprofile.server.Main</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy Dockerfile and Kubernetes resources</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/docker</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>Dockerfile</include>
-                  </includes>
-                </resource>
-                <resource>
-                  <filtering>true</filtering>
-                  <directory>src/main/k8s</directory>
-                  <includes>
-                    <include>jedis.secrets.template</include>
-                    <include>app.yaml</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <dependenciesDirectory>libs</dependenciesDirectory>
-    <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
-    <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
-  </properties>
-
 </project>

--- a/examples/integrations/cdi/oci-objectstorage/pom.xml
+++ b/examples/integrations/cdi/oci-objectstorage/pom.xml
@@ -19,231 +19,205 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-examples-oci-objectstorage</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.examples</groupId>
+        <artifactId>helidon-integrations-examples-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-examples-oci-objectstorage</artifactId>
+    <name>Helidon Integrations Examples OCI ObjectStorage</name>
 
-  <name>Helidon Integrations OCI ObjectStorage Example</name>
-  <description>${project.name}</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.examples</groupId>
-    <artifactId>helidon-integrations-examples-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <properties>
+        <dependenciesDirectory>libs</dependenciesDirectory>
+        <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
+        <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
 
-  <dependencyManagement>
+        <oci.auth.fingerprint>TODO: For testing only, you need to set your OCI fingerprint here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.fingerprint>
+        <oci.auth.keyFile>TODO: For testing only, you need to set the full path to your OCI keyFile here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.keyFile>
+        <oci.auth.passphraseCharacters>TODO: For testing only, you need to set your OCI keyFile passphrase here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.passphraseCharacters>
+        <oci.auth.tenancy>TODO: For testing only, you need to set your OCI tenancy here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.tenancy>
+        <oci.auth.user>TODO: For testing only, you need to set your OCI user here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.user>
+        <oci.objectstorage.compartmentId>TODO: For testing only, you need to set your OCI compartment ID here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.objectstorage.compartmentId>
+        <oci.objectstorage.region>TODO: For testing only, you need to set your OCI region here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.objectstorage.region>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeScope>test</excludeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
+                            <mainClass>io.helidon.microprofile.server.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/docker</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Dockerfile</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/main/k8s</directory>
+                                    <includes>
+                                        <include>oci.secrets.template</include>
+                                        <include>app.yaml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <oci.objectstorage.compartmentId>${oci.objectstorage.compartmentId}</oci.objectstorage.compartmentId>
+                        <oci.objectstorage.region>${oci.objectstorage.region}</oci.objectstorage.region>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
-      <dependency>
-        <groupId>io.helidon.integrations.cdi</groupId>
-        <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+            <scope>compile</scope>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.el</groupId>
+                    <artifactId>jboss-el-api_3.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.interceptor</groupId>
+                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.cdi</groupId>
+            <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
-
-  <dependencies>
-
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Runtime-scoped dependencies. -->
-
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.el</groupId>
-          <artifactId>jboss-el-api_3.0_spec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.interceptor</groupId>
-          <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.helidon.integrations.cdi</groupId>
-      <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.server</groupId>
-      <artifactId>helidon-microprofile-server</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>javax.activation-api</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <!-- Compile-scoped dependencies. -->
-
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>com.oracle.oci.sdk</groupId>
-      <artifactId>oci-java-sdk-objectstorage</artifactId>
-      <scope>compile</scope>
-      <type>pom</type>
-      <exclusions>
-        <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>javax.inject</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy all project dependencies to ${project.build.directory}/${dependenciesDirectory} for Docker image construction</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/${dependenciesDirectory}</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeScope>runtime</includeScope>
-              <excludeScope>test</excludeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>${dependenciesDirectory}</classpathPrefix>
-              <mainClass>io.helidon.microprofile.server.Main</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>Copy Dockerfile and Kubernetes resources</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/docker</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>Dockerfile</include>
-                  </includes>
-                </resource>
-                <resource>
-                  <filtering>true</filtering>
-                  <directory>src/main/k8s</directory>
-                  <includes>
-                    <include>oci.secrets.template</include>
-                    <include>app.yaml</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <oci.objectstorage.compartmentId>${oci.objectstorage.compartmentId}</oci.objectstorage.compartmentId>
-            <oci.objectstorage.region>${oci.objectstorage.region}</oci.objectstorage.region>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <dependenciesDirectory>libs</dependenciesDirectory>
-    <kubernetesSecretName>${project.artifactId}</kubernetesSecretName>
-    <spotbugs.exclude>${project.basedir}/src/main/spotbugs/exclusions.xml</spotbugs.exclude>
-    
-    <oci.auth.fingerprint>TODO: For testing only, you need to set your OCI fingerprint here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.fingerprint>
-    <oci.auth.keyFile>TODO: For testing only, you need to set the full path to your OCI keyFile here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.keyFile>
-    <oci.auth.passphraseCharacters>TODO: For testing only, you need to set your OCI keyFile passphrase here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.passphraseCharacters>
-    <oci.auth.tenancy>TODO: For testing only, you need to set your OCI tenancy here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.tenancy>
-    <oci.auth.user>TODO: For testing only, you need to set your OCI user here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.auth.user>
-    <oci.objectstorage.compartmentId>TODO: For testing only, you need to set your OCI compartment ID here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.objectstorage.compartmentId>
-    <oci.objectstorage.region>TODO: For testing only, you need to set your OCI region here.  For more information: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm</oci.objectstorage.region>
-  </properties>
-
 </project>

--- a/examples/integrations/cdi/pom.xml
+++ b/examples/integrations/cdi/pom.xml
@@ -20,61 +20,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.examples</groupId>
+        <artifactId>helidon-examples-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.integrations.examples</groupId>
+    <artifactId>helidon-integrations-examples-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon Integrations Examples</name>
 
-  <groupId>io.helidon.integrations.examples</groupId>
-  <artifactId>helidon-integrations-examples-project</artifactId>
-  <packaging>pom</packaging>
-
-  <name>Helidon Integrations Examples Project</name>
-  <description>Helidon Integrations Examples Project</description>
-  
-  <parent>
-    <groupId>io.helidon.examples</groupId>
-    <artifactId>helidon-examples-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
-  </parent>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-integrations-examples-datasource-hikaricp</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-integrations-examples-jedis</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-integrations-examples-oci-objectstorage</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>io.helidon.microprofile.config</groupId>
-        <artifactId>helidon-microprofile-config-cdi</artifactId>
-        <type>jar</type>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.helidon.microprofile.server</groupId>
-        <artifactId>helidon-microprofile-server</artifactId>
-        <type>jar</type>
-        <version>${project.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  
-  <modules>
-    <module>datasource-hikaricp</module>
-    <module>jedis</module>
-    <module>oci-objectstorage</module>
-  </modules>
-  
+    <modules>
+        <module>datasource-hikaricp</module>
+        <module>jedis</module>
+        <module>oci-objectstorage</module>
+    </modules>
 </project>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -19,105 +19,103 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-  
-  <name>Helidon HikariCP DataSource CDI Integration</name>
-  <description>${project.name}</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.cdi</groupId>
-    <artifactId>helidon-integrations-cdi-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.cdi</groupId>
+        <artifactId>helidon-integrations-cdi-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
+    <name>Helidon CDI Integrations HikariCP DataSource</name>
 
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <properties>
+        <!-- maven-javadoc-plugin property -->
+        <show>package</show>
+    </properties>
 
-    <!-- Runtime-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>io.helidon.serviceconfiguration</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.helidon.serviceconfiguration</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
+    <dependencies>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-config-source</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
-    <!-- Provided-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+        <!-- Provided-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-    <!-- Compile-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>io.helidon.serviceconfiguration</groupId>
-      <artifactId>helidon-serviceconfiguration-config-source</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.helidon.serviceconfiguration</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
+            <scope>runtime</scope>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
 
-  <properties>
-    <show>package</show>
-  </properties>
-  
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -50,13 +50,11 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/integrations/cdi/jedis-cdi/pom.xml
+++ b/integrations/cdi/jedis-cdi/pom.xml
@@ -20,89 +20,75 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-cdi-jedis</artifactId>
-  
-  <name>Helidon Jedis CDI Integration</name>
-  <description>${project.name}</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.cdi</groupId>
-    <artifactId>helidon-integrations-cdi-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.cdi</groupId>
+        <artifactId>helidon-integrations-cdi-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-cdi-jedis</artifactId>
+    <name>Helidon CDI Integrations Jedis</name>
 
-  <dependencies>
+    <properties>
+        <!-- maven-javadoc-plugin property -->
+        <show>package</show>
+    </properties>
 
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <dependencies>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
-    <!-- Runtime-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
+        <!-- Provided-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-    <!-- Provided-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
 
-    <!-- Compile-scoped dependencies. -->
-
-    <dependency>
-      <groupId>redis.clients</groupId>
-      <artifactId>jedis</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-  </dependencies>
-
-  <properties>
-    <show>package</show>
-  </properties>
-
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/integrations/cdi/oci-objectstorage-cdi/pom.xml
+++ b/integrations/cdi/oci-objectstorage-cdi/pom.xml
@@ -19,115 +19,99 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
-  
-  <name>Helidon OCI Object Storage CDI Integration</name>
-  <description>${project.name}</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations.cdi</groupId>
-    <artifactId>helidon-integrations-cdi-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations.cdi</groupId>
+        <artifactId>helidon-integrations-cdi-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-integrations-cdi-oci-objectstorage</artifactId>
+    <name>Helidon CDI Integrations OCI Object Storage</name>
 
-  <dependencies>
+    <properties>
+        <!-- maven-javadoc-plugin property -->
+        <show>package</show>
+        <oci.objectstorage.compartmentId/>
+        <oci.objectstorage.namespaceName/>
+        <oci.objectstorage.region/>
+    </properties>
 
-    <!-- Test-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <oci.objectstorage.compartmentId>${oci.objectstorage.compartmentId}</oci.objectstorage.compartmentId>
+                        <oci.objectstorage.namespaceName>${oci.objectstorage.namespaceName}</oci.objectstorage.namespaceName>
+                        <oci.objectstorage.region>${oci.objectstorage.region}</oci.objectstorage.region>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-    <!-- Runtime-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jandex</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>io.helidon.microprofile.config</groupId>
-      <artifactId>helidon-microprofile-config-cdi</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
+    <dependencies>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+            <scope>compile</scope>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>org.glassfish.jersey.inject</groupId>
-      <artifactId>jersey-hk2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    
+        <!-- Provided-scoped dependencies. -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-    <!-- Provided-scoped dependencies. -->
-    
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <!-- Compile-scoped dependencies. -->
-
-    <dependency>
-      <groupId>com.oracle.oci.sdk</groupId>
-      <artifactId>oci-java-sdk-objectstorage</artifactId>
-      <scope>compile</scope>
-      <type>pom</type>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <oci.objectstorage.compartmentId>${oci.objectstorage.compartmentId}</oci.objectstorage.compartmentId>
-            <oci.objectstorage.namespaceName>${oci.objectstorage.namespaceName}</oci.objectstorage.namespaceName>
-            <oci.objectstorage.region>${oci.objectstorage.region}</oci.objectstorage.region>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <show>package</show>
-    <oci.objectstorage.compartmentId/>
-    <oci.objectstorage.namespaceName/>
-    <oci.objectstorage.region/>
-  </properties>
-
+        <!-- Test-scoped dependencies. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/integrations/cdi/pom.xml
+++ b/integrations/cdi/pom.xml
@@ -20,49 +20,20 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations</groupId>
+        <artifactId>helidon-integrations-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.integrations.cdi</groupId>
+    <artifactId>helidon-integrations-cdi-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon CDI Integrations</name>
 
-  <groupId>io.helidon.integrations.cdi</groupId>
-  <artifactId>helidon-integrations-cdi-project</artifactId>
-  <packaging>pom</packaging>
-
-  <name>Helidon CDI Integrations</name>
-  <description>Helidon CDI Integrations</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations</groupId>
-    <artifactId>helidon-integrations-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-integrations-cdi-jedis</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>io.helidon.serviceconfiguration</groupId>
-        <artifactId>helidon-serviceconfiguration-project</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  
-  <modules>
-    <module>datasource-hikaricp</module>
-    <module>jedis-cdi</module>
-    <module>oci-objectstorage-cdi</module>
-  </modules>
-  
+    <modules>
+        <module>datasource-hikaricp</module>
+        <module>jedis-cdi</module>
+        <module>oci-objectstorage-cdi</module>
+    </modules>
 </project>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -20,61 +20,43 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon</groupId>
+        <artifactId>helidon-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.integrations</groupId>
+    <artifactId>helidon-integrations-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon Integrations Project</name>
 
-  <groupId>io.helidon.integrations</groupId>
-  <artifactId>helidon-integrations-project</artifactId>
-  <packaging>pom</packaging>
+    <properties>
+        <!-- maven-compiler-plugin properties -->
+        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
+        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
+        <!-- maven-surefire-plugin properties -->
+        <trimStackTrace>false</trimStackTrace>
+    </properties>
 
-  <name>Helidon Integrations Project</name>
-  <description>Helidon Integrations Project</description>
+    <modules>
+        <module>serviceconfiguration</module>
+        <module>cdi</module>
+    </modules>
 
-  <parent>
-    <groupId>io.helidon</groupId>
-    <artifactId>helidon-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-
-  <modules>
-    <module>serviceconfiguration</module>
-    <module>cdi</module>
-  </modules>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.helidon.microprofile.config</groupId>
-        <artifactId>helidon-microprofile-config-cdi</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <compilerArgs>
-              <arg>-Xlint:all</arg>
-              <arg>-parameters</arg>
-            </compilerArgs>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <properties>
-
-    <!-- maven-compiler-plugin properties; https://maven.apache.org/plugins/maven-compiler-plugin/ -->
-    <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-
-    <!-- maven-surefire-plugin properties -->
-    <trimStackTrace>false</trimStackTrace>
-
-  </properties>
-
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Xlint:all</arg>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/integrations/serviceconfiguration/pom.xml
+++ b/integrations/serviceconfiguration/pom.xml
@@ -20,76 +20,25 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.integrations</groupId>
+        <artifactId>helidon-integrations-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.serviceconfiguration</groupId>
+    <artifactId>helidon-serviceconfiguration-project</artifactId>
+    <packaging>pom</packaging>
 
-  <groupId>io.helidon.serviceconfiguration</groupId>
-  <artifactId>helidon-serviceconfiguration-project</artifactId>
-  <packaging>pom</packaging>
+    <name>Helidon Service Configuration Framework</name>
 
-  <name>Helidon Service Configuration Framework Projects</name>
-  <description>Helidon Service Configuration Framework Projects</description>
-  
-  <parent>
-    <groupId>io.helidon.integrations</groupId>
-    <artifactId>helidon-integrations-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-api</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-config-source</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
-        <version>${project.version}</version>
-        <type>jar</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  
-  <modules>
-    <module>serviceconfiguration-api</module>
-    <module>serviceconfiguration-config-source</module>
-    <module>serviceconfiguration-hikaricp</module>
-    <module>serviceconfiguration-hikaricp-accs</module>
-    <module>serviceconfiguration-hikaricp-localhost</module>
-    <module>serviceconfiguration-system-kubernetes</module>
-    <module>serviceconfiguration-system-oracle-accs</module>
-  </modules>
-  
+    <modules>
+        <module>serviceconfiguration-api</module>
+        <module>serviceconfiguration-config-source</module>
+        <module>serviceconfiguration-hikaricp</module>
+        <module>serviceconfiguration-hikaricp-accs</module>
+        <module>serviceconfiguration-hikaricp-localhost</module>
+        <module>serviceconfiguration-system-kubernetes</module>
+        <module>serviceconfiguration-system-oracle-accs</module>
+    </modules>
 </project>

--- a/integrations/serviceconfiguration/serviceconfiguration-api/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-api/pom.xml
@@ -20,17 +20,12 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
-  <artifactId>helidon-serviceconfiguration-api</artifactId>
-
-  <name>Helidon Service Configuration API</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-api</artifactId>
+    <name>Helidon Service Configuration API</name>
 </project>

--- a/integrations/serviceconfiguration/serviceconfiguration-config-source/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-config-source/pom.xml
@@ -20,30 +20,26 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-config-source</artifactId>
+    <name>Helidon Service Configuration ConfigSource</name>
 
-  <artifactId>helidon-serviceconfiguration-config-source</artifactId>
-
-  <name>Helidon Service Configuration ConfigSource</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-
-  <dependencies>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
@@ -17,52 +17,46 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
+    <name>Helidon ServiceConfiguration HikariCP ACCS</name>
+    <description>
+        Helidon HikariCP ServiceConfiguration Implementation for Application Container Cloud Service
+    </description>
 
-  <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-
-  <name>Helidon HikariCP ServiceConfiguration Implementation for Application Container Cloud Service</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.oracle.jdbc</groupId>
-      <artifactId>ojdbc8</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>
-

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-localhost/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-localhost/pom.xml
@@ -20,38 +20,32 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
+    <name>Helidon ServiceConfiguration HikariCP Localhost</name>
+    <description>Helidon HikariCP ServiceConfiguration Implementation for Local Testing</description>
 
-  <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-
-  <name>Helidon HikariCP ServiceConfiguration Implementation for Local Testing</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>
-

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp/pom.xml
@@ -20,38 +20,32 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+    <name>Helidon ServiceConfiguration HikariCP Implementation</name>
 
-  <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-
-  <name>Helidon HikariCP ServiceConfiguration Implementation</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>
 

--- a/integrations/serviceconfiguration/serviceconfiguration-system-kubernetes/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-system-kubernetes/pom.xml
@@ -20,32 +20,26 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
+    <name>Helidon Kubernetes System Implementation</name>
 
-  <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
-
-  <name>Helidon Kubernetes System Implementation</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>
-

--- a/integrations/serviceconfiguration/serviceconfiguration-system-oracle-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-system-oracle-accs/pom.xml
@@ -20,26 +20,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>0.10.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
+    <name>Helidon Oracle ACCS System Implementation</name>
 
-  <artifactId>helidon-serviceconfiguration-system-oracle-accs</artifactId>
-
-  <name>Helidon Oracle ACCS System Implementation</name>
-  <description>${project.name}</description>
-
-  <parent>
-    <groupId>io.helidon.serviceconfiguration</groupId>
-    <artifactId>helidon-serviceconfiguration-project</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
-  </parent>
-  
-  <dependencies>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>helidon-serviceconfiguration-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.serviceconfiguration</groupId>
+            <artifactId>helidon-serviceconfiguration-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>
-

--- a/microprofile/oidc/pom.xml
+++ b/microprofile/oidc/pom.xml
@@ -27,7 +27,7 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-oidc</artifactId>
-    <name>Helidon Microprofile Security integration with OIDC</name>
+    <name>Helidon Microprofile Security OIDC Integration</name>
 
     <description>
         Integration with Open ID Connect (OIDC)

--- a/microprofile/security/pom.xml
+++ b/microprofile/security/pom.xml
@@ -27,7 +27,7 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-microprofile-security</artifactId>
-    <name>Helidon Microprofile Security integration</name>
+    <name>Helidon Microprofile Security Integration</name>
 
     <description>
         Integration with Helidon Security

--- a/security/examples/jersey/pom.xml
+++ b/security/examples/jersey/pom.xml
@@ -27,7 +27,7 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-examples-jersey</artifactId>
-    <name>Helidon Security Examples Jersey integration</name>
+    <name>Helidon Security Examples Jersey Integration</name>
 
     <description>
         Integration of security with Jersey, shows how to use configuration based approach, builder approach, and programmatic

--- a/security/examples/outbound-override/pom.xml
+++ b/security/examples/outbound-override/pom.xml
@@ -26,8 +26,8 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-security-examples-outbound-override</artifactId>
+    <name>Helidon Security Examples Outbound Override</name>
 
     <dependencies>
         <dependency>

--- a/security/examples/spi-examples/pom.xml
+++ b/security/examples/spi-examples/pom.xml
@@ -27,7 +27,7 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-security-examples-spi</artifactId>
-    <name>Helidon Security Examples SPI implementation</name>
+    <name>Helidon Security Examples SPI Implementation</name>
 
     <description>
         Example of implementation of custom providers and other SPI implementations

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -24,8 +24,8 @@
         <version>0.10.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>helidon-security-provider-oidc-common</artifactId>
+    <name>Helidon Security Providers OIDC Common</name>
 
     <dependencies>
         <dependency>

--- a/security/tools/secure-config/pom.xml
+++ b/security/tools/secure-config/pom.xml
@@ -27,7 +27,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>helidon-security-tools-config</artifactId>
-    <name>Helidon Security Tools: Secured config</name>
+    <name>Helidon Security Tools Secured Config</name>
 
     <description>
         Configuration filter checking property values and decrypting them if needed. Also provides tools to encrypt values to


### PR DESCRIPTION
…amples, guide modules

Also updated a few more poms from security and microprofile.

- Use 4 space per ident
- Align order to the one used in every other module
- Update name to fit the reactor size
- Remove dependency management for helidon artifacts (we use project.version)
- Cleanup various white spaces