### PR TITLE
Zipkin support no longer requires jersey in module-info.java.

### DIFF
--- a/webserver/zipkin/pom.xml
+++ b/webserver/zipkin/pom.xml
@@ -42,6 +42,7 @@
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
@@ -51,11 +52,6 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
-        </dependency>
-        <dependency>
-            <!-- needed for correct module name -->
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
@@ -70,6 +66,12 @@
                     <artifactId>brave-tests</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- needed for correct module name -->
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/webserver/zipkin/src/main/java9/module-info.java
+++ b/webserver/zipkin/src/main/java9/module-info.java
@@ -20,21 +20,23 @@
 module io.helidon.webserver.zipkin {
     requires io.helidon.webserver;
     requires io.helidon.common;
-    requires opentracing.api;
-    requires jersey.client;
-    requires jersey.server;
-    requires jersey.common;
+    requires transitive opentracing.api;
 
     requires java.logging;
-    requires java.ws.rs;
     requires opentracing.util;
     requires java.annotation;
-    requires javax.inject;
     requires brave.opentracing;
     requires zipkin2.reporter;
     requires zipkin2.reporter.urlconnection;
     requires zipkin2;
     requires brave;
+
+    // Support for injection and outbound context propagation
+    requires static javax.inject;
+    requires static jersey.client;
+    requires static jersey.server;
+    requires static jersey.common;
+    requires static java.ws.rs;
 
     exports io.helidon.webserver.opentracing;
     exports io.helidon.webserver.zipkin;


### PR DESCRIPTION
Other fixes to dependency tree.
Fixes #115