### PR TITLE
Special handling for "/" during service registration

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathPattern.java
@@ -316,7 +316,7 @@ final class PathPattern {
             Objects.requireNonNull(path, "Parameter 'path' is null!");
             String s = path.toString();
             if (s.startsWith(pattern)) {
-                String rightPart = s.substring(pattern.length());
+                String rightPart = pattern.equals("/") ? s : s.substring(pattern.length());
                 if (rightPart.isEmpty()) {
                     rightPart = "/";
                 }
@@ -471,6 +471,24 @@ final class PathPattern {
         @Override
         public String remainingPart() {
             return rightPart;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PositiveResult that = (PositiveResult) o;
+            return Objects.equals(params, that.params)
+                    && Objects.equals(rightPart, that.rightPart);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(params, rightPart);
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/CanonicalPathMatcherTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/CanonicalPathMatcherTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Class CanonicalPathMatcherTest.
+ */
+public class CanonicalPathMatcherTest {
+
+    @Test
+    public void testLeadingSlashMatching() {
+        PathPattern.CanonicalPathMatcher matcher = new PathPattern.CanonicalPathMatcher("/");
+        assertEquals(new PathPattern.PositiveResult(null, "/greet/me"),
+                     matcher.prefixMatch("/greet/me"));
+    }
+}


### PR DESCRIPTION
See example in Issue #165. Special processing is required when matching "/" at service level.