### PR TITLE
Small memory improvement

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
@@ -199,7 +199,8 @@ public class FaultToleranceCommand extends HystrixCommand<Object> {
 
             // Update waiting time histogram
             if (introspector.isAsynchronous() && queuedNanos != -1L) {
-                FaultToleranceMetrics.getHistogram(introspector.getMethod(), FaultToleranceMetrics.BULKHEAD_WAITING_DURATION)
+                FaultToleranceMetrics.getHistogram(introspector.getMethod(),
+                                                   FaultToleranceMetrics.BULKHEAD_WAITING_DURATION)
                                      .update(System.nanoTime() - queuedNanos);
             }
         }


### PR DESCRIPTION
Small memory improvement that discards data associated with a command when it is being reset. If the circuit breaker is used again, the data will be re-created instead.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>