### PR TITLE
Use nanos instead of millis to compute jitter factor

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandRetrier.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandRetrier.java
@@ -84,8 +84,8 @@ public class CommandRetrier {
 
             // Processing for jitter and delay
             if (retry.jitter() > 0) {
-                long delay = TimeUtil.convertToMillis(retry.delay(), retry.delayUnit());
-                long jitter = TimeUtil.convertToMillis(retry.jitter(), retry.jitterDelayUnit());
+                long delay = TimeUtil.convertToNanos(retry.delay(), retry.delayUnit());
+                long jitter = TimeUtil.convertToNanos(retry.jitter(), retry.jitterDelayUnit());
 
                 /*
                  * We need jitter <= delay so we compute factor for Failsafe so we split
@@ -100,7 +100,7 @@ public class CommandRetrier {
                 } else {
                     factor = ((double) jitter) / delay;
                 }
-                this.retryPolicy.withDelay(delay, TimeUnit.MILLISECONDS);
+                this.retryPolicy.withDelay(delay, TimeUnit.NANOSECONDS);
                 this.retryPolicy.withJitter(factor);
             } else if (retry.delay() > 0) {
                 this.retryPolicy.withDelay(retry.delay(), TimeUtil.chronoUnitToTimeUnit(retry.delayUnit()));

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeUtil.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeUtil.java
@@ -95,6 +95,18 @@ public class TimeUtil {
         return TimeUnit.MILLISECONDS.convert(duration, timeUnit);
     }
 
+    /**
+     * Converts a duration and its chrono unit to nanos.
+     *
+     * @param duration The duration.
+     * @param chronoUnit The unit of the duration.
+     * @return Nanoseconds.
+     */
+    public static long convertToNanos(long duration, ChronoUnit chronoUnit) {
+        final TimeUnit timeUnit = chronoUnitToTimeUnit(chronoUnit);
+        return TimeUnit.NANOSECONDS.convert(duration, timeUnit);
+    }
+
     private TimeUtil() {
     }
 }


### PR DESCRIPTION
Using millis may result in rounding errors if user specifies nanos or micros.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>