### PR TITLE
Corrected the 'java -version' command in the quickstart guides

### DIFF
--- a/docs/src/main/docs/getting-started/01_prerequisites.adoc
+++ b/docs/src/main/docs/getting-started/01_prerequisites.adoc
@@ -44,7 +44,7 @@ The following list shows the minimum versions.
 [source,bash]
 .Verify Prerequisites
 ----
-java --version
+java -version
 mvn --version
 docker --version
 kubectl version --short

--- a/examples/helidon-quickstart-mp/README.md
+++ b/examples/helidon-quickstart-mp/README.md
@@ -14,7 +14,7 @@ This example implements a simple Hello World REST service using MicroProfile
 
 Verify prerequisites
 ```
-java --version
+java -version
 mvn --version
 docker --version
 minikube version

--- a/examples/helidon-quickstart-se/README.md
+++ b/examples/helidon-quickstart-se/README.md
@@ -13,7 +13,7 @@ This example implements a simple Hello World REST service.
 
 Verify prerequisites
 ```
-java --version
+java -version
 mvn --version
 docker --version
 minikube version


### PR DESCRIPTION
The existing command 'java --version' returns an error in JDK 8.

Confirmed by @romain-grecourt and @tjquinno .