### PR TITLE
WIP: Fixes #242 by eliminating raw type usage of Routing.Rules.

### DIFF
--- a/examples/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -56,7 +56,7 @@ public class GreetService implements Service {
      * @param rules the routing rules.
      */
     @Override
-    public void update(Routing.Rules rules) {
+    public void update(Routing.Rules<?> rules) {
         rules
             .get("/", this::getDefaultMessage)
             .get("/{name}", this::getMessage)

--- a/microprofile/metrics/metrics-se/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/microprofile/metrics/metrics-se/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -274,7 +274,7 @@ public final class MetricsSupport implements Service {
     }
 
     @Override
-    public void update(Routing.Rules rules) {
+    public void update(Routing.Rules<?> rules) {
         // register the metric registry and factory to be available to all
         rules.any((req, res) -> {
             req.context().register(app);

--- a/security/integration/webserver/src/main/java/io/helidon/security/webserver/WebSecurity.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/webserver/WebSecurity.java
@@ -317,7 +317,7 @@ public final class WebSecurity implements Service {
     }
 
     @Override
-    public void update(Routing.Rules routing) {
+    public void update(Routing.Rules<?> routing) {
         routing.any(this::registerContext);
 
         if (null != config) {

--- a/security/providers/oidc-provider/src/main/java/io/helidon/security/oidc/OidcSupport.java
+++ b/security/providers/oidc-provider/src/main/java/io/helidon/security/oidc/OidcSupport.java
@@ -96,7 +96,7 @@ public final class OidcSupport implements Service {
     }
 
     @Override
-    public void update(Routing.Rules rules) {
+    public void update(Routing.Rules<?> rules) {
         rules.get(oidcConfig.redirectUri(), (req, res) -> {
             // redirected from IDCS
             Optional<String> codeParam = req.queryParams().first(CODE_PARAM_NAME);

--- a/webserver/examples/basics/src/main/java/io/helidon/webserver/examples/basics/Catalog.java
+++ b/webserver/examples/basics/src/main/java/io/helidon/webserver/examples/basics/Catalog.java
@@ -27,7 +27,7 @@ import io.helidon.webserver.Service;
 public class Catalog implements Service {
 
     @Override
-    public void update(Routing.Rules rules) {
+    public void update(Routing.Rules<?> rules) {
         rules.get("/", this::list)
              .get("/{id}", (req, res) -> getSingle(res, req.path().param("id")));
     }

--- a/webserver/examples/comment-aas/src/main/java/io/helidon/webserver/examples/comments/CommentsService.java
+++ b/webserver/examples/comment-aas/src/main/java/io/helidon/webserver/examples/comments/CommentsService.java
@@ -37,7 +37,7 @@ public class CommentsService implements Service {
     private final ConcurrentHashMap<String, List<Comment>> topicsAndComments = new ConcurrentHashMap<>();
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules
                 .get("/{topic}", this::handleListComments)
                 .post("/{topic}", this::handleAddComment);

--- a/webserver/examples/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
+++ b/webserver/examples/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
@@ -37,7 +37,7 @@ public class CounterService implements Service {
     private final AtomicInteger apiAccessCounter = new AtomicInteger();
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.any(this::handleAny)
                     .register("/api", JsonSupport.get())
                     .get("/api/counter", this::handleGet);

--- a/webserver/examples/streaming/src/main/java/io/helidon/webserver/examples/streaming/StreamingService.java
+++ b/webserver/examples/streaming/src/main/java/io/helidon/webserver/examples/streaming/StreamingService.java
@@ -46,7 +46,7 @@ public class StreamingService implements Service {
     }
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.get("/download", this::download)
                 .post("/upload", this::upload);
     }

--- a/webserver/examples/tutorial/src/main/java/io/helidon/webserver/examples/tutorial/CommentService.java
+++ b/webserver/examples/tutorial/src/main/java/io/helidon/webserver/examples/tutorial/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService implements Service {
     private final ConcurrentHashMap<String, List<Comment>> data = new ConcurrentHashMap<>();
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.get((req, res) -> {
                     // Register a publisher for comment
                     res.registerWriter(List.class, MediaType.TEXT_PLAIN.withCharset("UTF-8"), this::publish);

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -115,7 +115,7 @@ public class JerseySupport implements Service {
     }
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.any(handler);
     }
 

--- a/webserver/json/src/main/java/io/helidon/webserver/json/JsonSupport.java
+++ b/webserver/json/src/main/java/io/helidon/webserver/json/JsonSupport.java
@@ -122,7 +122,7 @@ public final class JsonSupport implements Service, Handler {
      * @see Routing
      */
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.any(this);
     }
 

--- a/webserver/prometheus/src/main/java/io/helidon/webserver/prometheus/PrometheusSupport.java
+++ b/webserver/prometheus/src/main/java/io/helidon/webserver/prometheus/PrometheusSupport.java
@@ -59,7 +59,7 @@ public final class PrometheusSupport implements Service {
     }
 
     @Override
-    public void update(Routing.Rules rules) {
+    public void update(Routing.Rules<?> rules) {
         rules.get(path, this::process);
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
@@ -77,7 +77,7 @@ public interface Routing {
      *
      * @see Builder
      */
-    interface Rules<T extends Rules> {
+    interface Rules<T extends Rules<T>> {
 
         /**
          * Registers builder consumer. It enables to separate complex routing definitions to dedicated classes.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Service.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Service.java
@@ -30,5 +30,5 @@ public interface Service {
      *
      * @param rules a routing rules to update
      */
-    void update(Routing.Rules rules);
+    void update(Routing.Rules<?> rules);
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
@@ -53,7 +53,7 @@ public class StaticContentSupport implements Service {
     }
 
     @Override
-    public void update(Routing.Rules routing) {
+    public void update(Routing.Rules<?> routing) {
         routing.onNewWebServer(new Consumer<WebServer>() {
             @Override
             public void accept(WebServer ws) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
@@ -123,7 +123,7 @@ public class RoutingTest {
     static class UserService implements Service {
 
         @Override
-        public void update(Routing.Rules routingRules) {
+        public void update(Routing.Rules<?> routingRules) {
             routingRules.get("{userName}", this::getUser)
                         .post(this::createUser);
         }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/UserManagementService.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/UserManagementService.java
@@ -21,7 +21,7 @@ package io.helidon.webserver;
 public class UserManagementService implements Service {
 
     @Override
-    public void update(Routing.Rules routingRules) {
+    public void update(Routing.Rules<?> routingRules) {
         routingRules.get("/{name}", this::getUser)
                     .post("/", this::setUser);
     }


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

There are two main components to this change, which fixes #242:
1. `Routing.Rules` has been defined to be `Routing.Rules<T extends Routing.Rules<T>>`.
2. All _usages_ of `Routing.Rules` as a raw type have been replaced with `Routing.Rules<?>`.

**This is an alternative to #248.  Only one of these two PRs (if any) should be merged.**

`mvn clean install` passes on my laptop from the root.