### PR TITLE
Fixes #242 by removing type parameter from Routing.Rules

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/RouteListRoutingRules.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RouteListRoutingRules.java
@@ -30,7 +30,7 @@ import io.helidon.common.http.Http;
 /**
  * A {@link Routing.Rules} implementation collecting all routings into single {@link RouteList}.
  */
-class RouteListRoutingRules implements Routing.Rules<RouteListRoutingRules> {
+class RouteListRoutingRules implements Routing.Rules {
 
     private final List<Record> records = new ArrayList<>();
     private final List<Consumer<WebServer>> newWebServerCallbacks = new ArrayList<>();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Routing.java
@@ -73,11 +73,9 @@ public interface Routing {
     /**
      * An API to define HTTP request routing rules.
      *
-     * @param <T> the type to be returned by the subclasses (to support fluent API style)
-     *
      * @see Builder
      */
-    interface Rules<T extends Rules> {
+    interface Rules {
 
         /**
          * Registers builder consumer. It enables to separate complex routing definitions to dedicated classes.
@@ -85,7 +83,7 @@ public interface Routing {
          * @param services services to register
          * @return Updated routing configuration
          */
-        T register(Service... services);
+        Rules register(Service... services);
 
         /**
          * Registers builder consumer. It enables to separate complex routing definitions to dedicated classes.
@@ -94,7 +92,7 @@ public interface Routing {
          *                        method execution
          * @return Updated routing configuration
          */
-        T register(io.helidon.common.Builder<? extends Service>... serviceBuilders);
+        Rules register(io.helidon.common.Builder<? extends Service>... serviceBuilders);
 
         /**
          * Registers builder consumer. It enables to separate complex routing definitions to dedicated classes.
@@ -103,7 +101,7 @@ public interface Routing {
          * @param services    services to register
          * @return Updated routing configuration
          */
-        T register(String pathPattern, Service... services);
+        Rules register(String pathPattern, Service... services);
 
         /**
          * Registers builder consumer. It enables to separate complex routing definitions to dedicated classes.
@@ -113,7 +111,7 @@ public interface Routing {
          *                        method execution
          * @return an updated routing configuration
          */
-        T register(String pathPattern, io.helidon.common.Builder<? extends Service>... serviceBuilders);
+        Rules register(String pathPattern, io.helidon.common.Builder<? extends Service>... serviceBuilders);
 
         /**
          * Routes all GET requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -122,7 +120,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T get(Handler... requestHandlers);
+        Rules get(Handler... requestHandlers);
 
         /**
          * Routes GET requests with corresponding path to provided handler(s). Request handler can call
@@ -132,7 +130,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T get(String pathPattern, Handler... requestHandlers);
+        Rules get(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes GET requests with corresponding path to provided handler(s). Request handler can call
@@ -142,7 +140,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T get(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules get(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all PUT requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -151,7 +149,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T put(Handler... requestHandlers);
+        Rules put(Handler... requestHandlers);
 
         /**
          * Routes PUT requests with corresponding path to provided handler(s). Request handler can call
@@ -161,7 +159,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T put(String pathPattern, Handler... requestHandlers);
+        Rules put(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes PUT requests with corresponding path to provided handler(s). Request handler can call
@@ -171,7 +169,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T put(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules put(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all POST requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -180,7 +178,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T post(Handler... requestHandlers);
+        Rules post(Handler... requestHandlers);
 
         /**
          * Routes POST requests with corresponding path to provided handler(s). Request handler can call
@@ -190,7 +188,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T post(String pathPattern, Handler... requestHandlers);
+        Rules post(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes POST requests with corresponding path to provided handler(s). Request handler can call
@@ -200,7 +198,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T post(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules post(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all DELETE requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -209,7 +207,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T delete(Handler... requestHandlers);
+        Rules delete(Handler... requestHandlers);
 
         /**
          * Routes DELETE requests with corresponding path to provided handler(s). Request handler can call
@@ -219,7 +217,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T delete(String pathPattern, Handler... requestHandlers);
+        Rules delete(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes DELETE requests with corresponding path to provided handler(s). Request handler can call
@@ -229,7 +227,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T delete(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules delete(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all OPTIONS requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -238,7 +236,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T options(Handler... requestHandlers);
+        Rules options(Handler... requestHandlers);
 
         /**
          * Routes OPTIONS requests with corresponding path to provided handler(s). Request handler can call
@@ -248,7 +246,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T options(String pathPattern, Handler... requestHandlers);
+        Rules options(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes OPTIONS requests with corresponding path to provided handler(s). Request handler can call
@@ -258,7 +256,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T options(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules options(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all HEAD requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -267,7 +265,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T head(Handler... requestHandlers);
+        Rules head(Handler... requestHandlers);
 
         /**
          * Routes HEAD requests with corresponding path to provided handler(s). Request handler can call
@@ -277,7 +275,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T head(String pathPattern, Handler... requestHandlers);
+        Rules head(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes HEAD requests with corresponding path to provided handler(s). Request handler can call
@@ -287,7 +285,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T head(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules head(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all TRACE requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -296,7 +294,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T trace(Handler... requestHandlers);
+        Rules trace(Handler... requestHandlers);
 
         /**
          * Routes TRACE requests with corresponding path to provided handler(s). Request handler can call
@@ -306,7 +304,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T trace(String pathPattern, Handler... requestHandlers);
+        Rules trace(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes TRACE requests with corresponding path to provided handler(s). Request handler can call
@@ -316,7 +314,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T trace(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules trace(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes all requests to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -325,7 +323,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T any(Handler... requestHandlers);
+        Rules any(Handler... requestHandlers);
 
         /**
          * Routes all requests with corresponding path to provided handler(s). Request handler can call
@@ -335,7 +333,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T any(String pathPattern, Handler... requestHandlers);
+        Rules any(String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes all requests with corresponding path to provided handler(s). Request handler can call
@@ -345,7 +343,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T any(PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules any(PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Routes requests any specified method to provided handler(s). Request handler can call {@link ServerRequest#next()}
@@ -355,7 +353,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T anyOf(Iterable<Http.RequestMethod> methods, Handler... requestHandlers);
+        Rules anyOf(Iterable<Http.RequestMethod> methods, Handler... requestHandlers);
 
         /**
          * Routes requests with any specified method and corresponding path to provided handler(s). Request handler can call
@@ -366,7 +364,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T anyOf(Iterable<Http.RequestMethod> methods, String pathPattern, Handler... requestHandlers);
+        Rules anyOf(Iterable<Http.RequestMethod> methods, String pathPattern, Handler... requestHandlers);
 
         /**
          * Routes requests with any specified method and corresponding path to provided handler(s). Request handler can call
@@ -377,7 +375,7 @@ public interface Routing {
          * @param requestHandlers handlers to tryProcess HTTP request
          * @return an updated routing configuration
          */
-        T anyOf(Iterable<Http.RequestMethod> methods, PathMatcher pathMatcher, Handler... requestHandlers);
+        Rules anyOf(Iterable<Http.RequestMethod> methods, PathMatcher pathMatcher, Handler... requestHandlers);
 
         /**
          * Registers callback on created new {@link WebServer} instance with this routing.
@@ -385,13 +383,13 @@ public interface Routing {
          * @param webServerConsumer a WebServer creation callback
          * @return updated routing configuration
          */
-        T onNewWebServer(Consumer<WebServer> webServerConsumer);
+        Rules onNewWebServer(Consumer<WebServer> webServerConsumer);
     }
 
     /**
      * A {@link Routing} builder.
      */
-    class Builder implements Rules<Builder>, io.helidon.common.Builder<Routing> {
+    class Builder implements Rules, io.helidon.common.Builder<Routing> {
 
         private final RouteListRoutingRules delegate = new RouteListRoutingRules();
         private final List<RequestRouting.ErrorHandlerRecord<?>> errorHandlerRecords = new ArrayList<>();


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

This PR fixes #242 by removing the type parameter from `Routing.Rules` altogether.