### PR TITLE
Guard TCKs with a 'tck' profile 

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -47,6 +47,6 @@ inject_credentials
 
 mvn -f ${WS_DIR}/pom.xml \
     clean install \
-    -Pexamples,integrations,spotbugs,javadoc,docs,sources,ossrh-releases
+    -Pexamples,integrations,spotbugs,javadoc,docs,sources,ossrh-releases,tck
 
 examples/archetypes/test-archetypes.sh

--- a/microprofile/tests/pom.xml
+++ b/microprofile/tests/pom.xml
@@ -40,6 +40,14 @@
 
     <modules>
         <module>arquillian</module>
-        <module>tck</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>tck</id>
+            <modules>
+                <module>tck</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Guard TCKs with a 'tck' profile to avoid running them during a normal. Updated build.sh to active 'tck' in our pipelines.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>