### PR TITLE
Dev guidelines - Using Supplier instead of Builder in

### DIFF
--- a/examples/security/attribute-based-access-control/src/main/java/io/helidon/security/examples/abac/AbacJerseyMain.java
+++ b/examples/security/attribute-based-access-control/src/main/java/io/helidon/security/examples/abac/AbacJerseyMain.java
@@ -19,6 +19,7 @@ package io.helidon.security.examples.abac;
 import java.time.DayOfWeek;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -26,7 +27,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import io.helidon.common.Builder;
 import io.helidon.security.AuthorizationResponse;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
@@ -68,7 +68,7 @@ public final class AbacJerseyMain {
         server = startIt(routing);
     }
 
-    static WebServer startIt(Builder<? extends Routing> routing) {
+    static WebServer startIt(Supplier<? extends Routing> routing) {
         WebServer server = WebServer.create(routing);
 
         long t = System.nanoTime();

--- a/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsUtil.java
+++ b/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsUtil.java
@@ -20,8 +20,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
-import io.helidon.common.Builder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerConfiguration;
 import io.helidon.webserver.WebServer;
@@ -38,7 +38,7 @@ public class IdcsUtil {
     private IdcsUtil() {
     }
 
-    static WebServer startIt(Builder<? extends Routing> routing) throws UnknownHostException {
+    static WebServer startIt(Supplier<? extends Routing> routing) throws UnknownHostException {
         WebServer server = WebServer.create(ServerConfiguration.builder()
                                                     .port(PORT)
                                                     .bindAddress(InetAddress.getByName("localhost")),

--- a/examples/security/jersey/src/main/java/io/helidon/security/examples/jersey/JerseyUtil.java
+++ b/examples/security/jersey/src/main/java/io/helidon/security/examples/jersey/JerseyUtil.java
@@ -19,8 +19,8 @@ package io.helidon.security.examples.jersey;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
-import io.helidon.common.Builder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 
@@ -33,7 +33,7 @@ class JerseyUtil {
     private JerseyUtil() {
     }
 
-    static WebServer startIt(Builder<? extends Routing> routing) {
+    static WebServer startIt(Supplier<? extends Routing> routing) {
         WebServer server = WebServer.create(routing);
 
         long t = System.nanoTime();

--- a/security/security/src/main/java/io/helidon/security/SecurityContext.java
+++ b/security/security/src/main/java/io/helidon/security/SecurityContext.java
@@ -271,8 +271,8 @@ public interface SecurityContext {
      * @see SecurityEnvironment#derive()
      * @see SecurityEnvironment#builder(SecurityTime)
      */
-    default void env(io.helidon.common.Builder<SecurityEnvironment> envBuilder) {
-        env(envBuilder.build());
+    default void env(Supplier<SecurityEnvironment> envBuilder) {
+        env(envBuilder.get());
     }
 
     /**
@@ -303,8 +303,8 @@ public interface SecurityContext {
      *
      * @param epBuilder builder of an endpoint configuration
      */
-    default void endpointConfig(io.helidon.common.Builder<EndpointConfig> epBuilder) {
-        endpointConfig(epBuilder.build());
+    default void endpointConfig(Supplier<EndpointConfig> epBuilder) {
+        endpointConfig(epBuilder.get());
     }
 
     /**

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
@@ -29,8 +29,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
-import io.helidon.common.Builder;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.ReadOnlyParameters;
@@ -76,9 +76,9 @@ public class TestClient {
      * @return new instance
      * @throws NullPointerException if routing parameter is null
      */
-    public static TestClient create(Builder<Routing> routingBuilder) {
+    public static TestClient create(Supplier<Routing> routingBuilder) {
         Objects.requireNonNull(routingBuilder, "Parameter 'routingBuilder' must not be null!");
-        return create(routingBuilder.build());
+        return create(routingBuilder.get());
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -116,8 +116,8 @@ public interface WebServer {
      * @throws IllegalStateException if none SPI implementation found
      * @throws NullPointerException if 'routing' parameter is {@code null}
      */
-    static WebServer create(io.helidon.common.Builder<? extends ServerConfiguration> configurationBuilder, Routing routing) {
-        return create(configurationBuilder != null ? configurationBuilder.build() : null, routing);
+    static WebServer create(Supplier<? extends ServerConfiguration> configurationBuilder, Routing routing) {
+        return create(configurationBuilder != null ? configurationBuilder.get() : null, routing);
     }
 
     /**
@@ -130,10 +130,10 @@ public interface WebServer {
      * @throws IllegalStateException if none SPI implementation found
      * @throws NullPointerException  if 'routingBuilder' parameter is {@code null}
      */
-    static WebServer create(io.helidon.common.Builder<? extends ServerConfiguration> configurationBuilder,
-                            io.helidon.common.Builder<? extends Routing> routingBuilder) {
+    static WebServer create(Supplier<? extends ServerConfiguration> configurationBuilder,
+                            Supplier<? extends Routing> routingBuilder) {
         Objects.requireNonNull(routingBuilder, "Parameter 'routingBuilder' must not be null!");
-        return create(configurationBuilder != null ? configurationBuilder.build() : null, routingBuilder.build());
+        return create(configurationBuilder != null ? configurationBuilder.get() : null, routingBuilder.get());
     }
 
     /**
@@ -146,9 +146,9 @@ public interface WebServer {
      * @throws NullPointerException  if 'routingBuilder' parameter is {@code null}
      */
     static WebServer create(ServerConfiguration configuration,
-                            io.helidon.common.Builder<? extends Routing> routingBuilder) {
+                            Supplier<? extends Routing> routingBuilder) {
         Objects.requireNonNull(routingBuilder, "Parameter 'routingBuilder' must not be null!");
-        return create(configuration, routingBuilder.build());
+        return create(configuration, routingBuilder.get());
     }
 
     /**
@@ -188,9 +188,9 @@ public interface WebServer {
      * @throws IllegalStateException if none SPI implementation found
      * @throws NullPointerException  if 'routing' parameter is {@code null}
      */
-    static WebServer create(io.helidon.common.Builder<? extends Routing> routingBuilder) {
+    static WebServer create(Supplier<? extends Routing> routingBuilder) {
         Objects.requireNonNull(routingBuilder, "Parameter 'routingBuilder' must not be null!");
-        return create(routingBuilder.build());
+        return create(routingBuilder.get());
     }
 
     /**
@@ -199,9 +199,9 @@ public interface WebServer {
      * @param routingBuilder the routing builder; must not be {@code null}
      * @return the builder
      */
-    static Builder builder(io.helidon.common.Builder<? extends Routing> routingBuilder) {
+    static Builder builder(Supplier<? extends Routing> routingBuilder) {
         Objects.requireNonNull(routingBuilder, "Parameter 'routingBuilder' must not be null!");
-        return builder(routingBuilder.build());
+        return builder(routingBuilder.get());
     }
 
     /**


### PR DESCRIPTION
builder methods.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Missed cases where Builder was used as a parameter to another builder. Now using Supplier as intended.