### PR TITLE
Fixing copyright errors

### DIFF
--- a/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/java/io/helidon/integrations/examples/datasource/hikaricp/jaxrs/TablesResource.java
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/java/io/helidon/integrations/examples/datasource/hikaricp/jaxrs/TablesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/java/io/helidon/integrations/examples/datasource/hikaricp/jaxrs/package-info.java
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/java/io/helidon/integrations/examples/datasource/hikaricp/jaxrs/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/resources/META-INF/beans.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/spotbugs/exclusions.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/src/main/spotbugs/exclusions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/integrations/cdi/datasource-hikaricp/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/integrations/cdi/datasource-hikaricp/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 # and
 # https://technology.amis.nl/2017/11/18/run-oracle-database-in-docker-using-prebaked-image-from-oracle-container-registry-a-two-minute-guide/
 javax.sql.DataSource.example.dataSourceClassName=oracle.jdbc.pool.OracleDataSource
-javax.sql.DataSource.example.dataSource.url = jdbc:oracle:thin:@oracle:1521:ORCL
+javax.sql.DataSource.example.dataSource.url = jdbc:oracle:thin:@localhost:1521:ORCL
 javax.sql.DataSource.example.dataSource.user = sys as sysoper
 javax.sql.DataSource.example.dataSource.password = Oracle
 

--- a/examples/integrations/cdi/pom.xml
+++ b/examples/integrations/cdi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

Fixing copyright errors.  Wercker did not catch these on my prior PR (#284) for some reason.  Build passes locally with `checkstyle` and `copyright` profiles activated.

Reference: https://app.wercker.com/Helidon/helidon/runs/copyright/5c3698e0a42c40001824ad25?step=5c3698fd63e9460007589d27