### PR TITLE
Ensure proper path encoding with Jersey

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package io.helidon.webserver.jersey;
 
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Map;
@@ -121,8 +123,9 @@ public class JerseySupport implements Service {
 
     private static URI requestUri(ServerRequest req) {
         try {
-            URI partialUri = new URI(req.isSecure() ? "https" : "http", null, req.localAddress(),
-                                     req.localPort(), req.path().absolute().toString(), null, null);
+            // Creating a URI from a URL avoids re-encoding of characters like '%'
+            URI partialUri = new URL(req.isSecure() ? "https" : "http", req.localAddress(),
+                                     req.localPort(), req.path().absolute().toString()).toURI();
             StringBuilder sb = new StringBuilder(partialUri.toString());
             if (req.uri().toString().endsWith("/") && sb.charAt(sb.length() - 1) != '/') {
                 sb.append('/');
@@ -138,7 +141,7 @@ public class JerseySupport implements Service {
                   .append(req.fragment());
             }
             return new URI(sb.toString());
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | MalformedURLException e) {
             throw new IllegalStateException("Unable to create a request URI from the request info.", e);
         }
     }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,7 +175,6 @@ public class JerseyExampleResource {
         return Response.accepted(content).build();
     }
 
-
     @GET
     @Path("query")
     public Response query(@QueryParam("a") String a, @QueryParam("b") String b) {
@@ -192,5 +191,17 @@ public class JerseyExampleResource {
     @Path("requestUri")
     public String getRequestUri(@Context UriInfo uriInfo) {
         return uriInfo.getRequestUri().getPath();
+    }
+
+    @GET
+    @Path("encoding/{id}")
+    public String pathEncoding1(@PathParam("id") String param) {
+        return param;
+    }
+
+    @Path("encoding/{id:[^/_]*}/done")
+    @GET
+    public String pathEncoding2(@PathParam("id") String param) {
+        return param;
     }
 }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -271,6 +271,24 @@ public class JerseySupportTest {
         inputStream.close();
 
         assertThat(s, endsWith("/requestUri"));
+    }
+
+    @Test
+    public void pathEncoding1() {
+        Response response = webTarget.path("jersey/first/encoding/abc%3F")
+                .request()
+                .get();
+
+        doAssert(response, "abc?");
+    }
+
+    @Test
+    public void pathEncoding2() {
+        Response response = webTarget.path("jersey/first/encoding/abc%3B/done")
+                .request()
+                .get();
+
+        doAssert(response, "abc;");
     }
 
     static StringBuilder longData(int bytes) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ class RequestRouting implements Routing {
                         return null;
                     });
             // Process path
-            String p = bareRequest.uri().normalize().getPath();
+            String p = bareRequest.uri().normalize().getRawPath();
             if (p.charAt(p.length() - 1) == '/') {
                 p = p.substring(0, p.length() - 1);
             }


### PR DESCRIPTION
Ensure proper path encoding. Some new tests added. See issue #150 for more information.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>