### PR TITLE
Implement RequestPredicate

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,8 @@ public class ReadOnlyParameters implements Parameters {
 
     @Override
     public Optional<String> first(String name) {
-        return Optional.ofNullable(data.get(name)).map(l -> l.get(0));
+        return Optional.ofNullable(data.get(name)).map(l ->
+                l != null && !l.isEmpty() ? l.get(0) : null);
     }
 
     @Override

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -86,7 +86,7 @@ public class ReadOnlyParameters implements Parameters {
     @Override
     public Optional<String> first(String name) {
         return Optional.ofNullable(data.get(name)).map(l ->
-                l != null && !l.isEmpty() ? l.get(0) : null);
+                !l.isEmpty() ? l.get(0) : null);
     }
 
     @Override

--- a/docs/src/main/docs/webserver/03_routing.adoc
+++ b/docs/src/main/docs/webserver/03_routing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ requests accepted by the predicate. All other requests are _nexted_, meaning tha
 [source,java]
 ----
 .post("/foo",
-      RequestPredicate.whenRequest()
+      RequestPredicate.create()
                       .containsHeader("my-gr8-header")
                       .accepts(MediaType.TEXT_PLAIN)
                       .and(this::isUserAuthenticated)

--- a/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
@@ -168,7 +168,7 @@ public class Main {
      */
     public void advancedRouting() {
         Routing routing = Routing.builder()
-                                 .get("/foo", RequestPredicate.whenRequest()
+                                 .get("/foo", RequestPredicate.create()
                                                               .accepts(MediaType.TEXT_PLAIN)
                                                               .containsHeader("bar")
                                                               .thenApply((req, res) -> res.send()))

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestHeaders.java
@@ -70,21 +70,23 @@ public interface RequestHeaders extends Headers {
     List<MediaType> acceptedTypes();
 
     /**
-     * Test if provided type is acceptable as a response for this request.
+     * Test if the given media type is acceptable as a response for this request.
+     * A media type is accepted if the {@code Accept} header is not present in the
+     * request or if it contains the provided media type.
      *
-     * @param mediaType a media type to test if it is acceptable.
-     * @return {@code true} if provided type is acceptable.
-     * @throws NullPointerException if parameter {@code mediaType} is {@code null}.
+     * @param mediaType the media type to test
+     * @return {@code true} if provided type is acceptable, {@code false} otherwise
+     * @throws NullPointerException if the provided type is {@code null}.
      */
     boolean isAccepted(MediaType mediaType);
 
     /**
-     * Optionally returns single media type from provided parameters which is best accepted by the client.
-     * Method uses content negotiation {@value io.helidon.common.http.Http.Header#ACCEPT} header parameter and returns an empty
-     * value in case
-     * that nothing match.
+     * Optionally returns a single media type from the given media types that is the
+     * best one accepted by the client.
+     * Method uses content negotiation {@value io.helidon.common.http.Http.Header#ACCEPT}
+     * header parameter and returns an empty value in case nothing matches.
      *
-     * @param mediaTypes Supported media type candidates.
+     * @param mediaTypes media type candidates.
      * @return an accepted media type.
      */
     Optional<MediaType> bestAccepted(MediaType... mediaTypes);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,216 +16,508 @@
 
 package io.helidon.webserver;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
+import io.helidon.common.http.Http.Method;
 import io.helidon.common.http.MediaType;
 
 /**
- * Fluent API to define complex request conditions. Suitable for definition of more complex routing in {@link Routing.Rules}.
- * <p>
- * Construct condition using {@link #whenRequest()} method and fluent API. Then create request handler using
- * {@link #thenApply(Handler)})} method.
+ * Fluent API to compose complex request conditions.
+ *
+ * First you start by creating a new instance with the {@link #create()} method,
+ * then you chain methods that represent a logical expression, finally you terminate
+ * with s using the {@link #thenApply(Handler) } method.
+ *
  * <h3>Examples</h3>
- * <p>Creates {@link Handler} which executes provided logic only if request contains {@code foo} header and accepts
- * {@code text/plain}. If not, then it calls {@link ServerRequest#next() req.next()}.
+ * <p>Invoke a {@link Handler} only when the request contains a header {@code foo}
+ * and accepts {@code text/plain}, otherwise return a response with {@code 404} code.
  * <pre>{@code
- * RequestPredicate.whenRequest()
+ * RequestPredicate.create()
  *                 .containsHeader("foo")
  *                 .accepts(MediaType.TEXT_PLAIN)
  *                 .thenApply((req, resp) -> {
- *                     // Some logic
+ *                     // handler logic
  *                 });
  * }</pre>
- * <p>Creates {@link Handler} which executes provided logic only if request contains {@code foo} header. If not, then it executes
- * '<i>otherwise logic</i>' which, in this case, throws a {@code RuntimeException}.
+ * <p>Invoke a {@link Handler} that is invoked only when the request contains
+ * a header {@code foo} header, otherwise invoke another handler that throws an
+ * exception.
  * <pre>{@code
- * RequestPredicate.whenRequest()
+ * RequestPredicate.create()
  *                 .containsHeader("foo")
  *                 .thenApply((req, resp) -> {
- *                     // Some logic
+ *                     // handler logic
  *                 })
  *                 .otherwise(req, resp) -> {
  *                     throw new RuntimeException("Missing 'foo' header!");
  *                 });
  * }</pre>
  */
-public interface RequestPredicate extends Predicate<ServerRequest> {
+public final class RequestPredicate {
+
+    /**
+     * An expression that returns the current value.
+     */
+    private static final Expression EMPTY_EXPR = (a, b) -> a;
+
+    /**
+     * The first predicate in the expression chain.
+     */
+    private final RequestPredicate tail;
+
+    /**
+     * The next predicate in the expression chain.
+     */
+    private RequestPredicate next;
+
+    /**
+     * The expression for this predicate.
+     */
+    private final Expression expr;
+
+    /**
+     * Create the new empty predicate.
+     */
+    private RequestPredicate(){
+        this.tail = this;
+        this.next = null;
+        this.expr = EMPTY_EXPR;
+    }
+
+    /**
+     * Create a composed predicate with the given expression.
+     * @param tail the first predicate in the chain
+     * @param expr the expression for the new predicate
+     */
+    private RequestPredicate(final RequestPredicate tail,
+            final Expression expr){
+
+        this.tail = tail;
+        this.next = null;
+        this.expr = expr;
+    }
+
+    /**
+     * Create a composed predicate and add it in the predicate chain.
+     * @param newExpr the expression for the new predicate
+     * @return the created predicate
+     */
+    private RequestPredicate nextExpr(final Expression newExpr){
+        this.next = new RequestPredicate(this.tail, newExpr);
+        return this.next;
+    }
+
+    /**
+     * Set the {@link Handler} to use when this predicate matches the request.
+     *
+     * @param handler handler to use this predicate instance matches
+     * @return instance of {@link ConditionalHandler} that can be used to
+     * specify another {@link Handler} to use when this predicates does not
+     * match the request
+     * @see {@link ConditionalHandler#otherwise(Handler) }
+     */
+    public ConditionalHandler thenApply(final Handler handler) {
+        return new ConditionalHandler(this, handler);
+    }
+
+    /**
+     * Compute the current value for this predicate.
+     * @param request the server request
+     * @return the computed value
+     */
+    public boolean test(final ServerRequest request) {
+        return eval(/* initial value */ true, this.tail, request);
+    }
+
+    /**
+     * Returns a composed predicate that represents a logical AND expression
+     * between this predicate and another predicate.
+     *
+     * @param predicate predicate to compose with
+     * @return composed predicate between the logical expression of the current
+     * predicate <b>and</b> the provided predicate
+     */
+    public RequestPredicate and(final Predicate<ServerRequest> predicate) {
+        return nextExpr((exprVal, req) -> exprVal && predicate.test(req));
+    }
+
+    /**
+     * Returns a composed predicate that represents a logical OR expression
+     * between this predicate and another predicate.
+     *
+     * @param predicate predicate that compute the new value
+     * @return composed predicate between the logical expression of the current
+     * predicate <b>or</b> the provided predicate
+     */
+    public RequestPredicate or(final Predicate<ServerRequest> predicate) {
+        return nextExpr((exprVal, req) -> exprVal || predicate.test(req));
+    }
+
+    /**
+     * Return a predicate that represents the logical negation of this predicate.
+     * @return new predicate that represents the logical negation of this predicate.
+     */
+    public RequestPredicate negate() {
+        return nextExpr((exprVal, req) -> !exprVal);
+    }
 
     /**
      * Accepts only requests with one of specified HTTP methods.
      *
-     * @param methodNames Acceptable method names.
-     * @return New enhanced instance.
+     * @param methods Acceptable method names
+     * @return new predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
      */
-    RequestPredicate isOfMethod(String... methodNames);
-
-    /**
-     * Accepts only requests with specified header name.
-     *
-     * @param headerName Header name.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsHeader(String headerName);
-
-    /**
-     * Accepts only requests with specified header containing valid value.
-     * <p>
-     * If request contains more then one header instance, then value predicate is called for all instances. Request is accepted
-     * if ANY predicate call returns {@code true}.
-     *
-     * @param headerName Header name.
-     * @param headerValuePredicate Predicate for header value. Is called for all header values.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsHeader(String headerName, Predicate<String> headerValuePredicate);
-
-    /**
-     * Accepts only requests with specified header containing valid value.
-     * <p>
-     * If request contains more then one header instance, then value is tested for all instances. Request is accepted
-     * if ANY value equals to provided.
-     *
-     * @param headerName Header name.
-     * @param value Expected header value.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsHeader(String headerName, String value);
-
-    /**
-     * Accepts only requests with specified query parameter.
-     *
-     * @param queryParameterName Query parameter
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsQueryParameter(String queryParameterName);
-
-    /**
-     * Accepts only requests with specified query parameter.
-     *
-     * @param queryParameterName Query parameter name.
-     * @param parameterValuePredicate Predicate for a parameter value.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsQueryParameter(String queryParameterName, Predicate<String> parameterValuePredicate);
-
-    /**
-     * Accepts only requests with specified query parameter.
-     *
-     * @param queryParameterName Query parameter name.
-     * @param value Expected value.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsQueryParameter(String queryParameterName, String value);
-
-    /**
-     * Accepts only requests with specified cookie name.
-     *
-     * @param cookieName Cookie name.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsCookie(String cookieName);
-
-    /**
-     * Accepts only requests with specified cookie containing valid value.
-     *
-     * @param cookieName Header name.
-     * @param cookieValuePredicate Predicate for a cookie value.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsCookie(String cookieName, Predicate<String> cookieValuePredicate);
-
-    /**
-     * Accepts only requests with specified cookie containing valid value.
-     *
-     * @param cookieName Header name.
-     * @param value Predicate for a cookie value.
-     * @return New enhanced instance.
-     */
-    RequestPredicate containsCookie(String cookieName, String value);
-
-    /**
-     * Accepts only requests accepting any of specified content types.
-     *
-     * @param contentType Content type.
-     * @return New enhanced instance.
-     */
-    RequestPredicate accepts(String... contentType);
-
-    /**
-     * Accepts only requests accepting any of specified content types.
-     *
-     * @param contentType Content type.
-     * @return New enhanced instance.
-     */
-    RequestPredicate accepts(MediaType... contentType);
-
-    /**
-     * Accepts only requests of any specified content types.
-     *
-     * @param contentType Content type.
-     * @return New enhanced instance.
-     */
-    RequestPredicate hasContentType(String... contentType);
-
-    /**
-     * Accepts by free form condition. Equivalent method for {@link #and(Predicate)}.
-     *
-     * @param requestPredicate A request predicate.
-     * @return New enhanced instance.
-     */
-    RequestPredicate is(Predicate<? super ServerRequest> requestPredicate);
-
-    /**
-     * Creates request-response handler/filter which calls provided handler only if this predicate accepts provided request,
-     * otherwise call {@link ServerRequest#next()} method.
-     *
-     * @param handler to apply if this instance accepts provided request.
-     * @return a conditional handler.
-     */
-    ConditionalHandler thenApply(Handler handler);
-
-    @Override
-    default RequestPredicate and(Predicate<? super ServerRequest> other) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    default RequestPredicate negate() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    default RequestPredicate or(Predicate<? super ServerRequest> other) {
-        throw new UnsupportedOperationException();
+    public RequestPredicate isOfMethod(final String... methods) {
+        Objects.requireNonNull(methods, "methods");
+        return and((req) ->
+                Arrays.asList(methods)
+                        .stream()
+                        .map(String::toUpperCase)
+                        .anyMatch(req.method().name()::equals));
     }
 
     /**
-     * Creates new empty instance {@link RequestPredicate} instance. It can be used as a base for fluent construction of
-     * complex predicate.
+     * Accepts only requests with one of specified HTTP methods.
      *
-     * @return New empty instance (accepts all requests).
+     * @param methods Acceptable method names
+     * @return new predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
      */
-    static RequestPredicate create() {
-        throw new UnsupportedOperationException();
+    public RequestPredicate isOfMethod(final Method... methods) {
+        Objects.requireNonNull(methods, "methods");
+        return and((req) ->
+                Arrays.asList(methods)
+                        .stream()
+                        .map(Method::name)
+                        .anyMatch(req.method().name()::equals));
     }
 
     /**
-     * A {@link Handler} which executes provided logic only if provided condition is satisfied.
-     * An instance can be created using {@link RequestPredicate#thenApply(Handler)} method.
+     * Accept requests only when the specified header name exists.
+     *
+     * @param name header name
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name is null
      */
-    class ConditionalHandler implements Handler {
+    public RequestPredicate containsHeader(final String name) {
+        Objects.requireNonNull(name, "header name");
+        return and((req) ->
+                req.headers().value(name).isPresent());
+    }
 
+    /**
+     * Accept requests only when the specified header is valid.
+     *
+     * A header is valid when the supplied predicate matches the header value.
+     * If the request contains more than one header, it will be accepted if the
+     * predicate matches <b>any</b> of the values.
+     *
+     * @param name header name
+     * @param predicate predicate to match the header value
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or predicate is null
+     */
+    public RequestPredicate containsHeader(final String name,
+            final Predicate<String> predicate) {
+
+        Objects.requireNonNull(name, "header name");
+        Objects.requireNonNull(predicate, "header predicate");
+        return and((req) -> {
+            Optional<String> headerValue = req.headers().value(name);
+            return headerValue.isPresent()
+                    && predicate.test(headerValue.get());
+        });
+    }
+
+    /**
+     * Accept requests only when the specified header contains a given value.
+     *
+     * If the request contains more then one header, it will be accepted
+     * if <b>any</b> of the values is equal to the provided value.
+     *
+     * @param name header name
+     * @param value the expected header value
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or value is null
+     */
+    public RequestPredicate containsHeader(final String name,
+            final String value) {
+
+        Objects.requireNonNull(name, "header name");
+        Objects.requireNonNull(value, "header value");
+        return and((req) -> {
+            Optional<String> headerValue = req.headers().value(name);
+            return headerValue.isPresent()
+                    && headerValue.get().equals(value);
+        });
+    }
+
+    /**
+     * Accept requests only when the specified query parameter exists.
+     *
+     * @param name query parameter name
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name is null
+     */
+    public RequestPredicate containsQueryParameter(final String name) {
+        Objects.requireNonNull(name, "query param name");
+        return and((req) -> req.queryParams()
+                .first(name)
+                .isPresent());
+    }
+
+    /**
+     * Accept requests only when the specified query parameter is valid.
+     *
+     * @param name query parameter name
+     * @param predicate to match the query parameter value
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or predicate is null
+     */
+    public RequestPredicate containsQueryParameter(final String name,
+            final Predicate<String> predicate) {
+
+        Objects.requireNonNull(name, "query param name");
+        Objects.requireNonNull(predicate, "query param predicate");
+        return and((req) -> req.queryParams()
+                .all(name)
+                .stream()
+                .anyMatch(predicate));
+    }
+
+    /**
+     * Accept requests only when the specified query parameter contains a given
+     * value.
+     *
+     * @param name query parameter name
+     * @param value expected query parameter value
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or value is null
+     */
+    public RequestPredicate containsQueryParameter(final String name,
+            final String value) {
+
+        Objects.requireNonNull(name, "query param name");
+        Objects.requireNonNull(value, "query param value");
+        return and((req) -> req.queryParams()
+                .all(name)
+                .stream()
+                .anyMatch(value::equals));
+    }
+
+    /**
+     * Accept request only when the specified cookie exists.
+     *
+     * @param name cookie name
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name is null
+     */
+    public RequestPredicate containsCookie(final String name) {
+        Objects.requireNonNull(name, "cookie name");
+        return and((req) -> req.headers()
+                .values("cookie")
+                .stream()
+                .anyMatch((c) -> c.startsWith(name + "=")));
+    }
+
+    /**
+     * Accept requests only when the specified cookie is valid.
+     *
+     * @param name cookie name
+     * @param predicate predicate to match the cookie value
+     * @return new predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or predicate is null
+     */
+    public RequestPredicate containsCookie(final String name,
+            final Predicate<String> predicate) {
+
+        Objects.requireNonNull(name, "cookie name");
+        Objects.requireNonNull(predicate, "cookie predicate");
+        return and((req) -> req.headers()
+                .cookies()
+                .all(name)
+                .stream()
+                .anyMatch((c) -> predicate.test(c)));
+    }
+
+    /**
+     * Accept requests only when the specified cookie contains a given value.
+     *
+     * @param name cookie name
+     * @param value expected cookie value
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified name or value is null
+     */
+    public RequestPredicate containsCookie(final String name,
+            final String value) {
+
+        Objects.requireNonNull(name, "cookie name");
+        Objects.requireNonNull(value, "cookie value");
+        return and((req) -> req.headers()
+                .cookies()
+                .all(name)
+                .stream()
+                .anyMatch(value::equals));
+    }
+
+    /**
+     * Accept requests only when it accepts any of the given content types.
+     *
+     * @param contentType the content types to test
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
+     */
+    public RequestPredicate accepts(final String... contentType) {
+        Objects.requireNonNull(contentType, "content types");
+        return and((req) ->
+                Stream.of(contentType).anyMatch((mt) ->
+                        req.headers().isAccepted(MediaType.parse(mt))));
+    }
+
+    /**
+     * Only accept request that accepts any of the given content types.
+     *
+     * @param contentType the content types to test
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
+     */
+    public RequestPredicate accepts(final MediaType... contentType) {
+        Objects.requireNonNull(contentType, "accepted media types");
+        return and((req) ->
+                Stream.of(contentType).anyMatch((mt) ->
+                        req.headers().isAccepted(mt)));
+    }
+
+    /**
+     * Only accept requests with any of the given content types.
+     *
+     * @param contentType Content type
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
+     */
+    public RequestPredicate hasContentType(final String... contentType) {
+        Objects.requireNonNull(contentType, "accepted media types");
+        return and((req) -> {
+            Optional<MediaType> actualContentType = req.headers().contentType();
+            return actualContentType.isPresent()
+                    && Stream.of(contentType)
+                        .anyMatch((mt) -> actualContentType.get()
+                                .equals(MediaType.parse(mt)));
+                });
+    }
+
+    /**
+     * Only accept requests with any of the given content types.
+     *
+     * @param contentType Content type
+     * @return composed predicate representing the logical expression of the previous
+     * predicate expression <b>and</b> the logical expression implemented by this
+     * method
+     * @throws NullPointerException if the specified content type array is null
+     */
+    public RequestPredicate hasContentType(final MediaType... contentType) {
+        Objects.requireNonNull(contentType, "content types");
+        return and((req) -> {
+            Optional<MediaType> actualContentType = req.headers().contentType();
+            return actualContentType.isPresent()
+                    && Stream.of(contentType)
+                        .anyMatch((mt) -> actualContentType.get()
+                                .equals(mt));
+                });
+    }
+
+    /**
+     * Creates new empty {@link RequestPredicate} instance.
+     *
+     * @return new empty predicate (accepts all requests).
+     */
+    public static RequestPredicate create() {
+        return new RequestPredicate();
+    }
+
+    /**
+     * A {@link Handler} that conditionally delegates to other {link Handler}
+     * instances based on a {@link RequestPredicate}.
+     *
+     * There can be at most 2 handlers: a required one for matched requests and
+     * an optional one non matched requests. If the handler for non matched
+     * requests is not provided, such request will return a {@code 404} response.
+     */
+    public static class ConditionalHandler implements Handler {
+
+        /**
+         * The condition for the delegation.
+         */
         private final RequestPredicate condition;
+
+        /**
+         * The {@link Handler} to use when the predicate matches.
+         */
         private final Handler acceptHandler;
+
+        /**
+         * The {@link Handler} to use when the predicate does not match.
+         */
         private final Handler declineHandler;
 
-        private ConditionalHandler(RequestPredicate condition, Handler acceptHandler, Handler declineHandler) {
+        /**
+         * Create a new instance.
+         * @param condition the predicate
+         * @param acceptHandler the predicate to use when the predicate matches
+         * @param declineHandler the predicate to use when the predicate does not
+         * match.
+         */
+        private ConditionalHandler(final RequestPredicate condition,
+                final Handler acceptHandler, final Handler declineHandler) {
+
             this.condition = condition;
             this.acceptHandler = acceptHandler;
-            this.declineHandler = declineHandler == null ? ((req, res) -> req.next()) : declineHandler;
+            this.declineHandler = declineHandler == null
+                    ? ((req, res) -> req.next()) : declineHandler;
         }
 
-        ConditionalHandler(RequestPredicate condition, Handler acceptHandler) {
+        /**
+         * Create a new instance.
+         * @param condition the predicate
+         * @param acceptHandler the predicate to use when the predicate matches
+         * match
+         */
+        private ConditionalHandler(final RequestPredicate condition,
+                final Handler acceptHandler) {
+
             this(condition, acceptHandler, null);
         }
 
@@ -239,14 +531,48 @@ public interface RequestPredicate extends Predicate<ServerRequest> {
         }
 
         /**
-         * Creates new {@link Handler} instance which executes this handler if condition was satisfied, <i>otherwise</i>
-         * executes provided {@code handler}.
+         * Set the {@link Handler} to use when the predicate does not match the
+         * request.
          *
-         * @param handler a handler which is executed when condition was not satisfied.
-         * @return a new handler.
+         * @param handler handler to use when the predicate does not match
+         * @return created {@link Handler}
          */
-        public Handler otherwise(Handler handler) {
-            return new ConditionalHandler(condition.negate(), handler, acceptHandler);
+        public Handler otherwise(final Handler handler) {
+            return new ConditionalHandler(condition, acceptHandler, handler);
         }
+    }
+
+    /**
+     * Recursive evaluation of a predicate chain.
+     * @param currentValue the initial value
+     * @param predicate the predicate to resolve the new value
+     * @param request the server request
+     * @return the evaluated value
+     */
+    private static boolean eval(final boolean currentValue,
+            final RequestPredicate predicate, final ServerRequest request){
+
+        boolean newValue = predicate.expr.eval(currentValue, request);
+        if (predicate.next != null) {
+            return eval(newValue, predicate.next, request);
+        }
+        return newValue;
+    }
+
+    /**
+     * An expression is part of a chain of other expressions, it computes a value
+     * based on an input object and the current value of the chain.
+     * @param <T> input object type
+     */
+    @FunctionalInterface
+    private interface Expression {
+
+        /**
+         * Evaluate this expression.
+         * @param currentValue the current value
+         * @param input the input object
+         * @return the new value
+         */
+        boolean eval(boolean currentValue, ServerRequest input);
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -28,12 +28,12 @@ import io.helidon.common.http.MediaType;
 /**
  * Fluent API to compose complex request conditions.
  *
- * First you start by creating a new instance with the {@link #create()} method,
- * then you chain methods that represent a logical expression, finally you terminate
- * with s using the {@link #thenApply(Handler) } method.
+ * Use {@link #create()} to initialize a new instance, then add conditions by
+ * chaining method calls and finally use the {@link #thenApply(Handler)} to create
+ * a {@link ConditionalHandler}.
  *
  * <h3>Examples</h3>
- * <p>Invoke a {@link Handler} only when the request contains a header {@code foo}
+ * <p>Invoke a {@link Handler} only when the request contains a header name {@code foo}
  * and accepts {@code text/plain}, otherwise return a response with {@code 404} code.
  * <pre>{@code
  * RequestPredicate.create()
@@ -44,7 +44,7 @@ import io.helidon.common.http.MediaType;
  *                 });
  * }</pre>
  * <p>Invoke a {@link Handler} that is invoked only when the request contains
- * a header {@code foo} header, otherwise invoke another handler that throws an
+ * a header named {@code foo} header, otherwise invoke another handler that throws an
  * exception.
  * <pre>{@code
  * RequestPredicate.create()
@@ -469,7 +469,7 @@ public final class RequestPredicate {
     }
 
     /**
-     * A {@link Handler} that conditionally delegates to other {link Handler}
+     * A {@link Handler} that conditionally delegates to other {@link Handler}
      * instances based on a {@link RequestPredicate}.
      *
      * There can be at most 2 handlers: a required one for matched requests and

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -205,17 +205,7 @@ public interface RequestPredicate extends Predicate<ServerRequest> {
      *
      * @return New empty instance (accepts all requests).
      */
-    static RequestPredicate whenRequest() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Combines several provided predicates in short circuit OR manner.
-     *
-     * @param predicates to combine.
-     * @return Combined predicate.
-     */
-    static RequestPredicate any(RequestPredicate... predicates) {
+    static RequestPredicate create() {
         throw new UnsupportedOperationException();
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -127,7 +127,7 @@ public final class RequestPredicate {
      * @return the created predicate
      */
     private RequestPredicate nextCondition(final Condition newCondition){
-        if(next != null){
+        if (next != null) {
             throw new IllegalStateException("next predicate already set");
         }
         this.next = new RequestPredicate(this.first, newCondition);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -118,7 +118,7 @@ public final class RequestPredicate {
      * @return instance of {@link ConditionalHandler} that can be used to
      * specify another {@link Handler} to use when this predicates does not
      * match the request
-     * @see {@link ConditionalHandler#otherwise(Handler) }
+     * @see ConditionalHandler#otherwise(Handler)
      */
     public ConditionalHandler thenApply(final Handler handler) {
         return new ConditionalHandler(this, handler);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.http.MediaType;
+import io.helidon.webserver.RoutingTest.RoutingChecker;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static io.helidon.common.CollectionsHelper.listOf;
+import static io.helidon.common.CollectionsHelper.mapOf;
+import static io.helidon.webserver.RoutingTest.mockResponse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests {@link RequestPredicate}.
+ */
+public class RequestPredicateTest {
+
+    @Test
+    public void isOfMethod1() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .any("/getOrPost", RequestPredicate.create()
+                        .isOfMethod("GET", "POST")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("methodFound");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("methodNotFound");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .isOfMethod((String[]) null);
+        });
+
+        routing.route(mockRequest("/getOrPost"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("methodFound"));
+
+        checker.reset();
+        routing.route(mockRequest("/getOrPost", Http.Method.PUT), mockResponse());
+        assertThat(checker.handlersInvoked(), is("methodNotFound"));
+    }
+
+    @Test
+    public void isOfMethod2() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .any("/getOrPost", RequestPredicate.create()
+                        .isOfMethod(Http.Method.GET, Http.Method.POST)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("methodFound");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("methodNotFound");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .isOfMethod((Http.Method[]) null);
+        });
+
+        routing.route(mockRequest("/getOrPost"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("methodFound"));
+
+        checker.reset();
+        routing.route(mockRequest("/getOrPost", Http.Method.PUT), mockResponse());
+        assertThat(checker.handlersInvoked(), is("methodNotFound"));
+    }
+
+    @Test
+    public void containsHeader() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/exists", RequestPredicate.create()
+                        .containsHeader("my-header")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("headerFound");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("headerNotFound");
+                        }))
+                .get("/valid", RequestPredicate.create()
+                        .containsHeader("my-header", "abc"::equals)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("headerIsValid");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("headerIsNotValid");
+                        }))
+                .get("/equals", RequestPredicate.create()
+                        .containsHeader("my-header", "abc")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("headerIsEqual");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("headerIsNotEqual");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsHeader(null);
+        });
+
+        routing.route(mockRequest("/exists", mapOf("my-header", listOf("abc"))),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerFound"));
+
+        checker.reset();
+        routing.route(mockRequest("/exists", mapOf()), mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerNotFound"));
+    }
+
+    @Test
+    public void containsValidHeader() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/valid", RequestPredicate.create()
+                        .containsHeader("my-header", "abc"::equals)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("headerIsValid");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("headerIsNotValid");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsHeader("my-header", (Predicate<String>) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsHeader(null, "abc"::equals);
+        });
+
+        routing.route(mockRequest("/valid", mapOf("my-header", listOf("abc"))),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerIsValid"));
+
+        checker.reset();
+        routing.route(mockRequest("/valid", mapOf("my-header", listOf("def"))),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerIsNotValid"));
+    }
+
+    @Test
+    public void containsExactHeader() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/equals", RequestPredicate.create()
+                        .containsHeader("my-header", "abc")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("headerIsEqual");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("headerIsNotEqual");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsHeader("my-header", (String) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsHeader(null, "abc");
+        });
+
+        routing.route(mockRequest("/equals", mapOf("my-header", listOf("abc"))),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerIsEqual"));
+
+        checker.reset();
+        routing.route(mockRequest("/equals", mapOf("my-header", listOf("def"))),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("headerIsNotEqual"));
+    }
+
+    @Test
+    public void containsQueryParam() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/exists", RequestPredicate.create()
+                        .containsQueryParameter("my-param")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("queryParamFound");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("queryParamNotFound");
+                        }))
+                .get("/valid", RequestPredicate.create()
+                        .containsQueryParameter("my-param", "abc"::equals)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("queryParamIsValid");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("queryParamIsNotValid");
+                        }))
+                .get("/equals", RequestPredicate.create()
+                        .containsQueryParameter("my-param", "abc")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("queryParamIsEqual");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("queryParamIsNotEqual");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsQueryParameter(null);
+        });
+
+        routing.route(mockRequest("/exists?my-param=abc"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamFound"));
+
+        checker.reset();
+        routing.route(mockRequest("/exists"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamNotFound"));
+    }
+
+    @Test
+    public void containsValidQueryParam() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/valid", RequestPredicate.create()
+                        .containsQueryParameter("my-param", "abc"::equals)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("queryParamIsValid");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("queryParamIsNotValid");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsQueryParameter("my-param", (Predicate<String>) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsQueryParameter(null, "abc");
+        });
+
+        routing.route(mockRequest("/valid?my-param=abc"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamIsValid"));
+
+        checker.reset();
+        routing.route(mockRequest("/valid?my-param=def"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamIsNotValid"));
+    }
+
+    @Test
+    public void containsExactQueryParam() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/equals", RequestPredicate.create()
+                        .containsQueryParameter("my-param", "abc")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("queryParamIsEqual");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("queryParamIsNotEqual");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsQueryParameter("my-param", (String) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsQueryParameter(null, "abc");
+        });
+
+        routing.route(mockRequest("/equals?my-param=abc"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamIsEqual"));
+
+        checker.reset();
+        routing.route(mockRequest("/equals?my-param=def"), mockResponse());
+        assertThat(checker.handlersInvoked(), is("queryParamIsNotEqual"));
+    }
+
+    @Test
+    public void containsCookie() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/exists", RequestPredicate.create()
+                        .containsCookie("my-cookie")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("cookieFound");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("cookieNotFound");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsCookie(null);
+        });
+
+        routing.route(mockRequest("/exists", mapOf("cookie",
+                listOf("my-cookie=abc"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieFound"));
+
+        checker.reset();
+        routing.route(mockRequest("/exists", mapOf("cookie",
+                listOf("other-cookie=abc"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieNotFound"));
+    }
+
+    @Test
+    public void containsValidCookie() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/valid", RequestPredicate.create()
+                        .containsCookie("my-cookie", "abc"::equals)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("cookieIsValid");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("cookieIsNotValid");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsCookie("my-cookie", (Predicate<String>) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsCookie(null, "abc");
+        });
+
+        routing.route(mockRequest("/valid", mapOf("cookie",
+                listOf("my-cookie=abc"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieIsValid"));
+
+        checker.reset();
+        routing.route(mockRequest("/valid", mapOf("cookie",
+                listOf("my-cookie=def"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieIsNotValid"));
+
+        checker.reset();
+        routing.route(mockRequest("/valid", mapOf("cookie",
+                listOf("my-cookie="))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieIsNotValid"));
+    }
+
+    @Test
+    public void containsExactCookie() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/equals", RequestPredicate.create()
+                        .containsCookie("my-cookie", "abc")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("cookieIsEqual");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("cookieIsNotEqual");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsCookie("my-cookie", (String) null);
+        });
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .containsCookie(null, "abc");
+        });
+
+        routing.route(mockRequest("/equals", mapOf("cookie",
+                listOf("my-cookie=abc"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieIsEqual"));
+
+        checker.reset();
+        routing.route(mockRequest("/equals", mapOf("cookie",
+                listOf("my-cookie=def"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("cookieIsNotEqual"));
+    }
+
+    @Test
+    public void accepts1() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/accepts1", RequestPredicate.create()
+                        .accepts("text/plain", "application/json")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("acceptsMediaType");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("doesNotAcceptMediaType");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .accepts((String[]) null);
+        });
+
+        routing.route(mockRequest("/accepts1", mapOf("Accept",
+                listOf("application/json"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts1", mapOf("Accept",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts1", mapOf("Accept",
+                listOf("text/plain", "application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts1", mapOf("Accept", listOf())),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts1", mapOf()), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts1", mapOf("Accept",
+                listOf("application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotAcceptMediaType"));
+    }
+
+    @Test
+    public void accepts2() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/accepts2", RequestPredicate.create()
+                        .accepts(MediaType.TEXT_PLAIN,
+                                MediaType.APPLICATION_JSON)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("acceptsMediaType");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("doesNotAcceptMediaType");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .accepts((MediaType[]) null);
+        });
+
+        routing.route(mockRequest("/accepts2", mapOf("Accept",
+                listOf("application/json"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts2", mapOf("Accept",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts2", mapOf("Accept",
+                listOf("text/plain", "application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts2", mapOf("Accept", listOf())),
+                mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts2", mapOf()), mockResponse());
+        assertThat(checker.handlersInvoked(), is("acceptsMediaType"));
+
+        checker.reset();
+        routing.route(mockRequest("/accepts2", mapOf("Accept",
+                listOf("application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotAcceptMediaType"));
+    }
+
+    @Test
+    public void hasContentType1() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/contentType1", RequestPredicate.create()
+                        .hasContentType("text/plain", "application/json")
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("hasContentType");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("doesNotHaveContentType");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .hasContentType((String[]) null);
+        });
+
+        routing.route(mockRequest("/contentType1", mapOf("Content-Type",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType1", mapOf("Content-Type",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType1", mapOf("Content-Type",
+                listOf("application/json"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType1", mapOf("Content-Type",
+                listOf("application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType1", mapOf("Content-Type",
+                listOf())), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType1", mapOf()), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+    }
+
+    @Test
+    public void hasContentType2() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .get("/contentType2", RequestPredicate.create()
+                        .hasContentType(MediaType.TEXT_PLAIN,
+                                MediaType.APPLICATION_JSON)
+                        .thenApply((req, resp) -> {
+                            checker.handlerInvoked("hasContentType");
+                        }).otherwise((req, res) -> {
+                            checker.handlerInvoked("doesNotHaveContentType");
+                        }))
+                .build();
+
+        assertThrows(NullPointerException.class, () -> {
+            RequestPredicate.create()
+                    .hasContentType((MediaType[]) null);
+        });
+
+        routing.route(mockRequest("/contentType2", mapOf("Content-Type",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType2", mapOf("Content-Type",
+                listOf("text/plain"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType2", mapOf("Content-Type",
+                listOf("application/json"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("hasContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType2", mapOf("Content-Type",
+                listOf("application/xml"))), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType2", mapOf("Content-Type",
+                listOf())), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+
+        checker.reset();
+        routing.route(mockRequest("/contentType2", mapOf()), mockResponse());
+        assertThat(checker.handlersInvoked(), is("doesNotHaveContentType"));
+    }
+
+    private static BareRequest mockRequest(final String path) {
+        BareRequest bareRequestMock = RoutingTest.mockRequest(path,
+                Http.Method.GET);
+        return bareRequestMock;
+    }
+
+    private static BareRequest mockRequest(final String path,
+            final Http.Method method) {
+
+        BareRequest bareRequestMock = RoutingTest.mockRequest(path, method);
+        return bareRequestMock;
+    }
+
+    private static BareRequest mockRequest(final String path,
+            final Map<String, List<String>> headers) {
+
+        BareRequest bareRequestMock = RoutingTest.mockRequest(path,
+                Http.Method.GET);
+        Mockito.doReturn(headers).when(bareRequestMock).headers();
+        return bareRequestMock;
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
@@ -702,7 +702,7 @@ public class RequestPredicateTest {
         RequestPredicate requestPredicate = RequestPredicate.create()
                 .containsCookie("my-cookie");
         requestPredicate.containsHeader("my-header");
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             requestPredicate.containsHeader("my-param");
         });
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RequestPredicateTest.java
@@ -697,6 +697,16 @@ public class RequestPredicateTest {
         assertThat(checker.handlersInvoked(), is("doesNotHaveAllConditions"));
     }
 
+    @Test
+    public void nextAlreadySet(){
+        RequestPredicate requestPredicate = RequestPredicate.create()
+                .containsCookie("my-cookie");
+        requestPredicate.containsHeader("my-header");
+        assertThrows(IllegalArgumentException.class, () -> {
+            requestPredicate.containsHeader("my-param");
+        });
+    }
+
     private static BareRequest mockRequest(final String path) {
         BareRequest bareRequestMock = RoutingTest.mockRequest(path,
                 Http.Method.GET);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,101 +16,131 @@
 
 package io.helidon.webserver;
 
+import java.net.URI;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.http.Http;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Demonstrates routing configuration API included in WebServer builder.
  * Demonstrates other outing features
  */
-@Disabled("Routing is in incremental implementation tryProcess!")
 public class RoutingTest {
 
     /**
      * Use fluent routing API to cover HTTP methods and Paths with handlers.
      */
     @Test
-    public void basicRouting() throws Exception {
-        assertThrows(RuntimeException.class, () -> {
-            Routing.builder()
-                     .post("/user", (req, resp) -> {
-                         // Do something GR8 with response.
-                     })
-                     .get("/user/{name}", (req, resp) -> {
-                         // Do something GR8 with response.
-                     })
-                     .build();
-        });
+    public void basicRouting() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .post("/user", (req, resp) -> {
+                    checker.handlerInvoked("defaultUserHandler");
+                })
+                .get("/user/{name}", (req, resp) -> {
+                    checker.handlerInvoked("namedUserHandler");
+                })
+                .build();
+
+        routing.route(requestStub("/user", Http.Method.POST), responseStub());
+        assertThat(checker.handlersInvoked(), is("defaultUserHandler"));
+
+        checker.reset();
+        routing.route(requestStub("/user/john", Http.Method.GET), responseStub());
+        assertThat(checker.handlersInvoked(), is("namedUserHandler"));
     }
 
     /**
      * Use routing API to register filter. Filter is just handler which calls {@code request.next()}.
      */
     @Test
-    public void routeFilters() throws Exception {
-        assertThrows(RuntimeException.class, () -> {
-            Routing.builder()
-                     .any((req, resp) -> { // Any http request, any path
-                         // Transform request cookie to session
-                         req.next();
-                     }, (req, resp) -> { // More filters/handlers can be registered in one method, just for convenience
-                         // Another filtering logic
-                         req.next();
-                     })
-                     .any("/admin/", (req, resp) -> {
-                         // If not authorize admin throw RuntimeException or response something, else
-                         req.next();
-                     })
-                     .post("/admin", (req, resp) -> {
-                         // Write audit record about modification request
-                         req.next();
-                     })
-                     .post("/admin/user", (req, resp) -> {
-                         // Do something GR8 with response.
-                     })
-                     .get("/admin/user/{name}", (req, resp) -> {
-                         // Do something GR8 with response.
-                     })
-                     .build();
-        });
+    public void routeFilters() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .any((req, resp) -> {
+                    checker.handlerInvoked("anyPath1");
+                    req.next();
+                }, (req, resp) -> {
+                    checker.handlerInvoked("anyPath2");
+                    req.next();
+                })
+                .any("/admin", (req, resp) -> {
+                    checker.handlerInvoked("anyAdmin");
+                    req.next();
+                })
+                .post("/admin", (req, resp) -> {
+                    checker.handlerInvoked("postAdminAudit");
+                    req.next();
+                })
+                .post("/admin/user", (req, resp) -> {
+                    checker.handlerInvoked("postAdminUser");
+                })
+                .get("/admin/user/{name}", (req, resp) -> {
+                    checker.handlerInvoked("getAdminUser");
+                })
+                .build();
+
+        routing.route(requestStub("/admin/user", Http.Method.POST), responseStub());
+        assertThat(checker.handlersInvoked(), is("anyPath1,anyPath2,postAdminUser"));
+
+        checker.reset();
+        routing.route(requestStub("/admin/user/john", Http.Method.GET), responseStub());
+        assertThat(checker.handlersInvoked(), is("anyPath1,anyPath2,getAdminUser"));
+
+        checker.reset();
+        routing.route(requestStub("/admin", Http.Method.POST), responseStub());
+        assertThat(checker.handlersInvoked(), is("anyPath1,anyPath2,anyAdmin,postAdminAudit"));
     }
 
     /**
      * Use <i>sub-routers</i> to organize code to services/resources or attach third party filters.
      */
     @Test
-    public void subRouting() throws Exception {
-        assertThrows(RuntimeException.class, () -> {
-            Routing.builder()
-                     .register("/user", new UserService())
-                     .build();
-        });
+    public void subRouting() {
+        final RoutingChecker checker = new RoutingChecker();
+        Routing routing = Routing.builder()
+                .register("/user", (rules) -> {
+                    rules.get("/{name}", (req, res) -> {
+                        checker.handlerInvoked("getUser");
+                    }).post((req, res) -> {
+                        checker.handlerInvoked("createUser");
+                    });
+                }).build();
+
+        routing.route(requestStub("/user/john", Http.Method.GET), responseStub());
+        assertThat(checker.handlersInvoked(), is("getUser"));
+
+        checker.reset();
+        routing.route(requestStub("/user", Http.Method.POST), responseStub());
+        assertThat(checker.handlersInvoked(), is("createUser"));
     }
 
     /**
-     * Use Selector fluent API for more advanced routing.
+     * Use RequestPredicate fluent API for more advanced routing.
      */
     @Test
-    public void filteringExample() throws Exception {
+    public void filteringExample() {
         assertThrows(RuntimeException.class, () -> {
             Routing.builder()
                     .anyOf(Arrays.asList(Http.Method.PUT, Http.Method.POST), "/foo", RequestPredicate.whenRequest()
-                                                                                                     .containsHeader("my-gr8-header")
-                                                                                                     .thenApply((req, resp) -> {
-                                                                                     // Some logic.
-                                                                                 }))
+                            .containsHeader("my-gr8-header")
+                            .thenApply((req, resp) -> {
+                                // Some logic.
+                            }))
                     .get("/foo", RequestPredicate.whenRequest()
-                                              .is(req -> isUserAuthenticated(req))
-                                              .accepts("application/json")
-                                              .thenApply((req, resp) -> {
-                                                  // Something with authenticated user
-                                              }))
+                            .is(req -> isUserAuthenticated(req))
+                            .accepts("application/json")
+                            .thenApply((req, resp) -> {
+                                // Something with authenticated user
+                            }))
                     .build();
         });
 
@@ -120,18 +150,37 @@ public class RoutingTest {
         return true;
     }
 
-    static class UserService implements Service {
+    private static BareRequest requestStub(String path, Http.Method method) {
+        BareRequest bareRequestMock = Mockito.mock(BareRequest.class);
+        Mockito.doReturn(URI.create("http://0.0.0.0:1234/" + path)).when(bareRequestMock).uri();
+        Mockito.doReturn(method).when(bareRequestMock).method();
+        Mockito.doReturn(Mockito.mock(WebServer.class)).when(bareRequestMock).webServer();
+        return bareRequestMock;
+    }
 
-        @Override
-        public void update(Routing.Rules routingRules) {
-            routingRules.get("{userName}", this::getUser)
-                        .post(this::createUser);
+    private static BareResponse responseStub(){
+        BareResponse bareResponseMock = Mockito.mock(BareResponse.class);
+        final CompletableFuture<BareResponse> completedFuture =
+                CompletableFuture.completedFuture(bareResponseMock);
+        Mockito.doReturn(completedFuture).when(bareResponseMock).whenCompleted();
+        Mockito.doReturn(completedFuture).when(bareResponseMock).whenHeadersCompleted();
+        return bareResponseMock;
+    }
+
+    private static final class RoutingChecker {
+
+        String str = "";
+
+        public void handlerInvoked(String id){
+            str += str.isEmpty() ? id : "," + id;
         }
 
-        public void createUser(ServerRequest request, ServerResponse response) {
+        public void reset(){
+            str = "";
         }
 
-        public void getUser(ServerRequest request, ServerResponse response) {
+        public String handlersInvoked(){
+            return str;
         }
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RoutingTest.java
@@ -130,12 +130,12 @@ public class RoutingTest {
     public void filteringExample() {
         assertThrows(RuntimeException.class, () -> {
             Routing.builder()
-                    .anyOf(Arrays.asList(Http.Method.PUT, Http.Method.POST), "/foo", RequestPredicate.whenRequest()
+                    .anyOf(Arrays.asList(Http.Method.PUT, Http.Method.POST), "/foo", RequestPredicate.create()
                             .containsHeader("my-gr8-header")
                             .thenApply((req, resp) -> {
                                 // Some logic.
                             }))
-                    .get("/foo", RequestPredicate.whenRequest()
+                    .get("/foo", RequestPredicate.create()
                             .is(req -> isUserAuthenticated(req))
                             .accepts("application/json")
                             .thenApply((req, resp) -> {


### PR DESCRIPTION
Fixes #297

- Implement RequestPredicate:
     - change RequestPredicate from interface to public final class
     - removed implements Predicate<ServerRequest>, instead made the API similar to Predicate
     - Rename RequestPredicate.whenRequest to RequestPredicate.create
     - add variant for method isOfMethod to accept Http.Method[]
     - add variant for method hasContentType to accept MediaType[]
     - update javadoc
     - add a unit test to cover all the new code
- Update the javadoc of RequestHeaders.isAccepted to state the behavior when the 'Accept' header is not present.
- Minor comestic update to the javadoc of RequestHeaders.bestAccept
- Fix ReadOnlyParameters.first to handle null or empty list
- Enable RoutingTest, mock bareRequest/bareResponse to test routing in a meaningful way