### PR TITLE
Fix #329 Use JsonBuilderFactory instead of Json.create

### DIFF
--- a/docs/src/main/docs/webserver/08_json-support.adoc
+++ b/docs/src/main/docs/webserver/08_json-support.adoc
@@ -56,7 +56,7 @@ Routing.builder()
 [source,java]
 .Handler that receives and returns JSON objects
 ----
-private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null); <1>
+private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Collections.emptyMap()); <1>
 
 private void sayHello(ServerRequest req, ServerResponse res, JsonObject json) { // <2>
         JsonObject msg = jsonFactory.createObjectBuilder()   // <3>

--- a/docs/src/main/docs/webserver/08_json-support.adoc
+++ b/docs/src/main/docs/webserver/08_json-support.adoc
@@ -56,16 +56,19 @@ Routing.builder()
 [source,java]
 .Handler that receives and returns JSON objects
 ----
-private void sayHello(ServerRequest req, ServerResponse res, JsonObject json) { // <1>
-        JsonObject msg = Json.createObjectBuilder()   // <2>
+private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null); <1>
+
+private void sayHello(ServerRequest req, ServerResponse res, JsonObject json) { // <2>
+        JsonObject msg = jsonFactory.createObjectBuilder()   // <3>
           .add("message", "Hello " + json.getString("name"))
           .build();
-        res.send(msg);                            // <3>
+        res.send(msg);                            // <4>
 }
 ----
-<1> JsonObject is passed to handler
-<2> Create a JsonObject using JSON-P to hold return data
-<3> Send JsonObject in response
+<1> Using a `JsonBuilderFactory` is more efficient than `Json.createObjectBuilder()`
+<2> JsonObject is passed to handler
+<3> Create a JsonObject using JSON-P to hold return data
+<4> Send JsonObject in response
 
 [source,bash]
 .Example of posting JSON to sayHello endpoint

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
@@ -16,6 +16,8 @@
 
 package io.helidon.guides.mp.restfulwebservice;
 
+import java.util.Collections;
+
 // tag::javaxImports[]
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
@@ -55,7 +57,7 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 public class GreetResource {
 // end::classDecl[]
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The greeting message provider.

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package io.helidon.guides.mp.restfulwebservice;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -53,6 +54,9 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 @RequestScoped
 public class GreetResource {
 // end::classDecl[]
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+
     /**
      * The greeting message provider.
      */
@@ -128,7 +132,7 @@ public class GreetResource {
     public JsonObject updateGreeting(@PathParam("greeting") String newGreeting) { // <4>
         greeting.setMessage(newGreeting);
 
-        return Json.createObjectBuilder()
+        return jsonFactory.createObjectBuilder()
                 .add("greeting", newGreeting)
                 .build();
     }
@@ -138,7 +142,7 @@ public class GreetResource {
     private JsonObject createResponse(String who) { // <1>
         String msg = String.format("%s %s!", greeting.getMessage(), who); // <2>
 
-        return Json.createObjectBuilder() // <3>
+        return jsonFactory.createObjectBuilder() // <3>
                 .add("message", msg)
                 .build();
     }

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/GreetResource.java
@@ -55,7 +55,7 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 public class GreetResource {
 // end::classDecl[]
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The greeting message provider.
@@ -132,7 +132,7 @@ public class GreetResource {
     public JsonObject updateGreeting(@PathParam("greeting") String newGreeting) { // <4>
         greeting.setMessage(newGreeting);
 
-        return jsonFactory.createObjectBuilder()
+        return JSON.createObjectBuilder()
                 .add("greeting", newGreeting)
                 .build();
     }
@@ -142,7 +142,7 @@ public class GreetResource {
     private JsonObject createResponse(String who) { // <1>
         String msg = String.format("%s %s!", greeting.getMessage(), who); // <2>
 
-        return jsonFactory.createObjectBuilder() // <3>
+        return JSON.createObjectBuilder() // <3>
                 .add("message", msg)
                 .build();
     }

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.guides.mp.restfulwebservice;
 
+import java.util.Collections;
+
 // tag::javaxImports[]
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
@@ -36,7 +38,7 @@ import javax.ws.rs.core.Response;
 public class HealthResource {
 // end::classDecl[]
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     // tag::greetingDecl[]
     @Inject // <1>

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.guides.mp.restfulwebservice;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -34,6 +35,8 @@ import javax.ws.rs.core.Response;
 @RequestScoped
 public class HealthResource {
 // end::classDecl[]
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     // tag::greetingDecl[]
     @Inject // <1>
@@ -56,7 +59,7 @@ public class HealthResource {
         if (greetResourceError == null) {  // <4>
             response = Response.ok().build();
         } else {
-            JsonObject returnObject = Json.createObjectBuilder()
+            JsonObject returnObject = jsonFactory.createObjectBuilder()
                     .add("error", greetResourceError)
                     .build();
             response = Response

--- a/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
+++ b/examples/guides/mp-restful-webservice/src/main/java/io/helidon/guides/mp/restfulwebservice/HealthResource.java
@@ -36,7 +36,7 @@ import javax.ws.rs.core.Response;
 public class HealthResource {
 // end::classDecl[]
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     // tag::greetingDecl[]
     @Inject // <1>
@@ -59,7 +59,7 @@ public class HealthResource {
         if (greetResourceError == null) {  // <4>
             response = Response.ok().build();
         } else {
-            JsonObject returnObject = jsonFactory.createObjectBuilder()
+            JsonObject returnObject = JSON.createObjectBuilder()
                     .add("error", greetResourceError)
                     .build();
             response = Response

--- a/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -49,7 +49,7 @@ public class GreetService implements Service {
      */
     private static final Config CONFIG = Config.create().get("app");
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The config value for the key {@code greeting}.
@@ -77,7 +77,7 @@ public class GreetService implements Service {
                                    final ServerResponse response) {
         String msg = String.format("%s %s!", greeting, "World");
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -93,7 +93,7 @@ public class GreetService implements Service {
         String name = request.path().param("name");
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -108,7 +108,7 @@ public class GreetService implements Service {
                                 final ServerResponse response) {
         greeting = request.path().param("greeting");
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -16,6 +16,8 @@
 
 package io.helidon.guides.se.restfulwebservice;
 
+import java.util.Collections;
+
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
@@ -49,7 +51,7 @@ public class GreetService implements Service {
      */
     private static final Config CONFIG = Config.create().get("app");
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The config value for the key {@code greeting}.

--- a/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java-start/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.guides.se.restfulwebservice;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 
 import io.helidon.config.Config;
@@ -48,6 +49,8 @@ public class GreetService implements Service {
      */
     private static final Config CONFIG = Config.create().get("app");
 
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+
     /**
      * The config value for the key {@code greeting}.
      */
@@ -74,7 +77,7 @@ public class GreetService implements Service {
                                    final ServerResponse response) {
         String msg = String.format("%s %s!", greeting, "World");
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -90,7 +93,7 @@ public class GreetService implements Service {
         String name = request.path().param("name");
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -105,7 +108,7 @@ public class GreetService implements Service {
                                 final ServerResponse response) {
         greeting = request.path().param("greeting");
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.guides.se.restfulwebservice;
 
 //tag::importsStart[]
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 
 import io.helidon.config.Config;
@@ -60,6 +61,8 @@ public class GreetService implements Service {
     // tag::CONFIG[]
     private static final Config CONFIG = Config.create().get("app"); // <1>
     // end::CONFIG[]
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     /**
      * The config value for the key {@code greeting}.
@@ -112,7 +115,7 @@ public class GreetService implements Service {
                                    final ServerResponse response) {
         String msg = String.format("%s %s!", greeting, "World"); // <1>
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("message", msg) // <2>
                 .build();
         response.send(returnObject); // <3>
@@ -130,7 +133,7 @@ public class GreetService implements Service {
         String name = request.path().param("name"); // <1>
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -147,7 +150,7 @@ public class GreetService implements Service {
                                 final ServerResponse response) {
         greeting = request.path().param("greeting"); // <1>
 
-        JsonObject returnObject = Json.createObjectBuilder() // <2>
+        JsonObject returnObject = jsonFactory.createObjectBuilder() // <2>
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -62,7 +62,7 @@ public class GreetService implements Service {
     private static final Config CONFIG = Config.create().get("app"); // <1>
     // end::CONFIG[]
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The config value for the key {@code greeting}.
@@ -115,7 +115,7 @@ public class GreetService implements Service {
                                    final ServerResponse response) {
         String msg = String.format("%s %s!", greeting, "World"); // <1>
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg) // <2>
                 .build();
         response.send(returnObject); // <3>
@@ -133,7 +133,7 @@ public class GreetService implements Service {
         String name = request.path().param("name"); // <1>
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -150,7 +150,7 @@ public class GreetService implements Service {
                                 final ServerResponse response) {
         greeting = request.path().param("greeting"); // <1>
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder() // <2>
+        JsonObject returnObject = JSON.createObjectBuilder() // <2>
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/GreetService.java
@@ -16,6 +16,8 @@
 
 package io.helidon.guides.se.restfulwebservice;
 
+import java.util.Collections;
+
 //tag::importsStart[]
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
@@ -62,7 +64,7 @@ public class GreetService implements Service {
     private static final Config CONFIG = Config.create().get("app"); // <1>
     // end::CONFIG[]
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The config value for the key {@code greeting}.

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -55,7 +55,7 @@ public final class Main {
     private static GreetService greetService;
     // end::greetServiceDecl[]
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * Cannot be instantiated.
@@ -159,7 +159,7 @@ public final class Main {
                     .status(Http.Status.OK_200) //<2>
                     .send();
         } else {
-            JsonObject returnObject = jsonFactory.createObjectBuilder() //<3>
+            JsonObject returnObject = JSON.createObjectBuilder() //<3>
                     .add("error", greetServiceError)
                     .build();
             response

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -17,6 +17,7 @@
 package io.helidon.guides.se.restfulwebservice;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.logging.LogManager;
 
 // tag::importsHealth1[]
@@ -55,7 +56,7 @@ public final class Main {
     private static GreetService greetService;
     // end::greetServiceDecl[]
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * Cannot be instantiated.

--- a/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
+++ b/examples/guides/se-restful-webservice/src/main/java/io/helidon/guides/se/restfulwebservice/Main.java
@@ -42,6 +42,7 @@ import io.helidon.webserver.json.JsonSupport;
 // end::importsEnd[]
 // tag::importsHealth3[]
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 // end::importsHealth3[]
 
@@ -53,6 +54,8 @@ public final class Main {
     // tag::greetServiceDecl[]
     private static GreetService greetService;
     // end::greetServiceDecl[]
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     /**
      * Cannot be instantiated.
@@ -156,7 +159,7 @@ public final class Main {
                     .status(Http.Status.OK_200) //<2>
                     .send();
         } else {
-            JsonObject returnObject = Json.createObjectBuilder() //<3>
+            JsonObject returnObject = jsonFactory.createObjectBuilder() //<3>
                     .add("error", greetServiceError)
                     .build();
             response

--- a/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
+++ b/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     @BeforeAll
     public static void startTheServer() throws Exception {
@@ -60,14 +60,14 @@ public class MainTest {
 
         conn = getURLConnection("GET","/greet");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response1");
-        JsonReader jsonReader = jsonFactory.createReader(conn.getInputStream());
+        JsonReader jsonReader = JSON.createReader(conn.getInputStream());
         JsonObject jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         conn = getURLConnection("GET", "/greet/Joe");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
-        jsonReader = jsonFactory.createReader(conn.getInputStream());
+        jsonReader = JSON.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
@@ -76,7 +76,7 @@ public class MainTest {
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
-        jsonReader = jsonFactory.createReader(conn.getInputStream());
+        jsonReader = JSON.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");

--- a/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
+++ b/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 
 import io.helidon.webserver.WebServer;
 
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     @BeforeAll
     public static void startTheServer() throws Exception {
@@ -58,14 +60,14 @@ public class MainTest {
 
         conn = getURLConnection("GET","/greet");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response1");
-        JsonReader jsonReader = Json.createReader(conn.getInputStream());
+        JsonReader jsonReader = jsonFactory.createReader(conn.getInputStream());
         JsonObject jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         conn = getURLConnection("GET", "/greet/Joe");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
-        jsonReader = Json.createReader(conn.getInputStream());
+        jsonReader = jsonFactory.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
@@ -74,7 +76,7 @@ public class MainTest {
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
-        jsonReader = Json.createReader(conn.getInputStream());
+        jsonReader = jsonFactory.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");

--- a/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
+++ b/examples/guides/se-restful-webservice/src/test/java/io/helidon/guides/se/restfulwebservice/MainTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.guides.se.restfulwebservice;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.net.URL;
 import java.net.HttpURLConnection;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     @BeforeAll
     public static void startTheServer() throws Exception {

--- a/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
@@ -40,7 +40,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("helloworld")
 @RequestScoped
 public class HelloWorldResource {
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
     private final Config config;
     private final String applicationName;
     private final URI applicationUri;
@@ -86,7 +86,7 @@ public class HelloWorldResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getHello(@PathParam("name") String name) {
-        return jsonFactory.createObjectBuilder()
+        return JSON.createObjectBuilder()
                 .add("name", name)
                 .add("appName", applicationName)
                 .add("appUri", String.valueOf(applicationUri))

--- a/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
@@ -17,6 +17,7 @@
 package io.helidon.microprofile.example.helloworld.explicit;
 
 import java.net.URI;
+import java.util.Collections;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.spi.BeanManager;
@@ -40,7 +41,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("helloworld")
 @RequestScoped
 public class HelloWorldResource {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     private final Config config;
     private final String applicationName;
     private final URI applicationUri;

--- a/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/HelloWorldResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -39,6 +40,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("helloworld")
 @RequestScoped
 public class HelloWorldResource {
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
     private final Config config;
     private final String applicationName;
     private final URI applicationUri;
@@ -84,7 +86,7 @@ public class HelloWorldResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getHello(@PathParam("name") String name) {
-        return Json.createObjectBuilder()
+        return jsonFactory.createObjectBuilder()
                 .add("name", name)
                 .add("appName", applicationName)
                 .add("appUri", String.valueOf(applicationUri))

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
@@ -17,6 +17,7 @@
 package io.helidon.microprofile.example.helloworld.implicit;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.RequestScoped;
@@ -45,7 +46,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @RequestScoped
 public class HelloWorldResource {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     private final Config config;
     private final Logger logger;

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -43,6 +44,9 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @Path("helloworld")
 @RequestScoped
 public class HelloWorldResource {
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+
     private final Config config;
     private final Logger logger;
     private final int requestId;
@@ -96,7 +100,7 @@ public class HelloWorldResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getHello(@PathParam("name") String name) {
-        return Json.createObjectBuilder()
+        return jsonFactory.createObjectBuilder()
                 .add("name", name)
                 .add("requestId", requestId)
                 .add("appName", applicationName)

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/HelloWorldResource.java
@@ -45,7 +45,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @RequestScoped
 public class HelloWorldResource {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     private final Config config;
     private final Logger logger;
@@ -100,7 +100,7 @@ public class HelloWorldResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject getHello(@PathParam("name") String name) {
-        return jsonFactory.createObjectBuilder()
+        return JSON.createObjectBuilder()
                 .add("name", name)
                 .add("requestId", requestId)
                 .add("appName", applicationName)

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -47,7 +47,7 @@ import javax.ws.rs.core.MediaType;
 @RequestScoped
 public class GreetResource {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The greeting message provider.
@@ -105,7 +105,7 @@ public class GreetResource {
     public JsonObject updateGreeting(@PathParam("greeting") String newGreeting) {
         greetingProvider.setMessage(newGreeting);
 
-        return jsonFactory.createObjectBuilder()
+        return JSON.createObjectBuilder()
                 .add("greeting", newGreeting)
                 .build();
     }
@@ -113,7 +113,7 @@ public class GreetResource {
     private JsonObject createResponse(String who) {
         String msg = String.format("%s %s!", greetingProvider.getMessage(), who);
 
-        return jsonFactory.createObjectBuilder()
+        return JSON.createObjectBuilder()
                 .add("message", msg)
                 .build();
     }

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.examples.quickstart.mp;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -45,6 +46,8 @@ import javax.ws.rs.core.MediaType;
 @Path("/greet")
 @RequestScoped
 public class GreetResource {
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     /**
      * The greeting message provider.
@@ -102,7 +105,7 @@ public class GreetResource {
     public JsonObject updateGreeting(@PathParam("greeting") String newGreeting) {
         greetingProvider.setMessage(newGreeting);
 
-        return Json.createObjectBuilder()
+        return jsonFactory.createObjectBuilder()
                 .add("greeting", newGreeting)
                 .build();
     }
@@ -110,7 +113,7 @@ public class GreetResource {
     private JsonObject createResponse(String who) {
         String msg = String.format("%s %s!", greetingProvider.getMessage(), who);
 
-        return Json.createObjectBuilder()
+        return jsonFactory.createObjectBuilder()
                 .add("message", msg)
                 .build();
     }

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -16,6 +16,8 @@
 
 package io.helidon.examples.quickstart.mp;
 
+import java.util.Collections;
+
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.Json;
@@ -47,7 +49,7 @@ import javax.ws.rs.core.MediaType;
 @RequestScoped
 public class GreetResource {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The greeting message provider.

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -26,6 +26,8 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
+import java.util.Collections;
+
 /**
  * A simple service to greet you. Examples:
  *
@@ -48,7 +50,7 @@ public class GreetService implements Service {
      */
     private String greeting;
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     GreetService(Config config) {
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -17,6 +17,7 @@
 package io.helidon.examples.quickstart.se;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 
 import io.helidon.config.Config;
@@ -46,6 +47,8 @@ public class GreetService implements Service {
      * The config value for the key {@code greeting}.
      */
     private String greeting;
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     GreetService(Config config) {
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");
@@ -87,7 +90,7 @@ public class GreetService implements Service {
     private void sendResponse(ServerResponse response, String name) {
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -102,7 +105,7 @@ public class GreetService implements Service {
                                 ServerResponse response) {
         greeting = request.path().param("greeting");
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = jsonFactory.createObjectBuilder()
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -16,6 +16,8 @@
 
 package io.helidon.examples.quickstart.se;
 
+import java.util.Collections;
+
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
@@ -25,8 +27,6 @@ import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
-
-import java.util.Collections;
 
 /**
  * A simple service to greet you. Examples:

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -48,7 +48,7 @@ public class GreetService implements Service {
      */
     private String greeting;
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     GreetService(Config config) {
         this.greeting = config.get("app.greeting").asString().orElse("Ciao");
@@ -90,7 +90,7 @@ public class GreetService implements Service {
     private void sendResponse(ServerResponse response, String name) {
         String msg = String.format("%s %s!", greeting, name);
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg)
                 .build();
         response.send(returnObject);
@@ -105,7 +105,7 @@ public class GreetService implements Service {
                                 ServerResponse response) {
         greeting = request.path().param("greeting");
 
-        JsonObject returnObject = jsonFactory.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 
 import io.helidon.webserver.WebServer;
 
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     @BeforeAll
     public static void startTheServer() throws Exception {
@@ -65,14 +67,14 @@ public class MainTest {
 
         conn = getURLConnection("GET","/greet");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response1");
-        JsonReader jsonReader = Json.createReader(conn.getInputStream());
+        JsonReader jsonReader = jsonFactory.createReader(conn.getInputStream());
         JsonObject jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         conn = getURLConnection("GET", "/greet/Joe");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
-        jsonReader = Json.createReader(conn.getInputStream());
+        jsonReader = jsonFactory.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
@@ -81,7 +83,7 @@ public class MainTest {
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
-        jsonReader = Json.createReader(conn.getInputStream());
+        jsonReader = jsonFactory.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.examples.quickstart.se;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.net.URL;
 import java.net.HttpURLConnection;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     @BeforeAll
     public static void startTheServer() throws Exception {

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class MainTest {
 
     private static WebServer webServer;
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     @BeforeAll
     public static void startTheServer() throws Exception {
@@ -67,14 +67,14 @@ public class MainTest {
 
         conn = getURLConnection("GET","/greet");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response1");
-        JsonReader jsonReader = jsonFactory.createReader(conn.getInputStream());
+        JsonReader jsonReader = JSON.createReader(conn.getInputStream());
         JsonObject jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         conn = getURLConnection("GET", "/greet/Joe");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
-        jsonReader = jsonFactory.createReader(conn.getInputStream());
+        jsonReader = JSON.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
@@ -83,7 +83,7 @@ public class MainTest {
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
-        jsonReader = jsonFactory.createReader(conn.getInputStream());
+        jsonReader = JSON.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -52,6 +53,8 @@ import io.opentracing.Span;
 @Authorized
 @ApplicationScoped
 public class JaxRsBackendResource {
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     /**
      * The database service facade.
@@ -84,7 +87,7 @@ public class JaxRsBackendResource {
                 .asChildOf(context.tracingSpan())
                 .start();
 
-        JsonArrayBuilder builder = Json.createArrayBuilder();
+        JsonArrayBuilder builder = jsonFactory.createArrayBuilder();
         backendService.list(context.tracingSpan(), getUserId(context))
                       .forEach(data -> builder.add(data.forRest()));
 

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
@@ -54,7 +54,7 @@ import io.opentracing.Span;
 @ApplicationScoped
 public class JaxRsBackendResource {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The database service facade.
@@ -87,7 +87,7 @@ public class JaxRsBackendResource {
                 .asChildOf(context.tracingSpan())
                 .start();
 
-        JsonArrayBuilder builder = jsonFactory.createArrayBuilder();
+        JsonArrayBuilder builder = JSON.createArrayBuilder();
         backendService.list(context.tracingSpan(), getUserId(context))
                       .forEach(data -> builder.add(data.forRest()));
 

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/JaxRsBackendResource.java
@@ -16,6 +16,7 @@
 
 package io.helidon.demo.todos.backend;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -54,7 +55,7 @@ import io.opentracing.Span;
 @ApplicationScoped
 public class JaxRsBackendResource {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The database service facade.

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
@@ -18,6 +18,7 @@ package io.helidon.demo.todos.backend;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.UUID;
 
 import javax.json.Json;
@@ -42,7 +43,7 @@ public final class Todo {
     /**
      * Factory for creating JSON builders.
      */
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     /**
      * The TODO ID.

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
@@ -42,7 +42,7 @@ public final class Todo {
     /**
      * Factory for creating JSON builders.
      */
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     /**
      * The TODO ID.
@@ -175,7 +175,7 @@ public final class Todo {
      */
     public JsonObject forDb() {
         //to store to DB
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         return builder.add("id", id)
                 .add("user", userId)
                 .add("message", title)
@@ -190,7 +190,7 @@ public final class Todo {
      */
     public JsonObject forRest() {
         //to send over to rest
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         return builder.add("id", id)
                 .add("user", userId)
                 .add("title", title)

--- a/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
+++ b/examples/todo-app/demo-backend/src/main/java/io/helidon/demo/todos/backend/Todo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -37,6 +38,11 @@ public final class Todo {
      */
     private static final DateTimeFormatter DATE_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSVV");
+
+    /**
+     * Factory for creating JSON builders.
+     */
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     /**
      * The TODO ID.
@@ -169,7 +175,7 @@ public final class Todo {
      */
     public JsonObject forDb() {
         //to store to DB
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         return builder.add("id", id)
                 .add("user", userId)
                 .add("message", title)
@@ -184,7 +190,7 @@ public final class Todo {
      */
     public JsonObject forRest() {
         //to send over to rest
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         return builder.add("id", id)
                 .add("user", userId)
                 .add("title", title)

--- a/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
@@ -54,7 +54,7 @@ import io.helidon.webserver.json.JsonSupport;
  */
 public class Main {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     // ---------------- EXAMPLES
 
@@ -272,7 +272,7 @@ public class Main {
         Routing routing = Routing.builder()
                                  .register(StaticContentSupport.create("/static"))
                                  .register("/hello", JsonSupport.create())
-                                 .get("/hello/{what}", (req, res) -> res.send(jsonFactory.createObjectBuilder()
+                                 .get("/hello/{what}", (req, res) -> res.send(JSON.createObjectBuilder()
                                                                                   .add("message",
                                                                                        "Hello " + req.path()
                                                                                                      .param("what"))

--- a/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
@@ -52,6 +53,8 @@ import io.helidon.webserver.json.JsonSupport;
  * It is also java executable main class. Use a method name as a command line parameter to execute.
  */
 public class Main {
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     // ---------------- EXAMPLES
 
@@ -269,7 +272,7 @@ public class Main {
         Routing routing = Routing.builder()
                                  .register(StaticContentSupport.create("/static"))
                                  .register("/hello", JsonSupport.create())
-                                 .get("/hello/{what}", (req, res) -> res.send(Json.createObjectBuilder()
+                                 .get("/hello/{what}", (req, res) -> res.send(jsonFactory.createObjectBuilder()
                                                                                   .add("message",
                                                                                        "Hello " + req.path()
                                                                                                      .param("what"))

--- a/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
+++ b/examples/webserver/basics/src/main/java/io/helidon/webserver/examples/basics/Main.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
@@ -54,7 +55,7 @@ import io.helidon.webserver.json.JsonSupport;
  */
 public class Main {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     // ---------------- EXAMPLES
 

--- a/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
+++ b/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 
 import io.helidon.webserver.Routing;
@@ -33,6 +34,7 @@ import io.helidon.webserver.json.JsonSupport;
  */
 public class CounterService implements Service {
 
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
     private final LongAdder allAccessCounter = new LongAdder();
     private final AtomicInteger apiAccessCounter = new AtomicInteger();
 
@@ -50,7 +52,7 @@ public class CounterService implements Service {
 
     private void handleGet(ServerRequest request, ServerResponse response) {
         int apiAcc = apiAccessCounter.incrementAndGet();
-        JsonObject result = Json.createObjectBuilder()
+        JsonObject result = jsonFactory.createObjectBuilder()
                                 .add("all", allAccessCounter.longValue())
                                 .add("api", apiAcc)
                                 .build();

--- a/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
+++ b/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
@@ -34,7 +34,7 @@ import io.helidon.webserver.json.JsonSupport;
  */
 public class CounterService implements Service {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
     private final LongAdder allAccessCounter = new LongAdder();
     private final AtomicInteger apiAccessCounter = new AtomicInteger();
 
@@ -52,7 +52,7 @@ public class CounterService implements Service {
 
     private void handleGet(ServerRequest request, ServerResponse response) {
         int apiAcc = apiAccessCounter.incrementAndGet();
-        JsonObject result = jsonFactory.createObjectBuilder()
+        JsonObject result = JSON.createObjectBuilder()
                                 .add("all", allAccessCounter.longValue())
                                 .add("api", apiAcc)
                                 .build();

--- a/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
+++ b/examples/webserver/static-content/src/main/java/io/helidon/webserver/examples/staticcontent/CounterService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.webserver.examples.staticcontent;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -34,7 +35,7 @@ import io.helidon.webserver.json.JsonSupport;
  */
 public class CounterService implements Service {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     private final LongAdder allAccessCounter = new LongAdder();
     private final AtomicInteger apiAccessCounter = new AtomicInteger();
 

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
@@ -53,6 +54,8 @@ public final class HealthSupport implements Service {
     public static final String DEFAULT_WEB_CONTEXT = "/health";
 
     private static final Logger LOGGER = Logger.getLogger(HealthSupport.class.getName());
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     private final String webContext;
     private final List<HealthCheck> healthChecks;
@@ -105,17 +108,17 @@ public final class HealthSupport implements Service {
     }
 
     private JsonObject toJson(State state, List<HcResponse> responses) {
-        final JsonObjectBuilder jsonBuilder = Json.createObjectBuilder()
+        final JsonObjectBuilder jsonBuilder = jsonFactory.createObjectBuilder()
                 .add("outcome", state.toString());
 
-        final JsonArrayBuilder checkArrayBuilder = Json.createArrayBuilder();
+        final JsonArrayBuilder checkArrayBuilder = jsonFactory.createArrayBuilder();
 
         for (HcResponse r : responses) {
-            JsonObjectBuilder checkBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder checkBuilder = jsonFactory.createObjectBuilder();
             checkBuilder.add("name", r.name());
             checkBuilder.add("state", r.state().toString());
             Optional<Map<String, Object>> data = r.data();
-            data.ifPresent(m -> checkBuilder.add("data", Json.createObjectBuilder(m)));
+            data.ifPresent(m -> checkBuilder.add("data", jsonFactory.createObjectBuilder(m)));
 
             checkArrayBuilder.add(checkBuilder);
         }

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -55,7 +55,7 @@ public final class HealthSupport implements Service {
 
     private static final Logger LOGGER = Logger.getLogger(HealthSupport.class.getName());
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     private final String webContext;
     private final List<HealthCheck> healthChecks;
@@ -108,17 +108,17 @@ public final class HealthSupport implements Service {
     }
 
     private JsonObject toJson(State state, List<HcResponse> responses) {
-        final JsonObjectBuilder jsonBuilder = jsonFactory.createObjectBuilder()
+        final JsonObjectBuilder jsonBuilder = JSON.createObjectBuilder()
                 .add("outcome", state.toString());
 
-        final JsonArrayBuilder checkArrayBuilder = jsonFactory.createArrayBuilder();
+        final JsonArrayBuilder checkArrayBuilder = JSON.createArrayBuilder();
 
         for (HcResponse r : responses) {
-            JsonObjectBuilder checkBuilder = jsonFactory.createObjectBuilder();
+            JsonObjectBuilder checkBuilder = JSON.createObjectBuilder();
             checkBuilder.add("name", r.name());
             checkBuilder.add("state", r.state().toString());
             Optional<Map<String, Object>> data = r.data();
-            data.ifPresent(m -> checkBuilder.add("data", jsonFactory.createObjectBuilder(m)));
+            data.ifPresent(m -> checkBuilder.add("data", JSON.createObjectBuilder(m)));
 
             checkArrayBuilder.add(checkBuilder);
         }

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -17,6 +17,7 @@ package io.helidon.health;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -55,7 +56,7 @@ public final class HealthSupport implements Service {
 
     private static final Logger LOGGER = Logger.getLogger(HealthSupport.class.getName());
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     private final String webContext;
     private final List<HealthCheck> healthChecks;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonHistogram.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Histogram;
@@ -155,7 +156,7 @@ final class HelidonHistogram extends MetricImpl implements Histogram {
 
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         Snapshot snapshot = getSnapshot();

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonHistogram.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonHistogram.java
@@ -19,8 +19,6 @@ package io.helidon.metrics;
 import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Histogram;
@@ -156,7 +154,7 @@ final class HelidonHistogram extends MetricImpl implements Histogram {
 
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder myBuilder = JSON.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         Snapshot snapshot = getSnapshot();

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
@@ -21,8 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Metadata;
@@ -134,7 +132,7 @@ final class HelidonMeter extends MetricImpl implements Meter {
     */
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder myBuilder = JSON.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         myBuilder.add("meanRate", getMeanRate());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Metadata;
@@ -133,7 +134,7 @@ final class HelidonMeter extends MetricImpl implements Meter {
     */
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         myBuilder.add("meanRate", getMeanRate());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
@@ -21,8 +21,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Histogram;
@@ -200,7 +198,7 @@ final class HelidonTimer extends MetricImpl implements Timer {
 
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder myBuilder = JSON.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         myBuilder.add("meanRate", getMeanRate());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Histogram;
@@ -199,7 +200,7 @@ final class HelidonTimer extends MetricImpl implements Timer {
 
     @Override
     public void jsonData(JsonObjectBuilder builder) {
-        JsonObjectBuilder myBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder myBuilder = jsonFactory.createObjectBuilder();
 
         myBuilder.add("count", getCount());
         myBuilder.add("meanRate", getMeanRate());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Metadata;
@@ -35,6 +36,8 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * Base for our implementations of various metrics.
  */
 abstract class MetricImpl extends Metadata implements HelidonMetric {
+    static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+
     private static final Pattern DOUBLE_UNDERSCORE = Pattern.compile("__");
     private static final Pattern COLON_UNDERSCORE = Pattern.compile(":_");
     private static final Pattern CAMEL_CASE = Pattern.compile("(.)(\\p{Upper})");
@@ -48,6 +51,7 @@ abstract class MetricImpl extends Metadata implements HelidonMetric {
     private static final long KILOBYTES = 1000;
     private static final long MEGABYTES = 1000 * KILOBYTES;
     private static final long GIGABYTES = 1000 * MEGABYTES;
+
 
     static {
         //see https://prometheus.io/docs/practices/naming/#base-units
@@ -125,7 +129,7 @@ abstract class MetricImpl extends Metadata implements HelidonMetric {
 
     @Override
     public void jsonMeta(JsonObjectBuilder builder) {
-        JsonObjectBuilder metaBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder metaBuilder = jsonFactory.createObjectBuilder();
 
         addNonEmpty(metaBuilder, "unit", getUnit());
         addNonEmpty(metaBuilder, "unit", getUnit());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -31,8 +32,6 @@ import javax.json.JsonObjectBuilder;
 
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricUnits;
-
-import java.util.Collections;
 
 /**
  * Base for our implementations of various metrics.

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -32,11 +32,13 @@ import javax.json.JsonObjectBuilder;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricUnits;
 
+import java.util.Collections;
+
 /**
  * Base for our implementations of various metrics.
  */
 abstract class MetricImpl extends Metadata implements HelidonMetric {
-    static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     private static final Pattern DOUBLE_UNDERSCORE = Pattern.compile("__");
     private static final Pattern COLON_UNDERSCORE = Pattern.compile(":_");

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -36,7 +36,7 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * Base for our implementations of various metrics.
  */
 abstract class MetricImpl extends Metadata implements HelidonMetric {
-    static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     private static final Pattern DOUBLE_UNDERSCORE = Pattern.compile("__");
     private static final Pattern COLON_UNDERSCORE = Pattern.compile(":_");
@@ -129,7 +129,7 @@ abstract class MetricImpl extends Metadata implements HelidonMetric {
 
     @Override
     public void jsonMeta(JsonObjectBuilder builder) {
-        JsonObjectBuilder metaBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder metaBuilder = JSON.createObjectBuilder();
 
         addNonEmpty(metaBuilder, "unit", getUnit());
         addNonEmpty(metaBuilder, "unit", getUnit());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -17,10 +17,10 @@
 package io.helidon.metrics;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -77,7 +77,7 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * }</pre>
  */
 public final class MetricsSupport implements Service {
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
     private static final String DEFAULT_CONTEXT = "/metrics";
     private final Registry base;
     private final Registry app;
@@ -242,7 +242,7 @@ public final class MetricsSupport implements Service {
 
     // unit testable
     static JsonObject toJsonData(Registry... registries) {
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         for (Registry registry : registries) {
             if (!registry.empty()) {
                 builder.add(registry.type(), toJsonData(registry));
@@ -252,14 +252,14 @@ public final class MetricsSupport implements Service {
     }
 
     static JsonObject toJsonData(Registry registry) {
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         registry.stream()
                 .forEach(mpMetric -> mpMetric.jsonData(builder));
         return builder.build();
     }
 
     static JsonObject toJsonMeta(Registry... registries) {
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         for (Registry registry : registries) {
             if (!registry.empty()) {
                 builder.add(registry.type(), toJsonMeta(registry));
@@ -269,7 +269,7 @@ public final class MetricsSupport implements Service {
     }
 
     static JsonObject toJsonMeta(Registry registry) {
-        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder builder = JSON.createObjectBuilder();
         registry.stream()
                 .forEach(mpMetric -> mpMetric.jsonMeta(builder));
         return builder.build();
@@ -311,7 +311,7 @@ public final class MetricsSupport implements Service {
         OptionalHelper.from(registry.getMetric(metricName))
                 .ifPresentOrElse(metric -> {
                     if (requestsJsonData(req.headers())) {
-                        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+                        JsonObjectBuilder builder = JSON.createObjectBuilder();
                         metric.jsonData(builder);
                         res.send(builder.build());
                     } else {
@@ -346,7 +346,7 @@ public final class MetricsSupport implements Service {
         OptionalHelper.from(registry.getMetric(metricName))
                 .ifPresentOrElse(metric -> {
                     if (req.headers().isAccepted(MediaType.APPLICATION_JSON)) {
-                        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
+                        JsonObjectBuilder builder = JSON.createObjectBuilder();
                         metric.jsonMeta(builder);
                         res.send(builder.build());
                     } else {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -16,6 +16,7 @@
 
 package io.helidon.metrics;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -77,7 +78,7 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * }</pre>
  */
 public final class MetricsSupport implements Service {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     private static final String DEFAULT_CONTEXT = "/metrics";
     private final Registry base;
     private final Registry app;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
@@ -76,6 +77,7 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * }</pre>
  */
 public final class MetricsSupport implements Service {
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
     private static final String DEFAULT_CONTEXT = "/metrics";
     private final Registry base;
     private final Registry app;
@@ -240,7 +242,7 @@ public final class MetricsSupport implements Service {
 
     // unit testable
     static JsonObject toJsonData(Registry... registries) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         for (Registry registry : registries) {
             if (!registry.empty()) {
                 builder.add(registry.type(), toJsonData(registry));
@@ -250,14 +252,14 @@ public final class MetricsSupport implements Service {
     }
 
     static JsonObject toJsonData(Registry registry) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         registry.stream()
                 .forEach(mpMetric -> mpMetric.jsonData(builder));
         return builder.build();
     }
 
     static JsonObject toJsonMeta(Registry... registries) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         for (Registry registry : registries) {
             if (!registry.empty()) {
                 builder.add(registry.type(), toJsonMeta(registry));
@@ -267,7 +269,7 @@ public final class MetricsSupport implements Service {
     }
 
     static JsonObject toJsonMeta(Registry registry) {
-        JsonObjectBuilder builder = Json.createObjectBuilder();
+        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
         registry.stream()
                 .forEach(mpMetric -> mpMetric.jsonMeta(builder));
         return builder.build();
@@ -309,7 +311,7 @@ public final class MetricsSupport implements Service {
         OptionalHelper.from(registry.getMetric(metricName))
                 .ifPresentOrElse(metric -> {
                     if (requestsJsonData(req.headers())) {
-                        JsonObjectBuilder builder = Json.createObjectBuilder();
+                        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
                         metric.jsonData(builder);
                         res.send(builder.build());
                     } else {
@@ -344,7 +346,7 @@ public final class MetricsSupport implements Service {
         OptionalHelper.from(registry.getMetric(metricName))
                 .ifPresentOrElse(metric -> {
                     if (req.headers().isAccepted(MediaType.APPLICATION_JSON)) {
-                        JsonObjectBuilder builder = Json.createObjectBuilder();
+                        JsonObjectBuilder builder = jsonFactory.createObjectBuilder();
                         metric.jsonMeta(builder);
                         res.send(builder.build());
                     } else {

--- a/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -90,7 +91,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class JwtAuthProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final Logger LOGGER = Logger.getLogger(JwtAuthProvider.class.getName());
 
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     /**
      * Configure this for outbound requests to override user to use.

--- a/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReaderFactory;
 
 import io.helidon.common.CollectionsHelper;
 import io.helidon.common.Errors;
@@ -88,6 +89,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class JwtAuthProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final Logger LOGGER = Logger.getLogger(JwtAuthProvider.class.getName());
+
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     /**
      * Configure this for outbound requests to override user to use.
@@ -631,7 +634,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                         .resource(Resource.create("public key from PKCS8", jwkJson))
                         .build();
             }
-            JsonObject jsonObject = Json.createReader(new StringReader(jwkJson)).readObject();
+            JsonObject jsonObject = jsonFactory.createReader(new StringReader(jwkJson)).readObject();
             return JwkKeys.builder().addKey(Jwk.create(jsonObject)).build();
         }
 

--- a/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -90,7 +90,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class JwtAuthProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final Logger LOGGER = Logger.getLogger(JwtAuthProvider.class.getName());
 
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     /**
      * Configure this for outbound requests to override user to use.
@@ -634,7 +634,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                         .resource(Resource.create("public key from PKCS8", jwkJson))
                         .build();
             }
-            JsonObject jsonObject = jsonFactory.createReader(new StringReader(jwkJson)).readObject();
+            JsonObject jsonObject = JSON.createReader(new StringReader(jwkJson)).readObject();
             return JwkKeys.builder().addKey(Jwk.create(jsonObject)).build();
         }
 

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -54,7 +54,7 @@ import io.helidon.security.jwt.jwk.Jwk;
 @SuppressWarnings("WeakerAccess") // getters should be public
 public class Jwt {
 
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     /*
     Header claims
     */

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -54,7 +54,7 @@ import io.helidon.security.jwt.jwk.Jwk;
 @SuppressWarnings("WeakerAccess") // getters should be public
 public class Jwt {
 
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
     /*
     Header claims
     */
@@ -500,7 +500,7 @@ public class Jwt {
             return rawValue;
         }
 
-        return jsonFactory.createArrayBuilder()
+        return JSON.createArrayBuilder()
                 .add(rawValue)
                 .build();
     }
@@ -835,7 +835,7 @@ public class Jwt {
      * @return JsonObject for header
      */
     public JsonObject headerJson() {
-        JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder objectBuilder = JSON.createObjectBuilder();
         headerClaims.forEach(objectBuilder::add);
 
         algorithm.ifPresent(it -> objectBuilder.add("alg", it));
@@ -852,7 +852,7 @@ public class Jwt {
      * @return JsonObject for payload
      */
     public JsonObject payloadJson() {
-        JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
+        JsonObjectBuilder objectBuilder = JSON.createObjectBuilder();
         payloadClaims.forEach(objectBuilder::add);
 
         // known payload
@@ -863,12 +863,12 @@ public class Jwt {
         this.subject.ifPresent(it -> objectBuilder.add("sub", it));
         this.userPrincipal.ifPresent(it -> objectBuilder.add("upn", it));
         this.userGroups.ifPresent(it -> {
-            JsonArrayBuilder jab = jsonFactory.createArrayBuilder();
+            JsonArrayBuilder jab = JSON.createArrayBuilder();
             it.forEach(jab::add);
             objectBuilder.add("groups", jab);
         });
         this.audience.ifPresent(it -> {
-            JsonArrayBuilder jab = jsonFactory.createArrayBuilder();
+            JsonArrayBuilder jab = JSON.createArrayBuilder();
             it.forEach(jab::add);
             objectBuilder.add("aud", jab);
         });

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
@@ -52,6 +53,8 @@ import io.helidon.security.jwt.jwk.Jwk;
  */
 @SuppressWarnings("WeakerAccess") // getters should be public
 public class Jwt {
+
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
     /*
     Header claims
     */
@@ -497,7 +500,7 @@ public class Jwt {
             return rawValue;
         }
 
-        return Json.createArrayBuilder()
+        return jsonFactory.createArrayBuilder()
                 .add(rawValue)
                 .build();
     }
@@ -832,7 +835,7 @@ public class Jwt {
      * @return JsonObject for header
      */
     public JsonObject headerJson() {
-        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
         headerClaims.forEach(objectBuilder::add);
 
         algorithm.ifPresent(it -> objectBuilder.add("alg", it));
@@ -849,7 +852,7 @@ public class Jwt {
      * @return JsonObject for payload
      */
     public JsonObject payloadJson() {
-        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
         payloadClaims.forEach(objectBuilder::add);
 
         // known payload
@@ -860,12 +863,12 @@ public class Jwt {
         this.subject.ifPresent(it -> objectBuilder.add("sub", it));
         this.userPrincipal.ifPresent(it -> objectBuilder.add("upn", it));
         this.userGroups.ifPresent(it -> {
-            JsonArrayBuilder jab = Json.createArrayBuilder();
+            JsonArrayBuilder jab = jsonFactory.createArrayBuilder();
             it.forEach(jab::add);
             objectBuilder.add("groups", jab);
         });
         this.audience.ifPresent(it -> {
-            JsonArrayBuilder jab = Json.createArrayBuilder();
+            JsonArrayBuilder jab = jsonFactory.createArrayBuilder();
             it.forEach(jab::add);
             objectBuilder.add("aud", jab);
         });

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -29,6 +29,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -60,7 +61,7 @@ public final class JwtUtil {
     private static final Pattern LOCALE_PATTERN = Pattern.compile("(\\w+)_(\\w+)");
 
     // Avoid reloading JSON providers. See https://github.com/eclipse-ee4j/jsonp/issues/154
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
 
     private JwtUtil() {

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -46,6 +46,7 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
 import javax.json.JsonValue;
+import javax.json.spi.JsonProvider;
 
 /**
  * Utilities for JWT and JWK parsing.
@@ -57,7 +58,10 @@ public final class JwtUtil {
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
     private static final Pattern LOCALE_PATTERN = Pattern.compile("(\\w+)_(\\w+)");
+
+    // Avoid reloading JSON providers. See https://github.com/eclipse-ee4j/jsonp/issues/154
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonProvider JSON_PROVIDER = JsonProvider.provider();
 
     private JwtUtil() {
     }
@@ -245,22 +249,22 @@ public final class JwtUtil {
 
     private static JsonValue toJson(Object object) {
         if (object instanceof String) {
-            return Json.createValue((String) object);
+            return JSON_PROVIDER.createValue((String) object);
         }
         if (object instanceof Integer) {
-            return Json.createValue((Integer) object);
+            return JSON_PROVIDER.createValue((Integer) object);
         }
         if (object instanceof Double) {
-            return Json.createValue((Double) object);
+            return JSON_PROVIDER.createValue((Double) object);
         }
         if (object instanceof Long) {
-            return Json.createValue((Long) object);
+            return JSON_PROVIDER.createValue((Long) object);
         }
         if (object instanceof BigDecimal) {
-            return Json.createValue((BigDecimal) object);
+            return JSON_PROVIDER.createValue((BigDecimal) object);
         }
         if (object instanceof BigInteger) {
-            return Json.createValue((BigInteger) object);
+            return JSON_PROVIDER.createValue((BigInteger) object);
         }
         if (object instanceof Boolean) {
             return ((Boolean) object) ? JsonValue.TRUE : JsonValue.FALSE;
@@ -271,7 +275,7 @@ public final class JwtUtil {
         if (object instanceof Collection) {
             return JSON.createArrayBuilder((Collection) object).build();
         }
-        return Json.createValue(String.valueOf(object));
+        return JSON_PROVIDER.createValue(String.valueOf(object));
     }
 
     private static Locale toLocale(String locale) {

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import javax.crypto.Mac;
 import javax.json.Json;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -56,6 +57,7 @@ public final class JwtUtil {
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
     private static final Pattern LOCALE_PATTERN = Pattern.compile("(\\w+)_(\\w+)");
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     private JwtUtil() {
     }
@@ -267,7 +269,7 @@ public final class JwtUtil {
             return ((Address) object).getJson();
         }
         if (object instanceof Collection) {
-            return Json.createArrayBuilder((Collection) object).build();
+            return jsonFactory.createArrayBuilder((Collection) object).build();
         }
         return Json.createValue(String.valueOf(object));
     }
@@ -425,7 +427,7 @@ public final class JwtUtil {
          * @return Address as a Json object
          */
         public JsonObject getJson() {
-            JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
 
             formatted.ifPresent(it -> objectBuilder.add("formatted", it));
             streetAddress.ifPresent(it -> objectBuilder.add("street_address", it));

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -57,7 +57,7 @@ public final class JwtUtil {
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
     private static final Pattern LOCALE_PATTERN = Pattern.compile("(\\w+)_(\\w+)");
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     private JwtUtil() {
     }
@@ -269,7 +269,7 @@ public final class JwtUtil {
             return ((Address) object).getJson();
         }
         if (object instanceof Collection) {
-            return jsonFactory.createArrayBuilder((Collection) object).build();
+            return JSON.createArrayBuilder((Collection) object).build();
         }
         return Json.createValue(String.valueOf(object));
     }
@@ -427,7 +427,7 @@ public final class JwtUtil {
          * @return Address as a Json object
          */
         public JsonObject getJson() {
-            JsonObjectBuilder objectBuilder = jsonFactory.createObjectBuilder();
+            JsonObjectBuilder objectBuilder = JSON.createObjectBuilder();
 
             formatted.ifPresent(it -> objectBuilder.add("formatted", it));
             streetAddress.ifPresent(it -> objectBuilder.add("street_address", it));

--- a/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReaderFactory;
 
 import io.helidon.common.Errors;
 import io.helidon.security.jwt.jwk.Jwk;
@@ -39,6 +40,7 @@ public final class SignedJwt {
             .compile("([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9_\\-/=+]*)");
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     private final String tokenContent;
     private final JsonObject headerJson;
@@ -181,7 +183,7 @@ public final class SignedJwt {
 
     private static JsonObject parseJson(String jsonString, Errors.Collector collector, String description) {
         try {
-            return Json.createReader(new StringReader(jsonString)).readObject();
+            return jsonFactory.createReader(new StringReader(jsonString)).readObject();
         } catch (Exception e) {
             collector.fatal(jsonString, description + " is not a valid JSON object");
             return null;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
@@ -20,6 +20,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,7 +41,7 @@ public final class SignedJwt {
             .compile("([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9_\\-/=+]*)");
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     private final String tokenContent;
     private final JsonObject headerJson;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
@@ -40,7 +40,7 @@ public final class SignedJwt {
             .compile("([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9_\\-/=+]*)");
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     private final String tokenContent;
     private final JsonObject headerJson;
@@ -183,7 +183,7 @@ public final class SignedJwt {
 
     private static JsonObject parseJson(String jsonString, Errors.Collector collector, String description) {
         try {
-            return jsonFactory.createReader(new StringReader(jsonString)).readObject();
+            return JSON.createReader(new StringReader(jsonString)).readObject();
         } catch (Exception e) {
             collector.fatal(jsonString, description + " is not a valid JSON object");
             return null;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
@@ -18,6 +18,7 @@ package io.helidon.security.jwt.jwk;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -50,7 +51,7 @@ import io.helidon.common.configurable.Resource;
  */
 public final class JwkKeys {
     private static final Logger LOGGER = Logger.getLogger(JwkKeys.class.getName());
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     private final Map<String, Jwk> keyMap = new HashMap<>();
     private final List<Jwk> noKeyIdKeys = new LinkedList<>();

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
 
 import io.helidon.common.configurable.Resource;
 
@@ -49,6 +51,7 @@ import io.helidon.common.configurable.Resource;
  */
 public final class JwkKeys {
     private static final Logger LOGGER = Logger.getLogger(JwkKeys.class.getName());
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     private final Map<String, Jwk> keyMap = new HashMap<>();
     private final List<Jwk> noKeyIdKeys = new LinkedList<>();
@@ -135,7 +138,7 @@ public final class JwkKeys {
         public Builder resource(Resource resource) {
             Objects.requireNonNull(resource, "Json resource must not be null");
             try (InputStream is = resource.stream()) {
-                JsonObject jsonObject = Json.createReader(is).readObject();
+                JsonObject jsonObject = jsonFactory.createReader(is).readObject();
                 addKeys(jsonObject);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to close input stream on resource: " + resource);

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkKeys.java
@@ -30,7 +30,6 @@ import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
-import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
 
 import io.helidon.common.configurable.Resource;
@@ -51,7 +50,7 @@ import io.helidon.common.configurable.Resource;
  */
 public final class JwkKeys {
     private static final Logger LOGGER = Logger.getLogger(JwkKeys.class.getName());
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     private final Map<String, Jwk> keyMap = new HashMap<>();
     private final List<Jwk> noKeyIdKeys = new LinkedList<>();
@@ -138,7 +137,7 @@ public final class JwkKeys {
         public Builder resource(Resource resource) {
             Objects.requireNonNull(resource, "Json resource must not be null");
             try (InputStream is = resource.stream()) {
-                JsonObject jsonObject = jsonFactory.createReader(is).readObject();
+                JsonObject jsonObject = JSON.createReader(is).readObject();
                 addKeys(jsonObject);
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Failed to close input stream on resource: " + resource);

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -56,7 +56,7 @@ import io.helidon.security.spi.SubjectMappingProvider;
 public final class IdcsRoleMapperProvider implements SubjectMappingProvider {
     private static final Logger LOGGER = Logger.getLogger(IdcsRoleMapperProvider.class.getName());
     private static final String ACCESS_TOKEN_KEY = "access_token";
-    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
 
     private final EvictableCache<String, List<? extends Grant>> roleCache;
     private final WebTarget assertEndpoint;
@@ -136,10 +136,10 @@ public final class IdcsRoleMapperProvider implements SubjectMappingProvider {
 
     private Optional<List<? extends Grant>> getGrantsFromServer(String subject) {
         return getAppToken().flatMap(appToken -> {
-            JsonObjectBuilder requestBuilder = jsonFactory.createObjectBuilder();
+            JsonObjectBuilder requestBuilder = JSON.createObjectBuilder();
             requestBuilder.add("mappingAttributeValue", subject);
             requestBuilder.add("includeMemberships", true);
-            JsonArrayBuilder arrayBuilder = jsonFactory.createArrayBuilder();
+            JsonArrayBuilder arrayBuilder = JSON.createArrayBuilder();
             arrayBuilder.add("urn:ietf:params:scim:schemas:oracle:idcs:Asserter");
             requestBuilder.add("schemas", arrayBuilder);
 

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
+import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.ws.rs.client.Entity;
@@ -55,6 +56,7 @@ import io.helidon.security.spi.SubjectMappingProvider;
 public final class IdcsRoleMapperProvider implements SubjectMappingProvider {
     private static final Logger LOGGER = Logger.getLogger(IdcsRoleMapperProvider.class.getName());
     private static final String ACCESS_TOKEN_KEY = "access_token";
+    private static final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(null);
 
     private final EvictableCache<String, List<? extends Grant>> roleCache;
     private final WebTarget assertEndpoint;
@@ -134,10 +136,10 @@ public final class IdcsRoleMapperProvider implements SubjectMappingProvider {
 
     private Optional<List<? extends Grant>> getGrantsFromServer(String subject) {
         return getAppToken().flatMap(appToken -> {
-            JsonObjectBuilder requestBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder requestBuilder = jsonFactory.createObjectBuilder();
             requestBuilder.add("mappingAttributeValue", subject);
             requestBuilder.add("includeMemberships", true);
-            JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+            JsonArrayBuilder arrayBuilder = jsonFactory.createArrayBuilder();
             arrayBuilder.add("urn:ietf:params:scim:schemas:oracle:idcs:Asserter");
             requestBuilder.add("schemas", arrayBuilder);
 

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.security.providers.idcs.mapper;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -56,7 +57,7 @@ import io.helidon.security.spi.SubjectMappingProvider;
 public final class IdcsRoleMapperProvider implements SubjectMappingProvider {
     private static final Logger LOGGER = Logger.getLogger(IdcsRoleMapperProvider.class.getName());
     private static final String ACCESS_TOKEN_KEY = "access_token";
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(null);
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     private final EvictableCache<String, List<? extends Grant>> roleCache;
     private final WebTarget assertEndpoint;

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -17,6 +17,7 @@
 package io.helidon.security.providers.oidc.common;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 import javax.json.Json;
@@ -237,7 +238,7 @@ public final class OidcConfig {
 
     private static final Logger LOGGER = Logger.getLogger(OidcConfig.class.getName());
 
-    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     static final int DEFAULT_PROXY_PORT = 80;
     static final String DEFAULT_OIDC_METADATA_URI = "/.well-known/openid-configuration";

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -237,7 +237,7 @@ public final class OidcConfig {
 
     private static final Logger LOGGER = Logger.getLogger(OidcConfig.class.getName());
 
-    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(null);
 
     static final int DEFAULT_PROXY_PORT = 80;
     static final String DEFAULT_OIDC_METADATA_URI = "/.well-known/openid-configuration";
@@ -804,7 +804,7 @@ public final class OidcConfig {
             if ((null == oidcMetadata) && oidcMetadataWellKnown) {
                 try {
                     String wellKnown = identityUri + OidcConfig.DEFAULT_OIDC_METADATA_URI;
-                    oidcMetadata = jsonFactory.createReader(Resource.create(URI.create(wellKnown)).stream()).readObject();
+                    oidcMetadata = JSON.createReader(Resource.create(URI.create(wellKnown)).stream()).readObject();
                     LOGGER.finest(() -> "OIDC Metadata loaded from well known URI: " + wellKnown);
                 } catch (Exception e) {
                     collector.fatal(e, "Failed to load metadata: " + e.getClass().getName() + ": " + e.getMessage());
@@ -1000,7 +1000,7 @@ public final class OidcConfig {
          * @return udpated builder instance
          */
         public Builder oidcMetadata(Resource resource) {
-            this.oidcMetadata = jsonFactory.createReader(resource.stream()).readObject();
+            this.oidcMetadata = JSON.createReader(resource.stream()).readObject();
             return this;
         }
 

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 
 import javax.json.Json;
 import javax.json.JsonObject;
+import javax.json.JsonReaderFactory;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -235,6 +236,8 @@ public final class OidcConfig {
     public static final String PARAM_HEADER_NAME = "X_OIDC_TOKEN_HEADER";
 
     private static final Logger LOGGER = Logger.getLogger(OidcConfig.class.getName());
+
+    private static final JsonReaderFactory jsonFactory = Json.createReaderFactory(null);
 
     static final int DEFAULT_PROXY_PORT = 80;
     static final String DEFAULT_OIDC_METADATA_URI = "/.well-known/openid-configuration";
@@ -801,7 +804,7 @@ public final class OidcConfig {
             if ((null == oidcMetadata) && oidcMetadataWellKnown) {
                 try {
                     String wellKnown = identityUri + OidcConfig.DEFAULT_OIDC_METADATA_URI;
-                    oidcMetadata = Json.createReader(Resource.create(URI.create(wellKnown)).stream()).readObject();
+                    oidcMetadata = jsonFactory.createReader(Resource.create(URI.create(wellKnown)).stream()).readObject();
                     LOGGER.finest(() -> "OIDC Metadata loaded from well known URI: " + wellKnown);
                 } catch (Exception e) {
                     collector.fatal(e, "Failed to load metadata: " + e.getClass().getName() + ": " + e.getMessage());
@@ -997,7 +1000,7 @@ public final class OidcConfig {
          * @return udpated builder instance
          */
         public Builder oidcMetadata(Resource resource) {
-            this.oidcMetadata = Json.createReader(resource.stream()).readObject();
+            this.oidcMetadata = jsonFactory.createReader(resource.stream()).readObject();
             return this;
         }
 


### PR DESCRIPTION
This replaces most of our use of `Json.create*` methods with appropriate builder methods. Fixes #329.

Security has some use of `Json.createValue()`. For these I fetch and cache the JsonProvider.

Here is the JSON-P issue describing the problem this PR is a workaround for:  https://github.com/eclipse-ee4j/jsonp/issues/154
