### PR TITLE
Various clean-up to the config examples

### DIFF
--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -1,4 +1,5 @@
 
 # Helidon SE Config Examples
 
-
+Each subdirectory contains example code that highlights specific aspects of
+Helidon configuration.

--- a/examples/config/basics/README.md
+++ b/examples/config/basics/README.md
@@ -1,12 +1,13 @@
 
 # Helidon Config Basic Example
 
-This example shows the basics of using Helidon SE Config:
+This example shows the basics of using Helidon SE Config. The
+[Main.java](./src/main/java/io/helidon/config/examples/basics/Main.java) class shows:
 
-* Loading configuration from a resource (`application.conf`) on the
-classpath containing config in HOCON 
-(Human-Optimized Config Object Notation) format
-* Getting configuration values of various types
+* loading configuration from a resource 
+[`application.conf`](./src/main/resources/application.conf) on the classpath 
+containing config in HOCON (Human-Optimized Config Object Notation) format
+* getting configuration values of various types
 
 ## Build
 

--- a/examples/config/basics/README.md
+++ b/examples/config/basics/README.md
@@ -3,7 +3,9 @@
 
 This example shows the basics of using Helidon SE Config:
 
-* Loading configuration from `application.conf`
+* Loading configuration from a resource (`application.conf`) on the
+classpath containing config in HOCON 
+(Human-Optimized Config Object Notation) format
 * Getting configuration values of various types
 
 ## Build

--- a/examples/config/changes/README.md
+++ b/examples/config/changes/README.md
@@ -1,8 +1,31 @@
 
 # Helidon Config Changes Example
 
-This example shows how an application can detect changes to its
+This example shows how an application can deal with changes to 
 configuration.
+
+## Change notification
+The example highlights two approaches to change notification:
+
+1. [`ChangesSubscriberExample.java`](./src/main/java/io/helidon/config/examples/changes/ChangesSubscriberExample.java):
+uses `Config.changes` to register an application-specific `Flow.Subscriber` with a 
+config-provided `Flow.Publisher` to be notified of changes to the underlying 
+configuration source as they occur
+2. [`OnChangeExample.java`](./src/main/java/io/helidon/config/examples/changes/OnChangeExample.java):
+uses `Config.onChange`, passing either a method reference or a lambda expression
+which the config system invokes when the config source changes
+)
+
+## Latest-value supplier
+A third example illustrates a different solution. 
+Recall that once your application obtains a `Config` instance, its config values 
+do not change. The 
+[`AsSupplierExample.java`](./src/main/java/io/helidon/config/examples/changes/AsSupplierExample.java)
+example shows how your application can get a config _supplier_ that always reports 
+the latest config value for a key, including any changes made after your
+application obtained the `Config` object. Although this approach does not notify
+your application _when_ changes occur, it _does_ permit your code to always use 
+the most up-to-date value. Sometimes that is all you need.
 
 ## Build
 

--- a/examples/config/changes/README.md
+++ b/examples/config/changes/README.md
@@ -12,8 +12,8 @@ uses `Config.changes` to register an application-specific `Flow.Subscriber` with
 config-provided `Flow.Publisher` to be notified of changes to the underlying 
 configuration source as they occur
 2. [`OnChangeExample.java`](./src/main/java/io/helidon/config/examples/changes/OnChangeExample.java):
-uses `Config.onChange`, passing either a method reference or a lambda expression
-which the config system invokes when the config source changes
+uses `Config.onChange`, passing either a method reference (a lambda expression
+would also work) which the config system invokes when the config source changes
 )
 
 ## Latest-value supplier

--- a/examples/config/changes/src/main/java/io/helidon/config/examples/changes/ChangesSubscriberExample.java
+++ b/examples/config/changes/src/main/java/io/helidon/config/examples/changes/ChangesSubscriberExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.config.examples.changes;
 
 import java.util.logging.Level;
@@ -29,12 +28,31 @@ import static io.helidon.config.PollingStrategies.regular;
 import static java.time.Duration.ofSeconds;
 
 /**
- * Example shows how to listen on Config node changes using {@link Flow.Subscriber}.
- * Method {@link Flow.Subscriber#onNext(Object) onNext} is invoked with new instance of Config,
- * see {@link Config#changes()} for more detail.
+ * Example shows how to listen on Config node changes using
+ * {@link Flow.Subscriber}. Method {@link Flow.Subscriber#onNext(Object) onNext}
+ * is invoked with new instance of Config, see {@link Config#changes()} for more
+ * detail.
  * <p>
- * The feature is based on using {@link io.helidon.config.spi.PollingStrategy} with
- * selected config source(s) to check for changes.
+ * The feature is based on using {@link io.helidon.config.spi.PollingStrategy}
+ * with selected config source(s) to check for changes.
+ * <p>
+ * <h2>A note about {@code Config.changes() }, {@code Flow.Publisher}, and
+ * {@code Flow.Subscriber}</h2>
+ * This example uses the {@link Config#changes() } API. That method is marked as
+ * deprecated because it its return type is the Helidon-specific interface
+ * {@link Flow.Publisher} which mimics the interface with the same name in Java
+ * 9 and later. Similarly the {@link Flow.Publisher#subscribe} method accepts a
+ * Helidon-specific {@link Flow.Subscriber}.
+ * <p>
+ * Once Helidon requires Java 9 or later (as opposed to Java 8), the
+ * {@code Config.changes()} API might change to return the Java
+ * {@code Flow.Subscriber} interface instead of the Helidon-specific one. By
+ * marking the method as deprecated we encourage developers to be very careful
+ * in how they use the method and, specifically, its return value and the
+ * argument to {@code subscribe}. Developers should avoid propagating these
+ * Helidon-specific types throughout their code to minimize the disruption
+ * if and when the {@code Config.changes()} method evolves to return the Java,
+ * not Helidon, {@code Flow.Publisher}.
  */
 public class ChangesSubscriberExample {
 
@@ -46,18 +64,18 @@ public class ChangesSubscriberExample {
     public void run() {
         Config config = Config
                 .create(file("conf/dev.yaml")
-                              .optional()
-                              .pollingStrategy(PollingStrategies::watch),
+                        .optional()
+                        .pollingStrategy(PollingStrategies::watch),
                         file("conf/config.yaml")
-                              .optional()
-                              .pollingStrategy(regular(ofSeconds(2))),
+                                .optional()
+                                .pollingStrategy(regular(ofSeconds(2))),
                         classpath("default.yaml")
-                              .pollingStrategy(regular(ofSeconds(10))));
+                                .pollingStrategy(regular(ofSeconds(10))));
 
         // first greeting
         greeting(config.get("app"));
 
-        // subscribe using custom Flow.Subscriber
+        // subscribe using custom Flow.Subscriber - see class-level JavaDoc
         config.get("app").changes()
                 .subscribe(new AppConfigSubscriber());
     }
@@ -84,8 +102,8 @@ public class ChangesSubscriberExample {
         @Override
         public void onError(Throwable throwable) {
             LOGGER.log(Level.WARNING,
-                       throwable,
-                       () -> "Config Changes support failed. " + throwable.getLocalizedMessage());
+                    throwable,
+                    () -> "Config Changes support failed. " + throwable.getLocalizedMessage());
         }
 
         @Override

--- a/examples/config/changes/src/main/java/io/helidon/config/examples/changes/OnChangeExample.java
+++ b/examples/config/changes/src/main/java/io/helidon/config/examples/changes/OnChangeExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,14 +49,13 @@ public class OnChangeExample {
 
         logSecrets(secrets);
 
-        // subscribe using simple onChange function
+        // subscribe using simple onChange consumer -- could be a lambda as well
         secrets.onChange(OnChangeExample::logSecrets);
     }
 
-    private static boolean logSecrets(Config secrets) {
+    private static void logSecrets(Config secrets) {
         LOGGER.info("Loaded secrets are u: " + secrets.get("username").asString().get()
                             + ", p: " + secrets.get("password").asString().get());
-        return true; // -> continue listening on config changes
     }
 
 }

--- a/examples/config/git/README.md
+++ b/examples/config/git/README.md
@@ -7,9 +7,11 @@ and switch which branch to load from at runtime.
 ## Prerequisites
 The example assumes that the GitHub repository <https://github.com/helidonrobot/test-config>
 has a branch named `test` that contains `application.conf` which sets the key
-`greeting` to value `hello`. (This repository and branch should always be present.)
+`greeting` to value `hello`. (The Helidon team has created and populated this 
+repository.)
 
-The code uses the environment variable `ENVIRONMENT_NAME` to fetch the branch name
+The code in [`Main.java`](./src/main/java/io/helidon/config/examples/git/Main.java)
+uses the environment variable `ENVIRONMENT_NAME` to fetch the branch name
 in the GitHub repository to use; it uses `master` by default (which does _not_ 
 contain the expected value).
 

--- a/examples/config/git/README.md
+++ b/examples/config/git/README.md
@@ -4,6 +4,19 @@
 This example shows how to load configuration from a Git repository
 and switch which branch to load from at runtime.
 
+## Prerequisites
+The example assumes that the GitHub repository <https://github.com/helidonrobot/test-config>
+has a branch named `test` that contains `application.conf` which sets the key
+`greeting` to value `hello`. (This repository and branch should always be present.)
+
+The code uses the environment variable `ENVIRONMENT_NAME` to fetch the branch name
+in the GitHub repository to use; it uses `master` by default (which does _not_ 
+contain the expected value).
+
+The example application constructs a `Config` instance from that file in the 
+GitHub repository and branch, prints out the value for key `greeting`, and 
+checks to make sure the value is the expected `hello`.
+
 ## Build
 
 ```
@@ -16,6 +29,3 @@ mvn package
 export ENVIRONMENT_NAME=test
 mvn exec:java
 ```
-
-Note that the application determines which Git branch to load from
-based on the `ENVIRONMENT_NAME` environment variable.

--- a/examples/config/git/src/main/java/io/helidon/config/examples/git/Main.java
+++ b/examples/config/git/src/main/java/io/helidon/config/examples/git/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.helidon.config.examples.git;
 
 import java.io.IOException;
@@ -25,6 +24,25 @@ import io.helidon.config.git.GitConfigSourceBuilder;
 
 /**
  * Git source example.
+ * <p>
+ * This example expects:
+ * <ol>
+ * <li>a Git repository {@code helidonrobot/test-config} which contains:
+ * <ol type="a">
+ * <li>the branch {@code test} containing {@code application.conf} which sets
+ * {@code greeting} to {@code hello},
+ * <li>the branch {@code main} containing the file {@code application.conf}
+ * which sets the property {@code greeting} to any value other than
+ * {@code hello},
+ * <li>optionally, any other branch in which {@code application.conf} sets
+ * {@code greeting} to {@code hello}.
+ * </ol>
+ * <li>the environment variable {@code ENVIRONMENT_NAME} set to:
+ * <ol type="a">
+ * <li>{@code test}, or
+ * <li>the name of the optional additional branch described above.
+ * </ol>
+ * </ol>
  */
 public class Main {
 
@@ -43,14 +61,13 @@ public class Main {
 
         // we expect a name of the current environment in envvar ENVIRONMENT_NAME
         // in this example we just set envvar in maven plugin 'exec', but can be set in k8s pod via ConfigMap
-
         Config env = Config.create(ConfigSources.environmentVariables());
 
         System.out.println("Loading from branch " + env.get(ENVIRONMENT_NAME_PROPERTY).asString().orElse("null"));
 
         Config config = Config.create(
                 GitConfigSourceBuilder.create("application.conf")
-                        .uri(URI.create("https://github.com/okosatka/test-config.git"))
+                        .uri(URI.create("https://github.com/helidonrobot/test-config.git"))
                         .branch(env.get(ENVIRONMENT_NAME_PROPERTY).asString().orElse("master"))
                         .build());
 

--- a/examples/config/mapping/README.md
+++ b/examples/config/mapping/README.md
@@ -1,8 +1,20 @@
 
 # Helidon Config Mapping Example
 
-This example shows how to implement mappers that map configuration
+This example shows how to implement mappers that convert configuration
 to POJOs.
+
+1. [`BuilderExample.java`](./src/main/java/io/helidon/config/examples/mapping/BuilderExample.java)
+shows how you can add a `builder()` method to a POJO. That method returns a `Builder` 
+object which the config system uses to update with various key settings and then,
+finally, invoke `build()` so the builder can instantiate the POJO with the
+assigned values.
+2. [`DeserializationExample.java`](./src/main/java/io/helidon/config/examples/mapping/DeserializationExample.java)
+uses the config system's support for automatic mapping to POJOs that have bean-style
+setter methods.
+3. [`FactoryMethodExample.java`](./src/main/java/io/helidon/config/examples/mapping/FactoryMethodExample.java)
+illustrates how you can add a static factory method `create` to a POJO to tell the config
+system how to construct a POJO instance.
 
 ## Build
 

--- a/examples/config/overrides/README.md
+++ b/examples/config/overrides/README.md
@@ -2,7 +2,20 @@
 # Helidon Config Overrides Example
 
 This example shows how to load configuration from multiple 
-configuration sources.
+configuration sources, specifically where one of the sources _overrides_ other
+sources.
+
+The application treats `resources/application.yaml` and `conf/priority-config.yaml` 
+files as the config sources for the its configuration. 
+
+The `application.yaml` file is packaged along with the application code, while
+the files in `conf` would be provided during deployment to tailor the behavior
+of the application to that specific environment.
+
+The application also loads `conf/overrides.properties` but as an _override_ config
+source. This file contains key _expressions_ (including wildcards) and values which
+take precedence over the settings in the original config sources.
+
 
 ## Build
 

--- a/examples/config/overrides/README.md
+++ b/examples/config/overrides/README.md
@@ -5,14 +5,18 @@ This example shows how to load configuration from multiple
 configuration sources, specifically where one of the sources _overrides_ other
 sources.
 
-The application treats `resources/application.yaml` and `conf/priority-config.yaml` 
-files as the config sources for the its configuration. 
+The application treats 
+[`resources/application.yaml`](./src/main/resources/application.yaml) and 
+[`conf/priority-config.yaml`](./conf/priority-config.yaml)
+as the config sources for the its configuration. 
 
 The `application.yaml` file is packaged along with the application code, while
 the files in `conf` would be provided during deployment to tailor the behavior
 of the application to that specific environment.
 
-The application also loads `conf/overrides.properties` but as an _override_ config
+The application also loads 
+[`conf/overrides.properties`](./conf/overrides.properties) but as an 
+_override_ config
 source. This file contains key _expressions_ (including wildcards) and values which
 take precedence over the settings in the original config sources.
 

--- a/examples/config/overrides/src/main/java/io/helidon/config/examples/overrides/Main.java
+++ b/examples/config/overrides/src/main/java/io/helidon/config/examples/overrides/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/config/overrides/src/main/java/io/helidon/config/examples/overrides/Main.java
+++ b/examples/config/overrides/src/main/java/io/helidon/config/examples/overrides/Main.java
@@ -31,7 +31,7 @@ import static io.helidon.config.PollingStrategies.regular;
  * <p>
  * Shows the Overrides feature where values from config sources might be overridden by override source.
  * <p>
- * In this example, {@code application.yaml} is mean to be default application configuration distributed with an app, containing
+ * In this example, {@code application.yaml} is meant to be default application configuration distributed with an app, containing
  * a wildcard configuration nodes representing the defaults for every environment and pod as well as a default definition of
  * these values. The source {@code conf/priority-config.yaml} is a higher priority configuration source which can be in a real
  * app dynamically changed (i.e. {@code Kubernetes ConfigMap} mapped as the file) and contains the current {@code env} and {@code

--- a/examples/config/sources/README.md
+++ b/examples/config/sources/README.md
@@ -4,6 +4,18 @@
 This example shows how to load configuration from multiple 
 configuration sources.
 
+1. [`DirectorySourceExample.java`](./src/main/java/io/helidon/config/examples/sources/DirectorySourceExample.java)
+reads configuration from multiple files in a directory by specifying only the directory.
+2. [`LoadSourcesExample.java`](./src/main/java/io/helidon/config/examples/source/LoadSourcesExample.java)
+uses _meta-configuration_ files [`conf/meta-config.yaml`](./conf/meta-config.yaml) 
+and [`src/main/resources/meta-config.yaml`](./src/main/resources/meta-config.yaml)
+which contain not the configuration itself but
+_instructions for loading_ the configuration: what type, from where, etc. It also
+applies a filter to modify config values whose keys match a certain pattern.
+3. [`WithSourcesExample.java`](./src/main/java/io/helidon/config/examples/sources/WithSourcesExample.java)
+combines multiple config sources into a single configuration instance (and adds a
+filter.
+
 ## Build
 
 ```

--- a/examples/config/sources/README.md
+++ b/examples/config/sources/README.md
@@ -6,7 +6,7 @@ configuration sources.
 
 1. [`DirectorySourceExample.java`](./src/main/java/io/helidon/config/examples/sources/DirectorySourceExample.java)
 reads configuration from multiple files in a directory by specifying only the directory.
-2. [`LoadSourcesExample.java`](./src/main/java/io/helidon/config/examples/source/LoadSourcesExample.java)
+2. [`LoadSourcesExample.java`](./src/main/java/io/helidon/config/examples/sources/LoadSourcesExample.java)
 uses _meta-configuration_ files [`conf/meta-config.yaml`](./conf/meta-config.yaml) 
 and [`src/main/resources/meta-config.yaml`](./src/main/resources/meta-config.yaml)
 which contain not the configuration itself but


### PR DESCRIPTION
* Fix which github repo we use for the git example
* Add comments about use of deprecated method and in another case use a non-deprecated method instead
* add some description to the README.md files

Note: The git example will fail until helidonrobot/test-config is created. @barchetta or @romain-grecourt can one of you either create that or grant me what I need to do so? (see also my slack note for added details)

Addresses issue #273 