### PR TITLE
Update README.adoc files with recent updates to logging properties…

### DIFF
--- a/examples/guides/mp-restful-webservice/README.adoc
+++ b/examples/guides/mp-restful-webservice/README.adoc
@@ -273,7 +273,7 @@ handlers=java.util.logging.ConsoleHandler
 # Helidon Web Server has a custom log formatter that extends SimpleFormatter.
 # It replaces "!thread!" with the current thread name
 java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.netty.WebServerLogFormatter
+java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 ----
 

--- a/examples/guides/se-restful-webservice/README.adoc
+++ b/examples/guides/se-restful-webservice/README.adoc
@@ -228,7 +228,7 @@ handlers=java.util.logging.ConsoleHandler
 # Helidon Web Server has a custom log formatter that extends SimpleFormatter.
 # It replaces "!thread!" with the current thread name
 java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.netty.WebServerLogFormatter
+java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 ----
 


### PR DESCRIPTION
Recent changes to logging properties files in the SE and MP restful web service guides were not incorporated into the `README.adoc` files, causing the newly-installed re-generation and checks to fail.

This change updates the `README.adoc` files appropriately.