### PR TITLE
Use variable to hold GreetService instance -- easier for the guide

### DIFF
--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -95,6 +95,7 @@ public final class Main {
      */
     private static Routing createRouting(Config config) {
 
+        GreetService greetService = new GreetService(config);
         HealthSupport health = HealthSupport.builder()
                 .add(HealthChecks.healthChecks())   // Adds a convenient set of checks
                 .build();
@@ -103,7 +104,7 @@ public final class Main {
                 .register(JsonSupport.create())
                 .register(health)                   // Health at "/health"
                 .register(MetricsSupport.create())  // Metrics at "/metrics"
-                .register("/greet", new GreetService(config))
+                .register("/greet", greetService)
                 .build();
     }
 


### PR DESCRIPTION
The guide adds an app-specific health check, and the code it adds to do so requires that the same instance of `GreetService` be plugged into the health apparatus as is registered with the `/greet` path. 

The original quick-start code instantiated `GreetService` in-line as an argument to `.register`, and having the quick-start code use a variable makes it easier in the guide.