### PR TITLE
URL encoding of characters for Webserver and Jersey

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
+++ b/common/http/src/main/java/io/helidon/common/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,14 @@ public interface HttpRequest {
          * @return a path
          */
         String toString();
+
+        /**
+         * Returns a path string representation with leading slash without
+         * any character decoding.
+         *
+         * @return an undecoded path
+         */
+        String toRawString();
 
         /**
          * If the instance represents a path relative to some context root then returns absolute requested path otherwise

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -123,9 +123,9 @@ public class JerseySupport implements Service {
 
     private static URI requestUri(ServerRequest req) {
         try {
-            // Creating a URI from a URL avoids re-encoding of characters like '%'
+            // Use raw string representation and URL to avoid re-encoding chars like '%'
             URI partialUri = new URL(req.isSecure() ? "https" : "http", req.localAddress(),
-                                     req.localPort(), req.path().absolute().toString()).toURI();
+                                     req.localPort(), req.path().absolute().toRawString()).toURI();
             StringBuilder sb = new StringBuilder(partialUri.toString());
             if (req.uri().toString().endsWith("/") && sb.charAt(sb.length() - 1) != '/') {
                 sb.append('/');

--- a/webserver/webserver/src/test/java/io/helidon/webserver/EncodingTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/EncodingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.utils.SocketHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+
+/**
+ * The PlainTest.
+ */
+public class EncodingTest {
+
+    private static final Logger LOGGER = Logger.getLogger(EncodingTest.class.getName());
+
+    private static WebServer webServer;
+
+    /**
+     * Start the Web Server
+     *
+     * @param port the port on which to start the server; if less than 1,
+     * the port is dynamically selected
+     * @throws Exception in case of an error
+     */
+    private static void startServer(int port) throws Exception {
+        webServer = WebServer.create(
+                ServerConfiguration.builder().port(port).build(),
+                Routing.builder()
+                        .get("/foo", (req, res) -> res.send("It works!"))
+                        .get("/foo/{bar}", (req, res) -> res.send(req.path().param("bar")))
+                        .any(Handler.create(String.class, (req, res, entity) -> res.send("Oops " + entity)))
+                        .build())
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+    }
+
+    /**
+     * Test path decoding and matching.
+     *
+     * @throws Exception If an error occurs.
+     */
+    @Test
+    public void testEncodedUrl() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/f%6F%6F", Http.Method.GET, null, webServer);
+        assertThat(cutPayloadAndCheckHeadersFormat(s), is("9\nIt works!\n0\n\n"));
+        Map<String, String> headers = cutHeaders(s);
+        assertThat(headers, hasEntry("connection", "keep-alive"));
+    }
+
+    /**
+     * Test path decoding with params and matching.
+     *
+     * @throws Exception If an error occurs.
+     */
+    @Test
+    public void testEncodedUrlParams() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/f%6F%6F/b%61%72", Http.Method.GET, null, webServer);
+        assertThat(cutPayloadAndCheckHeadersFormat(s), is("3\nbar\n0\n\n"));
+        Map<String, String> headers = cutHeaders(s);
+        assertThat(headers, hasEntry("connection", "keep-alive"));
+    }
+
+    private Map<String, String> cutHeaders(String response) {
+        assertThat(response, notNullValue());
+        int index = response.indexOf("\n\n");
+        if (index < 0) {
+            throw new AssertionError("Missing end of headers in response!");
+        }
+        String hdrsPart = response.substring(0, index);
+        String[] lines = hdrsPart.split("\\n");
+        if (lines.length <= 1) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>(lines.length - 1);
+        boolean first = true;
+        for (String line : lines) {
+            if (first) {
+                first = false;
+                continue;
+            }
+            int i = line.indexOf(':');
+            if (i < 0) {
+                throw new AssertionError("Header without semicolon - " + line);
+            }
+            result.put(line.substring(0, i).trim(), line.substring(i + 1).trim());
+        }
+        return result;
+    }
+
+    private String cutPayloadAndCheckHeadersFormat(String response) {
+        assertThat(response, notNullValue());
+        int index = response.indexOf("\n\n");
+        if (index < 0) {
+            throw new AssertionError("Missing end of headers in response!");
+        }
+        String headers = response.substring(0, index);
+        String[] lines = headers.split("\\n");
+        assertThat(lines[0], startsWith("HTTP/"));
+        for (int i = 1; i < lines.length; i++) {
+            assertThat(lines[i], containsString(":"));
+        }
+        return response.substring(index + 2);
+    }
+
+    @BeforeAll
+    public static void startServer() throws Exception {
+        // start the server at a free port
+        startServer(0);
+    }
+
+    @AfterAll
+    public static void close() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
Keep track of encoded and decoded paths during crawling. Make sure that JerseySupport passes the encoded path (as provided in the request) in order for Jersey to match special characters correctly. Note that Helidon webserver continues to use decoded paths to ensure compatibility.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>