### PR TITLE
Upgrading to Hystrix 1.5.18

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,13 +182,10 @@ class MethodIntrospector {
         // Circuit breakers
         result.put("circuitBreaker.enabled", hasCircuitBreaker());
         if (hasCircuitBreaker()) {
-            final CircuitBreaker circuitBreaker = getCircuitBreaker();
-            result.put("circuitBreaker.requestVolumeThreshold",
-                       circuitBreaker.requestVolumeThreshold());
-            result.put("circuitBreaker.errorThresholdPercentage",
-                       (int) (circuitBreaker.failureRatio() * 100));
-            result.put("circuitBreaker.sleepWindowInMilliseconds",
-                       TimeUtil.convertToMillis(circuitBreaker.delay(), circuitBreaker.delayUnit()));
+            // We are implementing this logic internally, so set to high values
+            result.put("circuitBreaker.requestVolumeThreshold", Integer.MAX_VALUE);
+            result.put("circuitBreaker.errorThresholdPercentage", 100);
+            result.put("circuitBreaker.sleepWindowInMilliseconds", Long.MAX_VALUE);
         }
 
         // Timeouts

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,7 +214,6 @@ public class MetricsTest extends FaultToleranceTest {
         for (int i = 0; i < CircuitBreakerBean.REQUEST_VOLUME_THRESHOLD; i++) {
             assertThrows(RuntimeException.class, () -> bean.exerciseBreaker(false));
         }
-        Thread.sleep(1000);
         assertThrows(CircuitBreakerOpenException.class, () -> bean.exerciseBreaker(false));
 
         assertThat(getCounter(bean, "exerciseBreaker",
@@ -249,7 +248,6 @@ public class MetricsTest extends FaultToleranceTest {
 
         }
         assertThrows(RuntimeException.class, () -> bean.exerciseGauges(false));
-        Thread.sleep(1000);
         assertThrows(CircuitBreakerOpenException.class, () -> bean.exerciseGauges(false));
 
         assertThat(getGauge(bean, "exerciseGauges",

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <version.lib.typesafe-config>1.3.3</version.lib.typesafe-config>
         <version.lib.weld>3.0.3.Final</version.lib.weld>
         <version.lib.zipkin>2.6.0</version.lib.zipkin>
-        <version.lib.hystrix>1.5.12</version.lib.hystrix>
+        <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.failsafe>1.1.0</version.lib.failsafe>
         <!--
         !Version statement! - end


### PR DESCRIPTION
Upgrading to Hystrix 1.5.18. New strategy to support circuit breaker state transitions as defined by the FT spec. Most of the Hystrix circuit breaker support is turned off and state transitions are implemented manually using Hystrix dynamic properties. The old strategy was difficult to extend with the new version of Hystrix and the new implementation is simpler to understand.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>