### PR TITLE
Change quickstart examples so that PUT uses a json body and not path param

### DIFF
--- a/docs/src/main/docs/getting-started/02_base-example.adoc
+++ b/docs/src/main/docs/getting-started/02_base-example.adoc
@@ -122,7 +122,7 @@ curl -X GET http://localhost:8080/greet
 curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
-curl -X PUT http://localhost:8080/greet/greeting/Hola
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
 {"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose

--- a/docs/src/main/docs/getting-started/02_base-example.adoc
+++ b/docs/src/main/docs/getting-started/02_base-example.adoc
@@ -123,7 +123,6 @@ curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
 curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
-{"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose
 {"message":"Hola Jose!"}

--- a/examples/quickstarts/helidon-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-quickstart-mp/README.md
@@ -42,8 +42,8 @@ curl -X GET http://localhost:8080/greet
 curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
-curl -X PUT http://localhost:8080/greet/greeting/Hola
-{"gretting":"Hola"}
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+{"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose
 {"message":"Hola Jose!"}

--- a/examples/quickstarts/helidon-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-quickstart-mp/README.md
@@ -43,7 +43,6 @@ curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
 curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
-{"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose
 {"message":"Hola Jose!"}

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -108,16 +108,16 @@ public class GreetResource {
     public Response updateGreeting(JsonObject jsonObject) {
 
         if (!jsonObject.containsKey("greeting")) {
-            return Response.status(Response.Status.NO_CONTENT).build();
+            JsonObject entity = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(entity).build();
         }
 
         String newGreeting = jsonObject.getString("greeting");
 
         greetingProvider.setMessage(newGreeting);
-        JsonObject entity = JSON.createObjectBuilder()
-                   .add("greeting", newGreeting)
-                   .build();
-        return Response.status(Response.Status.OK).entity(entity).build();
+        return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     private JsonObject createResponse(String who) {

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -106,7 +106,7 @@ public class GreetResource {
     @Produces(MediaType.APPLICATION_JSON)
     public JsonObject updateGreeting(JsonObject jsonObject) {
 
-        if (jsonObject.isNull("greeting")) {
+        if (!jsonObject.containsKey("greeting")) {
             Response.status(Response.Status.BAD_REQUEST);
             return JSON.createObjectBuilder()
                        .add("error", "No greeting provided")

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * A simple JAX-RS resource to greet you. Examples:
@@ -41,7 +42,7 @@ import javax.ws.rs.core.MediaType;
  * curl -X GET http://localhost:8080/greet/Joe
  *
  * Change greeting
- * curl -X PUT http://localhost:8080/greet/greeting/Hola
+ * curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting
  *
  * The message is returned as a JSON object.
  */
@@ -96,20 +97,28 @@ public class GreetResource {
     /**
      * Set the greeting to use in future messages.
      *
-     * @param newGreeting the new greeting message
      * @return {@link JsonObject}
      */
     @SuppressWarnings("checkstyle:designforextension")
-    @Path("/greeting/{greeting}")
+    @Path("/greeting")
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public JsonObject updateGreeting(@PathParam("greeting") String newGreeting) {
-        greetingProvider.setMessage(newGreeting);
+    public JsonObject updateGreeting(JsonObject jsonObject) {
 
+        if (jsonObject.isNull("greeting")) {
+            Response.status(Response.Status.BAD_REQUEST);
+            return JSON.createObjectBuilder()
+                       .add("error", "No greeting provided")
+                       .build();
+        }
+
+        String newGreeting = jsonObject.getString("greeting");
+
+        greetingProvider.setMessage(newGreeting);
         return JSON.createObjectBuilder()
-                .add("greeting", newGreeting)
-                .build();
+                   .add("greeting", newGreeting)
+                   .build();
     }
 
     private JsonObject createResponse(String who) {

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -97,6 +97,7 @@ public class GreetResource {
     /**
      * Set the greeting to use in future messages.
      *
+     * @param jsonObject JSON containing the new greeting
      * @return {@link JsonObject}
      */
     @SuppressWarnings("checkstyle:designforextension")

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -98,7 +98,7 @@ public class GreetResource {
      * Set the greeting to use in future messages.
      *
      * @param jsonObject JSON containing the new greeting
-     * @return {@link JsonObject}
+     * @return {@link Response}
      */
     @SuppressWarnings("checkstyle:designforextension")
     @Path("/greeting")

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -108,10 +108,7 @@ public class GreetResource {
     public Response updateGreeting(JsonObject jsonObject) {
 
         if (!jsonObject.containsKey("greeting")) {
-            JsonObject entity = JSON.createObjectBuilder()
-                    .add("error", "No greeting provided")
-                    .build();
-            return Response.status(Response.Status.BAD_REQUEST).entity(entity).build();
+            return Response.status(Response.Status.NO_CONTENT).build();
         }
 
         String newGreeting = jsonObject.getString("greeting");

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/java/io/helidon/examples/quickstart/mp/GreetResource.java
@@ -105,21 +105,22 @@ public class GreetResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public JsonObject updateGreeting(JsonObject jsonObject) {
+    public Response updateGreeting(JsonObject jsonObject) {
 
         if (!jsonObject.containsKey("greeting")) {
-            Response.status(Response.Status.BAD_REQUEST);
-            return JSON.createObjectBuilder()
-                       .add("error", "No greeting provided")
-                       .build();
+            JsonObject entity = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(entity).build();
         }
 
         String newGreeting = jsonObject.getString("greeting");
 
         greetingProvider.setMessage(newGreeting);
-        return JSON.createObjectBuilder()
+        JsonObject entity = JSON.createObjectBuilder()
                    .add("greeting", newGreeting)
                    .build();
+        return Response.status(Response.Status.OK).entity(entity).build();
     }
 
     private JsonObject createResponse(String who) {

--- a/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
@@ -59,9 +59,9 @@ class MainTest {
                 "hello Joe message");
 
         Response r = client
-                .target(getConnectionString("/greet/greeting/Hola"))
+                .target(getConnectionString("/greet/greeting"))
                 .request()
-                .put(Entity.entity("", MediaType.APPLICATION_JSON));
+                .put(Entity.entity("{\"greeting\" : \"Hola\"}", MediaType.APPLICATION_JSON));
         Assertions.assertEquals(200, r.getStatus(), "PUT status code");
 
         jsonObject = client

--- a/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
@@ -62,7 +62,7 @@ class MainTest {
                 .target(getConnectionString("/greet/greeting"))
                 .request()
                 .put(Entity.entity("{\"greeting\" : \"Hola\"}", MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(200, r.getStatus(), "PUT status code");
+        Assertions.assertEquals(204, r.getStatus(), "PUT status code");
 
         jsonObject = client
                 .target(getConnectionString("/greet/Jose"))

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -41,8 +41,8 @@ curl -X GET http://localhost:8080/greet
 curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
-curl -X PUT http://localhost:8080/greet/greeting/Hola
-{"gretting":"Hola"}
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+{"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose
 {"message":"Hola Jose!"}

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -42,7 +42,6 @@ curl -X GET http://localhost:8080/greet/Joe
 {"message":"Hello Joe!"}
 
 curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
-{"greeting":"Hola"}
 
 curl -X GET http://localhost:8080/greet/Jose
 {"message":"Hola Jose!"}

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -102,11 +102,7 @@ public class GreetService implements Service {
     private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
 
         if (!jo.containsKey("greeting")) {
-            JsonObject jsonErrorObject = JSON.createObjectBuilder()
-                    .add("error", "No greeting provided")
-                    .build();
-            response.status(Http.Status.BAD_REQUEST_400)
-                    .send(jsonErrorObject);
+            response.status(Http.Status.NO_CONTENT_204).send();
             return;
         }
 

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -101,7 +101,7 @@ public class GreetService implements Service {
 
     private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
 
-        if (jo.isNull("greeting")) {
+        if (!jo.containsKey("greeting")) {
             JsonObject jsonErrorObject = JSON.createObjectBuilder()
                     .add("error", "No greeting provided")
                     .build();
@@ -112,7 +112,7 @@ public class GreetService implements Service {
 
         greeting = jo.getString("greeting");
 
-        JsonObject returnObject = Json.createObjectBuilder()
+        JsonObject returnObject = JSON.createObjectBuilder()
                 .add("greeting", greeting)
                 .build();
         response.send(returnObject);

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -22,6 +22,7 @@ import javax.json.Json;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 
+import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
@@ -38,7 +39,7 @@ import io.helidon.webserver.Service;
  * curl -X GET http://localhost:8080/greet/Joe
  *
  * Change greeting
- * curl -X PUT http://localhost:8080/greet/greeting/Hola
+ * curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting
  *
  * The message is returned as a JSON object
  */
@@ -65,7 +66,7 @@ public class GreetService implements Service {
         rules
             .get("/", this::getDefaultMessageHandler)
             .get("/{name}", this::getMessageHandler)
-            .put("/greeting/{greeting}", this::updateGreetingHandler);
+            .put("/greeting", this::updateGreetingHandler);
     }
 
     /**
@@ -98,19 +99,33 @@ public class GreetService implements Service {
         response.send(returnObject);
     }
 
+    private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
+
+        if (jo.isNull("greeting")) {
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            response.status(Http.Status.BAD_REQUEST_400)
+                    .send(jsonErrorObject);
+            return;
+        }
+
+        greeting = jo.getString("greeting");
+
+        JsonObject returnObject = Json.createObjectBuilder()
+                .add("greeting", greeting)
+                .build();
+        response.send(returnObject);
+    }
+
     /**
      * Set the greeting to use in future messages.
      * @param request the server request
      * @param response the server response
      */
     private void updateGreetingHandler(ServerRequest request,
-                                ServerResponse response) {
-        greeting = request.path().param("greeting");
-
-        JsonObject returnObject = JSON.createObjectBuilder()
-                .add("greeting", greeting)
-                .build();
-        response.send(returnObject);
+                                       ServerResponse response) {
+        request.content().as(JsonObject.class).thenAccept(jo -> updateGreetingFromJson(jo, response) );
     }
 
 }

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -125,7 +125,7 @@ public class GreetService implements Service {
      */
     private void updateGreetingHandler(ServerRequest request,
                                        ServerResponse response) {
-        request.content().as(JsonObject.class).thenAccept(jo -> updateGreetingFromJson(jo, response) );
+        request.content().as(JsonObject.class).thenAccept(jo -> updateGreetingFromJson(jo, response));
     }
 
 }

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -102,16 +102,16 @@ public class GreetService implements Service {
     private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
 
         if (!jo.containsKey("greeting")) {
-            response.status(Http.Status.NO_CONTENT_204).send();
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            response.status(Http.Status.BAD_REQUEST_400)
+                    .send(jsonErrorObject);
             return;
         }
 
         greeting = jo.getString("greeting");
-
-        JsonObject returnObject = JSON.createObjectBuilder()
-                .add("greeting", greeting)
-                .build();
-        response.send(returnObject);
+        response.status(Http.Status.NO_CONTENT_204).send();
     }
 
     /**

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -87,7 +87,7 @@ public class MainTest {
         OutputStream os = conn.getOutputStream();
         os.write("{\"greeting\" : \"Hola\"}".getBytes());
         os.close();
-        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
+        Assertions.assertEquals(204, conn.getResponseCode(), "HTTP response3");
 
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");

--- a/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.examples.quickstart.se;
 
+import java.io.OutputStream;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.net.URL;
@@ -80,8 +81,14 @@ public class MainTest {
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
 
-        conn = getURLConnection("PUT", "/greet/greeting/Hola");
+        conn = getURLConnection("PUT", "/greet/greeting");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        OutputStream os = conn.getOutputStream();
+        os.write("{\"greeting\" : \"Hola\"}".getBytes());
+        os.close();
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response3");
+
         conn = getURLConnection("GET", "/greet/Jose");
         Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
         jsonReader = JSON.createReader(conn.getInputStream());


### PR DESCRIPTION
The quickstart examples (also used by the maven archetypes) support changing of the greeting via a path param. This does not follow REST best practices.

This PR changes the examples to that you PUT json to change the greeting. Specifically:

```
 curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting
```