### PR TITLE
Avoid using Zipkin v1 in example config

### DIFF
--- a/docs/src/main/docs/tracing/02_zipkin.adoc
+++ b/docs/src/main/docs/tracing/02_zipkin.adoc
@@ -70,9 +70,9 @@ tracing:
     protocol: "https"
     host: "192.168.1.1"
     port: 9987
-    api-version: 1
-    # this is the default path for API version 1
-    path: "/api/v1/spans"
+    api-version: 2
+    # this is the default path for API version 2
+    path: "/api/v2/spans"
     tags:
       tag1: "tag1-value"
       tag2: "tag2-value"


### PR DESCRIPTION
While Zipkin v1 is still available, we do not want to encourage new users to use it. Some users may copy/paste and edit the example config given, so this changes it to Zipkin v2 version/path.