### PR TITLE
Some code cleanup and optimizations when writing data from Jersey

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
@@ -87,7 +87,7 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
                     throw new IOException("Output stream already closed.");
                 }
 
-                sub.onNext(ByteBuffer.wrap(buffer, offset, length));
+                sub.onNext(createBuffer(buffer, offset, length));
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -113,5 +113,21 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
                 sub.onError(t);
             }
         });
+    }
+
+    /**
+     * Creates a {@link ByteBuffer} by making a copy of the underlying
+     * byte array. Jersey will reuse this array, so it needs to be
+     * copied here.
+     *
+     * @param buffer The buffer.
+     * @param offset Offset in buffer.
+     * @param length Length of buffer.
+     * @return Newly created {@link ByteBuffer}.
+     */
+    private ByteBuffer createBuffer(byte[] buffer, int offset, int length) {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(length - offset);
+        byteBuffer.put(buffer, offset, length);
+        return (ByteBuffer) byteBuffer.clear();     // resets counters
     }
 }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver.jersey;
 
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
@@ -25,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import javax.ws.rs.core.MediaType;
+
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.reactive.OutputStreamPublisher;
@@ -32,6 +33,7 @@ import io.helidon.common.reactive.ReactiveStreamsAdapter;
 import io.helidon.webserver.ConnectionClosedException;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
+
 import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.spi.ContainerResponseWriter;
@@ -138,7 +140,7 @@ class ResponseWriter implements ContainerResponseWriter {
 
         res.send(ReactiveStreamsAdapter.publisherToFlow(
                     ReactiveStreamsAdapter.publisherFromFlow(publisher)
-                        .map(byteBuffer -> DataChunk.create(true, byteBuffer))));
+                        .map(byteBuffer -> DataChunk.create(doFlush, byteBuffer))));
 
         return publisher;
     }


### PR DESCRIPTION
More details:

- Improve code to copy write buffers coming from Jersey
- Let Netty re-schedule writes on the correct NIO thread
- Do not use latches to synchronize Jersey and Netty threads

Although all tests are passing we should keep an eye for any regressions resulting from these changes. Note that all these changes are exclusive to Jersey and Helidon MP.