### PR TITLE
Invalid JWT token no longer fails with 500.

### DIFF
--- a/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -190,7 +190,13 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
     AuthenticationResponse authenticate(ProviderRequest providerRequest, LoginConfig loginConfig) {
         return atnTokenHandler.extractToken(providerRequest.env().headers())
                 .map(token -> {
-                    SignedJwt signedJwt = SignedJwt.parseToken(token);
+                    SignedJwt signedJwt;
+                    try {
+                        signedJwt = SignedJwt.parseToken(token);
+                    } catch (Exception e) {
+                        //invalid token
+                        return AuthenticationResponse.failed("Invalid token", e);
+                    }
                     Errors errors = signedJwt.verifySignature(verifyKeys, defaultJwk);
                     if (errors.isValid()) {
                         Jwt jwt = signedJwt.getJwt();

--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityDefinition.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityDefinition.java
@@ -204,15 +204,13 @@ class SecurityDefinition {
 
     public void analyzerResponse(AnnotationAnalyzer analyzer, AnnotationAnalyzer.AnalyzerResponse analyzerResponse) {
         analyzerResponses.put(analyzer, analyzerResponse);
-        // JWT auth returns required for parent (@RolesAllow)
-        // generic analyzer returns optional (@PermitAll)
+
         switch (analyzerResponse.authenticationResponse()) {
         case REQUIRED:
             requiresAuthentication = true;
             authnOptional = false;
             break;
         case OPTIONAL:
-            // only update this in case authentication is not required already
             requiresAuthentication = true;
             authnOptional = true;
             break;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
@@ -166,8 +166,8 @@ public final class SignedJwt {
 
             String signedContent = headerBase64 + '.' + payloadBase64;
 
-            JsonObject headerJson = parseJson(headerJsonString, collector, "JWT header");
-            JsonObject contentJson = parseJson(payloadJsonString, collector, "JWT payload");
+            JsonObject headerJson = parseJson(headerJsonString, collector, headerBase64, "JWT header");
+            JsonObject contentJson = parseJson(payloadJsonString, collector, payloadBase64, "JWT payload");
 
             collector.collect().checkValid();
 
@@ -182,11 +182,11 @@ public final class SignedJwt {
         }
     }
 
-    private static JsonObject parseJson(String jsonString, Errors.Collector collector, String description) {
+    private static JsonObject parseJson(String jsonString, Errors.Collector collector, String base64, String description) {
         try {
             return JSON.createReader(new StringReader(jsonString)).readObject();
         } catch (Exception e) {
-            collector.fatal(jsonString, description + " is not a valid JSON object");
+            collector.fatal(base64, description + " is not a valid JSON object (value is base64 encoded)");
             return null;
         }
     }

--- a/security/jwt/src/test/java/io/helidon/security/jwt/SignedJwtTest.java
+++ b/security/jwt/src/test/java/io/helidon/security/jwt/SignedJwtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link SignedJwt}.
@@ -38,6 +39,9 @@ public class SignedJwtTest {
 
     private static final String AUTH_0_TOKEN =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6QkNNRE0xUVRJMk1qUkZNVEZETkRCRFJUWXdSa1U0UkRkRU16VTVSVGN3TkRSQk5qaENOUSJ9.eyJpc3MiOiJodHRwczovL2xhbmdvc2guZXUuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU5NGEzNzJkNDUxN2FmMTA0ZjFiZGUzMCIsImF1ZCI6InliZlBpcnBwUTZaT094U0dLa2pnTWUxa2ZGTGZkbXlQIiwiZXhwIjoxNDk4MDgzOTI2LCJpYXQiOjE0OTgwNDc5MjZ9.nyMs5VfDV7Njd6hnQmbrSp_xVbIdvdP3ChzEtdffH2FWMqeW34gZT7dKJfgirdcBfXD4cDNDF2yjKZTe9-yCLWCFYtrfpvS_nlbt1hVM5ZR2HsGFSKdws0gOTsKCOTnD0SmfiQHCP-tzu87qWcVIwQcm-7AuLSfQ3WPxHAGPcQDOZiJBfcpBN4OGPKF0qq7PdNzBDDHmzpt2TbSsHmnSW-QbWZ1QHr52jsRCl1O_UTYHo2HE3ShE3WWBgYcJdJhgXNkhvJJh95oqmq_bfH5Saw-REmg-roU1bAh_yzFkmVSnhKmzHff432glRxcgDgF87kqJNodMD6UN6wRVt9vAPg";
+
+    private static final String WRONG_TOKEN =
+            "yJ4NXQjUzI1NiI6IlZjeXl1TVdxSGp4UjRVNmYzOTV3YmhUZXNZRmFaWXFSbDdBbUxjZE5sNXciLCJ4NXQiOiJTdEZFTlFaM2NMNndQaHFxODZnVmJTTG54TkUiLCJraWQiOiJTSUdOSU5HX0tFWSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJIU01BcHAtY2xpZW50X0FQUElEIiwidXNlci50ZW5hbnQubmFtZSI6ImlkY3MtNzNmYTNlZDY5ZTgxNDFhN2I5MDFmYWY3Zjg3M2U3OGUiLCJzdWJfbWFwcGluZ2F0dHIiOiJ1c2VyTmFtZSIsImlzcyI6Imh0dHBzOlwvXC9pZGVudGl0eS5vcmFjbGVjbG91ZC5jb21cLyIsInRva190eXBlIjoiQVQiLCJjbGllbnRfaWQiOiJIU01BcHAtY2xpZW50X0FQUElEIiwiYXVkIjoiaHR0cDpcL1wvc2NhMDBjangudXMub3JhY2xlLmNvbTo3Nzc3Iiwic3ViX3R5cGUiOiJjbGllbnQiLCJzY29wZSI6InVybjpvcGM6cmVzb3VyY2U6Y29uc3VtZXI6OmFsbCIsImNsaWVudF90ZW5hbnRuYW1lIjoiaWRjcy03M2ZhM2VkNjllODE0MWE3YjkwMWZhZjdmODczZTc4ZSIsImV4cCI6MTU1MDU5NTk0MiwiaWF0IjoxNTUwNTA5NTQyLCJ0ZW5hbnRfaXNzIjoiaHR0cHM6XC9cL2lkY3MtNzNmYTNlZDY5ZTgxNDFhN2I5MDFmYWY3Zjg3M2U3OGUuaWRlbnRpdHkuYzlkZXYxLm9jOXFhZGV2LmNvbSIsImNsaWVudF9ndWlkIjoiN2JmZDM3MjM1ZGY3NDVjNDg5ZjYxZDM1ZTYzZGQ4ZmUiLCJjbGllbnRfbmFtZSI6IkhTTUFwcC1jbGllbnQiLCJ0ZW5hbnQiOiJpZGNzLTczZmEzZWQ2OWU4MTQxYTdiOTAxZmFmN2Y4NzNlNzhlIiwianRpIjoiYzRkNjlhZjUtOGQ4OC00N2Q2LTkzMDctN2RjMmI3NWY4MDQyIn0.ZsngUzzso_sW6rMg3jB-lueiC2sknIDRlgvjumMjp5rRSdLux2X4XZIm2Oa15JbcrnC6I4sgqB0xU1Wte-TW4hbBDLFhaJKYKiNaHBE0L7J73ZK7ITg7dORKkyjLrofGt0m8Rse1OlE9AWevz-l27gtQMO_mctGfHri2BxiMbSN1HwOjWW3kGoqPgCJZJfh2TiFlocEpsXDH4qB1qwhuIoT91gw3kIJlQov0_a9uGEepMU_RWMRjVZCIvuV2hPq_mdeWy2IhkHPxq422CLZ9MDOfbv8F6dY6DralCH4mmKbGM3dbqpZokWQxXG7LG9vWX1PFWw0N9clYHJ4QqBJ4pA";
 
     private static JwkKeys auth0Keys;
     private static JwkKeys customKeys;
@@ -127,5 +131,10 @@ public class SignedJwtTest {
         assertThat(errors, notNullValue());
         errors.log(LOGGER);
         errors.checkValid();
+    }
+
+    @Test
+    public void testWrongToken() {
+        assertThrows(Errors.ErrorMessagesException.class, () -> SignedJwt.parseToken(WRONG_TOKEN));
     }
 }

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
@@ -267,31 +267,6 @@ public interface AnnotationAnalyzer {
             }
 
             /**
-             * Register an object later available through
-             * {@link io.helidon.security.providers.common.spi.AnnotationAnalyzer.AnalyzerResponse#registry()}.
-             *
-             * @param anInstance instance to register by its class
-             * @return updated builder instance
-             */
-            public Builder register(Object anInstance) {
-                registry.putInstance(anInstance);
-                return this;
-            }
-
-            /**
-             * Register an object later available through
-             * {@link io.helidon.security.providers.common.spi.AnnotationAnalyzer.AnalyzerResponse#registry()}.
-             *
-             * @param theClass class to register the instance by
-             * @param anInstance instance to register
-             * @return updated builder instance
-             */
-            public <T> Builder register(Class<? super T> theClass, T anInstance) {
-                registry.putInstance(theClass, anInstance);
-                return this;
-            }
-
-            /**
              * Authentication response.
              *
              * @param atnResponse response for authentication

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
@@ -241,6 +241,16 @@ public interface AnnotationAnalyzer {
                 return this;
             }
 
+            public Builder register(Object anInstance) {
+                registry.putInstance(anInstance);
+                return this;
+            }
+
+            public <T> Builder register(Class<? super T> theClass, T anInstance) {
+                registry.putInstance(theClass, anInstance);
+                return this;
+            }
+
             /**
              * Register an object later available through
              * {@link io.helidon.security.providers.common.spi.AnnotationAnalyzer.AnalyzerResponse#registry()}.

--- a/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
+++ b/security/providers/common/src/main/java/io/helidon/security/providers/common/spi/AnnotationAnalyzer.java
@@ -241,11 +241,26 @@ public interface AnnotationAnalyzer {
                 return this;
             }
 
+            /**
+             * Register an object later available through
+             * {@link io.helidon.security.providers.common.spi.AnnotationAnalyzer.AnalyzerResponse#registry()}.
+             *
+             * @param anInstance instance to register by its class
+             * @return updated builder instance
+             */
             public Builder register(Object anInstance) {
                 registry.putInstance(anInstance);
                 return this;
             }
 
+            /**
+             * Register an object later available through
+             * {@link io.helidon.security.providers.common.spi.AnnotationAnalyzer.AnalyzerResponse#registry()}.
+             *
+             * @param theClass class to register the instance by
+             * @param anInstance instance to register
+             * @return updated builder instance
+             */
             public <T> Builder register(Class<? super T> theClass, T anInstance) {
                 registry.putInstance(theClass, anInstance);
                 return this;

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,13 @@ public class JwtProvider extends SynchronousProvider implements AuthenticationPr
 
         return atnTokenHandler.extractToken(providerRequest.env().headers())
                 .map(token -> {
-                    SignedJwt signedJwt = SignedJwt.parseToken(token);
+                    SignedJwt signedJwt;
+                    try {
+                        signedJwt = SignedJwt.parseToken(token);
+                    } catch (Exception e) {
+                        //invalid token
+                        return AuthenticationResponse.failed("Invalid token", e);
+                    }
                     Errors errors = signedJwt.verifySignature(verifyKeys);
                     if (errors.isValid()) {
                         Jwt jwt = signedJwt.getJwt();


### PR DESCRIPTION
And returns correct response.
Resolves #426 