### PR TITLE
Disable bulkhead tests until pipeline issues are resolved

### DIFF
--- a/microprofile/tests/tck/tck-fault-tolerance/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/src/test/tck-suite.xml
@@ -30,12 +30,17 @@
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.RetryMetricTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClashingNameTest"/>
+
+            <!--
+              - Disabled due to pipeline intermittent failures #303
+              -
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
                 <methods>
-                    <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/372 -->
+                    - - https://github.com/eclipse/microprofile-fault-tolerance/issues/372 - -
                     <exclude name="bulkheadMetricAsyncTest"/>
                 </methods>
-            </class>
+            </class -->
+
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.TimeoutMetricTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.ClassLevelMetricTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.MetricsDisabledTest"/>
@@ -63,6 +68,10 @@
             <class name="org.eclipse.microprofile.fault.tolerance.tck.config.ConfigPropertyGlobalVsClassVsMethodTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest"/>
+
+            <!--
+              - Disabled due to pipeline intermittent failures #303
+              -
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest"/>
@@ -70,17 +79,18 @@
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest">
                 <methods>
-                    <!-- should be fixed by newer version - fails tests intermittently, though often -->
+                    - - should be fixed by newer version - fails tests intermittently, though often - -
                     <exclude name="testBulkheadClassSemaphore3"/>
                 </methods>
             </class>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
                 <methods>
-                    <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/357 -->
+                    - - https://github.com/eclipse/microprofile-fault-tolerance/issues/357 - -
                     <exclude name="testBulkheadClassAsynchronous55RetryOverload"/>
                     <exclude name="testBulkheadMethodAsynchronous55RetryOverload"/>
                 </methods>
-            </class>
+            </class -->
+
             <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.ConfigTest"/>
             <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest"/>


### PR DESCRIPTION
Disable bulkhead tests until pipeline issues are resolved.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>