### PR TITLE
Ensure shutdownFuture is completed 

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -230,9 +230,9 @@ class NettyWebServer implements WebServer {
                     if (t != null) {
                         LOGGER.log(Level.WARNING, "Netty Thread Groups were unable to shutdown.", t);
                     }
+                    shutdownFuture.complete(this);
                     startFuture.completeExceptionally(new IllegalStateException("WebServer was unable to start.",
                                                                                 throwable));
-                    shutdownFuture.complete(this);
                 });
         return null;
     }


### PR DESCRIPTION
Ensure `shutdownFuture` is completed before exceptionally completing`startFuture` as assumed in some tests. This patch attempts to address #472. Since the problem is only visible in the pipeline, I suggest we accept this change and continue monitoring the issue. It does appear plausible for the `shutdownFuture` not to be completed by the time the exception from `startFuture` is caught and processed.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>