### PR TITLE
ClientSecurityFeature.PROPERTY_CONTEXT settable from WebTarget/Client (#487)

### DIFF
--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
@@ -94,6 +94,11 @@ public class ClientSecurityFilter implements ClientRequestFilter {
                     .headers(HttpUtil.toSimpleMap(requestContext.getStringHeaders()));
 
             EndpointConfig.Builder outboundEp = context.endpointConfig().derive();
+
+            for (String name : requestContext.getConfiguration().getPropertyNames()) {
+                outboundEp.addAtribute(name, requestContext.getConfiguration().getProperty(name));
+            }
+
             for (String name : requestContext.getPropertyNames()) {
                 outboundEp.addAtribute(name, requestContext.getProperty(name));
             }

--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/ClientSecurityFilter.java
@@ -71,7 +71,7 @@ public class ClientSecurityFilter implements ClientRequestFilter {
         // from there
 
         // first try to find the context on request configuration
-        SecurityContext context = (SecurityContext) requestContext.getProperty(ClientSecurityFeature.PROPERTY_CONTEXT);
+        SecurityContext context = resolveProperty(requestContext, ClientSecurityFeature.PROPERTY_CONTEXT);
 
         if (null == context) {
             LOGGER.finest("Security not propagated, as the property \""
@@ -146,5 +146,14 @@ public class ClientSecurityFilter implements ClientRequestFilter {
 
             throw e;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T resolveProperty(ClientRequestContext requestContext, final String property) {
+        Object value = requestContext.getProperty(property);
+        if (null == value) {
+            value = requestContext.getConfiguration().getProperty(property);
+        }
+        return (T) value;
     }
 }

--- a/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
+++ b/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
+++ b/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/BasicAuthOutboundOverrideTest.java
@@ -19,9 +19,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Optional;
 
 import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -37,6 +39,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +64,10 @@ public class BasicAuthOutboundOverrideTest {
 
         ClientRequestContext requestContext = mock(ClientRequestContext.class);
 
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getPropertyNames()).thenReturn(Collections.emptyList());
+
+        when(requestContext.getConfiguration()).thenReturn(configuration);
         when(requestContext.getProperty(ClientSecurityFeature.PROPERTY_CONTEXT)).thenReturn(context);
         when(requestContext.getProperty(ClientSecurityFeature.PROPERTY_PROVIDER)).thenReturn("http-basic-auth");
         when(requestContext.getProperty(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER)).thenReturn(user);


### PR DESCRIPTION
Fix for #487. There's a similar method in ClientTracingFilter, but I don't know what should be the good place for shared jersey code, seems like there's no such module yet.