### PR TITLE
Don't skip the handling and forwarding of 404 responses with content …

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
@@ -109,7 +109,7 @@ class ResponseWriter implements ContainerResponseWriter {
         //
         // TODO also check that nothing was written an nothing was read
         //
-        if (context.getStatus() == 404) {
+        if (context.getStatus() == 404 && contentLength == 0) {
             whenHandleFinishes.thenRun(() -> {
                 LOGGER.finer("Skipping the handling and forwarding to downstream WebServer filters.");
 

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleResource.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -204,4 +205,11 @@ public class JerseyExampleResource {
     public String pathEncoding2(@PathParam("id") String param) {
         return param;
     }
+
+    @DELETE
+    @Path("notfound")
+    public Response deleteNotFound(@Context UriInfo uriInfo) {
+    	throw new WebApplicationException(Response.status(404).entity("Not Found").build());
+    }
+
 }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -195,6 +195,13 @@ public class JerseySupportTest {
         doAssert(response, "", Response.Status.NOT_FOUND);
     }
 
+    @Test
+    public void notFoundResponse() throws Exception {
+        Response response = delete("jersey/first/notfound");
+
+        doAssert(response, "Not Found", Response.Status.NOT_FOUND);
+    }
+
     /**
      * In this test, we need to properly end the connection because the request data won't be fully consumed.
      */
@@ -305,6 +312,12 @@ public class JerseySupportTest {
         return webTarget.path(path)
                         .request()
                         .post(Entity.entity("my-entity", MediaType.TEXT_PLAIN_TYPE));
+    }
+
+    private Response delete(String path) {
+        return webTarget.path(path)
+                        .request()
+                        .delete();
     }
 
     private void doAssert(Response response, String expected) {


### PR DESCRIPTION
…to downstream WebServer filters (oracle#390)

* Only skip the handling and forwarding of 404 responses in io.helidon.webserver.jersey.ResponseWriter if there is no content