### PR TITLE
Remove exception stacktraces from unit tests (oracle#466)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,7 @@
                     <configuration>
                         <!-- DO NOT override argLine instead use surefire.argLine -->
                         <argLine>${surefire.argLine} ${surefire.coverage.argline}</argLine>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -326,6 +327,7 @@
                     <configuration>
                         <!-- DO NOT override argLine instead use failsafe.argLine -->
                         <argLine>${failsafe.argLine} ${failsafe.coverage.argline}</argLine>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
* Specify surefire and failsafe redirectTestOutputToFile=true configuration properties in top-level parent pom.xml to suppress unit test exceptions