### PR TITLE
Finish write-content span before completing delegate

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
@@ -128,11 +128,11 @@ class SendHeadersFirstPublisher<T> implements Flow.Publisher<T> {
         public void onComplete() {
             try {
                 sendHeadersIfNeeded();
-                delegate.onComplete();
             } finally {
                 if (span != null) {
                     span.finish();
                 }
+                delegate.onComplete();
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/SendHeadersFirstPublisher.java
@@ -19,7 +19,6 @@ package io.helidon.webserver;
 import java.util.Objects;
 
 import io.helidon.common.reactive.Flow;
-
 import io.opentracing.Span;
 
 /**
@@ -128,11 +127,15 @@ class SendHeadersFirstPublisher<T> implements Flow.Publisher<T> {
         public void onComplete() {
             try {
                 sendHeadersIfNeeded();
-            } finally {
                 if (span != null) {
                     span.finish();
                 }
                 delegate.onComplete();
+            } catch (Exception e) {
+                if (span != null) {
+                    span.finish();      // no-op if called more than once
+                }
+                throw e;
             }
         }
     }


### PR DESCRIPTION
Finish write-content span before completing delegate to ensure it is terminated before the span for the HTTP request itself.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>