### PR TITLE
Removed unnecessary synchronization

### DIFF
--- a/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
@@ -117,9 +117,7 @@ public final class ContentReaders {
                 @Override
                 public void onNext(DataChunk item) {
                     try {
-                        synchronized (bytes) {
-                            Utils.write(item.data(), bytes);
-                        }
+                        Utils.write(item.data(), bytes);
                     } catch (IOException e) {
                         onError(new IllegalArgumentException("Cannot convert byte buffer to a byte array!", e));
                     } finally {


### PR DESCRIPTION
The reader that converts a Flow into a ByteArray has unnecessary synchronization in onNext. See #573.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>