### PR TITLE
Primitive types long and boolean now supported by MP-JWT-Auth

### DIFF
--- a/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@ public class JwtAuthCdiExtension implements Extension {
         try {
             Claims claims = Claims.valueOf(claimLiteral.name);
             //check if field type and claim type are compatible
-            if ((clazz.equals(Long.class) || JsonNumber.class.isAssignableFrom(clazz))
+            if ((clazz.equals(Long.class) || clazz.equals(long.class) || JsonNumber.class.isAssignableFrom(clazz))
                     && (Long.class.equals(claims.getType()) || JsonNumber.class.isAssignableFrom(claims.getType()))) {
                 return;
             }
@@ -247,7 +247,7 @@ public class JwtAuthCdiExtension implements Extension {
                 return;
             }
 
-            if ((clazz.equals(Boolean.class) || JsonValue.class.isAssignableFrom(clazz))
+            if ((clazz.equals(Boolean.class) || clazz.equals(boolean.class) || JsonValue.class.isAssignableFrom(clazz))
                     && (Boolean.class.equals(claims.getType()) || JsonValue.class.isAssignableFrom(claims.getType()))) {
                 return;
             }

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
@@ -168,6 +168,22 @@ class JwtAuthTest {
         private String issuer;
 
         @Inject
+        @Claim(standard = Claims.exp)
+        private long expirationPrimitive;
+
+        @Inject
+        @Claim(standard = Claims.exp)
+        private Long expiration;
+
+        @Inject
+        @Claim(standard = Claims.email_verified)
+        private Boolean emailVerified;
+
+        @Inject
+        @Claim(standard = Claims.email_verified)
+        private boolean emailVerifiedPrimitive;
+
+        @Inject
         @Claim("iss")
         private JsonString issuerJson;
 


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>
Fixes #522 