### PR TITLE
Add property <exec.mainClass> property to the quickstart examples pom

### DIFF
--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <helidon.version>1.0.3-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.mp.Main</mainClass>
+        <exec.mainClass>${mainClass}</exec.mainClass>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <libs.classpath.prefix>libs</libs.classpath.prefix>

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -31,6 +31,7 @@
         <helidon.version>1.0.3-SNAPSHOT</helidon.version>
         <helidon.plugin.version>1.0.10</helidon.plugin.version>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
+        <exec.mainClass>${mainClass}</exec.mainClass>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <libs.classpath.prefix>libs</libs.classpath.prefix>


### PR DESCRIPTION
Fixes #591 
Add property <exec.mainClass>${mainClass}</exec.mainClass> to the pom.xml of the quickstart examples.
This enables "mvn exec:java" out of the box on the quickstart examples.