### PR TITLE
light cleanup and refactor around helidon-media

### DIFF
--- a/docs/src/main/docs/microprofile/07_tracing.adoc
+++ b/docs/src/main/docs/microprofile/07_tracing.adoc
@@ -1,0 +1,108 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2018,2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+= Tracing
+:description: Helidon MP Tracing Support
+= :keywords: helidon, tracing, microprofile, micro-profile
+
+== Configuring Tracing with Helidon MP
+Tracing support is implemented for both for Helidon MP Server and for Jersey client.
+
+Declare the following dependency in your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.microprofile.tracing</groupId>
+    <artifactId>helidon-microprofile-tracing</artifactId>
+</dependency>
+----
+
+In addition you need to add one of the tracer implementations (Zipkin or Jaeger).
+
+The minimal required configuration is `tracing.service` that contains
+the service name to be associated with tracing spans sent by this instance.
+
+All tracer specific configuration is expected in config under `tracing`.
+
+Example `microprofile-config.properties` with minimal tracer configuration:
+
+----
+tracing.service=helidon-mp
+----
+
+For additional supported properties, please see <<tracing/01_tracing.adoc#Tracing-config,tracing configuration>>
+
+== Creating custom spans
+Microprofile OpenTracing implementation will add support to simply
+add custom spans by annotation. Until we implement this support, you
+can configure custom spans as follows (in JAX-RS resources):
+
+[source,java]
+----
+@Context
+io.helidon.webserver.ServerRequest serverRequest;
+
+//...
+
+Span span = GlobalTracer.get()
+        .buildSpan("my-operation")
+        .asChildOf(serverRequest.spanContext())
+        .start();
+----
+
+== Trace propagation across services
+Automated trace propagation is supported currently only with Jersey client.
+
+Tracing propagation works automatically as long as you execute
+the client call in the same thread as the Jersey server side.
+
+_Exceptions that require manual handling_:
+
+- When the resource method is annotated with Fault Tolerance annotations (e.g. `@Fallback`)
+- When you use `async()` on the Jersey client request
+
+In such cases, you must provide the SpanContext by hand:
+[source,java]
+.Tracing propagation with Jersey client (on a different thread)
+----
+import static io.helidon.tracing.jersey.client.ClientTracingFilter.CURRENT_SPAN_CONTEXT_PROPERTY_NAME;
+import static io.helidon.tracing.jersey.client.ClientTracingFilter.TRACER_PROPERTY_NAME;
+
+// ...
+
+Response response = client.target(serviceEndpoint)
+    .request()
+    // tracer should be provided unless available as GlobalTracer
+    .property(TRACER_PROPERTY_NAME, tracer)
+    .property(CURRENT_SPAN_CONTEXT_PROPERTY_NAME, spanContext)
+    .get();
+----
+
+Tracer and SpanContext can be obtained from `ServerRequest` that can be injected into Resource classes:
+
+----
+@Context
+io.helidon.webserver.ServerRequest serverRequest;
+
+//...
+
+SpanContext spanContext = serverRequest.spanContext();
+// optional, you could also use GlobalTracer.get() if it is configured
+Tracer tracer = req.webServer().configuration().tracer();
+----

--- a/docs/src/main/docs/tracing/01_tracing.adoc
+++ b/docs/src/main/docs/tracing/01_tracing.adoc
@@ -29,11 +29,11 @@ the abstraction layer and provide a specific tracer implementation as a Java
 `ServiceLoader` service.
 
 
-=== Maven Coordinates
+== Configuring Tracing with Helidon SE
 
 Declare the following dependency in your project to use the tracer abstraction:
 
-[source,xml,subs="verbatim,attributes"]
+[source,xml]
 .Tracer Abstraction
 ----
 <dependency>
@@ -41,8 +41,6 @@ Declare the following dependency in your project to use the tracer abstraction:
     <artifactId>helidon-tracing</artifactId>
 </dependency>
 ----
-
-=== Configuring Tracing
 
 To configure tracer with WebServer:
 
@@ -57,3 +55,64 @@ ServerConfiguration.builder()
 ----
 <1> The name of the application (service) to associate with the tracing events
 <2> The endpoint for tracing events, specific to the tracer used, usually loaded from Config
+
+=== Configuration using Helidon Config [[Tracing-config]]
+There is a set of common configuration options that this section describes. In addition each tracer implementation
+may have additional configuration options - please see the documentation of each of them.
+
+Each implementation may provide defaults for these options.
+
+All common configuration options:
+|===
+|key |description
+
+|service |Name of the service sending the tracing information. This is usually visible in the trace data to
+                distinguish actors in a conversation (e.g. when multiple microservices are connected together)
+|protocol |Protocol of the tracing collector (e.g. `http`, `https`)
+|host |Host of the tracing collector (e.g. `localhost`)
+|port |Port of the tracing collector (e.g. `9411`)
+|path |Path of the tracing collector service that is used to send spans to
+|enabled |If set to false, tracing would be disabled
+|tags |String tags that are to be added to each span reported (object node of string-string pairs)
+|boolean-tags |Boolean tags that are to be added to each span reported (object node of string-boolean pairs)
+|int-tags |Int tags that are to be added to each span reported (object node of string-int pairs)
+
+|===
+
+== Creating custom spans
+To create a custom span that is a child of the WebServer request:
+
+[source,java]
+----
+// or you can register the tracer as a global tracer
+// and use GlobalTracer.get()
+Tracer tracer = request.webServer().configuration().tracer();
+Span span = tracer
+        .buildSpan("my-operation")
+        .asChildOf(serverRequest.spanContext())
+                         .start();
+----
+
+
+== Trace propagation across services
+Semi-automated trace propagation is supported currently only with Jersey client.
+
+Currently you need to provide the tracer and parent span context to the client:
+
+[source,java]
+.Tracing propagation with Jersey client
+----
+import static io.helidon.tracing.jersey.client.ClientTracingFilter.CURRENT_SPAN_CONTEXT_PROPERTY_NAME;
+import static io.helidon.tracing.jersey.client.ClientTracingFilter.TRACER_PROPERTY_NAME;
+
+//...
+
+Response response = client.target(serviceEndpoint)
+    .request()
+    // tracer should be provided unless available as GlobalTracer
+    .property(TRACER_PROPERTY_NAME, tracer)
+    .property(CURRENT_SPAN_CONTEXT_PROPERTY_NAME, spanContext)
+    .get();
+----
+
+`Tracer` and `SpanContext` can be obtained from `ServerRequest`.

--- a/docs/src/main/docs/tracing/02_zipkin.adoc
+++ b/docs/src/main/docs/tracing/02_zipkin.adoc
@@ -18,7 +18,7 @@
 
 = Zipkin Tracing
 :description: Helidon Tracing Support
-:keywords: helidon, tracing
+:keywords: helidon, tracing, zipkin
 
 Helidon is integrated with the Zipkin tracer.
 
@@ -31,7 +31,7 @@ on the Zipkin tracer.
 To use Zipkin as a tracer,
     add the following dependency to your project:
 
-[source,xml,subs="verbatim,attributes"]
+[source,xml]
 ----
 <dependency>
     <groupId>io.helidon.tracing</groupId>

--- a/docs/src/main/docs/tracing/03_jaeger.adoc
+++ b/docs/src/main/docs/tracing/03_jaeger.adoc
@@ -1,0 +1,102 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+= Jaeger Tracing
+:description: Helidon Tracing Support
+:keywords: helidon, tracing, jaeger
+
+Helidon is integrated with the Jaeger tracer.
+
+The Jaeger builder is loaded through `ServiceLoader` and configured. You could
+also use the Jaeger builder directly, though this would create a source-code dependency
+on the Jaeger tracer.
+
+
+== Prerequisites
+To use Jaeger as a tracer,
+    add the following dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.tracing</groupId>
+    <artifactId>helidon-tracing-jaeger</artifactId>
+</dependency>
+----
+
+== Configuring Jaeger
+
+The Jaeger tracer supports the following configuration options:
+
+|===
+|Key            |Default value      |Builder method     |Description
+
+|service        |N/A                |serviceName        |Name of the service, to distinguish traces crossing service boundaries;
+                                                            Jaeger is using lower-case only, name will be automatically lower-cased
+|protocol       |http               |collectorProtocol  |Protocol of the Jaeger trace collector (`udp`, `http` or `https`), to switch
+                                                            to agent mode, use `udp`
+|host           |localhost          |collectorHost      |Host of the Jaeger trace collector (IP Address, hostname, or FQDN)
+|port           |14268              |collectorPort      |Port of the Jaeger trace collector
+|path           |/api/traces        |collectorPath      |Path of the Jaeger trace collector
+|token          |N/A                |token              |Authentication token to use (token authentication)
+|username       |N/A                |username           |User to authenticate (basic authentication)
+|password       |N/A                |password           |Password of the user to authenticate (basic authentication)
+|propagation    |library default    |addPropagation     |Propagation type (`jaeger` or `b3`)
+|log-spans      |library default    |logSpans           |Whether to log spans (boolean)
+|max-queue-size |library default    |maxQueueSize       |Maximal queue size of the reporter (int)
+|flush-interval-ms|library default  |flushInterval      |Reporter flush interval in milliseconds
+|sampler-type   |library default    |samplerType        |Sampler type (`probabilistic`, `ratelimiting`, `remote`)
+|sampler-param  |library default    |samplerParam       |Numeric parameter specifying details for the sampler type
+|sampler-manager|library default    |samplerManager     |Host and port of the sampler manager for `remote` type
+|enabled        |true               |enabled            |If set to false, tracing would be disabled
+|tags           |N/A                |addTracerTag(String, String) |`String` tags to add to each span
+|boolean-tags   |N/A                |addTracerTag(String, boolean)|`boolean` tags to add to each span
+|int-tags       |N/A                |addTracerTag(String, int)    |`int` tags to add to each span
+|===
+
+The following is an example of a Jaeger configuration, specified in the YAML format.
+[source,yaml]
+----
+tracing:
+    service: "helidon-full-http"
+    protocol: "https"     # JAEGER_ENDPOINT (if not udp, http is expected and endpoint is filled)
+    host: "192.168.1.3"   # JAEGER_ENDPOINT
+    port: 14240           # JAEGER_ENDPOINT
+    path: "/api/traces/mine"   # JAEGER_ENDPOINT
+    token: "token"        # JAEGER_AUTH_TOKEN
+    # Either token or username/password
+    #username:  "user"     # JAEGER_USER
+    #password: "pass"      # JAEGER_PASSWORD
+    propagation: "jaeger" # JAEGER_PROPAGATION either "jaeger" or "b3"
+    log-spans: false      # JAEGER_REPORTER_LOG_SPANS
+    max-queue-size: 42    # JAEGER_REPORTER_MAX_QUEUE_SIZE
+    flush-interval-ms: 10001 # JAEGER_REPORTER_FLUSH_INTERVAL
+    sampler-type: "remote"# JAEGER_SAMPLER_TYPE (https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
+    sampler-param: 0.5    # JAEGER_SAMPLER_PARAM (number)
+    sampler-manager: "localhost:47877" # JAEGER_SAMPLER_MANAGER_HOST_PORT
+    tags:
+      tag1: "tag1-value"  # JAEGER_TAGS
+      tag2: "tag2-value"  # JAEGER_TAGS
+    boolean-tags:
+      tag3: true          # JAEGER_TAGS
+      tag4: false         # JAEGER_TAGS
+    int-tags:
+      tag5: 145           # JAEGER_TAGS
+      tag6: 741           # JAEGER_TAGS
+----
+

--- a/docs/src/main/docs/webserver/03_routing.adoc
+++ b/docs/src/main/docs/webserver/03_routing.adoc
@@ -110,3 +110,31 @@ requests accepted by the predicate. All other requests are _nexted_, meaning tha
                       })
                       .otherwise((req, resp) -> { /* Otherwise logic */ }); // Optional. Default logic is req.next()
 ----
+
+== Organizing Code into Services
+
+By implementing the `Service` interface you can organize your code into one
+or more services, each with its own path prefix and set of handlers.
+
+[source,java]
+.Use `Routing.Builder.register` to register your service
+----
+.register("/hello", new HelloService())
+----
+
+[source,java]
+.Service implementation
+----
+public class HelloService implements Service {
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/subpath", this::getHandler);
+    }
+
+    private void getHandler(ServerRequest request,
+                            ServerResponse response) {
+        // Some logic
+    }
+}
+----
+In this example, the `GET` handler matches requests to `/hello/subpath`.

--- a/docs/src/main/docs/webserver/05_error-handling.adoc
+++ b/docs/src/main/docs/webserver/05_error-handling.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -97,23 +97,3 @@ exception called `req.next()`, then the exception is translated to an HTTP respo
  error code `500`.
 
 
-== Registering an application - Organizing code into services
-
-You can also register an application that has its own handlers at a path prefix or context root.
-[source,java]
-.Registering routing logic for a context root
-----
-.register("/context-root", new MyComplexApplication())
-----
-
-[source,java]
-.Routing logic implementation
-----
-public class MyComplexApplication implements Consumer<Routing.Config> {
-    @Override
-    public void accept(Routing.Config config) {
-        config.get("/subpath", (req, res) -> {/* handler */});
-    }
-}
-----
-In this example, the `GET` handler matches requests to `/context-root/subpath`.

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/GreetService.java
@@ -17,6 +17,7 @@
 package io.helidon.examples.quickstart.se;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
@@ -49,12 +50,12 @@ public class GreetService implements Service {
     /**
      * The config value for the key {@code greeting}.
      */
-    private String greeting;
+    private final AtomicReference<String> greeting = new AtomicReference<>();
 
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
 
     GreetService(Config config) {
-        this.greeting = config.get("app.greeting").asString().orElse("Ciao");
+        greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
     }
 
     /**
@@ -91,7 +92,7 @@ public class GreetService implements Service {
     }
 
     private void sendResponse(ServerResponse response, String name) {
-        String msg = String.format("%s %s!", greeting, name);
+        String msg = String.format("%s %s!", greeting.get(), name);
 
         JsonObject returnObject = JSON.createObjectBuilder()
                 .add("message", msg)
@@ -110,7 +111,7 @@ public class GreetService implements Service {
             return;
         }
 
-        greeting = jo.getString("greeting");
+        greeting.set(jo.getString("greeting"));
         response.status(Http.Status.NO_CONTENT_204).send();
     }
 

--- a/media/common/src/main/java/io/helidon/media/common/CharBuffer.java
+++ b/media/common/src/main/java/io/helidon/media/common/CharBuffer.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.media.common;
+
+import java.io.Writer;
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A character buffer that acts as a {@link Writer} and uses cached {@code char[]} arrays.
+ * <p>
+ * Instances of this class are <em>not</em> thread-safe.
+ */
+public class CharBuffer extends Writer {
+    private static final Pool POOL = new Pool(8192);
+    private char[] buffer;
+    private int count;
+
+    /**
+     * Constructor.
+     */
+    public CharBuffer() {
+        buffer = POOL.acquire();
+        count = 0;
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) {
+        if ((off < 0) || (off > cbuf.length) || (len < 0) || ((off + len) - cbuf.length > 0)) {
+            throw new IndexOutOfBoundsException();
+        }
+        ensureCapacity(count + len);
+        System.arraycopy(cbuf, off, buffer, count, len);
+        count += len;
+    }
+
+    /**
+     * Returns the number of characters written.
+     *
+     * @return The count.
+     */
+    int size() {
+        return count;
+    }
+
+    /**
+     * Returns the content encoded into the given character set.
+     *
+     * @param charset The character set.
+     * @return The encoded content.
+     */
+    ByteBuffer encode(Charset charset) {
+        final ByteBuffer result = charset.encode(java.nio.CharBuffer.wrap(buffer, 0, count));
+        POOL.release(buffer);
+        buffer = null;
+        return result;
+    }
+
+    private void ensureCapacity(int minCapacity) {
+        if (minCapacity - buffer.length > 0) {
+            grow(minCapacity);
+        }
+    }
+
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    private void grow(int minCapacity) {
+        int oldCapacity = buffer.length;
+        int newCapacity = oldCapacity << 1;
+        if (newCapacity - minCapacity < 0) {
+            newCapacity = minCapacity;
+        }
+        if (newCapacity - MAX_ARRAY_SIZE > 0) {
+            newCapacity = hugeCapacity(minCapacity);
+        }
+        buffer = Arrays.copyOf(buffer, newCapacity);
+    }
+
+    private static int hugeCapacity(int minCapacity) {
+        if (minCapacity < 0) {
+            throw new OutOfMemoryError();
+        }
+        return (minCapacity > MAX_ARRAY_SIZE)
+               ? Integer.MAX_VALUE
+               : MAX_ARRAY_SIZE;
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private static class Pool {
+        private volatile SoftReference<ConcurrentLinkedQueue<char[]>> reference;
+        private final int arraySize;
+
+        /**
+         * Constructor.
+         *
+         * @param arraySize The size array to allocate when required.
+         */
+        Pool(final int arraySize) {
+            this.arraySize = arraySize;
+        }
+
+        /**
+         * Acquires an array from the pool if available or creates a new one.
+         *
+         * @return The array.
+         */
+        char[] acquire() {
+            final char[] array = getQueue().poll();
+            return array == null ? new char[arraySize] : array;
+        }
+
+        /**
+         * Returns an array back to the pool.
+         *
+         * @param array The array to return.
+         */
+        void release(final char[] array) {
+            getQueue().offer(array);
+        }
+
+        private ConcurrentLinkedQueue<char[]> getQueue() {
+            final SoftReference<ConcurrentLinkedQueue<char[]>> reference = this.reference;
+            if (reference != null) {
+                final ConcurrentLinkedQueue<char[]> queue = reference.get();
+                if (queue != null) {
+                    return queue;
+                }
+            }
+            final ConcurrentLinkedQueue<char[]> queue = new ConcurrentLinkedQueue<>();
+            this.reference = new SoftReference<>(queue);
+            return queue;
+        }
+    }
+}

--- a/media/common/src/main/java/io/helidon/media/common/ContentTypeCharset.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentTypeCharset.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.media.common;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.http.MediaType;
+import io.helidon.common.http.Parameters;
+
+/**
+ * Accessor for the {@link Charset} specified by a content-type header.
+ */
+public class ContentTypeCharset {
+
+    /**
+     * Returns the {@link Charset} specified in the content-type header, using {@link StandardCharsets#UTF_8}
+     * as the default.
+     *
+     * @param headers The headers.
+     * @return The charset.
+     */
+    public static Charset determineCharset(Parameters headers) {
+        return determineCharset(headers, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Returns the {@link Charset} specified in the content type header. If not provided or an error occurs on lookup,
+     * the given default is returned.
+     *
+     * @param headers The headers.
+     * @param defaultCharset The default.
+     * @return The charset.
+     */
+    public static Charset determineCharset(Parameters headers, Charset defaultCharset) {
+        return headers.first(Http.Header.CONTENT_TYPE)
+                      .map(MediaType::parse)
+                      .flatMap(MediaType::charset)
+                      .map(sch -> {
+                          try {
+                              return Charset.forName(sch);
+                          } catch (Exception e) {
+                              return null;
+                          }
+                      })
+                      .orElse(defaultCharset);
+    }
+
+    private ContentTypeCharset() {
+    }
+}

--- a/media/jackson/server/pom.xml
+++ b/media/jackson/server/pom.xml
@@ -38,6 +38,18 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
             <version>${project.version}</version>

--- a/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
+++ b/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
@@ -31,13 +31,17 @@ import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import static io.helidon.media.common.ContentTypeCharset.determineCharset;
 
 /**
  * A {@link Service} and a {@link Handler} that provides Jackson
  * support to Helidon.
  */
 public final class JacksonSupport implements Service, Handler {
-
     private final BiFunction<? super ServerRequest, ? super ServerResponse, ? extends ObjectMapper> objectMapperProvider;
 
     /**
@@ -66,13 +70,10 @@ public final class JacksonSupport implements Service, Handler {
     public void accept(final ServerRequest request, final ServerResponse response) {
         final ObjectMapper objectMapper = this.objectMapperProvider.apply(request, response);
         request.content()
-            .registerReader(
-                    cls -> objectMapper.canDeserialize(objectMapper.constructType(cls)),
-                    JacksonProcessing.reader(objectMapper));
-        response.registerWriter(
-                payload -> objectMapper.canSerialize(payload.getClass())
-                        && testOrSetJsonContentType(request.headers(), response.headers()),
-                JacksonProcessing.writer(objectMapper));
+            .registerReader(cls -> objectMapper.canDeserialize(objectMapper.constructType(cls)),
+                            JacksonProcessing.reader(objectMapper));
+        response.registerWriter(payload -> objectMapper.canSerialize(payload.getClass()) && this.wantsJson(request, response),
+                                JacksonProcessing.writer(objectMapper, determineCharset(response.headers())));
         request.next();
     }
 
@@ -82,7 +83,11 @@ public final class JacksonSupport implements Service, Handler {
      * @return a new {@link JacksonSupport}
      */
     public static JacksonSupport create() {
-        return create((req, res) -> new ObjectMapper());
+        final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new ParameterNamesModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule());
+        return create((req, res) -> mapper);
     }
 
     /**
@@ -153,5 +158,4 @@ public final class JacksonSupport implements Service, Handler {
                     .findFirst();
         }
     }
-
 }

--- a/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
+++ b/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
@@ -72,8 +72,10 @@ public final class JacksonSupport implements Service, Handler {
         request.content()
             .registerReader(cls -> objectMapper.canDeserialize(objectMapper.constructType(cls)),
                             JacksonProcessing.reader(objectMapper));
-        response.registerWriter(payload -> objectMapper.canSerialize(payload.getClass()) && this.wantsJson(request, response),
-                                JacksonProcessing.writer(objectMapper, determineCharset(response.headers())));
+        response.registerWriter(
+                payload -> objectMapper.canSerialize(payload.getClass())
+                        && testOrSetJsonContentType(request.headers(), response.headers()),
+                JacksonProcessing.writer(objectMapper, determineCharset(response.headers())));
         request.next();
     }
 

--- a/media/jackson/server/src/main/java9/module-info.java
+++ b/media/jackson/server/src/main/java9/module-info.java
@@ -19,6 +19,9 @@
  */
 module io.helidon.media.jackson.server {
     requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.datatype.jdk8;
+    requires com.fasterxml.jackson.datatype.jsr310;
+    requires com.fasterxml.jackson.module.paramnames;
     requires io.helidon.media.jackson.common;
     requires io.helidon.webserver;
 

--- a/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonBinding.java
+++ b/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonBinding.java
@@ -16,9 +16,9 @@
 package io.helidon.media.jsonb.common;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -28,8 +28,11 @@ import javax.json.bind.JsonbException;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Reader;
 import io.helidon.common.reactive.Flow;
+import io.helidon.media.common.CharBuffer;
 import io.helidon.media.common.ContentReaders;
 import io.helidon.media.common.ContentWriters;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Contains utility methods for working with JSON-B.
@@ -71,17 +74,16 @@ public final class JsonBinding {
      * of {@link DataChunk}s by using the supplied {@link Jsonb}.
      *
      * @param jsonb the {@link Jsonb} to use; must not be {@code null}
+     * @param charset the charset to use; may be null
      * @return created function
      * @exception NullPointerException if {@code jsonb} is {@code null}
      */
-    public static Function<Object, Flow.Publisher<DataChunk>> writer(final Jsonb jsonb) {
+    public static Function<Object, Flow.Publisher<DataChunk>> writer(final Jsonb jsonb, final Charset charset) {
         Objects.requireNonNull(jsonb);
         return payload -> {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            jsonb.toJson(payload, baos);
-            return ContentWriters.byteArrayWriter(false)
-                .apply(baos.toByteArray());
+            CharBuffer buffer = new CharBuffer();
+            jsonb.toJson(payload, buffer);
+            return ContentWriters.charBufferWriter(charset == null ? UTF_8 : charset).apply(buffer);
         };
     }
-
 }

--- a/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
+++ b/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
@@ -34,6 +34,8 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
+import static io.helidon.media.common.ContentTypeCharset.determineCharset;
+
 /**
  * A {@link Service} and a {@link Handler} that provides <a
  * href="http://json-b.net/">JSON-B</a> support to Helidon.
@@ -58,12 +60,10 @@ public final class JsonBindingSupport implements Service, Handler {
     public void accept(final ServerRequest request, final ServerResponse response) {
         final Jsonb jsonb = this.jsonbProvider.apply(request, response);
         request.content()
-            .registerReader(
-                    cls -> true,
-                    JsonBinding.reader(jsonb));
-        response.registerWriter(
-                payload -> testOrSetJsonContentType(request.headers(), response.headers()),
-                JsonBinding.writer(jsonb));
+            .registerReader(cls -> true,
+                            JsonBinding.reader(jsonb));
+        response.registerWriter(payload -> wantsJson(request, response),
+                                JsonBinding.writer(jsonb, determineCharset(response.headers())));
         request.next();
     }
 

--- a/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
+++ b/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
@@ -62,7 +62,7 @@ public final class JsonBindingSupport implements Service, Handler {
         request.content()
             .registerReader(cls -> true,
                             JsonBinding.reader(jsonb));
-        response.registerWriter(payload -> wantsJson(request, response),
+        response.registerWriter(payload -> testOrSetJsonContentType(request.headers(), response.headers()),
                                 JsonBinding.writer(jsonb, determineCharset(response.headers())));
         request.next();
     }

--- a/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonProcessing.java
+++ b/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonProcessing.java
@@ -16,7 +16,6 @@
 package io.helidon.media.jsonp.common;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -36,8 +35,11 @@ import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Reader;
 import io.helidon.common.reactive.Flow;
+import io.helidon.media.common.CharBuffer;
 import io.helidon.media.common.ContentReaders;
 import io.helidon.media.common.ContentWriters;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Media type support for json processing.
@@ -129,14 +131,11 @@ public final class JsonProcessing {
      */
     public Function<JsonStructure, Flow.Publisher<DataChunk>> writer(Charset charset) {
         return json -> {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            JsonWriter writer = (charset == null)
-                    ? jsonWriterFactory.createWriter(baos)
-                    : jsonWriterFactory.createWriter(baos, charset);
+            CharBuffer buffer = new CharBuffer();
+            JsonWriter writer = jsonWriterFactory.createWriter(buffer);
             writer.write(json);
             writer.close();
-            return ContentWriters.byteArrayWriter(false)
-                    .apply(baos.toByteArray());
+            return ContentWriters.charBufferWriter(charset == null ? UTF_8 : charset).apply(buffer);
         };
     }
 

--- a/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
+++ b/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
@@ -31,7 +31,6 @@ import io.helidon.common.http.Content;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
-import io.helidon.common.http.Parameters;
 import io.helidon.common.http.Reader;
 import io.helidon.common.reactive.Flow;
 import io.helidon.media.jsonp.common.JsonProcessing;
@@ -43,6 +42,8 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 import io.helidon.webserver.WebServer;
+
+import static io.helidon.media.common.ContentTypeCharset.determineCharset;
 
 /**
  * It provides contains JSON-P ({@code javax.json}) support for {@link WebServer WebServer}'s
@@ -192,27 +193,6 @@ public final class JsonSupport implements Service, Handler {
                     .filter(Objects::nonNull)
                     .findFirst();
         }
-    }
-
-    /**
-     * Returns a charset from {@code Content-Type} header parameter or {@code null} if not defined.
-     *
-     * @param headers parameters representing request or response headers
-     * @return a charset or {@code UTF-8} as default
-     * @throws RuntimeException if charset is not supported
-     */
-    private Charset determineCharset(Parameters headers) {
-        return headers.first(Http.Header.CONTENT_TYPE)
-                .map(MediaType::parse)
-                .flatMap(MediaType::charset)
-                .map(sch -> {
-                    try {
-                        return Charset.forName(sch);
-                    } catch (Exception e) {
-                        return null; // Do not need default charset. Can use JSON specification.
-                    }
-                })
-                .orElse(null);
     }
 
     /**

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@ public class JwtAuthCdiExtension implements Extension {
         try {
             Claims claims = Claims.valueOf(claimLiteral.name);
             //check if field type and claim type are compatible
-            if ((clazz.equals(Long.class) || JsonNumber.class.isAssignableFrom(clazz))
+            if ((clazz.equals(Long.class) || clazz.equals(long.class) || JsonNumber.class.isAssignableFrom(clazz))
                     && (Long.class.equals(claims.getType()) || JsonNumber.class.isAssignableFrom(claims.getType()))) {
                 return;
             }
@@ -247,7 +247,7 @@ public class JwtAuthCdiExtension implements Extension {
                 return;
             }
 
-            if ((clazz.equals(Boolean.class) || JsonValue.class.isAssignableFrom(clazz))
+            if ((clazz.equals(Boolean.class) || clazz.equals(boolean.class) || JsonValue.class.isAssignableFrom(clazz))
                     && (Boolean.class.equals(claims.getType()) || JsonValue.class.isAssignableFrom(claims.getType()))) {
                 return;
             }

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
@@ -133,6 +133,14 @@ class JwtAuthTest {
                 .get(String.class);
 
         assertThat(httpResponse, is("Hello user1"));
+
+        httpResponse = target.path("/public")
+                .path("/hello")
+                .request()
+                .header("Authorization", signedToken)
+                .get(String.class);
+
+        assertThat(httpResponse, is("Hello user1"));
     }
 
     @Test
@@ -151,7 +159,7 @@ class JwtAuthTest {
     public static class MyApp extends Application {
         @Override
         public Set<Class<?>> getClasses() {
-            return CollectionsHelper.setOf(MyResource.class);
+            return CollectionsHelper.setOf(MyResource.class, ResourceWithPublicMethod.class);
         }
     }
 
@@ -168,6 +176,59 @@ class JwtAuthTest {
         private String issuer;
 
         @Inject
+        @Claim(standard = Claims.exp)
+        private long expirationPrimitive;
+
+        @Inject
+        @Claim(standard = Claims.exp)
+        private Long expiration;
+
+        @Inject
+        @Claim(standard = Claims.email_verified)
+        private Boolean emailVerified;
+
+        @Inject
+        @Claim(standard = Claims.email_verified)
+        private boolean emailVerifiedPrimitive;
+
+        @Inject
+        @Claim("iss")
+        private JsonString issuerJson;
+
+        @Inject
+        @Claim(standard = Claims.aud)
+        private ClaimValue<Optional<Set<String>>> audience;
+
+        @Path("/hello")
+        @GET
+        public String hello() {
+            return "Hello " + (null == callerPrincipal ? "Unknown" : callerPrincipal.getName());
+        }
+
+    }
+
+    @Path("/public")
+    @RequestScoped
+    public static class ResourceWithPublicMethod {
+        @Inject
+        private JsonWebToken callerPrincipal;
+
+        @Context
+        private SecurityContext securityContext;
+
+        @Inject
+        @Claim(standard = Claims.iss)
+        private String issuer;
+
+        @Inject
+        @Claim(standard = Claims.exp)
+        private Long expiration;
+
+        @Inject
+        @Claim(standard = Claims.email_verified)
+        private Boolean emailVerified;
+
+        @Inject
         @Claim("iss")
         private JsonString issuerJson;
 
@@ -182,7 +243,6 @@ class JwtAuthTest {
         }
 
         @PermitAll
-        @Path("/public")
         @GET
         public String noAuth() {
             return "Hello World";

--- a/microprofile/tracing/src/test/java/io/helidon/microprofile/tracing/TestTracerProvider.java
+++ b/microprofile/tracing/src/test/java/io/helidon/microprofile/tracing/TestTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,7 +189,7 @@ public class TestTracerProvider implements TracerProvider {
 
         @Override
         public Scope startActive(boolean finishSpanOnClose) {
-             return null;
+             return new TestScope((TestSpan) start());
         }
 
         @Override
@@ -303,6 +303,23 @@ public class TestTracerProvider implements TracerProvider {
             Map<String, String> map = CollectionsHelper.mapOf();
 
             return map.entrySet();
+        }
+    }
+
+    static class TestScope implements Scope {
+        private final TestSpan testSpan;
+
+        TestScope(TestSpan testSpan) {
+            this.testSpan = testSpan;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Span span() {
+            return testSpan;
         }
     }
 }

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -59,7 +59,7 @@ import io.opentracing.noop.NoopTracerFactory;
  *     </tr>
  *     <tr>
  *         <td>{@code protocol}</td>
- *         <td>{@code udp}</td>
+ *         <td>{@code http}</td>
  *         <td>The protocol to use. By default http is used. To switch to agent
  *          mode, use {@code udp}</td>
  *     </tr>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ContentTypeSelector.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ContentTypeSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,8 +220,8 @@ class ContentTypeSelector {
 
     MediaType determine(String filename, RequestHeaders requestHeaders) {
         MediaType mediaType = get(filename);
-        List<MediaType> accepted = requestHeaders.acceptedTypes();
         if (mediaType == null) {
+            List<MediaType> accepted = requestHeaders.acceptedTypes();
             // First from Accepted
             if (accepted.isEmpty()) {
                 // Most general

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashRequestHeaders.java
@@ -40,7 +40,7 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
 
     /**
      * Header value of the non compliant {@code Accept} header sent by
-     * {@link HTTPURLConnection} when none is set.
+     * {@link HttpURLConnection} when none is set.
      * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8163921">JDK-8163921</a>
      */
     static final String HUC_ACCEPT_DEFAULT = "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2";
@@ -135,7 +135,7 @@ class HashRequestHeaders extends ReadOnlyParameters implements RequestHeaders {
             return Optional.empty();
         }
         List<MediaType> accepts = acceptedTypes();
-        if (accepts == null || accepts.isEmpty()) {
+        if (accepts.isEmpty()) {
             return Optional.ofNullable(mediaTypes[0]);
         }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -141,7 +141,7 @@ class RequestRouting implements Routing {
         if (spanContext != null) {
             spanBuilder.asChildOf(spanContext);
         }
-        return spanBuilder.start();
+        return spanBuilder.startActive(true).span();
     }
 
     /**


### PR DESCRIPTION
just some minor cleanup around stuff that was bothering me in helidon-media
* consolidated/aligned/documented the Content-Type testOrSet/"wantsJson" methods across the Jackson/JSON-P/JSON-B support classes... it's now easier to see only-relevant-to-JSON duplicated code that might make sense to one day live in something like a "helidon-media-common-json" subproject.
* more `Optional` use and less `.orElse(null)`
* some places were doing null checks on `RequestHeaders.acceptedTypes()` even when the javadoc says it will never return null