### PR TITLE
Common service loader

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -318,6 +318,11 @@
                 <artifactId>helidon-common-key-util</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.common</groupId>
+                <artifactId>helidon-common-service-loader</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- tracing -->
             <dependency>

--- a/common/common/src/main/java/io/helidon/common/Prioritized.java
+++ b/common/common/src/main/java/io/helidon/common/Prioritized.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common;
+
+/**
+ * Interface to define that this class is a class with priority.
+ * One of the uses is for services loaded by a ServiceLoader.
+ */
+@FunctionalInterface
+public interface Prioritized {
+    /**
+     * Priority of this class (maybe because it is defined
+     * dynamically, so it cannot be defined by an annotation).
+     * If not dynamic, you can use the {@code javax.annotation.Priority}
+     * annotation rather then implementing this interface as long as
+     * it is supported by the library using this {@code Prioritized}.
+     *
+     * @return the priority of this service
+     */
+    int priority();
+}

--- a/common/common/src/main/java/io/helidon/common/Prioritized.java
+++ b/common/common/src/main/java/io/helidon/common/Prioritized.java
@@ -18,9 +18,26 @@ package io.helidon.common;
 /**
  * Interface to define that this class is a class with priority.
  * One of the uses is for services loaded by a ServiceLoader.
+ * <p>
+ * A {@code Prioritized} with lower priority number is more significant than a {@code Prioritized} with a
+ * higher priority number.
+ * <p>
+ * For cases where priority is the same, implementation must define ordering of such {@code Prioritized}.
+ * <p>
+ * <b>Negative priorities are not allowed and services using priorities should throw an
+ * {@link java.lang.IllegalArgumentException} if such a priority is used (unless such a service
+ * documents the specific usage of a negative priority)</b>
+ * <p>
+ * A {@code Prioritized} with priority {@code 1} is more significant (will be returned before) priority {@code 2}.
  */
 @FunctionalInterface
 public interface Prioritized {
+    /**
+     * Default priority for any prioritized component (whether it implements this interface
+     * or uses {@code javax.annotation.Priority} annotation.
+     */
+    int DEFAULT_PRIORITY = 5000;
+
     /**
      * Priority of this class (maybe because it is defined
      * dynamically, so it cannot be defined by an annotation).
@@ -28,7 +45,7 @@ public interface Prioritized {
      * annotation rather then implementing this interface as long as
      * it is supported by the library using this {@code Prioritized}.
      *
-     * @return the priority of this service
+     * @return the priority of this service, must be a non-negative number
      */
     int priority();
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -36,5 +36,6 @@
         <module>configurable</module>
         <module>key-util</module>
         <module>http</module>
+        <module>service-loader</module>
     </modules>
 </project>

--- a/common/service-loader/pom.xml
+++ b/common/service-loader/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>helidon-common-project</artifactId>
         <groupId>io.helidon.common</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/service-loader/pom.xml
+++ b/common/service-loader/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-common-project</artifactId>
+        <groupId>io.helidon.common</groupId>
+        <version>1.0.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-common-service-loader</artifactId>
+    <name>Helidon Common Service Loader</name>
+
+    <description>
+        Service loader utilities to extend functionality of
+        Java Service loader.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/common/service-loader/src/main/java/io/helidon/common/serviceloader/HelidonServiceLoader.java
+++ b/common/service-loader/src/main/java/io/helidon/common/serviceloader/HelidonServiceLoader.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.serviceloader;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import javax.annotation.Priority;
+
+import io.helidon.common.Prioritized;
+
+/**
+ * Helidon specific support for Java Service Loaders.
+ * <p>
+ * This service loader:
+ * <ul>
+ * <li>Can have additional implementations added</li>
+ * <li>Uses priorities defined either by {@link io.helidon.common.Prioritized}
+ * or by {@link javax.annotation.Priority}</li>
+ * <li>Can have exclusions defined by an exact implementation class name, either
+ * in {@link Builder#addExcludedClass(Class)} or {@link Builder#addExcludedClassName(String)} or
+ * by a system property {@value #SYSTEM_PROPERTY_EXCLUDE} that defines
+ * a comma separated list of fully qualified class names to be excluded.
+ * Note that if a class implements more than one service, it would be excluded from all.</li>
+ * </ul>
+ * <p>
+ * <i>Note on priority handling</i>
+ * <p>
+ * Service priority is defined by:
+ * <ul>
+ * <li>Value provided in {@link Builder#addService(Object, int)} (if used)</li>
+ * <li>then by {@link io.helidon.common.Prioritized#priority()} if service implements it</li>
+ * <li>then by {@link javax.annotation.Priority} annotation if present</li>
+ * <li>otherwise a default priority {@value #DEFAULT_PRIORITY} from {@link #DEFAULT_PRIORITY} is used</li>
+ * </ul>
+ * A service with lower priority number is returned before a service with a higher priority number.
+ * Services with the same priority have order defined by the order they are in the configured services
+ * and then as they are loaded from the {@link java.util.ServiceLoader}.
+ * Negative priorities are allowed.
+ * A service with priority {@code 1} will be returned before a service with priority {@code 2}.
+ * <p>
+ *
+ * @param <T> Type of the service to be loaded
+ * @see java.util.ServiceLoader
+ * @see #builder(java.util.ServiceLoader)
+ */
+public final class HelidonServiceLoader<T> implements Iterable<T> {
+    /**
+     * Default priority of a service.
+     */
+    public static final int DEFAULT_PRIORITY = 100;
+    /**
+     * System property used to exclude some implementation from the list of services that are configured for Java Service
+     * loader or services that are registered using {@link io.helidon.common.serviceloader.HelidonServiceLoader.Builder}.
+     */
+    public static final String SYSTEM_PROPERTY_EXCLUDE = "io.helidon.common.serviceloader.exclude";
+
+    private static final Logger LOGGER = Logger.getLogger(HelidonServiceLoader.class.getName());
+
+    private final List<T> services;
+
+    /**
+     * Create a builder for customizable service loader.
+     *
+     * @param javaServiceLoader the Java Service loader used to get service implementations
+     * @param <T>               type of the service
+     * @return a new fluent API builder
+     */
+    public static <T> Builder<T> builder(ServiceLoader<T> javaServiceLoader) {
+        return new Builder<>(javaServiceLoader);
+    }
+
+    /**
+     * Create a prioritized service loader from a Java Service loader.
+     *
+     * @param javaServiceLoader the Java service loader
+     * @param <T>               type of the service
+     * @return service loader with exclusions defined by system properties and no custom services
+     */
+    public static <T> HelidonServiceLoader<T> create(ServiceLoader<T> javaServiceLoader) {
+        Builder<T> builder = builder(javaServiceLoader);
+        return builder.build();
+    }
+
+    private HelidonServiceLoader(List<T> services) {
+        this.services = new LinkedList<>(services);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return Collections.unmodifiableList(services)
+                .iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action) {
+        this.services.forEach(action);
+    }
+
+    /**
+     * Provides a list of service implementations in prioritized order.
+     *
+     * @return list of service implementations
+     */
+    public List<T> asList() {
+        return new LinkedList<>(this.services);
+    }
+
+    /**
+     * Fluent api builder for {@link io.helidon.common.serviceloader.HelidonServiceLoader}.
+     *
+     * @param <T> type of the service to be loaded
+     */
+    public static final class Builder<T> implements io.helidon.common.Builder<HelidonServiceLoader<T>> {
+        private final ServiceLoader<T> serviceLoader;
+        private final List<ServiceWithPriority<T>> customServices = new LinkedList<ServiceWithPriority<T>>();
+        private final Set<String> excludedServiceClasses = new HashSet<>();
+        private boolean useSysPropExclude = true;
+        private boolean useJavaServiceLoader = true;
+        private boolean replaceImplementations = true;
+
+        private Builder(ServiceLoader<T> javaServiceLoader) {
+            this.serviceLoader = javaServiceLoader;
+        }
+
+        @Override
+        public HelidonServiceLoader<T> build() {
+            // first merge the lists together
+            List<ServiceWithPriority<T>> services = new LinkedList<>(customServices);
+            if (useJavaServiceLoader) {
+                Set<String> uniqueImplementations = new HashSet<>();
+
+                if (replaceImplementations) {
+                    customServices.stream()
+                            .map(ServiceWithPriority::instanceClassName)
+                            .forEach(uniqueImplementations::add);
+                }
+
+                serviceLoader.forEach(service -> {
+                    if (replaceImplementations) {
+                        if (!uniqueImplementations.contains(service.getClass().getName())) {
+                            services.add(new ServiceWithPriority<>(service));
+                        }
+                    } else {
+                        services.add(new ServiceWithPriority<>(service));
+                    }
+                });
+            }
+
+            if (useSysPropExclude) {
+                addSystemExcludes();
+            }
+            List<ServiceWithPriority<T>> withoutExclusions = services.stream()
+                    .filter(this::notExcluded)
+                    .collect(Collectors.toList());
+
+            // order by priority
+            return new HelidonServiceLoader<>(orderByPriority(withoutExclusions));
+        }
+
+        /**
+         * When configured to use system excludes, system property {@value #SYSTEM_PROPERTY_EXCLUDE} is used to get the
+         * comma separated list of service implementations to exclude them from the loaded list.
+         * <p>
+         * This defaults to {@code true}.
+         *
+         * @param useSysPropExclude whether to use a system property to exclude service implementations
+         * @return updated builder instance
+         */
+        public Builder<T> useSystemExcludes(boolean useSysPropExclude) {
+            this.useSysPropExclude = useSysPropExclude;
+            return this;
+        }
+
+        /**
+         * When configured to use Java Service loader, then the result is a combination of all service implementations
+         * loaded from the Java Service loader and those added by {@link #addService(Object)} or {@link #addService(Object, int)}.
+         * When set to {@code false} the Java Service loader is ignored.
+         * <p>
+         * This defaults to {@code true}.
+         *
+         * @param useJavaServiceLoader whether to use the Java Service loader
+         * @return updated builder instance
+         */
+        public Builder<T> useJavaServiceLoader(boolean useJavaServiceLoader) {
+            this.useJavaServiceLoader = useJavaServiceLoader;
+            return this;
+        }
+
+        /**
+         * When configured to replace implementations, then a service implementation configured through
+         * {@link #addService(Object)}
+         * will replace the same implementation loaded from the Java Service loader (compared by fully qualified class name).
+         * <p>
+         * This defaults to {@code true}.
+         *
+         * @param replace whether to replace service instances loaded by java service loader with the ones provided
+         *                through builder methods
+         * @return updated builder instance
+         */
+        public Builder<T> replaceImplementations(boolean replace) {
+            this.replaceImplementations = replace;
+            return this;
+        }
+
+        /**
+         * Add a custom service implementation to the list of services.
+         *
+         * @param service a new service instance
+         * @return updated builder instance
+         */
+        public Builder<T> addService(T service) {
+            this.customServices.add(new ServiceWithPriority<>(service));
+            return this;
+        }
+
+        /**
+         * Add a custom service implementation to the list of services with a custom priority.
+         *
+         * @param service  a new service instance
+         * @param priority priority to use when ordering service instances
+         * @return updated builder instance
+         */
+        public Builder<T> addService(T service, int priority) {
+            this.customServices.add(new ServiceWithPriority<>(service, priority));
+            return this;
+        }
+
+        /**
+         * Add an excluded implementation class - if such a service implementation is configured (either through
+         * Java Service loader or through {@link #addService(Object)}), it would be ignored.
+         *
+         * @param excluded excluded implementation class
+         * @return updated builder instance
+         */
+        public Builder<T> addExcludedClass(Class<? extends T> excluded) {
+            excludedServiceClasses.add(excluded.getName());
+            return this;
+        }
+
+        /**
+         * Add an excluded implementation class - if such a service implementation is configured (either through
+         * Java Service loader or through {@link #addService(Object)}), it would be ignored.
+         *
+         * @param excludeName excluded implementation class name
+         * @return updated builder instance
+         */
+        public Builder<T> addExcludedClassName(String excludeName) {
+            excludedServiceClasses.add(excludeName);
+            return this;
+        }
+
+        private boolean notExcluded(ServiceWithPriority<T> service) {
+            String className = service.instance.getClass().getName();
+            if (excludedServiceClasses.contains(className)) {
+                LOGGER.finest(() -> "Excluding service implementation " + className);
+                return false;
+            }
+            return true;
+        }
+
+        private List<T> orderByPriority(List<ServiceWithPriority<T>> services) {
+            services.sort(ServiceWithPriority.COMPARATOR);
+
+            List<T> result = services.stream()
+                    .map(ServiceWithPriority::instance)
+                    .collect(Collectors.toList());
+
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest("Final order of enabled service implementations for service: " + serviceLoader);
+                result.stream()
+                        .map(Object::getClass)
+                        .map(Class::getName)
+                        .forEach(LOGGER::finest);
+            }
+
+            return result;
+        }
+
+        private void addSystemExcludes() {
+            String excludes = System.getProperty(SYSTEM_PROPERTY_EXCLUDE);
+            if (null == excludes) {
+                return;
+            }
+
+            for (String exclude : excludes.split(",")) {
+                LOGGER.finest(() -> "Adding exclude from system properties: " + exclude);
+                addExcludedClassName(exclude);
+            }
+        }
+
+        private static final class ServiceWithPriority<T> {
+            public static final Comparator<ServiceWithPriority<?>> COMPARATOR = Comparator
+                    .comparingInt(ServiceWithPriority::priority);
+
+            private final T instance;
+            private final int priority;
+
+            private ServiceWithPriority(T instance, int priority) {
+                this.instance = instance;
+                this.priority = priority;
+            }
+
+            private ServiceWithPriority(T service) {
+                this(service, findPriority(service));
+            }
+
+            private int priority() {
+                return priority;
+            }
+
+            private T instance() {
+                return instance;
+            }
+
+            private String instanceClassName() {
+                return instance.getClass().getName();
+            }
+
+            private static int findPriority(Object o) {
+                if (o instanceof Prioritized) {
+                    return ((Prioritized) o).priority();
+                }
+                Priority prio = o.getClass().getAnnotation(Priority.class);
+                if (null == prio) {
+                    return DEFAULT_PRIORITY;
+                }
+                return prio.value();
+            }
+
+            @Override
+            public String toString() {
+                return instance.toString();
+            }
+        }
+    }
+}

--- a/common/service-loader/src/main/java/io/helidon/common/serviceloader/package-info.java
+++ b/common/service-loader/src/main/java/io/helidon/common/serviceloader/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Java Service loader extension.
+ */
+package io.helidon.common.serviceloader;

--- a/common/service-loader/src/main/java9/module-info.java
+++ b/common/service-loader/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/service-loader/src/main/java9/module-info.java
+++ b/common/service-loader/src/main/java9/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon Common Service Loader.
+ */
+module io.helidon.common.serviceloader {
+    requires java.logging;
+    requires io.helidon.common;
+    requires java.annotation;
+
+    exports io.helidon.common.serviceloader;
+}

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/HelidonServiceLoaderTest.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/HelidonServiceLoaderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.serviceloader;
+
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+/**
+ * Unit test for {@link io.helidon.common.serviceloader.HelidonServiceLoader}.
+ */
+class HelidonServiceLoaderTest {
+    private static ServiceLoader<ServiceInterface> javaLoader;
+
+    @BeforeAll
+    static void initClass() {
+        javaLoader = ServiceLoader.load(ServiceInterface.class);
+    }
+
+    @Test
+    void testJavaLoader() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.create(javaLoader).asList();
+
+        assertThat(loaded, hasSize(2));
+        assertThat(loaded.get(0).message(), is(ServiceImpl2.class.getName()));
+        assertThat(loaded.get(1).message(), is(ServiceImpl1.class.getName()));
+    }
+
+    @Test
+    void testCustomService() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl3())
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(3));
+        assertThat(loaded.get(0).message(), is(ServiceImpl2.class.getName()));
+        assertThat(loaded.get(1).message(), is(ServiceImpl3.class.getName()));
+        assertThat(loaded.get(2).message(), is(ServiceImpl1.class.getName()));
+    }
+
+    @Test
+    void testCustomServiceWithCustomPrio() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl3(), -1)
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(3));
+        assertThat(loaded.get(0).message(), is(ServiceImpl3.class.getName()));
+        assertThat(loaded.get(1).message(), is(ServiceImpl2.class.getName()));
+        assertThat(loaded.get(2).message(), is(ServiceImpl1.class.getName()));
+    }
+
+    @Test
+    void testExcludeService() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl3())
+                .addExcludedClass(ServiceImpl2.class)
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(2));
+        assertThat(loaded.get(0).message(), is(ServiceImpl3.class.getName()));
+        assertThat(loaded.get(1).message(), is(ServiceImpl1.class.getName()));
+    }
+
+    @Test
+    void testExcludeServiceNames() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl3())
+                .addExcludedClassName(ServiceImpl1.class.getName())
+                .addExcludedClassName(ServiceImpl3.class.getName())
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(1));
+        assertThat(loaded.get(0).message(), is(ServiceImpl2.class.getName()));
+    }
+
+    @Test
+    void testWithoutJavaServiceLoader() {
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl3())
+                .addService(new ServiceImpl2())
+                .useJavaServiceLoader(false)
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(2));
+        assertThat(loaded.get(0).message(), is(ServiceImpl2.class.getName()));
+        assertThat(loaded.get(1).message(), is(ServiceImpl3.class.getName()));
+    }
+
+    @Test
+    void testUniqueImplementations() {
+        String TEST_STRING = "custom messsage";
+
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl2(TEST_STRING))
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(2));
+        assertThat(loaded.get(0).message(), is(TEST_STRING));
+        assertThat(loaded.get(1).message(), is(ServiceImpl1.class.getName()));
+    }
+
+    @Test
+    void testNoUniqueImplementations() {
+        String TEST_STRING = "custom messsage";
+
+        List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl2(TEST_STRING), 11)
+                .replaceImplementations(false)
+                .build()
+                .asList();
+
+        assertThat(loaded, hasSize(3));
+        assertThat(loaded.get(0).message(), is(TEST_STRING));
+        assertThat(loaded.get(1).message(), is(ServiceImpl2.class.getName()));
+        assertThat(loaded.get(2).message(), is(ServiceImpl1.class.getName()));
+    }
+}
+

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/HelidonServiceLoaderTest.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/HelidonServiceLoaderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for {@link io.helidon.common.serviceloader.HelidonServiceLoader}.
@@ -62,7 +63,7 @@ class HelidonServiceLoaderTest {
     @Test
     void testCustomServiceWithCustomPrio() {
         List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
-                .addService(new ServiceImpl3(), -1)
+                .addService(new ServiceImpl3(), 0)
                 .build()
                 .asList();
 
@@ -99,11 +100,11 @@ class HelidonServiceLoaderTest {
     }
 
     @Test
-    void testWithoutJavaServiceLoader() {
+    void testWithoutSystemServiceLoader() {
         List<ServiceInterface> loaded = HelidonServiceLoader.builder(javaLoader)
                 .addService(new ServiceImpl3())
                 .addService(new ServiceImpl2())
-                .useJavaServiceLoader(false)
+                .useSystemServiceLoader(false)
                 .build()
                 .asList();
 
@@ -141,5 +142,24 @@ class HelidonServiceLoaderTest {
         assertThat(loaded.get(1).message(), is(ServiceImpl2.class.getName()));
         assertThat(loaded.get(2).message(), is(ServiceImpl1.class.getName()));
     }
+
+    @Test
+    void testNegativePrioFails() {
+        assertThrows(IllegalArgumentException.class, () -> HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl2("something"), -11)
+                .replaceImplementations(false)
+                .build()
+                .asList());
+    }
+
+    @Test
+    void testZeropPrioWorks() {
+        HelidonServiceLoader.builder(javaLoader)
+                .addService(new ServiceImpl2("something"), 0)
+                .replaceImplementations(false)
+                .build()
+                .asList();
+    }
+
 }
 

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl1.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl1.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.serviceloader;
+
+import javax.annotation.Priority;
+
+/**
+ * A service implementation.
+ */
+@Priority(47)
+public class ServiceImpl1 implements ServiceInterface {
+    @Override
+    public String message() {
+        return getClass().getName();
+    }
+}

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl2.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.serviceloader;
+
+import io.helidon.common.Prioritized;
+
+/**
+ * A service implementation.
+ */
+public class ServiceImpl2 implements ServiceInterface, Prioritized {
+    private final String message;
+
+    public ServiceImpl2() {
+        this.message = ServiceImpl2.class.getName();
+    }
+
+    public ServiceImpl2(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int priority() {
+        return 12;
+    }
+}

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl3.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceImpl3.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.serviceloader;
+
+import javax.annotation.Priority;
+
+/**
+ * A service implementation.
+ */
+@Priority(22)
+public class ServiceImpl3 implements ServiceInterface {
+    @Override
+    public String message() {
+        return getClass().getName();
+    }
+}

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceInterface.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceInterface.java
@@ -16,7 +16,7 @@
 package io.helidon.common.serviceloader;
 
 /**
- * TODO javadoc.
+ * Testing Java Service loader service interface.
  */
 public interface ServiceInterface {
     String message();

--- a/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceInterface.java
+++ b/common/service-loader/src/test/java/io/helidon/common/serviceloader/ServiceInterface.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.serviceloader;
+
+/**
+ * TODO javadoc.
+ */
+public interface ServiceInterface {
+    String message();
+}

--- a/common/service-loader/src/test/resources/META-INF/services/io.helidon.common.serviceloader.ServiceInterface
+++ b/common/service-loader/src/test/resources/META-INF/services/io.helidon.common.serviceloader.ServiceInterface
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/common/service-loader/src/test/resources/META-INF/services/io.helidon.common.serviceloader.ServiceInterface
+++ b/common/service-loader/src/test/resources/META-INF/services/io.helidon.common.serviceloader.ServiceInterface
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.common.serviceloader.ServiceImpl1
+io.helidon.common.serviceloader.ServiceImpl2

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -86,6 +86,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-service-loader</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <!-- Jersey integration with Weld -->
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-weld2-se</artifactId>

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -37,6 +38,7 @@ import javax.ws.rs.core.Application;
 
 import io.helidon.common.CollectionsHelper;
 import io.helidon.common.configurable.ThreadPoolSupplier;
+import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.microprofile.config.MpConfig;
 import io.helidon.microprofile.server.spi.MpService;
 
@@ -146,8 +148,8 @@ public interface Server {
         private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.builder");
 
         private final List<Class<?>> resourceClasses = new LinkedList<>();
-        private final List<MpService> extensions = new LinkedList<>();
         private final List<JaxRsApplication> applications = new LinkedList<>();
+        private HelidonServiceLoader.Builder<MpService> extensionBuilder;
         private ResourceConfig resourceConfig;
         private SeContainer cdiContainer;
         private MpConfig config;
@@ -158,6 +160,7 @@ public interface Server {
         private Supplier<? extends ExecutorService> defaultExecutorService;
 
         private Builder() {
+            extensionBuilder = HelidonServiceLoader.builder(ServiceLoader.load(MpService.class));
         }
 
         private static ResourceConfig configForResourceClasses(List<Class<?>> resourceClasses) {
@@ -333,8 +336,34 @@ public interface Server {
             return this;
         }
 
+        /**
+         * Configure the extension builder.
+         * This allows a fully customized handling of {@link io.helidon.microprofile.server.spi.MpService} instances
+         * to be used by the created {@link io.helidon.microprofile.server.Server}.
+         *
+         * @param loaderBuilder builder of server extensions
+         * @return updated builder instance
+         * @see io.helidon.common.serviceloader.HelidonServiceLoader.Builder#useJavaServiceLoader(boolean)
+         */
+        public Builder extensionsService(HelidonServiceLoader.Builder<MpService> loaderBuilder) {
+            this.extensionBuilder = loaderBuilder;
+            return this;
+        }
+
+        /**
+         * Add an extension to the list of extensions.
+         * All {@link io.helidon.microprofile.server.spi.MpService} configured for Java Service loader are loaded
+         * automatically.
+         * This serves as a possibility to add a service that is not loaded through a service loader.
+         * <p>
+         * To have a fully customized list of extensions, use
+         * {@link #extensionsService(io.helidon.common.serviceloader.HelidonServiceLoader.Builder)}.
+         *
+         * @param service service implementation
+         * @return updated builder instance
+         */
         public Builder addExtension(MpService service) {
-            extensions.add(service);
+            extensionBuilder.addService(service);
             return this;
         }
 
@@ -557,7 +586,7 @@ public interface Server {
         }
 
         List<MpService> extensions() {
-            return extensions;
+            return extensionBuilder.build().asList();
         }
 
         boolean containerCreated() {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -343,7 +343,7 @@ public interface Server {
          *
          * @param loaderBuilder builder of server extensions
          * @return updated builder instance
-         * @see io.helidon.common.serviceloader.HelidonServiceLoader.Builder#useJavaServiceLoader(boolean)
+         * @see io.helidon.common.serviceloader.HelidonServiceLoader.Builder#useSystemServiceLoader(boolean)
          */
         public Builder extensionsService(HelidonServiceLoader.Builder<MpService> loaderBuilder) {
             this.extensionBuilder = loaderBuilder;

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -192,8 +192,6 @@ public class ServerImpl implements Server {
                                 Routing.Builder routingBuilder,
                                 Map<String, Routing.Builder> namedRouting,
                                 ServerConfiguration.Builder serverConfigBuilder) {
-                                Routing.Builder routingBuilder,
-                                ServerConfiguration.Builder serverConfigBuilder) {
 
         List<JaxRsApplication> newApps = new LinkedList<>();
 
@@ -201,6 +199,7 @@ public class ServerImpl implements Server {
                                                           config,
                                                           apps,
                                                           routingBuilder,
+                                                          namedRouting,
                                                           serverConfigBuilder,
                                                           newApps);
 
@@ -217,6 +216,7 @@ public class ServerImpl implements Server {
                                                     Config config,
                                                     List<JaxRsApplication> apps,
                                                     Routing.Builder routingBuilder,
+                                                    Map<String, Routing.Builder> namedRouting,
                                                     ServerConfiguration.Builder serverConfigBuilder,
                                                     List<JaxRsApplication> newApps) {
         return new MpServiceContext() {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -25,7 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,7 +32,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import javax.annotation.Priority;
 import javax.enterprise.inject.se.SeContainer;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
@@ -44,7 +42,6 @@ import io.helidon.common.OptionalHelper;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.microprofile.config.MpConfig;
-import io.helidon.microprofile.server.spi.MpService;
 import io.helidon.microprofile.server.spi.MpServiceContext;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerConfiguration;
@@ -61,8 +58,6 @@ public class ServerImpl implements Server {
     private static final Logger LOGGER = Logger.getLogger(ServerImpl.class.getName());
     private static final Logger JERSEY_LOGGER = Logger.getLogger(ServerImpl.class.getName() + ".jersey");
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
-
-    private static final int DEFAULT_PRIORITY = 100;
 
     private final SeContainer container;
     private final boolean containerCreated;
@@ -190,15 +185,6 @@ public class ServerImpl implements Server {
         STARTUP_LOGGER.finest("Server created");
     }
 
-    private static int findPriority(Class<?> aClass) {
-        Priority priorityAnnot = aClass.getAnnotation(Priority.class);
-        if (null != priorityAnnot) {
-            return priorityAnnot.value();
-        }
-
-        return DEFAULT_PRIORITY;
-    }
-
     private void loadExtensions(Builder builder,
                                 MpConfig mpConfig,
                                 Config config,
@@ -206,14 +192,34 @@ public class ServerImpl implements Server {
                                 Routing.Builder routingBuilder,
                                 Map<String, Routing.Builder> namedRouting,
                                 ServerConfiguration.Builder serverConfigBuilder) {
-        // extensions
-        List<MpService> extensions = new LinkedList<>(builder.extensions());
-        ServiceLoader.load(MpService.class).forEach(extensions::add);
+                                Routing.Builder routingBuilder,
+                                ServerConfiguration.Builder serverConfigBuilder) {
 
         List<JaxRsApplication> newApps = new LinkedList<>();
-        // TODO order by Priority
 
-        MpServiceContext context = new MpServiceContext() {
+        MpServiceContext context = createExtensionContext(mpConfig,
+                                                          config,
+                                                          apps,
+                                                          routingBuilder,
+                                                          serverConfigBuilder,
+                                                          newApps);
+
+        // extensions
+        builder.extensions()
+                .forEach(extension -> {
+                    extension.configure(context);
+                    apps.addAll(newApps);
+                    newApps.clear();
+                });
+    }
+
+    private MpServiceContext createExtensionContext(MpConfig mpConfig,
+                                                    Config config,
+                                                    List<JaxRsApplication> apps,
+                                                    Routing.Builder routingBuilder,
+                                                    ServerConfiguration.Builder serverConfigBuilder,
+                                                    List<JaxRsApplication> newApps) {
+        return new MpServiceContext() {
             @Override
             public org.eclipse.microprofile.config.Config config() {
                 return mpConfig;
@@ -267,11 +273,6 @@ public class ServerImpl implements Server {
                 register.put(key, instance);
             }
         };
-        for (MpService extension : extensions) {
-            extension.configure(context);
-            apps.addAll(newApps);
-            newApps.clear();
-        }
     }
 
     @Override

--- a/microprofile/server/src/main/java9/module-info.java
+++ b/microprofile/server/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ module io.helidon.microprofile.server {
     requires transitive java.activation;
 
     requires java.logging;
+    requires io.helidon.common.serviceloader;
 
     exports io.helidon.microprofile.server;
     exports io.helidon.microprofile.server.spi;


### PR DESCRIPTION
Added common library to load prioritized services using Java Service loader and custom implementations.
Fixed a TODO in microprofile Server, as it was missing prioritized service loader.
This is also a prerequisite for Helidon DB, and it could be used to replace existing Java Service loader usages in other modules (such as Config).