### PR TITLE
Add Implementation headers to jar MANIFEST

### DIFF
--- a/common/common/src/main/templates/io/helidon/common/Version.java
+++ b/common/common/src/main/templates/io/helidon/common/Version.java
@@ -27,11 +27,16 @@ public class Version {
     public static final String VERSION = "${project.version}";
 
     /**
+     * Revision Number.
+     */
+    public static final String REVISION = "${buildNumber}";
+
+    /**
      * Display version
      *
      * @param args
      */
     public static void main(String[] args) {
-        System.out.println(VERSION);
+        System.out.println(VERSION + " " + REVISION);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
+        <version.plugin.buildnumber>1.4</version.plugin.buildnumber>
 
         <site.output.dir>${project.build.directory}/docs</site.output.dir>
     </properties>
@@ -374,6 +375,7 @@
                             </manifest>
                             <manifestEntries>
                                 <Implementation-URL>https://helidon.io</Implementation-URL>
+                                <Scm-Revision>${buildNumber}</Scm-Revision>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -505,6 +507,22 @@
                         <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${version.plugin.buildnumber}</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -561,6 +579,10 @@
                 <groupId>io.helidon.build-tools</groupId>
                 <artifactId>sitegen-maven-plugin</artifactId>
                 <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${version.plugin.jar}</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            </manifest>
+                            <manifestEntries>
+                                <Implementation-URL>https://helidon.io</Implementation-URL>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #617 

With this fix you get:
```
$ unzip -p $HOME/.m2/repository/io/helidon/webserver/helidon-webserver/1.0.4-SNAPSHOT/helidon-webserver-1.0.4-SNAPSHOT.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Implementation-Title: Helidon WebServer
Implementation-Version: 1.0.4-SNAPSHOT
Built-By: jdipol
Implementation-Vendor-Id: io.helidon.webserver
Created-By: Apache Maven 3.5.4
Build-Jdk: 1.8.0_162
Implementation-URL: https://helidon.io
Implementation-Vendor: Oracle Corporation
Scm-Revision: 03e3f264daa0a266bdb5fc09db5fe4359b95df73
```