### PR TITLE
Quickstarts: use mavenCentral() in build.gradle instead of url

### DIFF
--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -33,7 +33,7 @@ ext {
 }
 
 repositories {
-    maven { url "http://repo.maven.apache.org/maven2" }
+    mavenCentral()
     mavenLocal()
 }
 

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -33,7 +33,7 @@ ext {
 }
 
 repositories {
-    maven { url "http://repo.maven.apache.org/maven2" }
+    mavenCentral()
     mavenLocal()
 }
 


### PR DESCRIPTION
Uses the `mavenCentral()` in `build.gradle` to specify maven central repo instead of hardcoding URL. See https://docs.gradle.org/current/userguide/repository_types.html

 Also removes an `http` (no ssl) reference from our code.
