### PR TITLE
Add the ability for the MP Health extension to discover HealthCheck instances not only from CDI beans but also from providers discovered using the ServiceLoader.

### DIFF
--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -61,4 +61,29 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.health;
+
+import org.eclipse.microprofile.health.HealthCheck;
+
+/**
+ * A provider of {@link HealthCheck} instances.
+ * <p>
+ * Instances of {@link HealthCheckProvider} are discovered by the {@link HealthMpService}
+ * using the {@link io.helidon.common.serviceloader.HelidonServiceLoader} and all of the
+ * {@link HealthCheck} instances are added to the health endpoint.
+ */
+public interface HealthCheckProvider {
+    /**
+     * Return the provided {@link org.eclipse.microprofile.health.HealthCheck}s.
+     *
+     * @return  the {@link org.eclipse.microprofile.health.HealthCheck}s
+     */
+    HealthCheck[] healthChecks();
+}

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
@@ -16,6 +16,8 @@
 
 package io.helidon.microprofile.health;
 
+import java.util.List;
+
 import org.eclipse.microprofile.health.HealthCheck;
 
 /**
@@ -31,5 +33,5 @@ public interface HealthCheckProvider {
      *
      * @return  the {@link org.eclipse.microprofile.health.HealthCheck}s
      */
-    HealthCheck[] healthChecks();
+    List<HealthCheck> healthChecks();
 }

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthMpService.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthMpService.java
@@ -18,7 +18,9 @@ package io.helidon.microprofile.health;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
+import java.util.ServiceLoader;
 
+import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.microprofile.server.spi.MpService;
@@ -46,6 +48,9 @@ public class HealthMpService implements MpService {
                 })
                 .stream()
                 .forEach(builder::add);
+
+        HelidonServiceLoader.create(ServiceLoader.load(HealthCheckProvider.class))
+                .forEach(healthCheckProvider -> builder.add(healthCheckProvider.healthChecks()));
 
         healthConfig.get("routing")
                 .asString()

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/JvmRuntimeProducers.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/JvmRuntimeProducers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/JvmRuntimeProducers.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/JvmRuntimeProducers.java
@@ -29,7 +29,7 @@ import javax.enterprise.inject.Produces;
  * these dependencies are looked up.
  */
 @ApplicationScoped
-class HealthCheckProducer {
+class JvmRuntimeProducers {
     /**
      * Gets a ThreadMXBean implementation.
      *

--- a/microprofile/health/src/main/java9/module-info.java
+++ b/microprofile/health/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/main/java9/module-info.java
+++ b/microprofile/health/src/main/java9/module-info.java
@@ -35,5 +35,7 @@ module io.helidon.microprofile.health {
 
     exports io.helidon.microprofile.health;
 
+    uses io.helidon.microprofile.health.HealthCheckProvider;
+
     provides io.helidon.microprofile.server.spi.MpService with io.helidon.microprofile.health.HealthMpService;
 }

--- a/microprofile/health/src/main/java9/module-info.java
+++ b/microprofile/health/src/main/java9/module-info.java
@@ -22,6 +22,7 @@ module io.helidon.microprofile.health {
     requires java.management;
 
     requires io.helidon.common;
+    requires io.helidon.common.serviceloader;
     requires io.helidon.health;
     requires io.helidon.microprofile.server;
 

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -17,6 +17,8 @@
 package io.helidon.microprofile.health;
 
 import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -181,11 +183,10 @@ public class HealthMpServiceIT {
     public static class HealthCheckProviderOne
             implements HealthCheckProvider {
         @Override
-        public HealthCheck[] healthChecks() {
-            return new HealthCheck[]{
+        public List<HealthCheck> healthChecks() {
+            return Arrays.asList(
                     new HealthCheckStub("Three"),
-                    new HealthCheckStub("Four"),
-            };
+                    new HealthCheckStub("Four"));
         }
     }
 
@@ -197,11 +198,10 @@ public class HealthMpServiceIT {
     public static class HealthCheckProviderTwo
             implements HealthCheckProvider {
         @Override
-        public HealthCheck[] healthChecks() {
-            return new HealthCheck[]{
+        public List<HealthCheck> healthChecks() {
+            return Arrays.asList(
                     new HealthCheckStub("Five"),
-                    new HealthCheckStub("Six"),
-            };
+                    new HealthCheckStub("Six"));
         }
     }
 

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.health;
+
+import java.io.StringReader;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+
+import io.helidon.microprofile.server.Server;
+
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class HealthMpServiceIT {
+
+    private static final Logger LOGGER = Logger.getLogger(HealthMpServiceIT.class.getName());
+
+    private static Server server;
+
+    private static Client client;
+
+    @BeforeAll
+    public static void startServer() throws Exception {
+        LogManager.getLogManager().readConfiguration(HealthMpServiceIT.class.getResourceAsStream("/logging.properties"));
+
+        server = Server.create().start();
+
+        client = ClientBuilder.newBuilder()
+                .register(new LoggingFeature(LOGGER, Level.WARNING, LoggingFeature.Verbosity.PAYLOAD_ANY, 500))
+                .property(ClientProperties.FOLLOW_REDIRECTS, true)
+                .build();
+    }
+
+    @AfterAll
+    public static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    /**
+     * Verify that the {@link HealthCheck} CDI beans (inner classes below)
+     * annotated with {@link Health} are discovered and added to the json
+     * returned from the {@code /health} endpoint.
+     */
+    @Test
+    public void shouldAddHealthCheckBeans() {
+        JsonObject json = getHealthJson();
+        assertThat(healthCheckExists(json, "One"), is(true));
+        assertThat(healthCheckExists(json, "Two"), is(true));
+    }
+
+    /**
+     * Verify that the {@link HealthCheck} CDI bean (inner classes below)
+     * NOT annotated with {@link Health} is not added to the json returned
+     * from the {@code /health} endpoint.
+     */
+    @Test
+    public void shouldNotAddHealthCheckBeanNotAnnotatedWithHealth() {
+        JsonObject json = getHealthJson();
+        assertThat(healthCheckExists(json, "Bad"), is(false));
+    }
+
+    /**
+     * Verify that the {@link HealthCheckProvider}s (inner classes below)
+     * are discovered by the service loader and their provided {@link HealthCheck}s
+     * added to the json returned from the {@code /health} endpoint.
+     */
+    @Test
+    public void shouldAddProvidedHealthChecks() {
+        JsonObject json = getHealthJson();
+        assertThat(healthCheckExists(json, "Three"), is(true));
+        assertThat(healthCheckExists(json, "Four"), is(true));
+        assertThat(healthCheckExists(json, "Five"), is(true));
+        assertThat(healthCheckExists(json, "Six"), is(true));
+    }
+
+
+    private boolean healthCheckExists(JsonObject json, String name) {
+        return json.getJsonArray("checks")
+                   .stream()
+                   .map(JsonObject.class::cast)
+                   .anyMatch(check -> name.equals(check.getString("name")));
+    }
+
+    private JsonObject getHealthJson() {
+        // request the application metrics in json format from the web server
+        String health = client.target("http://localhost:" + server.port())
+                .path("health")
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .get(String.class);
+
+        JsonObject json = (JsonObject) Json.createReader(new StringReader(health)).read();
+        assertThat(json, is(notNullValue()));
+        return json;
+    }
+
+    /**
+     * A test {@link HealthCheck} bean that should be discovered
+     * by CDI and added to the health check endpoint.
+     */
+    @Health
+    @ApplicationScoped
+    public static class HealthCheckOne
+            implements HealthCheck {
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder().name("One").up().build();
+        }
+    }
+
+    /**
+     * A test {@link HealthCheck} bean that should be discovered
+     * by CDI and added to the health check endpoint.
+     */
+    @Health
+    @ApplicationScoped
+    public static class HealthCheckTwo
+            implements HealthCheck {
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder().name("Two").up().build();
+        }
+    }
+
+    /**
+     * A test {@link HealthCheck} bean that should be NOT discovered
+     * as it does not have the {@link Health} qualifier.
+     */
+    @ApplicationScoped
+    public static class HealthCheckBad
+            implements HealthCheck {
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder().name("Bad").up().build();
+        }
+    }
+
+    /**
+     * A test {@link HealthCheckProvider} bean that should be discovered
+     * by the service loader and its provided {@link HealthCheck}s added
+     * to the health check endpoint.
+     */
+    public static class HealthCheckProviderOne
+            implements HealthCheckProvider {
+        @Override
+        public HealthCheck[] healthChecks() {
+            return new HealthCheck[]{
+                    new HealthCheckStub("Three"),
+                    new HealthCheckStub("Four"),
+            };
+        }
+    }
+
+    /**
+     * A test {@link HealthCheckProvider} bean that should be discovered
+     * by the service loader and its provided {@link HealthCheck}s added
+     * to the health check endpoint.
+     */
+    public static class HealthCheckProviderTwo
+            implements HealthCheckProvider {
+        @Override
+        public HealthCheck[] healthChecks() {
+            return new HealthCheck[]{
+                    new HealthCheckStub("Five"),
+                    new HealthCheckStub("Six"),
+            };
+        }
+    }
+
+    /**
+     * A {@link HealthCheck} stub.
+     */
+    static class HealthCheckStub
+            implements HealthCheck {
+
+        private final String name;
+
+        HealthCheckStub(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder().name(name).up().build();
+        }
+    }
+}

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/JvmRuntimeProducersTest.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/JvmRuntimeProducersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/JvmRuntimeProducersTest.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/JvmRuntimeProducersTest.java
@@ -23,19 +23,19 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-class HealthCheckProducerTest {
+class JvmRuntimeProducersTest {
     @Test
     void getRuntime() {
-        assertThat(Runtime.getRuntime(), equalTo(new HealthCheckProducer().produceRuntime()));
+        assertThat(Runtime.getRuntime(), equalTo(new JvmRuntimeProducers().produceRuntime()));
     }
 
     @Test
     void getRuntimeMXBean() {
-        assertThat(ManagementFactory.getRuntimeMXBean(), equalTo(new HealthCheckProducer().produceRuntimeMXBean()));
+        assertThat(ManagementFactory.getRuntimeMXBean(), equalTo(new JvmRuntimeProducers().produceRuntimeMXBean()));
     }
 
     @Test
     void getThreadMXBean() {
-        assertThat(ManagementFactory.getThreadMXBean(), equalTo(new HealthCheckProducer().produceThreadMXBean()));
+        assertThat(ManagementFactory.getThreadMXBean(), equalTo(new JvmRuntimeProducers().produceThreadMXBean()));
     }
 }

--- a/microprofile/health/src/test/resources/META-INF/beans.xml
+++ b/microprofile/health/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/microprofile/health/src/test/resources/META-INF/services/io.helidon.microprofile.health.HealthCheckProvider
+++ b/microprofile/health/src/test/resources/META-INF/services/io.helidon.microprofile.health.HealthCheckProvider
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.microprofile.health.HealthMpServiceIT$HealthCheckProviderOne
+io.helidon.microprofile.health.HealthMpServiceIT$HealthCheckProviderTwo

--- a/microprofile/health/src/test/resources/logging.properties
+++ b/microprofile/health/src/test/resources/logging.properties
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=java.util.logging.ConsoleHandler
+
+# Global default logging level. Can be overriden by specific handlers and loggers
+.level=INFO
+
+# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
+# It replaces "!thread!" with the current thread name
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+        

--- a/microprofile/health/src/test/resources/logging.properties
+++ b/microprofile/health/src/test/resources/logging.properties
@@ -28,4 +28,3 @@ handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=INFO
 java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-        


### PR DESCRIPTION
This is a straight forward change to the `HealthMpService` class so that the `HealthCheck` instances that it adds to the `HealthSupport.Builder` can be provided by an alternative means than just discovering CDI beans that implement `HealthCheck` and are annotated with `Health`. This functionality is required by the future gRPC MP work so that the gRPC MP extension can supply health checks for all of the deployed gRPC services as these health checks would not come from annotated CDI beans.

A new interface called `HealthCheckProvider` has been added that has a single method that returns an array of `HealthCheck` instances. The `HealthMpService` uses the Helidon service loader to discover implementations of `HealthCheckProvider` and adds the provided `HealthCheck`s to the `HealthSupport.Builder`.

A new functional test was added to verify that this all works, which necessitated adding the fail-safe plugin to the MP health module's `pom.xml`.

The existing `HealthCheckProducer` class has been renamed as it was quite close in meaning to `HealthCheckProvider` but it did not actually produce any health checks and is in fact a CDI producer for some JVM runtime classes.