### PR TITLE
Support GraalVM 19.0.0

### DIFF
--- a/etc/dockerfiles/Dockerfile.jdk8-graalvm
+++ b/etc/dockerfiles/Dockerfile.jdk8-graalvm
@@ -22,10 +22,11 @@ RUN set -x \
     && apt-get -y update \
     && apt-get -y install curl
 
-RUN curl -O -L https://github.com/oracle/graal/releases/download/vm-1.0.0-rc13/graalvm-ce-1.0.0-rc13-linux-amd64.tar.gz && \
+RUN curl -O -L https://github.com/oracle/graal/releases/download/vm-19.0.0/graalvm-ce-linux-amd64-19.0.0.tar.gz && \
     tar -xvzf graalvm-*.tar.gz && \
     rm graalvm-*.tar.gz && \
-    mv graalvm-* graalvm
+    mv graalvm-* graalvm && \
+    graalvm/bin/gu install native-image
 
 RUN cd graalvm && \
     rm -rf \

--- a/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
@@ -30,7 +30,7 @@ RUN set -x && \
 
 RUN echo "done!"
 
-FROM helidon/jdk8-graalvm:1.0.0-rc13
+FROM helidon/jdk8-graalvm:19.0.0
 
 COPY --from=build /build/maven /usr/share/maven
 RUN ln -s /usr/share/maven/bin/mvn /bin/

--- a/etc/dockerfiles/build.sh
+++ b/etc/dockerfiles/build.sh
@@ -58,7 +58,7 @@ else
 fi
 readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
 
-readonly GRAALVM_VERSION=1.0.0-rc13
+readonly GRAALVM_VERSION=19.0.0
 
 docker build -f ${MY_DIR}/Dockerfile.jdk8-graalvm -t helidon/jdk8-graalvm:${GRAALVM_VERSION} ${MY_DIR}
 docker build -f ${MY_DIR}/Dockerfile.jdk8-graalvm-maven -t helidon/jdk8-graalvm-maven:${GRAALVM_VERSION} ${MY_DIR}

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -19,19 +19,16 @@ FROM helidon/jdk8-graalvm-maven:19.0.0 as build
 
 WORKDIR /helidon
 
-ARG X_REPO
-ADD settings.xml /
-
 # Create a first layer to cache the "Maven World" in the local repository.
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn -s /settings.xml package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn -s /settings.xml -U package -Pnative-image -Dnative.image.buildStatic -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -15,20 +15,23 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk8-graalvm-maven:1.0.0-rc13 as build
+FROM helidon/jdk8-graalvm-maven:19.0.0 as build
 
 WORKDIR /helidon
+
+ARG X_REPO
+ADD settings.xml /
 
 # Create a first layer to cache the "Maven World" in the local repository.
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn -s /settings.xml package -Pnative-image -Dnative.image.skip -DskipTests
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources
 ADD src src
-RUN mvn package -Pnative-image -Dnative.image.buildStatic -DskipTests
+RUN mvn -s /settings.xml -U package -Pnative-image -Dnative.image.buildStatic -DskipTests
 
 RUN echo "done!"
 

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -102,7 +102,7 @@ You can build a native executable in 2 different ways:
 ### Local build
 
 Download Graal VM at https://github.com/oracle/graal/releases, the version
- currently supported for Helidon is `1.0.0-rc13`.
+ currently supported for Helidon is `19.0.0`.
 
 ```
 # Setup the environment

--- a/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/native-image.properties
@@ -21,4 +21,5 @@
 Args=--report-unsupported-elements-at-runtime \
      --allow-incomplete-classpath \
      -H:ReflectionConfigurationResources=${.}/helidon-webserver-reflection-config.json \
-     --delay-class-initialization-to-runtime=io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf,io.netty.buffer.UnreleasableByteBuf,io.netty.handler.codec.http2.Http2ConnectionHandler,io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler,io.netty.handler.codec.http2.DefaultHttp2FrameWriter,io.netty.handler.codec.http2.Http2ServerUpgradeCodec
+     --no-fallback \
+     --initialize-at-run-time=io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf,io.netty.buffer.UnreleasableByteBuf,io.netty.handler.codec.http2.Http2ConnectionHandler,io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler,io.netty.handler.codec.http2.DefaultHttp2FrameWriter,io.netty.handler.codec.http2.Http2ServerUpgradeCodec,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine


### PR DESCRIPTION
Update Dockerfiles and helidon-quickstart-se example to support GraalVM 19.0.0