### PR TITLE
Make default sizing of Jersey thread pool dynamic, based on # of cores

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ServerThreadPoolSupplier.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ServerThreadPoolSupplier.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.configurable;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+import io.helidon.config.Config;
+
+/**
+ * Supplier of a custom thread pool with defaults appropriate for a thread-per-request server.
+ * The returned thread pool supports {@link io.helidon.common.context.Context} propagation.
+ */
+public final class ServerThreadPoolSupplier implements Supplier<ExecutorService> {
+
+    private static final int MINIMUM_CORES = 2;
+    private static final int DEFAULT_THREADS_PER_CORE = 8;
+    private static final int DEFAULT_QUEUE_CAPACITY = Integer.MAX_VALUE;
+
+    private final ThreadPoolSupplier supplier;
+
+    private ServerThreadPoolSupplier(final ThreadPoolSupplier.Builder builder) {
+        this.supplier = builder.build();
+    }
+
+    @Override
+    public ExecutorService get() {
+        return supplier.get();
+    }
+
+    /**
+     * Create a new fluent API builder to build thread pool supplier.
+     *
+     * @return a builder instance
+     */
+    public static ThreadPoolSupplier.Builder builder() {
+
+        // Set defaults appropriate to a thread-per-request model, based on the number of cores.
+
+        final int cores = Math.max(Runtime.getRuntime().availableProcessors(), MINIMUM_CORES);
+        final int corePoolSize = cores * DEFAULT_THREADS_PER_CORE;
+
+        // Since the ExecutorService only adds threads above the corePoolSize when the queue is full, setting
+        // maxPoolSize > corePoolSize with a large queue is meaningless unless under extreme load. To ensure
+        // we can actually use the max under normal load, use corePoolSize as maxPoolSize by default.
+
+        return ThreadPoolSupplier.builder()
+                                 .corePoolSize(corePoolSize)
+                                 .maxPoolSize(corePoolSize)
+                                 .queueCapacity(DEFAULT_QUEUE_CAPACITY);
+    }
+
+    /**
+     * Create a new thread pool supplier with default configuration.
+     *
+     * @return a new thread pool supplier with default configuration
+     */
+    public static ThreadPoolSupplier create() {
+        return builder().build();
+    }
+
+    /**
+     * Create supplier from configuration.
+     *
+     * @param config config instance
+     * @return a new thread pool supplier configured from config
+     */
+    public static ThreadPoolSupplier create(Config config) {
+        return builder().config(config)
+                        .build();
+    }
+}

--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.configurable;
+
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.helidon.common.context.ContextAwareExecutorService;
+
+/**
+ * A {@link ThreadPoolExecutor} that adds queue state accessors.
+ */
+public class ThreadPool extends ThreadPoolExecutor {
+    private static final Logger LOGGER = Logger.getLogger(ThreadPool.class.getName());
+
+    private final String name;
+    private final int queueCapacity;
+    private final AtomicInteger peakQueueSize;
+
+    /**
+     * Returns the given executor as a {@link ThreadPool} if possible.
+     *
+     * @param executor The executor.
+     * @return The thread pool or empty if not a {@link ThreadPool}.
+     */
+    public static Optional<ThreadPool> asThreadPool(ExecutorService executor) {
+        if (executor instanceof ThreadPool) {
+            return Optional.of((ThreadPool) executor);
+        } else if (executor instanceof ContextAwareExecutorService) {
+            return asThreadPool(((ContextAwareExecutorService) executor).unwrap());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Creates a new {@code ThreadPool} with the default rejected execution handler.
+     *
+     * @param name The pool name.
+     * @param corePoolSize the number of threads to keep in the pool, even
+     * if they are idle, unless {@code allowCoreThreadTimeOut} is set
+     * @param maximumPoolSize the maximum number of threads to allow in the
+     * pool
+     * @param keepAliveTime when the number of threads is greater than
+     * the core, this is the maximum time that excess idle threads
+     * will wait for new tasks before terminating.
+     * @param unit the time unit for the {@code keepAliveTime} argument
+     * @param workQueue the queue to use for holding tasks before they are
+     * executed.  This queue will hold only the {@code Runnable}
+     * tasks submitted by the {@code execute} method.
+     * @param workQueueCapacity The capacity of the work queue.
+     * @param threadFactory the factory to use when the executor
+     * creates a new thread
+     * @throws IllegalArgumentException if one of the following holds:<br>
+     * {@code corePoolSize < 0}<br>
+     * {@code keepAliveTime < 0}<br>
+     * {@code maximumPoolSize <= 0}<br>
+     * {@code maximumPoolSize < corePoolSize}
+     * @throws NullPointerException if {@code workQueue} is null
+     */
+    ThreadPool(final String name,
+               int corePoolSize,
+               int maximumPoolSize,
+               long keepAliveTime,
+               TimeUnit unit,
+               BlockingQueue<Runnable> workQueue,
+               int workQueueCapacity,
+               ThreadFactory threadFactory) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+        this.name = name;
+        this.queueCapacity = workQueueCapacity;
+        this.peakQueueSize = new AtomicInteger();
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(toString());
+        }
+    }
+
+    @Override
+    public void execute(final Runnable command) {
+        super.execute(command);
+        // Use a best-effort approach to maintaining the peak size without locking
+        final int queueSize = getQueue().size();
+        final int currentPeak = peakQueueSize.get();
+        if (queueSize > currentPeak) {
+            peakQueueSize.compareAndSet(currentPeak, queueSize);
+        }
+    }
+
+    /**
+     * Returns the name of this pool.
+     *
+     * @return The name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the queue capacity.
+     *
+     * @return The capacity.
+     */
+    public int getQueueCapacity() {
+        return queueCapacity;
+    }
+
+    /**
+     * Returns the peak queue size.
+     *
+     * @return The size.
+     */
+    public int getPeakQueueSize() {
+        return peakQueueSize.get();
+    }
+
+    @Override
+    public String toString() {
+        return "ThreadPool '" + getName() + "' {"
+               + "corePoolSize=" + getCorePoolSize()
+               + ", maxPoolSize=" + getMaximumPoolSize()
+               + (getMaximumPoolSize() > getCorePoolSize() ? ", largestPoolSize=" + getLargestPoolSize() : "")
+               + ", completedTasks=" + getCompletedTaskCount()
+               + ", peakQueueSize=" + getPeakQueueSize()
+               + ", queueCapacity=" + getQueueCapacity()
+               + '}';
+    }
+}

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -37,7 +37,7 @@ import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.Application;
 
 import io.helidon.common.CollectionsHelper;
-import io.helidon.common.configurable.ThreadPoolSupplier;
+import io.helidon.common.configurable.ServerThreadPoolSupplier;
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.microprofile.config.MpConfig;
 import io.helidon.microprofile.server.spi.MpService;
@@ -190,7 +190,10 @@ public interface Server {
             }
 
             if (null == defaultExecutorService) {
-                defaultExecutorService = ThreadPoolSupplier.create(config.helidonConfig().get("server.executor-service"));
+                defaultExecutorService = ServerThreadPoolSupplier.builder()
+                                                                 .name("server")
+                                                                 .config(config.helidonConfig().get("server.executor-service"))
+                                                                 .build();
             }
 
             STARTUP_LOGGER.finest("Configuration obtained");

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -77,7 +77,6 @@ import org.glassfish.jersey.server.model.Resource;
  * thread pool which can be configured by one of the JerseySupport constructor.
  */
 public class JerseySupport extends AbstractBinder implements Service {
-    private static final String THREAD_POOL_BINDING_NAME = "Jersey";
 
     /**
      * The request scoped span qualifier that can be injected into a Jersey resource.

--- a/webserver/jersey/src/main/java9/module-info.java
+++ b/webserver/jersey/src/main/java9/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.webserver.jersey {
     requires io.helidon.common.context;
     requires reactor.core;
     requires java.logging;
+    requires hk2.api;
 
     exports io.helidon.webserver.jersey;
 


### PR DESCRIPTION
Makes the default sizing of the Jersey thread pool dynamic, based on the # of cores. Sets the core and max sizes the same for now since the ThreadPoolExecutor does not add threads except under extreme conditions.

Adds tracking of peak queue sizes via ThreadPool, a subclass of ThreadPoolExecutor.

Enables injection of ThreadPool instances by name.