### PR TITLE
Complete writing a response before checking unconsumed request payload

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -192,6 +192,8 @@ class BareResponseImpl implements BareResponse {
         if (keepAlive) {
             LOGGER.finest(() -> log("Writing an empty last http content; keep-alive: true"));
 
+            writeLastContent(throwable, ChannelFutureListener.CLOSE_ON_FAILURE);
+
             if (!requestContentConsumed.getAsBoolean()) {
                 // the request content wasn't read, close the connection once the content is fully written.
                 LOGGER.finer(() -> log("Request content not fully read; trying to keep the connection; keep-alive: true"));
@@ -201,7 +203,6 @@ class BareResponseImpl implements BareResponse {
                 ctx.channel().read();
             }
 
-            writeLastContent(throwable, ChannelFutureListener.CLOSE_ON_FAILURE);
         } else {
 
             LOGGER.finest(() -> log("Closing with an empty buffer; keep-alive: " + keepAlive));


### PR DESCRIPTION
Complete writing a response before checking unconsumed request payload that may trigger a connection reset. The addresses the cause for some `PlainTest` failures under heavy load.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>