### PR TITLE
Remove netty-tcnative-boringssl-static dependency

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -40,7 +40,7 @@ readonly WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 source ${WS_DIR}/etc/scripts/wercker-env.sh
 
 if [ "${WERCKER}" = "true" ] ; then
-  apt-get update && apt-get -y install graphviz openssl
+  apt-get update && apt-get -y install graphviz openssl libapr1
 fi
 
 inject_credentials

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -40,7 +40,7 @@ readonly WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 source ${WS_DIR}/etc/scripts/wercker-env.sh
 
 if [ "${WERCKER}" = "true" ] ; then
-  apt-get update && apt-get -y install graphviz
+  apt-get update && apt-get -y install graphviz openssl
 fi
 
 inject_credentials

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -40,7 +40,7 @@ readonly WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 source ${WS_DIR}/etc/scripts/wercker-env.sh
 
 if [ "${WERCKER}" = "true" ] ; then
-  apt-get update && apt-get -y install graphviz openssl libapr1
+  apt-get update && apt-get -y install graphviz
 fi
 
 inject_credentials

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -62,9 +62,12 @@
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-grpc</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <artifactId>netty-tcnative</artifactId>
+            <classifier>${os.detected.classifier}</classifier>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -121,21 +124,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>org.glassfish.jersey.core</groupId>-->
-            <!--<artifactId>jersey-client</artifactId>-->
-            <!--<scope>test</scope>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>org.glassfish.jersey.inject</groupId>-->
-            <!--<artifactId>jersey-hk2</artifactId>-->
-            <!--<scope>test</scope>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>javax.activation</groupId>-->
-            <!--<artifactId>javax.activation-api</artifactId>-->
-            <!--<scope>test</scope>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>io.zipkin.zipkin2</groupId>
             <artifactId>zipkin-junit</artifactId>

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -167,12 +167,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks>
-                    <includes>
-                        <include>**/*IT.java</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <id>verify</id>
@@ -181,6 +175,12 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <reuseForks>false</reuseForks>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -167,6 +167,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>verify</id>
@@ -175,12 +181,6 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <reuseForks>false</reuseForks>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -242,15 +242,15 @@ public class GrpcServerImpl implements GrpcServer {
 
     private Resource findResource(String name) {
         try {
+            // Try to locate the resource on the classpath
             return Resource.create(name);
         } catch (NullPointerException ignored) {
             try {
-                // Not found, try File/Path
+                // Not found, try File
                 File file = new File(name);
                 return Resource.create(file.toPath());
             } catch (NullPointerException ignored2) {
                 // Not found, try URI
-                File file = new File(name);
                 return Resource.create(URI.create(name));
             }
         }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -140,8 +141,8 @@ public class GrpcServerImpl implements GrpcServer {
             if (sslConfig != null) {
                 if (sslConfig.isJdkSSL()) {
                     SSLContext sslCtx = SSLContextBuilder.create(KeyConfig.pemBuilder()
-                                                                         .key(Resource.create(sslConfig.getTLSKey()))
-                                                                         .certChain(Resource.create(sslConfig.getTLSCerts()))
+                                                                         .key(findResource(sslConfig.getTLSKey()))
+                                                                         .certChain(findResource(sslConfig.getTLSCerts()))
                                                                          .build()).build();
                     sslContext = new JdkSslContext(sslCtx, false, ClientAuth.NONE);
 
@@ -238,6 +239,22 @@ public class GrpcServerImpl implements GrpcServer {
     }
 
     // ---- helper methods --------------------------------------------------
+
+    private Resource findResource(String name) {
+        try {
+            return Resource.create(name);
+        } catch (NullPointerException ignored) {
+            try {
+                // Not found, try File/Path
+                File file = new File(name);
+                return Resource.create(file.toPath());
+            } catch (NullPointerException ignored2) {
+                // Not found, try URI
+                File file = new File(name);
+                return Resource.create(URI.create(name));
+            }
+        }
+    }
 
     private NettyServerBuilder configureNetty(NettyServerBuilder builder) {
         int workersCount = config.workers();
@@ -396,7 +413,8 @@ public class GrpcServerImpl implements GrpcServer {
             aX509Certificates = new X509Certificate[0];
         }
 
-        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(fileCerts, fileKey);
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(fileCerts, fileKey)
+                .sslProvider(SslProvider.OPENSSL);
 
         if (aX509Certificates.length > 0) {
             sslContextBuilder.trustManager(aX509Certificates)
@@ -405,7 +423,7 @@ public class GrpcServerImpl implements GrpcServer {
             sslContextBuilder.clientAuth(ClientAuth.OPTIONAL);
         }
 
-        return GrpcSslContexts.configure(sslContextBuilder, SslProvider.OPENSSL);
+        return GrpcSslContexts.configure(sslContextBuilder);
     }
 
     private static X509Certificate[] loadX509Cert(File... aFile)

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -18,14 +18,10 @@ package io.helidon.grpc.server;
 
 import java.io.File;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.net.ssl.SSLException;

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,14 @@
     </modules>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${version.plugin.os}</version>
+            </extension>
+        </extensions>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -829,8 +837,9 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <artifactId>netty-tcnative</artifactId>
                 <version>${version.netty.tcnative}</version>
+                <classifier>${os.detected.classifier}</classifier>
             </dependency>
             <dependency>
               <groupId>io.opentracing.contrib</groupId>


### PR DESCRIPTION
Remove the gRPC server module's dependency on `netty-tcnative-boringssl-static` and replace it with a test scoped dependency on `netty-tcnative`. This dependency is only used in the functional tests for gRPC with SSL/TLS. If a customer wants to enable SSL/TLS then they are free to use whichever approach they are comfortable with as described in the grpc-java project's [SECURITY.md](https://github.com/grpc/grpc-java/blob/master/SECURITY.md) document.