### PR TITLE
Upgrades OCI to version 1.5.2, which is now available in Maven Central

### DIFF
--- a/docs/src/main/docs/extensions/04_cdi_oci-objectstorage.adoc
+++ b/docs/src/main/docs/extensions/04_cdi_oci-objectstorage.adoc
@@ -29,31 +29,6 @@ This link:{cdi-extension-api-url}[CDI portable extension] provides support for
 
 == Prerequisites
 
-To install the extension for Oracle Cloud Infrastructure Object Storage clients,
- you must first clone and install the Oracle Cloud Infrastructure Java SDK because
- it is not available, currently, in Maven Central.
-
-Clone the SDK:
-
-[source,bash]
-----
-git clone --depth 1 --branch v1.2.44 https://github.com/oracle/oci-java-sdk.git
-----
-
-Install the SDK:
-
-[source,bash]
-----
-cd oci-java-sdk && mvn -B -U -f oci-java-sdk/pom.xml \
-        -Dmaven.test.skip=true \
-        -Dmaven.source.skip=true \
-        -Dmaven.javadoc.skip=true \
-        -Dlombok.delombok.skip=true \
-        -pl bmc-objectstorage \
-        -am \
-        install
-----
-
 Declare the following dependency in your project:
 
 [source,xml]

--- a/integrations/cdi/oci-objectstorage-cdi/README.adoc
+++ b/integrations/cdi/oci-objectstorage-cdi/README.adoc
@@ -5,24 +5,6 @@ http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#spi[CDI portable
 extension] that lets the end user inject an `ObjectStorage` client
 into her CDI application.
 
-== Prerequisites
-
-The OCI Java SDK is not available in Maven Central at the moment.
-You will need to populate your local Maven repository with the OCI Java SDK
- artifacts in order to resolve the helidon dependency described in the next section.
-
-```bash
-    git clone --depth 1 --branch v1.2.44 https://github.com/oracle/oci-java-sdk.git
-    mvn -B -U -f oci-java-sdk/pom.xml \
-        -Dmaven.test.skip=true \
-        -Dmaven.source.skip=true \
-        -Dmaven.javadoc.skip=true \
-        -Dlombok.delombok.skip=true \
-        -pl bmc-objectstorage \
-        -am \
-        install
-```
-
 == Installation
 
 Ensure that the Helidon OCI Object Storage CDI Integration project and

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
         <version.lib.netty>4.1.34.Final</version.lib.netty>
         <version.netty.tcnative>2.0.22.Final</version.netty.tcnative>
-        <version.lib.oci-java-sdk-objectstorage>1.2.44</version.lib.oci-java-sdk-objectstorage>
+        <version.lib.oci-java-sdk-objectstorage>1.5.2</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>12.2.0.1</version.lib.ojdbc8>
         <version.lib.opentracing>0.31.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.0.12</version.lib.opentracing.grpc>


### PR DESCRIPTION
Signed-off-by: Laird Nelson <laird.nelson@oracle.com>