### PR TITLE
Ensures that JPA javadocs are present in overall Helidon javadocs

### DIFF
--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -127,6 +127,24 @@
 
     <profiles>
         <profile>
+            <id>sources</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>resource-bundle</id>
+                                <goals>
+                                    <goal>resource-bundle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>xmlbind</id>
             <activation>
                 <jdk>[9,)</jdk>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -377,6 +377,16 @@
                 </dependency>
                 <dependency>
                     <groupId>io.helidon.integrations.cdi</groupId>
+                    <artifactId>helidon-integrations-cdi-jpa</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.integrations.cdi</groupId>
+                    <artifactId>helidon-integrations-cdi-jpa-weld</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.integrations.cdi</groupId>
                     <artifactId>helidon-integrations-cdi-jta</artifactId>
                     <version>${project.version}</version>
                 </dependency>


### PR DESCRIPTION
Fixes #718.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>