### PR TITLE
Updates to the recently-merged OpenAPI MP support

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -464,10 +464,15 @@
                 <artifactId>helidon-graal-native-image-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- SE OpenAPI support -->
+            <!-- OpenAPI support -->
             <dependency>
                 <groupId>io.helidon.openapi</groupId>
                 <artifactId>helidon-openapi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.openapi</groupId>
+                <artifactId>helidon-microprofile-openapi</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -66,7 +66,7 @@ public class IndexBuilder implements Extension {
                     + "so will build an in-memory index.%n"
                     + "This slows your app start-up and, depending on CDI configuration, "
                     + "might omit some type information needed for a complete OpenAPI document.%n"
-                    + "Consider using the Jandex plug-in to build the index "
+                    + "Consider using the Jandex maven plug-in to build the index "
                     + "and add it to your app at build-time",
                     INDEX_PATH));
         }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -66,8 +66,8 @@ public class IndexBuilder implements Extension {
                     + "so will build an in-memory index.%n"
                     + "This slows your app start-up and, depending on CDI configuration, "
                     + "might omit some type information needed for a complete OpenAPI document.%n"
-                    + "Consider using the Jandex maven plug-in to build the index "
-                    + "and add it to your app at build-time",
+                    + "Consider using the Jandex maven plug-in during your build "
+                    + "to create the index and add it to your app.",
                     INDEX_PATH));
         }
     }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -62,9 +62,11 @@ public class IndexBuilder implements Extension {
             LOGGER.log(Level.FINE, () -> String.format("Index file %s was located and will be used", INDEX_PATH));
         } else {
             LOGGER.log(Level.INFO, () -> String.format(
-                    "OpenAPI support could not locate the index file %s "
-                    + "so will build an in-memory index. This slows your app start-up.%n"
-                    + "Consider using the jandex maven plug-in to build the index "
+                    "OpenAPI support could not locate the Jandex index file %s "
+                    + "so will build an in-memory index.%n"
+                    + "This slows your app start-up and, depending on CDI configuration, "
+                    + "might omit some type information needed for a complete OpenAPI document.%n"
+                    + "Consider using the Jandex plug-in to build the index "
                     + "and add it to your app at build-time",
                     INDEX_PATH));
         }


### PR DESCRIPTION
I had omitted the new Helidon MP OpenAPI module from the BOM. 

This also captures a slightly longer but more accurate log message when we create the Jandex index just-in-time.