### PR TITLE
Handle special case of NaN's to avoid NumberFormatException's 

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -273,24 +274,31 @@ abstract class MetricImpl extends Metadata implements HelidonMetric {
         private static final long MICROSECONDS = 1000 * MILLISECONDS;
         private static final long NANOSECONDS = 1000 * MICROSECONDS;
 
+        // If object is NaN return string and avoid format exception in BigDecimal
+        private static final BiFunction<Object, Function<Object, Object>, Object> CHECK_NANS =
+                (o, f) -> o instanceof Double && ((Double) o).isNaN() ? String.valueOf(Double.NaN) : f.apply(o);
+
         private TimeUnits(String metricUnit, TimeUnit timeUnit) {
             super(metricUnit, "seconds", timeConverter(timeUnit));
         }
 
         static Function<Object, Object> timeConverter(TimeUnit from) {
             switch (from) {
-            case NANOSECONDS:
-                return (o) -> String.valueOf(new BigDecimal(String.valueOf(o)).doubleValue() / NANOSECONDS);
-            case MICROSECONDS:
-                return (o) -> String.valueOf(new BigDecimal(String.valueOf(o)).doubleValue() / MICROSECONDS);
-            case MILLISECONDS:
-                return (o) -> String.valueOf(new BigDecimal(String.valueOf(o)).doubleValue() / MILLISECONDS);
-            case SECONDS:
-                return String::valueOf;
-            default:
-                return (o) -> String.valueOf(TimeUnit.SECONDS.convert(new BigDecimal(String.valueOf(o)).longValue(), from));
+                case NANOSECONDS:
+                    return (o) -> CHECK_NANS.apply(o, p ->
+                            String.valueOf(new BigDecimal(String.valueOf(p)).doubleValue() / NANOSECONDS));
+                case MICROSECONDS:
+                    return (o) -> CHECK_NANS.apply(o, p ->
+                            String.valueOf(new BigDecimal(String.valueOf(o)).doubleValue() / MICROSECONDS));
+                case MILLISECONDS:
+                    return (o) -> CHECK_NANS.apply(o, p ->
+                            String.valueOf(new BigDecimal(String.valueOf(o)).doubleValue() / MILLISECONDS));
+                case SECONDS:
+                    return (o) -> CHECK_NANS.apply(o, String::valueOf);
+                default:
+                    return (o) -> CHECK_NANS.apply(o, p ->
+                            String.valueOf(TimeUnit.SECONDS.convert(new BigDecimal(String.valueOf(o)).longValue(), from)));
             }
-
         }
     }
 

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -273,10 +273,11 @@ abstract class MetricImpl extends Metadata implements HelidonMetric {
         private static final long MILLISECONDS = 1000;
         private static final long MICROSECONDS = 1000 * MILLISECONDS;
         private static final long NANOSECONDS = 1000 * MICROSECONDS;
+        private static final String DOUBLE_NAN = String.valueOf(Double.NaN);
 
         // If object is NaN return string and avoid format exception in BigDecimal
         private static final BiFunction<Object, Function<Object, Object>, Object> CHECK_NANS =
-                (o, f) -> o instanceof Double && ((Double) o).isNaN() ? String.valueOf(Double.NaN) : f.apply(o);
+                (o, f) -> o instanceof Double && ((Double) o).isNaN() ? DOUBLE_NAN : f.apply(o);
 
         private TimeUnits(String metricUnit, TimeUnit timeUnit) {
             super(metricUnit, "seconds", timeConverter(timeUnit));

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TimeUnitsTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TimeUnitsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Class TimeUnitsTest.
+ */
+public class TimeUnitsTest {
+
+    @Test
+    public void testBigDecimalNaNConversion() {
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.NANOSECONDS).apply(Double.NaN),
+                is(String.valueOf(Double.NaN)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MICROSECONDS).apply(Double.NaN),
+                is(String.valueOf(Double.NaN)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MILLISECONDS).apply(Double.NaN),
+                is(String.valueOf(Double.NaN)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.SECONDS).apply(Double.NaN),
+                is(String.valueOf(Double.NaN)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MINUTES).apply(Double.NaN),
+                is(String.valueOf(Double.NaN)));
+    }
+
+    @Test
+    public void testBigDecimalConversion() {
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.NANOSECONDS).apply(1000000000L),
+                is(String.valueOf(1.0d)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MICROSECONDS).apply(1000000),
+                is(String.valueOf(1.0d)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MILLISECONDS).apply(1000),
+                is(String.valueOf(1.0d)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.SECONDS).apply(1),
+                is(String.valueOf(1)));
+        assertThat(MetricImpl.TimeUnits.timeConverter(TimeUnit.MINUTES).apply(1),
+                is(String.valueOf(60)));
+    }
+}


### PR DESCRIPTION
Handle special case of NaN's to avoid NumberFormatException's that can result in 500 error conditions related to metrics. See #464. This does not address the reason for those NaN's but at least prevents 500 errors to be returned. Some new tests added.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>