### PR TITLE
Further `ConfigCdiExtension` fixes and improvements

### DIFF
--- a/microprofile/config/config/src/main/java/io/helidon/microprofile/config/MpConfig.java
+++ b/microprofile/config/config/src/main/java/io/helidon/microprofile/config/MpConfig.java
@@ -158,7 +158,7 @@ public final class MpConfig implements org.eclipse.microprofile.config.Config {
         return result;
     }
 
-    private <T> T findValue(String propertyName, Class<T> propertyType) {
+    <T> T findValue(String propertyName, Class<T> propertyType) {
         if (propertyType == Config.class) {
             return config.get().get(propertyName).as(propertyType).get();
         }

--- a/microprofile/config/config/src/test/java/io/helidon/microprofile/config/MpConfigTest.java
+++ b/microprofile/config/config/src/test/java/io/helidon/microprofile/config/MpConfigTest.java
@@ -18,9 +18,11 @@ package io.helidon.microprofile.config;
 
 import java.time.YearMonth;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import io.helidon.common.CollectionsHelper;
+import io.helidon.config.MissingValueException;
 import io.helidon.microprofile.config.Converters.Ctor;
 import io.helidon.microprofile.config.Converters.Of;
 import io.helidon.microprofile.config.Converters.Parse;
@@ -36,6 +38,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -122,6 +125,15 @@ class MpConfigTest {
         assertThat("Environment variables", ((Set<String>) propertyNames).contains("PATH"));
     }
 
+    @Test
+    public void testGetValueOfNonExistentValueShouldThrowNoSuchElementException() {
+        assertThrows(NoSuchElementException.class, () -> mpConfig.getValue("nonexistent.property", String.class));
+    }
+
+    @Test
+    public void testFindValueOfNonExistentValueShouldThrowMissingValueException() {
+        assertThrows(MissingValueException.class, () -> mpConfig.findValue("nonexistent.property", String.class));
+    }
 
     @Test
     public void testImplicitConversion() {


### PR DESCRIPTION
This PR continues to address the issues uncovered by #650.

Improvements and fixes include:
* Validation is now simplified, made more robust and performed via [`BeanManager#getInjectableReference(InjectionPoint, CreationalContext)`](http://docs.jboss.org/cdi/api/2.0/javax/enterprise/inject/spi/BeanManager.html#getInjectableReference-javax.enterprise.inject.spi.InjectionPoint-javax.enterprise.context.spi.CreationalContext-)
* Tests for class assignability are improved
* Methods that could be made `static` were made `static`
* A couple of additional tests added in `MpConfigTest`
* [`ConfigProvider#getConfig()`](https://static.javadoc.io/org.eclipse.microprofile.config/microprofile-config-api/1.3/org/eclipse/microprofile/config/ConfigProvider.html#getConfig--) now used instead of `ConfigProviderResolver.getInstance().getConfig()`, per Microprofile Config specification

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>