### PR TITLE
Replaced suspicious isAssignableFrom with equality 

### DIFF
--- a/microprofile/tests/tck/tck-health/src/test/java/io/helidon/microprofile/health/tck/HealthResourceProvider.java
+++ b/microprofile/tests/tck/tck-health/src/test/java/io/helidon/microprofile/health/tck/HealthResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class HealthResourceProvider implements ResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
-        return type.isAssignableFrom(URI.class);
+        return type == URI.class;
     }
 
 }


### PR DESCRIPTION
Replaced suspicious isAssignableFrom with equality given that URI is a final class. See #730.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>