### PR TITLE
Annotation analyzers now loaded via Helidon service loader,

### DIFF
--- a/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthAnnotationAnalyzer.java
+++ b/microprofile/jwt-auth/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthAnnotationAnalyzer.java
@@ -18,8 +18,10 @@ package io.helidon.microprofile.jwt.auth;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 
+import javax.annotation.Priority;
 import javax.annotation.security.RolesAllowed;
 
+import io.helidon.common.Prioritized;
 import io.helidon.config.Config;
 import io.helidon.security.providers.common.spi.AnnotationAnalyzer;
 
@@ -31,6 +33,8 @@ import static io.helidon.microprofile.jwt.auth.JwtAuthProviderService.PROVIDER_N
  * Implementation of {@link AnnotationAnalyzer} which checks for {@link LoginConfig} annotation if
  * JWT Authentication should be enabled.
  */
+// prioritized to run before RoleAnnotationAnalyzer, so we do not have to handle PermitAll
+@Priority(Prioritized.DEFAULT_PRIORITY - 100)
 public class JwtAuthAnnotationAnalyzer implements AnnotationAnalyzer {
     static final String LOGIN_CONFIG_METHOD = "MP-JWT";
 

--- a/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleAnnotationAnalyzer.java
+++ b/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleAnnotationAnalyzer.java
@@ -17,14 +17,17 @@ package io.helidon.security.abac.role;
 
 import java.lang.reflect.Method;
 
+import javax.annotation.Priority;
 import javax.annotation.security.PermitAll;
 
+import io.helidon.common.Prioritized;
 import io.helidon.security.providers.common.spi.AnnotationAnalyzer;
 
 /**
  * Implementation of {@link AnnotationAnalyzer} which checks for {@link PermitAll} annotation if
  * authentication is needed or not.
  */
+@Priority(Prioritized.DEFAULT_PRIORITY)
 public class RoleAnnotationAnalyzer implements AnnotationAnalyzer {
 
     @Override

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -51,6 +51,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-service-loader</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>

--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityFilter.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityFilter.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.UriInfo;
 
 import io.helidon.common.CollectionsHelper;
 import io.helidon.common.OptionalHelper;
+import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.security.AuditEvent;
 import io.helidon.security.Security;
@@ -126,6 +127,9 @@ public class SecurityFilter extends SecurityFilterCommon implements ContainerReq
     }
 
     private void loadAnalyzers() {
+        HelidonServiceLoader.builder(ServiceLoader.load(AnnotationAnalyzer.class))
+                .build()
+                .forEach(analyzers::add);
         ServiceLoader.load(AnnotationAnalyzer.class)
                 .forEach(analyzers::add);
     }

--- a/security/integration/jersey/src/main/java9/module-info.java
+++ b/security/integration/jersey/src/main/java9/module-info.java
@@ -25,6 +25,7 @@ module io.helidon.security.integration.jersey {
     requires transitive io.helidon.security.annotations;
     requires transitive io.helidon.security.providers.common;
     requires transitive io.helidon.security.util;
+    requires transitive io.helidon.common.serviceloader;
     requires transitive java.ws.rs;
     requires jersey.common;
     requires jersey.server;


### PR DESCRIPTION
 so priorities are used.
Add priority to JWT and Role annotation analyzers to make sure the
Role analyzer is last.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #710 