### PR TITLE
New method to run callables in a context that reports all exceptions …

### DIFF
--- a/common/context/src/main/java/io/helidon/common/context/Contexts.java
+++ b/common/context/src/main/java/io/helidon/common/context/Contexts.java
@@ -124,4 +124,24 @@ public final class Contexts {
             pop();
         }
     }
+
+    /**
+     * Run the callable in the provided context throwing any exception from
+     * its execution. The callable can use {@link #context()} to retrieve
+     * the context.
+     *
+     * @param context  context to run in
+     * @param callable callable to execute in context
+     * @param <T>      return type of the callable
+     * @return the result of the callable
+     * @throws java.lang.Exception  If thrown in {@link java.util.concurrent.Callable#call()}
+     */
+    public static <T> T runInContextWithThrow(Context context, Callable<T> callable) throws Exception {
+        push(context);
+        try {
+            return callable.call();
+        } finally {
+            pop();
+        }
+    }
 }

--- a/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
+++ b/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
@@ -166,6 +166,18 @@ class ContextsTest {
     }
 
     @Test
+    void testContextSubmitCallableWithThrow() throws Exception {
+        Callable<String> callable = () -> Contexts.context().get().get("message", String.class).orElse("No context found");
+
+        Context ctx = Context.create();
+        ctx.register("message", TEST_STRING + "_1");
+
+        Future<String> future = Contexts.runInContextWithThrow(ctx, () -> service.submit(callable));
+
+        assertThat(future.get(), is(TEST_STRING + "_1"));
+    }
+
+    @Test
     void testMultipleContexts() {
         Context topLevel = Context.create();
         topLevel.register("topLevel", TEST_STRING);

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
@@ -234,7 +234,7 @@ public class FaultToleranceCommand extends HystrixCommand<Object> {
         // Finally, invoke the user method
         try {
             runThread = Thread.currentThread();
-            return Contexts.runInContext(helidonContext, context::proceed);
+            return Contexts.runInContextWithThrow(helidonContext, context::proceed);
         } finally {
             if (introspector.hasBulkhead()) {
                 bulkheadHelper.markAsNotRunning(this);


### PR DESCRIPTION
New method to run callables in a context that reports all exceptions unwrapped. Use of this method in FT is required for the TCKs. See #739.

Signed-off-by: Santiago Pericas-Geertsen <Santiago.PericasGeertsen@oracle.com>