### PR TITLE
Create the OpenAPI SE example

### DIFF
--- a/examples/openapi/README.md
+++ b/examples/openapi/README.md
@@ -1,0 +1,40 @@
+
+# Helidon SE OpenAPI Example
+
+This example shows a simple greeting application, similar to the one from the 
+Helidon SE QuickStart, enhanced with OpenAPI support.
+
+Most of the OpenAPI document in this example comes from a static file packaged
+with the application.
+
+## Build
+
+```
+mvn package
+```
+
+## Run
+
+```
+mvn exec:java
+```
+
+Try the endpoints:
+
+```
+curl -X GET http://localhost:8080/greet
+{"message":"Hello World!"}
+
+curl -X GET http://localhost:8080/greet/Joe
+{"message":"Hello Joe!"}
+
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+
+curl -X GET http://localhost:8080/greet/Jose
+{"message":"Hola Jose!"}
+
+curl -X GET http://localhost:8080/openapi
+[lengthy OpenAPI document]
+```
+The output describes not only then endpoints in `GreetService` as described in
+the static file but also an endpoint contributed by the `SimpleAPIModelReader`.

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.examples</groupId>
+        <artifactId>helidon-examples-project</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-examples-openapi</artifactId>
+    <name>Helidon Examples OpenAPI </name>
+
+    <description>
+        Basic illustration of OpenAPI support in Helidon SE
+    </description>
+
+    <properties>
+        <mainClass>io.helidon.examples.openapi.Main</mainClass>
+    </properties>
+
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon</groupId>
+                <artifactId>helidon-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.1.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-checks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.openapi</groupId>
+            <artifactId>helidon-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <scope>test</scope>
+            <version>2.44.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.opera</groupId>
+            <artifactId>operadriver</artifactId>
+            <scope>test</scope>
+            <version>1.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-remote-driver</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <version>4.11</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetService.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.openapi;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+import javax.json.JsonWriter;
+
+import io.helidon.common.http.Http;
+import io.helidon.config.Config;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+/**
+ * A simple service to greet you. Examples:
+ *
+ * Get default greeting message:
+ * curl -X GET http://localhost:8080/greet
+ *
+ * Get greeting message for Joe:
+ * curl -X GET http://localhost:8080/greet/Joe
+ *
+ * Change greeting
+ * curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting
+ *
+ * The message is returned as a JSON object
+ */
+
+public class GreetService implements Service {
+
+    /**
+     * The config value for the key {@code greeting}.
+     */
+    private String greeting;
+
+    private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Collections.emptyMap());
+
+    private static final JsonReaderFactory JSON_RF = Json.createReaderFactory(Collections.emptyMap());
+
+    GreetService(Config config) {
+        this.greeting = config.get("app.greeting").asString().orElse("Ciao");
+    }
+
+    /**
+     * A service registers itself by updating the routine rules.
+     * @param rules the routing rules.
+     */
+    @Override
+    public void update(Routing.Rules rules) {
+        rules
+            .get("/", this::getDefaultMessageHandler)
+            .get("/{name}", this::getMessageHandler)
+            .put("/greeting", this::updateGreetingHandler);
+    }
+
+    /**
+     * Creates a {@link GreetingMessage} from the incoming HTTP payload.
+     *
+     * @param conn {@code HttpURLConnection} with the payload to convert
+     * @return {@code GreetingMessage} instance reflecting the payload
+     * @throws IOException in case of errors reading the payload
+     */
+    public static GreetingMessage fromPayload(HttpURLConnection conn) throws IOException {
+        JsonReader jsonReader = JSON_RF.createReader(conn.getInputStream());
+        return GreetingMessage.fromRest(jsonReader.readObject());
+    }
+
+    /**
+     * Writes the specified {@code GreetingMessage} into the payload of the
+     * specified connection.
+     *
+     * @param conn {@code HttpURLConnection} with the payload to be written
+     * @param msg {@code GreetingMessage} to be written to the payload
+     * @throws IOException in case of errors writing the payload
+     */
+    public static void toPayload(HttpURLConnection conn, GreetingMessage msg) throws IOException {
+        OutputStream os = conn.getOutputStream();
+        try (JsonWriter jsonWriter = Json.createWriter(os)) {
+            jsonWriter.writeObject(msg.forRest());
+        }
+    }
+    /**
+     * Return a worldly greeting message.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void getDefaultMessageHandler(ServerRequest request,
+                                   ServerResponse response) {
+        sendResponse(response, "World");
+    }
+
+    /**
+     * Return a greeting message using the name that was provided.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void getMessageHandler(ServerRequest request,
+                            ServerResponse response) {
+        String name = request.path().param("name");
+        sendResponse(response, name);
+    }
+
+    private void sendResponse(ServerResponse response, String name) {
+        GreetingMessage msg = new GreetingMessage(String.format("%s %s!", greeting, name));
+        response.send(msg.forRest());
+    }
+
+    private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
+
+        if (!jo.containsKey(GreetingMessage.JSON_LABEL)) {
+            JsonObject jsonErrorObject = JSON_BF.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            response.status(Http.Status.BAD_REQUEST_400)
+                    .send(jsonErrorObject);
+            return;
+        }
+
+        greeting = GreetingMessage.fromRest(jo).getMessage();
+        response.status(Http.Status.NO_CONTENT_204).send();
+    }
+
+    /**
+     * Set the greeting to use in future messages.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void updateGreetingHandler(ServerRequest request,
+                                       ServerResponse response) {
+        request.content().as(JsonObject.class).thenAccept(jo -> updateGreetingFromJson(jo, response));
+    }
+
+}

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetingMessage.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/GreetingMessage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.examples.openapi;
+
+import java.util.Collections;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+
+/**
+ * POJO for the greeting message exchanged between the server and the client.
+ */
+public class GreetingMessage {
+
+    /**
+     * Label for tagging a {@code GreetingMessage} instance in JSON.
+     */
+    public static final String JSON_LABEL = "greeting";
+
+    private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Collections.emptyMap());
+
+    private String message;
+
+    /**
+     * Create a new greeting with the specified message content.
+     *
+     * @param message the message to store in the greeting
+     */
+    public GreetingMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Returns the message value.
+     *
+     * @return the message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Sets the message value.
+     *
+     * @param message value to be set
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Converts a JSON object (typically read from the request payload)
+     * into a {@code GreetingMessage}.
+     *
+     * @param jsonObject the {@link JsonObject} to convert.
+     * @return {@code GreetingMessage} set according to the provided object
+     */
+    public static GreetingMessage fromRest(JsonObject jsonObject) {
+        return new GreetingMessage(jsonObject.getString(JSON_LABEL));
+    }
+
+    /**
+     * Prepares a {@link JsonObject} corresponding to this instance.
+     *
+     * @return {@code JsonObject} representing this {@code GreetingMessage} instance
+     */
+    public JsonObject forRest() {
+        JsonObjectBuilder builder = JSON_BF.createObjectBuilder();
+        return builder.add(JSON_LABEL, message)
+                .build();
+    }
+}

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.openapi;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+import io.helidon.config.Config;
+import io.helidon.health.HealthSupport;
+import io.helidon.health.checks.HealthChecks;
+import io.helidon.media.jsonp.server.JsonSupport;
+import io.helidon.metrics.MetricsSupport;
+import io.helidon.openapi.OpenAPISupport;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerConfiguration;
+import io.helidon.webserver.WebServer;
+
+/**
+ * Simple Hello World rest application.
+ */
+public final class Main {
+
+    /**
+     * Cannot be instantiated.
+     */
+    private Main() { }
+
+    /**
+     * Application main entry point.
+     * @param args command line arguments.
+     * @throws IOException if there are problems reading logging properties
+     */
+    public static void main(final String[] args) throws IOException {
+        startServer();
+    }
+
+    /**
+     * Start the server.
+     * @return the created {@link WebServer} instance
+     * @throws IOException if there are problems reading logging properties
+     */
+    static WebServer startServer() throws IOException {
+
+        // load logging configuration
+        LogManager.getLogManager().readConfiguration(
+                Main.class.getResourceAsStream("/logging.properties"));
+
+        // By default this will pick up application.yaml from the classpath
+        Config config = Config.create();
+
+        // Get webserver config from the "server" section of application.yaml
+        ServerConfiguration serverConfig =
+                ServerConfiguration.create(config.get("server"));
+
+        WebServer server = WebServer.create(serverConfig, createRouting(config));
+
+        // Try to start the server. If successful, print some info and arrange to
+        // print a message at shutdown. If unsuccessful, print the exception.
+        server.start()
+            .thenAccept(ws -> {
+                System.out.println(
+                        "WEB server is up! http://localhost:" + ws.port() + "/greet");
+                ws.whenShutdown().thenRun(()
+                    -> System.out.println("WEB server is DOWN. Good bye!"));
+                })
+            .exceptionally(t -> {
+                System.err.println("Startup failed: " + t.getMessage());
+                t.printStackTrace(System.err);
+                return null;
+            });
+
+        // Server threads are not daemon. No need to block. Just react.
+
+        return server;
+    }
+
+    /**
+     * Creates new {@link Routing}.
+     *
+     * @return routing configured with JSON support, a health check, and a service
+     * @param config configuration of this server
+     */
+    private static Routing createRouting(Config config) {
+
+        MetricsSupport metrics = MetricsSupport.create();
+        GreetService greetService = new GreetService(config);
+        HealthSupport health = HealthSupport.builder()
+                .add(HealthChecks.healthChecks())   // Adds a convenient set of checks
+                .build();
+
+        return Routing.builder()
+                .register(JsonSupport.create())
+                .register(OpenAPISupport.create(config))
+                .register(health)                   // Health at "/health"
+                .register(metrics)                  // Metrics at "/metrics"
+                .register("/greet", greetService)
+                .build();
+    }
+
+}

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIFilter.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.examples.openapi.internal;
+
+import java.util.Map;
+
+import org.eclipse.microprofile.openapi.OASFilter;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+
+/**
+ * Example OpenAPI filter which hides a single endpoint from the OpenAPI document.
+ */
+public class SimpleAPIFilter implements OASFilter {
+
+    @Override
+    public PathItem filterPathItem(PathItem pathItem) {
+        for (Map.Entry<PathItem.HttpMethod, Operation> methodOp
+                : pathItem.getOperations().entrySet()) {
+            if (SimpleAPIModelReader.DOOMED_OPERATION_ID
+                    .equals(methodOp.getValue().getOperationId())) {
+                return null;
+            }
+        }
+        return OASFilter.super.filterPathItem(pathItem);
+    }
+}

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIModelReader.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/SimpleAPIModelReader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.examples.openapi.internal;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.OASModelReader;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.Paths;
+
+/**
+ * Defines two paths using the OpenAPI model reader mechanism, one that should
+ * be suppressed by the filter class and one that should appear in the published
+ * OpenAPI document.
+ */
+public class SimpleAPIModelReader implements OASModelReader {
+
+    /**
+     * Path for the example endpoint added by this model reader that should be visible.
+     */
+    public static final String MODEL_READER_PATH = "/test/newpath";
+
+    /**
+     * Path for an endpoint that the filter should hide.
+     */
+    public static final String DOOMED_PATH = "/test/doomed";
+
+    /**
+     * ID for an endpoint that the filter should hide.
+     */
+    public static final String DOOMED_OPERATION_ID = "doomedPath";
+
+    /**
+     * Summary text for the endpoint.
+     */
+    public static final String SUMMARY = "A sample test endpoint from ModelReader";
+
+    @Override
+    public OpenAPI buildModel() {
+        /*
+         * Add two path items, one of which we expect to be removed by
+         * the filter and a very simple one that will appear in the
+         * published OpenAPI document.
+         */
+        PathItem newPathItem = OASFactory.createPathItem()
+                .GET(OASFactory.createOperation()
+                    .operationId("newPath")
+                    .summary(SUMMARY));
+        PathItem doomedPathItem = OASFactory.createPathItem()
+                .GET(OASFactory.createOperation()
+                    .operationId(DOOMED_OPERATION_ID)
+                    .summary("This should become invisible"));
+        OpenAPI openAPI = OASFactory.createOpenAPI();
+        Paths paths = OASFactory.createPaths()
+                .addPathItem(MODEL_READER_PATH, newPathItem)
+                .addPathItem(DOOMED_PATH, doomedPathItem);
+        openAPI.paths(paths);
+
+        return openAPI;
+    }
+}

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/package-info.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/internal/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Internal classes supporting the Helidon OpenAPI example.
+ */
+package io.helidon.examples.openapi.internal;

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/package-info.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Example application showing support for OpenAPI in Helidon SE
+ * <p>
+ * Start with {@link io.helidon.examples.openapi.Main} class.
+ *
+ * @see io.helidon.examples.openapi.Main
+ */
+package io.helidon.examples.openapi;

--- a/examples/openapi/src/main/resources/META-INF/openapi.yml
+++ b/examples/openapi/src/main/resources/META-INF/openapi.yml
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+openapi: 3.0.0
+info:
+  title: Helidon SE Quickstart Example
+  description: A very simple application to reply with friendly greetings
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8000
+    description: Local test server
+
+paths:
+  /greet:
+    get:
+      summary: Returns a generic greeting
+      description: Greets the user generically
+      responses:
+        default:
+          description: Simple JSON containing the greeting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GreetingMessage'
+  /greet/greeting:
+    put:
+      summary: Set the greeting prefix
+      description: Permits the client to set the prefix part of the greeting ("Hello")
+      requestBody:
+        description: Conveys the new greeting prefix to use in building greetings
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GreetingMessage'
+            examples:
+              greeting:
+                summary: Example greeting message to update
+                value: New greeting message
+      responses:
+        200:
+          description: OK
+          content:
+            application/json: {}
+  /greet/{name}:
+    get:
+      summary: Returns a personalized greeting
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Simple JSON containing the greeting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GreetingMessage'
+components:
+  schemas:
+    GreetingMessage:
+      properties:
+        message:
+          type: string

--- a/examples/openapi/src/main/resources/application.yaml
+++ b/examples/openapi/src/main/resources/application.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+app:
+  greeting: "Hello"
+
+server:
+  port: 8080
+  host: 0.0.0.0
+  
+openapi:
+  filter: io.helidon.examples.openapi.internal.SimpleAPIFilter
+  model:
+    reader: io.helidon.examples.openapi.internal.SimpleAPIModelReader
+# The following would change the endpoint path for retrieving the OpenAPI document
+#  web-context: /myopenapi

--- a/examples/openapi/src/main/resources/logging.properties
+++ b/examples/openapi/src/main/resources/logging.properties
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=java.util.logging.ConsoleHandler
+
+# Global default logging level. Can be overriden by specific handlers and loggers
+.level=INFO
+
+# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
+# It replaces "!thread!" with the current thread name
+java.util.logging.ConsoleHandler.level=FINER
+java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+#Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO
+io.helidon.openapi.OpenAPISupport.level=FINER

--- a/examples/openapi/src/test/java/io/helidon/examples/openapi/MainTest.java
+++ b/examples/openapi/src/test/java/io/helidon/examples/openapi/MainTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.openapi;
+
+import io.helidon.common.http.MediaType;
+import io.helidon.examples.openapi.internal.SimpleAPIModelReader;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.net.URL;
+import java.net.HttpURLConnection;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+
+import io.helidon.webserver.WebServer;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonPointer;
+import javax.json.JsonString;
+import javax.json.JsonWriter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MainTest {
+
+    private static WebServer webServer;
+
+    private static final JsonReaderFactory JSON_RF = Json.createReaderFactory(Collections.emptyMap());
+
+    private static final JsonBuilderFactory JSON_BF = Json.createBuilderFactory(Collections.emptyMap());
+
+    @BeforeAll
+    public static void startTheServer() throws Exception {
+        webServer = Main.startServer();
+
+        long timeout = 2000; // 2 seconds should be enough to start the server
+        long now = System.currentTimeMillis();
+
+        while (!webServer.isRunning()) {
+            Thread.sleep(100);
+            if ((System.currentTimeMillis() - now) > timeout) {
+                Assertions.fail("Failed to start webserver");
+            }
+        }
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                     .toCompletableFuture()
+                     .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testHelloWorld() throws Exception {
+        HttpURLConnection conn;
+
+        conn = getURLConnection("GET","/greet");
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response1");
+        Assertions.assertEquals("Hello World!", GreetService.fromPayload(conn).getMessage(),
+                "default message");
+
+        conn = getURLConnection("GET", "/greet/Joe");
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
+        Assertions.assertEquals("Hello Joe!", GreetService.fromPayload(conn).getMessage(),
+                "hello Joe message");
+
+        conn = getURLConnection("PUT", "/greet/greeting");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        GreetService.toPayload(conn, new GreetingMessage("Hola"));
+        Assertions.assertEquals(204, conn.getResponseCode(), "HTTP response3");
+
+        conn = getURLConnection("GET", "/greet/Jose");
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response4");
+        Assertions.assertEquals("Hola Jose!", GreetService.fromPayload(conn).getMessage(),
+                "hola Jose message");
+
+        conn = getURLConnection("GET", "/health");
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
+
+        conn = getURLConnection("GET", "/metrics");
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response2");
+    }
+
+    @Test
+    public void testOpenAPI() throws Exception {
+        HttpURLConnection conn;
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", MediaType.APPLICATION_JSON.toString());
+        /*
+         * If you change the OpenAPI endpoing path in application.yaml, then
+         * change the following path also.
+         */
+        conn = getURLConnection("GET", "/openapi", headers);
+        Assertions.assertEquals(200, conn.getResponseCode(), "HTTP response");
+        JsonReader jsonReader = JSON_RF.createReader(conn.getInputStream());
+        JsonObject paths = jsonReader.readObject().getJsonObject("paths");
+
+        JsonPointer jp = Json.createPointer("/" + escape("/greet/greeting") + "/put/summary");
+        JsonString js = JsonString.class.cast(jp.getValue(paths));
+        Assertions.assertEquals("Set the greeting prefix", js.getString(), "/greet/greeting.put.summary not as expected");
+
+        jp = Json.createPointer("/" + escape(SimpleAPIModelReader.MODEL_READER_PATH)
+                + "/get/summary");
+        js = JsonString.class.cast(jp.getValue(paths));
+        Assertions.assertEquals(SimpleAPIModelReader.SUMMARY, js.getString(),
+                "summary added by model reader does not match");
+
+        jp = Json.createPointer("/" + escape(SimpleAPIModelReader.DOOMED_PATH));
+        Assertions.assertFalse(jp.containsValue(paths), "/test/doomed should not appear but does");
+    }
+
+    private HttpURLConnection getURLConnection(String method, String path) throws Exception {
+        return getURLConnection(method, path, Collections.emptyMap());
+    }
+
+    private HttpURLConnection getURLConnection(String method, String path, Map<String, String> headers) throws Exception {
+        URL url = new URL("http://localhost:" + webServer.port() + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        for (Map.Entry<String,String> header : headers.entrySet()) {
+            conn.setRequestProperty(header.getKey(), header.getValue());
+        }
+        conn.setRequestMethod(method);
+        conn.setRequestProperty("Accept", "application/json");
+        System.out.println("Connecting: " + method + " " + url);
+        return conn;
+    }
+
+    private static String escape(String path) {
+        return path.replace("/", "~1");
+    }
+
+
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,6 +46,7 @@
         <module>quickstarts</module>
         <module>health</module>
         <module>grpc</module>
+        <module>openapi</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This example is inspired by the SE quickstart example, with support added for OpenAPI.

The code defines a `GreetingMessage` POJO which is used in reading and writing the HTTP request and response payloads. This is what the Todo example does, rather than repeatedly constructing the JSON object field-by-field (well, there's only one field here). 

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>