### PR TITLE
Create Helidon MP 2.2 bundle

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -269,6 +269,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.microprofile.bundles</groupId>
+                <artifactId>helidon-microprofile-2.2</artifactId>
+                <version>${project.version{</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.microprofile</groupId>
                 <artifactId>helidon-microprofile-security</artifactId>
                 <version>${project.version}</version>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -69,7 +69,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -80,12 +80,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-binding</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.openapi</groupId>
-            <artifactId>helidon-microprofile-openapi</artifactId>
-            <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/microprofile/bundles/helidon-microprofile-2.2/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-2.2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/bundles/helidon-microprofile-2.2/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-2.2/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.bundles</groupId>
+        <artifactId>bundles-project</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-microprofile-2.2</artifactId>
+    <name>Helidon Microprofile Bundles 2.2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-1.2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.openapi</groupId>
+            <artifactId>helidon-microprofile-openapi</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/bundles/helidon-microprofile-2.2/src/main/java9/module-info.java
+++ b/microprofile/bundles/helidon-microprofile-2.2/src/main/java9/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aggregator module for microprofile 2.2.
+ */
+module io.helidon.microprofile.v2_2 {
+    requires transitive io.helidon.microprofile.config.cdi;
+    requires transitive io.helidon.microprofile.config;
+    requires transitive io.helidon.microprofile.server;
+    requires transitive io.helidon.microprofile.health;
+    requires transitive io.helidon.microprofile.metrics;
+    requires transitive io.helidon.microprofile.faulttolerance;
+    requires transitive io.helidon.microprofile.jwt.auth.cdi;
+
+    requires io.helidon.health.checks;
+}

--- a/microprofile/bundles/pom.xml
+++ b/microprofile/bundles/pom.xml
@@ -42,6 +42,7 @@
         <module>helidon-microprofile-1.1</module>
         <module>helidon-microprofile-1.0</module>
         <module>helidon-microprofile-1.2</module>
+        <module>helidon-microprofile-2.2</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
I'm referencing only the OpenAPI-related dependency to the new MP 2.2 bundle (as well as depending on its predecessor 1.2 bundle).

Note that developers do _not_ compile against the Helidon MP OpenAPI code, so it is declared in the bundle with `runtime` scope and it does _not_ appear in the new bundle's `module-info.java`.

This PR also updates the Helidon MP OpenAPI example to use the new bundle and removes the earlier explicit dependency on the Helidon MP OpenAPI artifact (because it's now in the bundle).

Resolves #764 