### PR TITLE
Create helidon context in gRPC server implementation

### DIFF
--- a/examples/grpc/opentracing/src/main/java/io/helidon/grpc/examples/opentracing/ZipkinExampleMain.java
+++ b/examples/grpc/opentracing/src/main/java/io/helidon/grpc/examples/opentracing/ZipkinExampleMain.java
@@ -54,7 +54,7 @@ public class ZipkinExampleMain {
 
         Tracer tracer = TracerBuilder.create(config.get("tracing")).build();
 
-        TracingConfiguration tracingConfig = new TracingConfiguration.Builder()
+        TracingConfiguration tracingConfig = TracingConfiguration.builder()
                 .withStreaming()
                 .withVerbosity()
                 .withTracedAttributes(ServerRequestAttribute.CALL_ATTRIBUTES,

--- a/grpc/core/src/main/java/io/helidon/grpc/core/ContextKeys.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/ContextKeys.java
@@ -16,6 +16,7 @@
 
 package io.helidon.grpc.core;
 
+import io.grpc.Context;
 import io.grpc.Metadata;
 
 /**
@@ -27,6 +28,13 @@ public final class ContextKeys {
      */
     public static final Metadata.Key<String> AUTHORIZATION =
             Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+    /**
+     * The gRPC context key to use to obtain the Helidon {@link io.helidon.common.context.Context}
+     * from the gRPC {@link Context}.
+     */
+    public static final Context.Key<io.helidon.common.context.Context> HELIDON_CONTEXT =
+            Context.key(io.helidon.common.context.Context.class.getCanonicalName());
 
     /**
      * Private constructor for utility class.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-import io.helidon.common.http.ContextualRegistry;
+import io.helidon.common.context.Context;
 import io.helidon.grpc.core.PriorityBag;
 
 import io.grpc.ServerInterceptor;
@@ -51,7 +51,7 @@ public interface GrpcServer {
      *
      * @return a server context
      */
-    ContextualRegistry context();
+    Context context();
 
     /**
      * Starts the server. Has no effect if server is running.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import io.helidon.common.http.ContextualRegistry;
 import io.helidon.grpc.core.PriorityBag;
 
 import io.grpc.ServerInterceptor;
@@ -44,6 +45,13 @@ public interface GrpcServer {
      * @return Server configuration
      */
     GrpcServerConfiguration configuration();
+
+    /**
+     * Gets a {@link GrpcServer} context.
+     *
+     * @return a server context
+     */
+    ContextualRegistry context();
 
     /**
      * Starts the server. Has no effect if server is running.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
@@ -16,8 +16,9 @@
 
 package io.helidon.grpc.server;
 
+import io.helidon.common.context.Context;
+
 import io.opentracing.Tracer;
-import io.opentracing.util.GlobalTracer;
 
 /**
  * Configuration class for the {@link GrpcServer} implementations.
@@ -39,33 +40,23 @@ public class GrpcServerBasicConfig
 
     private final SslConfiguration sslConfig;
 
+    private final Context context;
+
     /**
      * Construct {@link GrpcServerBasicConfig} instance.
      *
-     * @param name            the server name
-     * @param port            the port to listen on
-     * @param workers         a count of threads in a pool used to tryProcess HTTP requests
-     * @param nativeTransport {@code true} to enable native transport for
-     *                        the server
-     * @param tracer          the tracer to use
-     * @param tracingConfig   the tracing configuration
-     * @param sslConfig       the SSL configuration
+     * @param builder the {@link GrpcServerConfiguration.Builder} to use to configure
+     *                this {@link GrpcServerBasicConfig}.
      */
-    public GrpcServerBasicConfig(String name,
-                                 int port,
-                                 int workers,
-                                 boolean nativeTransport,
-                                 Tracer tracer,
-                                 TracingConfiguration tracingConfig,
-                                 SslConfiguration sslConfig) {
-
-        this.name = name == null || name.trim().isEmpty() ? DEFAULT_NAME : name.trim();
-        this.port = port <= 0 ? 0 : port;
-        this.nativeTransport = nativeTransport;
-        this.tracer = tracer == null ? GlobalTracer.get() : tracer;
-        this.tracingConfig = tracingConfig == null ? new TracingConfiguration.Builder().build() : tracingConfig;
-        this.workers = workers > 0 ? workers : DEFAULT_WORKER_COUNT;
-        this.sslConfig = sslConfig;
+    GrpcServerBasicConfig(GrpcServerConfiguration.Builder builder) {
+        this.name = builder.name();
+        this.port = builder.port();
+        this.context = builder.context();
+        this.nativeTransport = builder.useNativeTransport();
+        this.tracer = builder.tracer();
+        this.tracingConfig = builder.tracingConfig();
+        this.workers = builder.workers();
+        this.sslConfig = builder.sslConfig();
     }
 
     // ---- accessors ---------------------------------------------------
@@ -88,6 +79,11 @@ public class GrpcServerBasicConfig
     @Override
     public int port() {
         return port;
+    }
+
+    @Override
+    public Context context() {
+        return context;
     }
 
     /**

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -479,8 +479,9 @@ public class GrpcServerImpl implements GrpcServer {
                                                                      Metadata headers,
                                                                      ServerCallHandler<ReqT, RespT> next) {
 
-            io.grpc.Context context = io.grpc.Context.current().withValue(ContextKeys.HELIDON_CONTEXT, context());
-            return io.grpc.Contexts.interceptCall(context, call, headers, next);
+            Context context = Context.create(context());
+            io.grpc.Context grpcContext = io.grpc.Context.current().withValue(ContextKeys.HELIDON_CONTEXT, context);
+            return io.grpc.Contexts.interceptCall(grpcContext, call, headers, next);
         }
     }
 
@@ -497,7 +498,10 @@ public class GrpcServerImpl implements GrpcServer {
 
         @Override
         public Thread newThread(Runnable runnable) {
-            return super.newThread(() -> Contexts.runInContext(context(), runnable));
+            return super.newThread(() -> {
+                Context context = Context.create(context());
+                Contexts.runInContext(context, runnable);
+            });
         }
     }
 }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -40,15 +40,14 @@ import javax.annotation.Priority;
 import javax.net.ssl.SSLContext;
 
 import io.helidon.common.configurable.Resource;
-import io.helidon.common.http.ContextualRegistry;
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.pki.KeyConfig;
 import io.helidon.grpc.core.ContextKeys;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.core.PriorityBag;
 
 import io.grpc.BindableService;
-import io.grpc.Context;
-import io.grpc.Contexts;
 import io.grpc.HandlerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
@@ -128,7 +127,7 @@ public class GrpcServerImpl implements GrpcServer {
      */
     private Map<String, ServiceDescriptor> services = new ConcurrentHashMap<>();
 
-    private final ContextualRegistry contextualRegistry;
+    private final Context context;
 
     // ---- constructors ----------------------------------------------------
 
@@ -139,7 +138,7 @@ public class GrpcServerImpl implements GrpcServer {
      */
     GrpcServerImpl(GrpcServerConfiguration config) {
         this.config = config;
-        this.contextualRegistry = ContextualRegistry.create(config.context());
+        this.context = config.context();
 
     }
 
@@ -230,8 +229,8 @@ public class GrpcServerImpl implements GrpcServer {
     }
 
     @Override
-    public ContextualRegistry context() {
-        return contextualRegistry;
+    public Context context() {
+        return context;
     }
 
     @Override
@@ -480,8 +479,8 @@ public class GrpcServerImpl implements GrpcServer {
                                                                      Metadata headers,
                                                                      ServerCallHandler<ReqT, RespT> next) {
 
-            Context context = Context.current().withValue(ContextKeys.HELIDON_CONTEXT, context());
-            return Contexts.interceptCall(context, call, headers, next);
+            io.grpc.Context context = io.grpc.Context.current().withValue(ContextKeys.HELIDON_CONTEXT, context());
+            return io.grpc.Contexts.interceptCall(context, call, headers, next);
         }
     }
 
@@ -498,7 +497,7 @@ public class GrpcServerImpl implements GrpcServer {
 
         @Override
         public Thread newThread(Runnable runnable) {
-            return super.newThread(() -> io.helidon.common.context.Contexts.runInContext(context(), runnable));
+            return super.newThread(() -> Contexts.runInContext(context(), runnable));
         }
     }
 }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/TracingConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/TracingConfiguration.java
@@ -94,13 +94,31 @@ public class TracingConfiguration {
     }
 
     /**
+     * Create a builder of {@link TracingConfiguration} instances.
+     *
+     * @return a builder of {@link TracingConfiguration} instances.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Create a default {@link TracingConfiguration} instances.
+     *
+     * @return a default {@link TracingConfiguration} instances.
+     */
+    public static TracingConfiguration create() {
+        return builder().build();
+    }
+
+    /**
      * Builds the configuration of a tracer.
      */
     public static class Builder {
         /**
          * Creates a Builder with default configuration.
          */
-        public Builder() {
+        Builder() {
             operationNameConstructor = OperationNameConstructor.DEFAULT;
             streaming = false;
             verbose = false;

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ContextIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ContextIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.grpc.server;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.grpc.core.ContextKeys;
+import io.helidon.grpc.server.test.Echo;
+import io.helidon.grpc.server.test.EchoServiceGrpc;
+
+import io.grpc.Channel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class ContextIT {
+
+    /**
+     * The {@link java.util.logging.Logger} to use for logging.
+     */
+    private static final Logger LOGGER = Logger.getLogger(TracingIT.class.getName());
+
+    /**
+     * The Helidon {@link io.helidon.grpc.server.GrpcServer} being tested.
+     */
+    private static GrpcServer grpcServer;
+
+    /**
+     * A gRPC {@link io.grpc.Channel} to connect to the test gRPC server
+     */
+    private static Channel channel;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        LogManager.getLogManager().readConfiguration(TracingIT.class.getResourceAsStream("/logging.properties"));
+
+        startGrpcServer();
+
+        channel = ManagedChannelBuilder.forAddress("localhost", grpcServer.port())
+                                       .usePlaintext()
+                                       .build();
+    }
+
+    @Test
+    public void shouldObtainValueFromContextForThread() {
+        TestValue value = new TestValue("Foo");
+        grpcServer.context().register(value);
+
+        Echo.EchoResponse response = EchoServiceGrpc.newBlockingStub(channel)
+                .echo(Echo.EchoRequest.newBuilder().setMessage("thread").build());
+
+        assertThat(response.getMessage(), is("Foo"));
+    }
+
+    @Test
+    public void shouldObtainValueFromContextForRequest() {
+        TestValue value = new TestValue("Bar");
+        grpcServer.context().register(value);
+
+        Echo.EchoResponse response = EchoServiceGrpc.newBlockingStub(channel)
+                .echo(Echo.EchoRequest.newBuilder().setMessage("request").build());
+
+        assertThat(response.getMessage(), is("Bar"));
+    }
+
+
+    /**
+     * Start the gRPC Server listening on an ephemeral port.
+     *
+     * @throws Exception in case of an error
+     */
+    private static void startGrpcServer() throws Exception {
+        // Add the EchoService
+        GrpcRouting routing = GrpcRouting.builder()
+                                         .register(new ContextService())
+                                         .build();
+
+        // Run the server on port 0 so that it picks a free ephemeral port
+        GrpcServerConfiguration serverConfig = GrpcServerConfiguration.builder()
+                .port(0)
+                .build();
+
+        grpcServer = GrpcServer.create(serverConfig, routing)
+                        .start()
+                        .toCompletableFuture()
+                        .get(10, TimeUnit.SECONDS);
+
+        LOGGER.info("Started gRPC server at: localhost:" + grpcServer.port());
+    }
+
+
+    /**
+     * A test gRPC service that obtains a value from the {@link io.helidon.common.http.ContextualRegistry}.
+     */
+    public static class ContextService
+            implements GrpcService {
+
+        @Override
+        public void update(ServiceDescriptor.Rules rules) {
+            rules.proto(Echo.getDescriptor())
+                 .name("EchoService")
+                 .unary("Echo", this::echo);
+        }
+
+        public void echo(Echo.EchoRequest request, StreamObserver<Echo.EchoResponse> observer) {
+            TestValue value;
+
+            if ("thread".equalsIgnoreCase(request.getMessage())) {
+                value = getValue(Contexts.context());
+            } else {
+                value = getValue(Optional.ofNullable(ContextKeys.HELIDON_CONTEXT.get()));
+            }
+
+            Echo.EchoResponse response = Echo.EchoResponse.newBuilder().setMessage(String.valueOf(value)).build();
+            complete(observer, response);
+        }
+
+        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+        private TestValue getValue(Optional<Context> optional) {
+            return optional.map(ctx -> ctx.get(TestValue.class))
+                    .filter(Optional::isPresent)
+                    .orElse(Optional.empty())
+                    .orElse(null);
+
+        }
+    }
+
+
+    /**
+     * A test value to register with the {@link io.helidon.common.http.ContextualRegistry}.
+     */
+    private class TestValue {
+        private final String value;
+
+        private TestValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+}

--- a/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
@@ -24,12 +24,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import javax.annotation.Priority;
+
+import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.server.test.Echo;
 import io.helidon.grpc.server.test.EchoServiceGrpc;
 import io.helidon.tracing.TracerBuilder;
 
 import io.grpc.Channel;
+import io.grpc.Context;
+import io.grpc.Contexts;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 
 import org.junit.jupiter.api.AfterAll;
@@ -41,6 +51,7 @@ import zipkin2.junit.ZipkinRule;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
 
@@ -71,6 +82,7 @@ public class TracingIT {
      */
     public static ZipkinRule zipkin = new ZipkinRule();
 
+    public static final TestInterceptor interceptor = new TestInterceptor();
 
     // ----- test lifecycle -------------------------------------------------
 
@@ -96,11 +108,11 @@ public class TracingIT {
     // ----- test methods ---------------------------------------------------
 
     @Test
-    public void shouldTraceMethodNameAndHeaders() throws Exception {
+    public void shouldTraceMethodNameAndHeaders() {
         // call the gRPC Echo service so that there should be tracing span sent to zipkin server
         EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
 
-        Eventually.assertThat(invoking(this).getSpanCount(), is(1));
+        Eventually.assertThat(invoking(this).getSpanCount(), is(not(0)));
 
         List<List<Span>> listTraces = zipkin.getTraces();
         assertThat(listTraces, is(notNullValue()));
@@ -114,6 +126,24 @@ public class TracingIT {
         assertThat("Tha traces should include attributes", sTraces.contains("grpc.call_attributes"));
     }
 
+    @Test
+    public void shouldAddTracerToContext() {
+        EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
+
+        io.helidon.common.context.Context context = interceptor.context();
+        assertThat(context, is(notNullValue()));
+        assertThat(context.get(Tracer.class), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldAddSpanContextToContext() {
+        EchoServiceGrpc.newBlockingStub(channel).echo(Echo.EchoRequest.newBuilder().setMessage("foo").build());
+
+        io.helidon.common.context.Context context = interceptor.context();
+        assertThat(context, is(notNullValue()));
+        assertThat(context.get(SpanContext.class), is(notNullValue()));
+    }
+
     // ----- helper methods -------------------------------------------------
 
     /**
@@ -125,13 +155,14 @@ public class TracingIT {
         // Add the EchoService
         GrpcRouting routing = GrpcRouting.builder()
                                          .register(new EchoService())
+                                         .intercept(interceptor)
                                          .build();
         // Enable tracing
-        Tracer tracer = (Tracer) TracerBuilder.create("Server")
+        Tracer tracer = TracerBuilder.create("Server")
                 .collectorUri(URI.create(zipkin.httpUrl() + "/api/v2/spans"))
                 .build();
 
-        TracingConfiguration tracingConfig = new TracingConfiguration.Builder()
+        TracingConfiguration tracingConfig = TracingConfiguration.builder()
                 .withStreaming()
                 .withVerbosity()
                 .withTracedAttributes(ServerRequestAttribute.CALL_ATTRIBUTES,
@@ -155,5 +186,30 @@ public class TracingIT {
      */
     public int getSpanCount() {
         return zipkin.collectorMetrics().spans();
+    }
+
+    /**
+     * A {@link io.grpc.ServerInterceptor} that captures the context set when
+     * the request executed.
+     */
+    @Priority(InterceptorPriorities.USER)
+    private static class TestInterceptor
+            implements ServerInterceptor {
+
+        private io.helidon.common.context.Context context;
+
+        private io.helidon.common.context.Context context() {
+            return context;
+        }
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                                     Metadata headers,
+                                                                     ServerCallHandler<ReqT, RespT> next) {
+
+            context = io.helidon.common.context.Contexts.context().orElse(null);
+
+            return Contexts.interceptCall(Context.current(), call, headers, next);
+        }
     }
 }

--- a/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
+++ b/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.server.GrpcRouting;
@@ -509,6 +510,8 @@ public final class GrpcSecurity
                     .env(env)
                     .endpointConfig(ec)
                     .build();
+
+            Contexts.context().ifPresent(ctx -> ctx.register(context));
 
             grpcContext = Context.current().withValue(SECURITY_CONTEXT, context);
         } else {


### PR DESCRIPTION
This pull request is for issue #698.

This change adds a ability to set a Helidon `io.helidon.common.context.Context` when creating the gRPC server by calling the `context(Context context)` method on the `GrpcServerConfiguration.Builder` when creating the server configuration that will be used to configure the gRPC server.

The Thread factory used by the gRPC server thread pool creates threads that have the context set so that the context can be obtained using the static `io.helidon.common.context.Contexts.context()` method in call handling code. The context can also be obtained from the gRPC call context inside a gRPC service method using the `io.helidon.grpc.core.ContextKeys.HELIDON_CONTEXT.get()` method.

If tracing is enabled, the `Tracer` and the current `SpanContext` are set into the `Context` at the start of a gRPC server call so that they are available during handling of the call.

If security is enabled then the `SecurityContext` is also set into the `Context`.
