### PR TITLE
Added support for the Oracle Universal Connection Pool

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -430,8 +430,33 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.helidon.serviceconfiguration</groupId>
+                <artifactId>helidon-serviceconfiguration-ucp-accs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.serviceconfiguration</groupId>
+                <artifactId>helidon-serviceconfiguration-ucp-localhost</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.serviceconfiguration</groupId>
+                <artifactId>helidon-serviceconfiguration-ucp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.integrations.cdi</groupId>
+                <artifactId>helidon-integrations-cdi-datasource</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.helidon.integrations.cdi</groupId>
                 <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.integrations.cdi</groupId>
+                <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -113,4 +113,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@
         <artifactId>helidon-integrations-cdi-project</artifactId>
         <version>1.1.2-SNAPSHOT</version>
     </parent>
-    <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-    <name>Helidon CDI Integrations HikariCP DataSource</name>
+    <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
+    <name>Helidon CDI Integrations UCP DataSource</name>
 
     <properties>
         <!-- maven-javadoc-plugin property -->
@@ -34,13 +34,7 @@
     </properties>
 
     <dependencies>
-      <!-- Compile-scoped dependencies. -->
-        <dependency>
-            <groupId>io.helidon.integrations.cdi</groupId>
-            <artifactId>helidon-integrations-cdi-datasource</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
+        <!-- Compile-scoped dependencies. -->
         <dependency>
             <groupId>io.helidon.serviceconfiguration</groupId>
             <artifactId>helidon-serviceconfiguration-config-source</artifactId>
@@ -48,15 +42,21 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>helidon-integrations-cdi-datasource</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ucp</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.oracle.jdbc</groupId>
+                    <artifactId>ojdbc10</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
@@ -77,20 +77,6 @@
         </dependency>
 
         <!-- Runtime-scoped dependencies. -->
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-            <scope>runtime</scope>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.ucp.cdi;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.CreationException;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.configurator.BeanConfigurator;
+import javax.inject.Named;
+import javax.sql.DataSource;
+
+import io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension;
+
+import oracle.ucp.jdbc.PoolDataSource;
+import oracle.ucp.jdbc.PoolDataSourceFactory;
+import oracle.ucp.jdbc.PoolDataSourceImpl;
+
+/**
+ * An {@link Extension} that arranges for named {@link DataSource}
+ * injection points to be satisfied by the <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html">Oracle
+ * Universal Connection Pool</a>.
+ */
+public class UCPBackedDataSourceExtension extends AbstractDataSourceExtension {
+
+    private static final Pattern DATASOURCE_NAME_PATTERN =
+        Pattern.compile("^(?:javax\\.sql\\.|oracle\\.ucp\\.jdbc\\.Pool)DataSource\\.([^.]+)\\.(.*)$");
+
+    /**
+     * Creates a new {@link UCPBackedDataSourceExtension}.
+     */
+    public UCPBackedDataSourceExtension() {
+        super();
+    }
+
+    @Override
+    protected final Matcher getDataSourcePropertyPatternMatcher(final String configPropertyName) {
+        final Matcher returnValue;
+        if (configPropertyName == null) {
+            returnValue = null;
+        } else {
+            returnValue = DATASOURCE_NAME_PATTERN.matcher(configPropertyName);
+        }
+        return returnValue;
+    }
+
+    @Override
+    protected final String getDataSourceName(final Matcher dataSourcePropertyPatternMatcher) {
+        final String returnValue;
+        if (dataSourcePropertyPatternMatcher == null) {
+            returnValue = null;
+        } else {
+            returnValue = dataSourcePropertyPatternMatcher.group(1);
+        }
+        return returnValue;
+    }
+
+    @Override
+    protected final String getDataSourcePropertyName(final Matcher dataSourcePropertyPatternMatcher) {
+        final String returnValue;
+        if (dataSourcePropertyPatternMatcher == null) {
+            returnValue = null;
+        } else {
+            returnValue = dataSourcePropertyPatternMatcher.group(2);
+        }
+        return returnValue;
+    }
+
+    @Override
+    protected final void addBean(final BeanConfigurator<DataSource> beanConfigurator,
+                                 final Named dataSourceName,
+                                 final Properties dataSourceProperties) {
+        beanConfigurator
+            .addQualifier(dataSourceName)
+            .addTransitiveTypeClosure(PoolDataSource.class)
+            .beanClass(PoolDataSourceImpl.class)
+            .scope(ApplicationScoped.class)
+            .createWith(cc -> {
+                    try {
+                        return createDataSource(dataSourceProperties);
+                    } catch (final IntrospectionException | ReflectiveOperationException exception) {
+                        throw new CreationException(exception.getMessage(), exception);
+                    }
+                })
+            .destroyWith((dataSource, ignored) -> {
+                    if (dataSource instanceof AutoCloseable) {
+                        try {
+                            ((AutoCloseable) dataSource).close();
+                        } catch (final RuntimeException runtimeException) {
+                            throw runtimeException;
+                        } catch (final Exception exception) {
+                            throw new CreationException(exception.getMessage(), exception);
+                        }
+                    }
+                });
+    }
+
+    private static PoolDataSource createDataSource(final Properties properties)
+        throws IntrospectionException, ReflectiveOperationException {
+        Objects.requireNonNull(properties);
+
+        // See
+        // https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/get-started.html#GUID-2CC8D6EC-483F-4942-88BA-C0A1A1B68226
+        // for the general pattern.
+        final PoolDataSource returnValue = PoolDataSourceFactory.getPoolDataSource();
+        assert returnValue != null;
+        final Set<String> propertyNames = properties.stringPropertyNames();
+        assert propertyNames != null;
+        if (!propertyNames.isEmpty()) {
+            final BeanInfo beanInfo = Introspector.getBeanInfo(returnValue.getClass());
+            assert beanInfo != null;
+            final PropertyDescriptor[] pds = beanInfo.getPropertyDescriptors();
+            assert pds != null;
+            assert pds.length > 0;
+            for (final String propertyName : propertyNames) {
+                if (propertyName != null) {
+                    for (final PropertyDescriptor pd : pds) {
+                        assert pd != null;
+                        if (propertyName.equals(pd.getName())) {
+                            final Method writeMethod = pd.getWriteMethod();
+                            if (writeMethod != null) {
+                                final Class<?> type = pd.getPropertyType();
+                                assert type != null;
+                                if (type.equals(String.class)) {
+                                    writeMethod.invoke(returnValue, properties.getProperty(propertyName));
+                                } else if (type.equals(Integer.TYPE)) {
+                                    writeMethod.invoke(returnValue, Integer.parseInt(properties.getProperty(propertyName)));
+                                } else if (type.equals(Long.TYPE)) {
+                                    writeMethod.invoke(returnValue, Long.parseLong(properties.getProperty(propertyName)));
+                                } else if (type.equals(Boolean.TYPE)) {
+                                    writeMethod.invoke(returnValue, Boolean.parseBoolean(properties.getProperty(propertyName)));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return returnValue;
+    }
+
+}

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/config/UCP.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/config/UCP.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.ucp.cdi.config;
+
+import io.helidon.service.configuration.api.ServiceConfiguration;
+import io.helidon.service.configuration.microprofile.config.ServiceConfigurationConfigSource;
+
+/**
+ * A {@link ServiceConfigurationConfigSource} that sits atop the
+ * {@code ucp} {@link ServiceConfiguration} in effect (if there
+ * is one).
+ */
+public final class UCP extends ServiceConfigurationConfigSource {
+
+    /**
+     * Creates a new {@link UCP}.
+     */
+    public UCP() {
+        super();
+    }
+
+}

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/config/package-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/config/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces marrying <a
+ * href="https://microprofile.io/project/eclipse/microprofile-config"
+ * target="_parent">MicroProfile Config</a> constructs and {@link
+ * io.helidon.service.configuration.api.ServiceConfiguration}
+ * constructs for the <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+ * target="_parent">Oracle Universal Connection Pool</a>.
+ *
+ * @see
+ * io.helidon.integrations.datasource.ucp.cdi.config.UCP
+ */
+package io.helidon.integrations.datasource.ucp.cdi.config;
+
+

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/package-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces that integrate the <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+ * target="_parent">Oracle Universal Connection Pool</a> into CDI as a
+ * provider of {@link javax.sql.DataSource} beans.
+ *
+ * @see
+ * io.helidon.integrations.datasource.ucp.cdi.UCPBackedDataSourceExtension
+ */
+package io.helidon.integrations.datasource.ucp.cdi;

--- a/integrations/cdi/datasource-ucp/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/integrations/cdi/datasource-ucp/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,14 @@
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+io.helidon.integrations.datasource.ucp.cdi.config.UCP

--- a/integrations/cdi/datasource/pom.xml
+++ b/integrations/cdi/datasource/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@
         <artifactId>helidon-integrations-cdi-project</artifactId>
         <version>1.1.2-SNAPSHOT</version>
     </parent>
-    <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
-    <name>Helidon CDI Integrations HikariCP DataSource</name>
+    <artifactId>helidon-integrations-cdi-datasource</artifactId>
+    <name>Helidon CDI Integrations DataSource</name>
 
     <properties>
         <!-- maven-javadoc-plugin property -->
@@ -34,30 +34,7 @@
     </properties>
 
     <dependencies>
-      <!-- Compile-scoped dependencies. -->
-        <dependency>
-            <groupId>io.helidon.integrations.cdi</groupId>
-            <artifactId>helidon-integrations-cdi-datasource</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-config-source</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <scope>compile</scope>
-        </dependency>
+        <!-- Compile-scoped dependencies. -->
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
@@ -77,20 +54,6 @@
         </dependency>
 
         <!-- Runtime-scoped dependencies. -->
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp-accs</artifactId>
-            <scope>runtime</scope>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.serviceconfiguration</groupId>
-            <artifactId>helidon-serviceconfiguration-hikaricp-localhost</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>

--- a/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
+++ b/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/AbstractDataSourceExtension.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.cdi;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.literal.NamedLiteral;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.configurator.BeanConfigurator;
+import javax.inject.Named;
+import javax.sql.DataSource;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * An abstract {@link Extension} whose subclasses arrange for {@link
+ * DataSource} instances to be added as CDI beans.
+ */
+public abstract class AbstractDataSourceExtension implements Extension {
+
+    private final Map<String, Properties> masterProperties;
+
+    private final Config config;
+
+    /**
+     * Creates a new {@link AbstractDataSourceExtension}.
+     */
+    protected AbstractDataSourceExtension() {
+        super();
+        this.masterProperties = new HashMap<>();
+        this.config = ConfigProvider.getConfig();
+    }
+
+    /**
+     * Returns a {@link Matcher} for a property name.
+     *
+     * <p>Implementations of this method must not return {@code null}.</p>
+     *
+     * <p>Given a {@link String} like
+     * <code>javax.sql.DataSource.<em>dataSourceName</em>.<em>dataSourcePropertyName</em></code>,
+     * any implementation of this method should return a non-{@code
+     * null} {@link Matcher} that is capable of being supplied to the
+     * {@link #getDataSourceName(Matcher)} and {@link
+     * #getDataSourcePropertyName(Matcher)} methods.</p>
+     *
+     * @param configPropertyName the name of a configuration property
+     * that logically contains a <em>data source name</em> and a
+     * <em>data source property name</em>; must not be {@code null}
+     *
+     * @return a non-{@code null} {@link Matcher}
+     *
+     * @see #getDataSourceName(Matcher)
+     *
+     * @see #getDataSourcePropertyName(Matcher)
+     */
+    protected abstract Matcher getDataSourcePropertyPatternMatcher(String configPropertyName);
+
+    /**
+     * Given a {@link Matcher} that has been produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method, returns
+     * the relevant data source name.
+     *
+     * <p>Implementations of this method may return {@code null}.</p>
+     *
+     * @param dataSourcePropertyPatternMatcher a {@link Matcher}
+     * produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method; must not
+     * be {@code null}
+     *
+     * @return a data source name, or {@code null}
+     *
+     * @see #getDataSourcePropertyPatternMatcher(String)
+     */
+    protected abstract String getDataSourceName(Matcher dataSourcePropertyPatternMatcher);
+
+    /**
+     * Given a {@link Matcher} that has been produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method, returns
+     * the relevant data source property name.
+     *
+     * <p>Implementations of this method may return {@code null}.</p>
+     *
+     * @param dataSourcePropertyPatternMatcher a {@link Matcher}
+     * produced by the {@link
+     * #getDataSourcePropertyPatternMatcher(String)} method; must not
+     * be {@code null}
+     *
+     * @return a data source property name, or {@code null}
+     *
+     * @see #getDataSourcePropertyPatternMatcher(String)
+     */
+    protected abstract String getDataSourcePropertyName(Matcher dataSourcePropertyPatternMatcher);
+
+    /**
+     * Called to permit subclasses to add a {@link DataSource}-typed
+     * bean using the supplied {@link BeanConfigurator}.
+     *
+     * <p>Implementations of this method will be called from an
+     * observer method that is observing the {@link
+     * AfterBeanDiscovery} container lifecycle event.</p>
+     *
+     * @param beanConfigurator the {@link BeanConfigurator} to use to
+     * actually add a new bean; must not be {@code null}
+     *
+     * @param name a {@link Named} instance qualifying the {@link
+     * DataSource}-typed bean to be added; may be {@code null}
+     *
+     * @param properties a {@link Properties} instance containing
+     * properties relevant to the data source; must not be {@code
+     * null}
+     */
+    protected abstract void addBean(BeanConfigurator<DataSource> beanConfigurator,
+                                    Named name,
+                                    Properties properties);
+
+    /**
+     * Returns the {@link Config} instance used to acquire
+     * configuration property values.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * @return a non-{@code null} {@link Config} instance
+     *
+     * @see Config
+     */
+    protected final Config getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Returns a {@link Set} of data source names known to this {@link
+     * AbstractDataSourceExtension} implementation.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>The {@link Set} returned by this method is {@linkplain
+     * Collections#unmodifiableSet(Set) unmodifiable}.</p>
+     *
+     * @return a non-{@code null}, {@linkplain
+     * Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>}
+     * of known data source names
+     */
+    protected final Set<String> getDataSourceNames() {
+        return Collections.unmodifiableSet(this.masterProperties.keySet());
+    }
+
+    /**
+     * Adds additional synthesized properties to an internal map of
+     * data source properties whose contents will be processed
+     * eventually by the {@link #addBean(BeanConfigurator, Named,
+     * Properties)} method.
+     *
+     * <p>This method may return {@code null}.</p>
+     *
+     * @param dataSourceName the name of the data source under which
+     * the supplied {@link Properties} will be indexed; may be {@code
+     * null}
+     *
+     * @param properties the {@link Properties} to put; may be {@code null}
+     *
+     * @return the prior {@link Properties} indexed under the supplied
+     * {@code dataSourceName}, or {@code null}
+     */
+    protected final Properties putDataSourceProperties(final String dataSourceName, final Properties properties) {
+        return this.masterProperties.put(dataSourceName, properties);
+    }
+
+    private void initializeMasterProperties(@Observes final BeforeBeanDiscovery event) {
+        final Set<? extends String> allPropertyNames = this.getPropertyNames();
+        if (allPropertyNames != null && !allPropertyNames.isEmpty()) {
+            for (final String propertyName : allPropertyNames) {
+                final Optional<String> propertyValue = this.config.getOptionalValue(propertyName, String.class);
+                if (propertyValue != null && propertyValue.isPresent()) {
+                    final Matcher matcher = this.getDataSourcePropertyPatternMatcher(propertyName);
+                    if (matcher != null && matcher.matches()) {
+                        final String dataSourceName = this.getDataSourceName(matcher);
+                        Properties properties = this.masterProperties.get(dataSourceName);
+                        if (properties == null) {
+                            properties = new Properties();
+                            this.masterProperties.put(dataSourceName, properties);
+                        }
+                        final String dataSourcePropertyName = this.getDataSourcePropertyName(matcher);
+                        properties.setProperty(dataSourcePropertyName, propertyValue.get());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns a {@link Set} of all known configuration property names.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>The {@link Set} returned by this method is {@linkplain
+     * Collections#unmodifiableSet(Set) unmodifiable}.</p>
+     *
+     * <p>The {@link Set} returned by this method is not safe for
+     * concurrent use by multiple threads.</p>
+     *
+     * <p>Any other semantics of the {@link Set} returned by this
+     * method are governed by the <a
+     * href="https://github.com/eclipse/microprofile-config"
+     * target="_parent">MicroProfile Config</a> specification.</p>
+     *
+     * @return a non-{@code null}, {@linkplain
+     * Collections#unmodifiableSet(Set) unmodifiable <code>Set</code>}
+     * of all known configuration property names
+     *
+     * @see Config#getConfigSources()
+     *
+     * @see ConfigSource#getPropertyNames()
+     */
+    protected final Set<String> getPropertyNames() {
+        // The MicroProfile Config specification does not say whether
+        // property names must be cached or must not be cached
+        // (https://github.com/eclipse/microprofile-config/issues/370).
+        // It is implied in the MicroProfile Google group
+        // (https://groups.google.com/d/msg/microprofile/tvjgSR9qL2Q/M2TNUQrOAQAJ),
+        // but not in the specification, that ConfigSources can be
+        // mutable and dynamic.  Consequently one would expect their
+        // property names to come and go.  Because of this we have to
+        // make sure to get all property names from all ConfigSources
+        // "by hand".
+        //
+        // (The MicroProfile Config specification also does not say
+        // whether a ConfigSource is thread-safe
+        // (https://github.com/eclipse/microprofile-config/issues/369),
+        // so iteration over its coming-and-going dynamic property
+        // names may be problematic, but there's nothing we can do.)
+        //
+        // As of this writing, the Helidon MicroProfile Config
+        // implementation caches all property names up front, which
+        // may not be correct, but is also not forbidden.
+        final Set<String> returnValue;
+        final Set<String> propertyNames = getPropertyNames(this.config.getConfigSources());
+        if (propertyNames == null || propertyNames.isEmpty()) {
+            returnValue = Collections.emptySet();
+        } else {
+            returnValue = Collections.unmodifiableSet(propertyNames);
+        }
+        return returnValue;
+    }
+
+    private static Set<String> getPropertyNames(final Iterable<? extends ConfigSource> configSources) {
+        final Set<String> returnValue = new HashSet<>();
+        if (configSources != null) {
+            for (final ConfigSource configSource : configSources) {
+                if (configSource != null) {
+                    final Set<String> configSourcePropertyNames = configSource.getPropertyNames();
+                    if (configSourcePropertyNames != null && !configSourcePropertyNames.isEmpty()) {
+                        returnValue.addAll(configSourcePropertyNames);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableSet(returnValue);
+    }
+
+    private void afterBeanDiscovery(@Observes final AfterBeanDiscovery event) {
+        if (event != null) {
+            final Set<? extends Entry<? extends String, ? extends Properties>> masterPropertiesEntries =
+                this.masterProperties.entrySet();
+            if (masterPropertiesEntries != null && !masterPropertiesEntries.isEmpty()) {
+                for (final Entry<? extends String, ? extends Properties> entry : masterPropertiesEntries) {
+                    if (entry != null) {
+                        this.addBean(event.addBean(), NamedLiteral.of(entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+        }
+        this.masterProperties.clear();
+    }
+
+}

--- a/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/package-info.java
+++ b/integrations/cdi/datasource/src/main/java/io/helidon/integrations/datasource/cdi/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces to assist in the development of
+ * {@link javax.sql.DataSource}-related CDI portable extensions.
+ *
+ * @see
+ * io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension
+ */
+package io.helidon.integrations.datasource.cdi;

--- a/integrations/cdi/pom.xml
+++ b/integrations/cdi/pom.xml
@@ -32,7 +32,9 @@
     <name>Helidon CDI Integrations</name>
 
     <modules>
+        <module>datasource</module>
         <module>datasource-hikaricp</module>
+        <module>datasource-ucp</module>
         <module>eclipselink-cdi</module>
         <module>jedis-cdi</module>
         <module>jpa-cdi</module>

--- a/integrations/serviceconfiguration/pom.xml
+++ b/integrations/serviceconfiguration/pom.xml
@@ -38,6 +38,9 @@
         <module>serviceconfiguration-hikaricp</module>
         <module>serviceconfiguration-hikaricp-accs</module>
         <module>serviceconfiguration-hikaricp-localhost</module>
+        <module>serviceconfiguration-ucp</module>
+        <module>serviceconfiguration-ucp-accs</module>
+        <module>serviceconfiguration-ucp-localhost</module>
         <module>serviceconfiguration-system-kubernetes</module>
         <module>serviceconfiguration-system-oracle-accs</module>
     </modules>

--- a/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-hikaricp-accs/pom.xml
@@ -74,6 +74,9 @@
             <releases>
                 <enabled>true</enabled>
             </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 </project>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-ucp-accs</artifactId>
+    <name>Helidon ServiceConfiguration UCP ACCS</name>
+
+    <dependencies>
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>com.h2database</groupId>
+          <artifactId>h2</artifactId>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>com.oracle.jdbc</groupId>
+          <artifactId>ojdbc8</artifactId>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+
+        <dependency>
+          <groupId>mysql</groupId>
+          <artifactId>mysql-connector-java</artifactId>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>helidon-serviceconfiguration-ucp</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+  </dependencies>
+
+</project>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/java/io/helidon/service/configuration/ucp/accs/UCPServiceConfigurationACCSProvider.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/java/io/helidon/service/configuration/ucp/accs/UCPServiceConfigurationACCSProvider.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp.accs;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.sql.DataSource; // for javadoc only
+
+import io.helidon.service.configuration.api.System;
+import io.helidon.service.configuration.ucp.UCPServiceConfiguration;
+import io.helidon.service.configuration.ucp.UCPServiceConfigurationProvider;
+
+/**
+ * A {@link UCPServiceConfigurationProvider} that provides {@link
+ * UCPServiceConfiguration} instances when running on the <a
+ * href="https://docs.oracle.com/en/cloud/paas/app-container-cloud/index.html">Oracle
+ * Application Container Cloud Service</a> {@linkplain System system}.
+ *
+ * @see UCPServiceConfiguration
+ *
+ * @see UCPServiceConfigurationProvider
+ */
+public class UCPServiceConfigurationACCSProvider extends UCPServiceConfigurationProvider {
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link UCPServiceConfigurationACCSProvider}.
+   */
+  public UCPServiceConfigurationACCSProvider() {
+    super();
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * Overrides the {@link
+   * UCPServiceConfigurationProvider#appliesTo(Properties,
+   * System, Properties)} method to return {@code true} if the
+   * supplied {@link System} {@linkplain System#isEnabled() is
+   * enabled} and has a {@linkplain System#getName() name} equal to
+   * {@code accs}, and if its {@linkplain System#getenv() environment}
+   * contains at least one key starting with either {@code MYSQLCS_}
+   * or {@code DBAAS_}, and if the {@link
+   * UCPServiceConfigurationProvider#appliesTo(Properties,
+   * System, Properties)} method also returns {@code true}.
+   *
+   * @param properties a {@link Properties} instance that will be used
+   * as the basis of the {@link UCPServiceConfiguration}
+   * implementation that will be returned by the {@link
+   * #create(Properties, System, Properties)} method; must not be
+   * {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return {@code true} if this {@link
+   * UCPServiceConfigurationACCSProvider} applies to the
+   * configuration space implied by the supplied parameters; {@code
+   * false} otherwise
+   *
+   * @exception NullPointerException if {@code properties} is {@code null}
+   */
+  @Override
+  protected boolean appliesTo(final Properties properties, final System system, final Properties coordinates) {
+    Objects.requireNonNull(properties);
+    boolean returnValue = false;
+    if (system != null && system.isEnabled() && "accs".equalsIgnoreCase(system.getName())) {
+      final Map<? extends String, ? extends String> env = system.getenv();
+      if (env != null && !env.isEmpty()) {
+        final Set<? extends String> keys = env.keySet();
+        if (keys != null && !keys.isEmpty()) {
+          boolean dbaas = false;
+          boolean mysqlcs = false;
+          for (final String key : keys) {
+            if (key != null) {
+              if (dbaas) {
+                if (mysqlcs || key.startsWith("MYSQLCS_")) {
+                  mysqlcs = true;
+                  break;
+                }
+              } else if (mysqlcs) {
+                if (key.startsWith("DBAAS_")) {
+                  dbaas = true;
+                  break;
+                }
+              } else if (key.startsWith("DBAAS_")) {
+                dbaas = true;
+              } else if (key.startsWith("MYSQLCS_")) {
+                mysqlcs = true;
+              }
+            }
+          }
+          if (dbaas) {
+            if (mysqlcs) {
+              // We deliberately get out of the business of trying to
+              // pick among competing service bindings.
+              returnValue = false;
+            } else {
+              returnValue = super.appliesTo(properties, system, coordinates);
+            }
+          } else if (mysqlcs) {
+            returnValue = super.appliesTo(properties, system, coordinates);
+          } else {
+            returnValue = false;
+          }
+        }
+      }
+    }
+    return returnValue;
+  }
+
+  /**
+   * Overrides the {@link
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)} to install data source-related
+   * properties discovered in the <a
+   * href="https://docs.oracle.com/en/cloud/paas/app-container-cloud/csjse/exploring-application-deployments-page.html#GUID-843F7013-B6FA-45E0-A9D3-29A0EFD53E11">Oracle
+   * Application Container Cloud Service environment</a>.
+   *
+   * <p>While reading the documentation for this method, note that the
+   * Oracle Application Container Cloud Service sets up automatic
+   * service bindings for only Oracle or MySQL databases.</p>
+   *
+   * <p>This method:</p>
+   *
+   * <ol>
+   *
+   * <li>Calls the {@link
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)} method.</li>
+   *
+   * <li>Checks to see if a property named {@code
+   * javax.sql.DataSource.}<em>{@code dataSourceName}</em>{@code
+   * .explicitlyConfigured} has a {@link String} value equal to
+   * anything other than {@code true}, including {@code null}.</li>
+   *
+   * <li>If so, <strong>and only if {@code dataSourceName} is {@code
+   * null}</strong>, then it {@linkplain
+   * Properties#setProperty(String, String) sets} certain properties
+   * on {@code target}.</li>
+   *
+   * <li>Specifically, if there is a MySQL service binding and not an
+   * Oracle database service binding, the following properties will be
+   * set:
+   *
+   * <ol>
+   *
+   * <li>{@code javax.sql.DataSource.dataSourceClassName =
+   * com.mysql.cj.jdbc.MysqlDataSource}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.url =
+   * jdbc:mysql://${MYSQLCS_CONNECT_STRING}}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.description =
+   * Autodiscovered}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.user =
+   * ${MYSQLCS_USER_NAME}}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.password =
+   * ${MYSQLCS_PASSWORD}}</li>
+   *
+   * </ol></li>
+   *
+   * <li>If instead there is an Oracle database service binding, but
+   * not also a MySQL service binding, the following properties will
+   * be set:
+   *
+   * <ol>
+   *
+   * <li>{@code javax.sql.DataSource.dataSourceClassName =
+   * oracle.jdbc.pool.OracleDataSource}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.url =
+   * jdbc:oracle:thin:@//${DBAAS_DEFAULT_CONNECT_DESCRIPTOR}}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.description =
+   * Autodiscovered}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.user =
+   * ${DBAAS_USER}}</li>
+   *
+   * <li>{@code javax.sql.DataSource.dataSource.password =
+   * ${DBAAS_PASSWORD}}</li>
+   *
+   * </ol></li>
+   *
+   * </ol>
+   *
+   * @param target a {@link Properties} instance that will be used as
+   * the basis of the {@link UCPServiceConfiguration}
+   * implementation that will be returned by the {@link
+   * #create(Properties, System, Properties)} method and into which
+   * properties may be installed; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @param dataSourceName the data source name in question; may be
+   * {@code null}
+   *
+   * @exception NullPointerException if {@code target} is {@code null}
+   *
+   * @see
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)
+   */
+  @Override
+  protected void installDataSourceProperties(final Properties target,
+                                             final System system,
+                                             final Properties coordinates,
+                                             String dataSourceName) {
+    Objects.requireNonNull(target);
+    super.installDataSourceProperties(target, system, coordinates, dataSourceName);
+
+    if (!"true".equalsIgnoreCase(this.getDataSourceProperty(target,
+                                                            system,
+                                                            coordinates,
+                                                            dataSourceName,
+                                                            "explicitlyConfigured"))) {
+      final String prefix = this.getPrefix();
+      assert prefix != null;
+      assert !prefix.isEmpty();
+
+      // For future reference, see also:
+      // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html
+      // and
+      // https://docs.oracle.com/database/121/JAJDB/oracle/jdbc/pool/OracleDataSource.html.
+
+      final String dataSourceClassName;
+      final String description;
+      final String url;
+      final String urlValue = getJdbcUrl(system, dataSourceName);
+      final String user;
+      final String password;
+      if (dataSourceName == null) {
+        dataSourceClassName = prefix + ".dataSourceClassName";
+        description = prefix + ".dataSource.description";
+        url = prefix + ".dataSource.url";
+        user = prefix + ".dataSource.user";
+        password = prefix + ".dataSource.password";
+      } else {
+        dataSourceName = dataSourceName.trim();
+        if (dataSourceName.isEmpty()) {
+          dataSourceClassName = prefix + ".dataSourceClassName";
+          description = prefix + ".dataSource.description";
+          url = prefix + ".dataSource.url";
+          user = prefix + ".dataSource.user";
+          password = prefix + ".dataSource.password";
+        } else {
+          dataSourceClassName = prefix + "." + dataSourceName + ".dataSourceClassName";
+          description = prefix + "." + dataSourceName + ".dataSource.description";
+          url = prefix + "." + dataSourceName + ".dataSource.url";
+          user = prefix + "." + dataSourceName + ".dataSource.user";
+          password = prefix + "." + dataSourceName + ".dataSource.password";
+        }
+      }
+
+      target.setProperty(dataSourceClassName, getDataSourceClassName(urlValue));
+      target.setProperty(url, urlValue);
+      target.setProperty(description, "Autodiscovered");
+      target.setProperty(user, getUser(system, dataSourceName));
+      target.setProperty(password, getPassword(system, dataSourceName));
+    }
+  }
+
+  /**
+   * Returns the name of a Java class that implements the {@link
+   * DataSource} interface that is appropriate for the supplied JDBC
+   * URL.
+   *
+   * <p>This method may return {@code null}.</p>
+   *
+   * <p>Overrides of this method may return {@code null}.</p>
+   *
+   * <p>Overrides of this method must return the same value for the
+   * same input.</p>
+   *
+   * <p>This implementation returns {@code
+   * com.mysql.cj.jdbc.MysqlDataSource} if the supplied {@code
+   * jdbcUrl} starts with {@code jdbc:mysql:}, and returns {@code
+   * oracle.jdbc.pool.OracleDataSource} if the supplied {@code
+   * jdbcUrl} starts with {@code jdbc:oracle:}, and {@code null} in
+   * all other cases.</p>
+   *
+   * @param jdbcUrl a JDBC URL in {@link String} form; must not be
+   * {@code null}
+   *
+   * @return a {@link DataSource} implementation class name, or {@code
+   * null}
+   *
+   * @exception NullPointerException if {@code jdbcUrl} is {@code
+   * null}
+   */
+  protected String getDataSourceClassName(final String jdbcUrl) {
+    Objects.requireNonNull(jdbcUrl);
+    String returnValue = null;
+    if (jdbcUrl.startsWith("jdbc:") && jdbcUrl.length() > "jdbc:".length()) {
+      final int colonIndex = jdbcUrl.indexOf(':', "jdbc:".length());
+      if (colonIndex > 0) {
+        final String type = jdbcUrl.substring("jdbc:".length(), colonIndex);
+        assert type != null;
+        assert !type.isEmpty();
+        switch (type) {
+        case "mysql":
+          returnValue = "com.mysql.cj.jdbc.MysqlDataSource";
+          break;
+        case "oracle":
+          returnValue = "oracle.jdbc.pool.OracleDataSource";
+          break;
+        default:
+          break;
+        }
+      }
+    }
+    return returnValue;
+  }
+
+  private static String getUser(final System system, final String suppliedDataSourceName) {
+    String returnValue = null;
+    if (system != null) {
+
+      final Map<?, ? extends String> env = system.getenv();
+      assert env != null;
+
+      String dataSourceName = null;
+      if (suppliedDataSourceName != null) {
+        dataSourceName = suppliedDataSourceName.trim().toUpperCase();
+        if (dataSourceName.isEmpty()) {
+          dataSourceName = null;
+        }
+      }
+
+      if (dataSourceName == null) {
+        if (env.containsKey("DBAAS_USER")) {
+          if (!env.containsKey("MYSQLCS_USER_NAME")) {
+            returnValue = env.get("DBAAS_USER");
+          }
+        } else if (env.containsKey("MYSQLCS_USER_NAME")) {
+          returnValue = env.get("MYSQLCS_USER_NAME");
+        }
+      } else if (env.containsKey("DBAAS_" + dataSourceName + "_USER")) {
+        if (!env.containsKey("MYSQLCS_" + dataSourceName + "_USER_NAME")) {
+          returnValue = env.get("DBAAS_" + dataSourceName + "_USER");
+        }
+      } else if (env.containsKey("MYSQLCS_ " + dataSourceName + "_USER_NAME")) {
+        returnValue = env.get("MYSQLCS_" + dataSourceName + "_USER_NAME");
+      }
+    }
+    return returnValue;
+  }
+
+  private static String getPassword(final System system, final String suppliedDataSourceName) {
+    String returnValue = null;
+    if (system != null) {
+
+      final Map<?, ? extends String> env = system.getenv();
+      assert env != null;
+
+      String dataSourceName = null;
+      if (suppliedDataSourceName != null) {
+        dataSourceName = suppliedDataSourceName.trim().toUpperCase();
+        if (dataSourceName.isEmpty()) {
+          dataSourceName = null;
+        }
+      }
+
+      if (dataSourceName == null) {
+        if (env.containsKey("DBAAS_PASSWORD")) {
+          if (!env.containsKey("MYSQLCS_USER_PASSWORD")) {
+            returnValue = env.get("DBAAS_PASSWORD");
+          }
+        } else if (env.containsKey("MYSQLCS_USER_PASSWORD")) {
+          returnValue = env.get("MYSQLCS_USER_PASSWORD");
+        }
+      } else if (env.containsKey("DBAAS_" + dataSourceName + "_PASSWORD")) {
+        if (!env.containsKey("MYSQLCS_" + dataSourceName + "_USER_PASSWORD")) {
+          returnValue = env.get("DBAAS_" + dataSourceName + "_PASSWORD");
+        }
+      } else if (env.containsKey("MYSQLCS_ " + dataSourceName + "_USER_PASSWORD")) {
+        returnValue = env.get("MYSQLCS_" + dataSourceName + "_USER_PASSWORD");
+      }
+    }
+    return returnValue;
+  }
+
+  private static String getJdbcUrl(final System system, final String suppliedDataSourceName) {
+    String returnValue = null;
+    if (system != null) {
+
+      final Map<?, ? extends String> env = system.getenv();
+      assert env != null;
+
+      String dataSourceName = null;
+      if (suppliedDataSourceName != null) {
+        dataSourceName = suppliedDataSourceName.trim().toUpperCase();
+        if (dataSourceName.isEmpty()) {
+          dataSourceName = null;
+        }
+      }
+
+      if (dataSourceName == null) {
+        if (env.containsKey("DBAAS_DEFAULT_CONNECT_DESCRIPTOR")) {
+          if (!env.containsKey("MYSQLCS_CONNECT_STRING")) {
+            returnValue = "jdbc:oracle:thin:@//" + env.get("DBAAS_DEFAULT_CONNECT_DESCRIPTOR");
+          }
+        } else if (env.containsKey("MYSQLCS_CONNECT_STRING")) {
+          returnValue = "jdbc:mysql://" + env.get("MYSQLCS_CONNECT_STRING");
+        }
+      } else if (env.containsKey("DBAAS_" + dataSourceName + "_CONNECT_DESCRIPTOR")) {
+        if (!env.containsKey("MYSQLCS_" + dataSourceName + "_URL")) {
+          returnValue = "jdbc:oracle:thin:@//" + env.get("DBAAS_" + dataSourceName + "_CONNECT_DESCRIPTOR");
+        }
+      } else if (env.containsKey("MYSQLCS_ " + dataSourceName + "_CONNECT_STRING")) {
+        returnValue = "jdbc:mysql://" + env.get("MYSQLCS_" + dataSourceName + "_CONNECT_STRING");
+      }
+
+    }
+    return returnValue;
+  }
+
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/java/io/helidon/service/configuration/ucp/accs/package-info.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/java/io/helidon/service/configuration/ucp/accs/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces for automatically discovering
+ * service configuration information relevant to <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/12.2/jjucp/toc.htm"
+ * target="_parent">Oracle Universal Connection Pool</a> componentry
+ * when running on the <a
+ * href="https://docs.oracle.com/en/cloud/paas/app-container-cloud/csjse/exploring-application-deployments-page.html#GUID-843F7013-B6FA-45E0-A9D3-29A0EFD53E11"
+ * target="_parent">Oracle Application Cloud Container Service</a>
+ * system.
+ *
+ * @see
+ * io.helidon.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider
+ */
+package io.helidon.service.configuration.ucp.accs;

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/javadoc/overview.html
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/javadoc/overview.html
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<body>
+  <p>Provides classes and interfaces for auto-discovering
+     configuration for
+     the <a href="https://docs.oracle.com/en/database/oracle/oracle-database/12.2/jjucp/toc.htm"
+     target="_parent">Oracle Universal Connection Pool</a>
+     <a href="https://docs.oracle.com/en/cloud/paas/app-container-cloud/csjse/exploring-application-deployments-page.html#GUID-843F7013-B6FA-45E0-A9D3-29A0EFD53E11"
+     target="_parent">when running on the Oracle Application Container
+     Cloud Service</a> system.</p>
+
+    @see com.oracle.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider
+</body>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
@@ -1,0 +1,2 @@
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+io.helidon.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
@@ -1,2 +1,14 @@
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 io.helidon.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/test/java/io/helidon/service/configuration/ucp/accs/TestPropertiesScenarios.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/test/java/io/helidon/service/configuration/ucp/accs/TestPropertiesScenarios.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp.accs;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.helidon.service.configuration.api.ServiceConfiguration;
+import io.helidon.service.configuration.api.System;
+import io.helidon.service.configuration.ucp.UCPServiceConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class TestPropertiesScenarios {
+
+  public TestPropertiesScenarios() {
+    super();
+  }
+
+  @Test
+  public void testBareBones() {
+    final ServiceConfiguration sc = ServiceConfiguration.getInstance("ucp");
+    assertNull(sc);
+  }
+
+  @Test
+  public void testACCSSystem() {
+    final Map<String, String> env = new HashMap<>();
+    env.put("MYSQLCS_CONNECT_STRING", "TODO");
+    env.put("MYSQLCS_USER_NAME", "sa");
+    env.put("MYSQLCS_USER_PASSWORD", "sa");
+    final System dummyAccsSystem = new System("accs", true) {
+        @Override
+        public final boolean isEnabled() {
+          return true;
+        }
+
+        @Override
+        public final Map<String, String> getenv() {
+          return env;
+        }
+      };
+    final UCPServiceConfigurationACCSProvider provider = new UCPServiceConfigurationACCSProvider();
+    final ServiceConfiguration sc = provider.buildFor(Collections.singleton(dummyAccsSystem), null);
+    assertNotNull(sc);
+    assertEquals("jdbc:mysql://TODO", sc.getProperty("javax.sql.DataSource.dataSource.url"));
+    
+  }
+  
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-ucp-localhost</artifactId>
+    <name>Helidon ServiceConfiguration UCP Localhost</name>
+
+    <dependencies>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.h2database</groupId>
+          <artifactId>h2</artifactId>
+          <scope>compile</scope>
+      </dependency>
+      <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>helidon-serviceconfiguration-ucp</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+      </dependency>
+  </dependencies>
+
+</project>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/UCPServiceConfigurationLocalhost.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/UCPServiceConfigurationLocalhost.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp.localhost;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import io.helidon.service.configuration.api.System;
+import io.helidon.service.configuration.ucp.UCPServiceConfiguration;
+
+/**
+ * A {@link UCPServiceConfiguration} that can dynamically add
+ * data source properties when they are requested.
+ *
+ * @see #getProperty(String, String)
+ *
+ * @see UCPServiceConfigurationLocalhostProvider
+ *
+ * @see UCPServiceConfiguration
+ */
+public class UCPServiceConfigurationLocalhost extends UCPServiceConfiguration {
+
+
+  /*
+   * Instance fields.
+   */
+
+
+  /**
+   * The {@link UCPServiceConfigurationLocalhostProvider} that
+   * {@linkplain
+   * io.helidon.service.configuration.ucp.UCPServiceConfigurationProvider#buildFor(Set,
+   * Properties) built} this {@link UCPServiceConfigurationLocalhost}.
+   *
+   * <p>This field is never {@code null}.</p>
+   *
+   * @see
+   * #UCPServiceConfigurationLocalhost(io.helidon.service.configuration.ucp.UCPServiceConfigurationLocalhostProvider,
+   * Properties, System, Properties)
+   */
+  private final UCPServiceConfigurationLocalhostProvider provider;
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link UCPServiceConfigurationLocalhost}.
+   *
+   * @param provider the {@link
+   * UCPServiceConfigurationLocalhostProvider} that {@linkplain
+   * io.helidon.service.configuration.ucp.UCPServiceConfigurationProvider#buildFor(Set,
+   * Properties) is building} this {@link
+   * UCPServiceConfigurationLocalhost}; must not be {@code null}
+   *
+   * @param properties a {@link Properties} instance that will be used
+   * as the basis of this implementation; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @exception NullPointerException if {@code provider} or {@code
+   * properties} is {@code null}
+   *
+   * @see UCPServiceConfigurationLocalhostProvider
+   */
+  public UCPServiceConfigurationLocalhost(final UCPServiceConfigurationLocalhostProvider provider,
+                                               final Properties properties,
+                                               final System system,
+                                               final Properties coordinates) {
+    super(Objects.requireNonNull(properties), system, coordinates);
+    this.provider = Objects.requireNonNull(provider);
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * Overrides the {@link UCPServiceConfiguration#getProperty(String,
+   * String)} method to return a value for the supplied {@code
+   * propertyName}, and, if one is not found and the {@code
+   * propertyName} parameter value starts with {@code
+   * javax.sql.Datasource.}, to "just-in-time" install certain
+   * properties related to the data source in question, before
+   * attempting its retrieval again.
+   *
+   * <p>This method may return {@code null} if {@code defaultValue} is
+   * {@code null}.</p>
+   *
+   * <p>Overrides of this method may return {@code null}.</p>
+   *
+   * @param propertyName the name of the property in question; must
+   * not be {@code null}
+   *
+   * @param defaultValue the value to return if all attempts to
+   * retrieve a property value fail; may be {@code null}
+   *
+   * @return a value for the property named by the supplied {@code
+   * propertyName}, or {@code defaultValue} if no such value exists
+   * and none could be generated
+   *
+   * @exception NullPointerException if {@code propertyName} is {@code
+   * null}
+   *
+   * @see
+   * UCPServiceConfigurationLocalhostProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)
+   */
+  @Override
+  public String getProperty(final String propertyName, final String defaultValue) {
+    String returnValue = this.properties.getProperty(Objects.requireNonNull(propertyName));
+    if (returnValue == null) {
+      final String prefix = this.provider.getPrefix();
+      assert prefix != null;
+      assert !prefix.isEmpty();
+      if (propertyName.startsWith(prefix + ".")) {
+        String dataSourceName = this.provider.extractDataSourceName(propertyName);
+        if (dataSourceName != null) {
+          dataSourceName = dataSourceName.trim();
+          if (!dataSourceName.isEmpty()) {
+            this.provider.installDataSourceProperties(this.properties, this.system, this.coordinates, dataSourceName);
+            returnValue = this.properties.getProperty(propertyName);
+          }
+        }
+      }
+    }
+    return returnValue;
+  }
+
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/UCPServiceConfigurationLocalhostProvider.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/UCPServiceConfigurationLocalhostProvider.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp.localhost;
+
+import java.util.Objects;
+import java.util.Properties;
+
+import io.helidon.service.configuration.api.System;
+import io.helidon.service.configuration.localhost.LocalhostSystem;
+import io.helidon.service.configuration.ucp.UCPServiceConfiguration;
+import io.helidon.service.configuration.ucp.UCPServiceConfigurationProvider;
+
+/**
+ * A {@link UCPServiceConfigurationProvider} that {@linkplain
+ * #installDataSourceProperties(Properties, System, Properties,
+ * String) automatically creates} <a
+ * href="http://www.h2database.com/html/features.html#in_memory_databases">in-memory
+ * H2 databases</a> as needed.
+ *
+ * @see #installDataSourceProperties(Properties, System, Properties, String)
+ *
+ * @see UCPServiceConfigurationLocalhost
+ *
+ * @see UCPServiceConfigurationProvider
+ */
+public class UCPServiceConfigurationLocalhostProvider extends UCPServiceConfigurationProvider {
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link UCPServiceConfigurationProvider}.
+   */
+  public UCPServiceConfigurationLocalhostProvider() {
+    super();
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * Overrides the {@link
+   * UCPServiceConfigurationProvider#create(Properties, System,
+   * Properties)} method to return a new {@link
+   * UCPServiceConfigurationLocalhost} instance when invoked.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>Overrides of this method must not return {@code null}.</p>
+   *
+   * <p>This method returns a new {@link
+   * UCPServiceConfigurationLocalhost} instance with each
+   * invocation.</p>
+   *
+   * <p>Overrides of this method must return a new {@link
+   * UCPServiceConfiguration} implementation of some kind.</p>
+   *
+   * @param properties a {@link Properties} instance that will be used
+   * as the basis of the {@link UCPServiceConfigurationLocalhost}
+   * implementation that will be returned; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return a new {@link UCPServiceConfigurationLocalhost}
+   * instance; never {@code null}
+   *
+   * @exception NullPointerException if {@code properties} is {@code
+   * null}
+   */
+  @Override
+  protected UCPServiceConfiguration create(final Properties properties, final System system, final Properties coordinates) {
+    return new UCPServiceConfigurationLocalhost(this, Objects.requireNonNull(properties), system, coordinates);
+  }
+
+  /**
+   * Overrides the {@link
+   * UCPServiceConfigurationProvider#appliesTo(Properties, System,
+   * Properties)} method to return {@code true} if the supplied {@link
+   * System} is {@linkplain System#isEnabled() enabled} and an
+   * instance of {@link LocalhostSystem} and if the {@linkplain
+   * UCPServiceConfigurationProvider#appliesTo(Properties, System,
+   * Properties)} method returns {@code true}.
+   *
+   * @param properties a {@link Properties} instance that will be used
+   * as the basis of the {@link UCPServiceConfigurationLocalhost}
+   * implementation that will be returned by the {@link
+   * #create(Properties, System, Properties)} method; must not be
+   * {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return {@code true} if this {@link
+   * UCPServiceConfigurationLocalhostProvider} applies to the
+   * configuration space implied by the supplied parameters; {@code
+   * false} otherwise
+   *
+   * @see UCPServiceConfigurationProvider#appliesTo(Properties,
+   * System, Properties)
+   */
+  @Override
+  protected boolean appliesTo(final Properties properties, final System system, final Properties coordinates) {
+    Objects.requireNonNull(properties);
+    final boolean returnValue =
+      system instanceof LocalhostSystem && system.isEnabled() && super.appliesTo(properties, system, coordinates);
+    return returnValue;
+  }
+
+  /**
+   * Overrides the {@link
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)} method to automatically create <a
+   * href="http://www.h2database.com/html/features.html#in_memory_databases">in-memory
+   * H2 databases</a> as needed.
+   *
+   * <p>Specifically, this method:</p>
+   *
+   * <ol>
+   *
+   * <li>Calls the {@link
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)} method with the supplied
+   * parameters.</li>
+   *
+   * <li>Checks to see if a property named {@code
+   * javax.sql.DataSource.}<em>{@code dataSourceName}</em>{@code
+   * .explicitlyConfigured} has a {@link String} value equal to
+   * anything other than {@code true}, including {@code null}.</li>
+   *
+   * <li>If so, then it {@linkplain Properties#setProperty(String,
+   * String) sets} certain properties on {@code target} as
+   * follows:
+   *
+   * <ol>
+   *
+   * <li>{@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .dataSourceClassName =
+   * org.h2.jdbcx.JdbcDataSource}</li>
+   *
+   * <li>{@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .dataSource.description = A local,
+   * transient, in-memory H2 database}</li>
+   *
+   * <li>{@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .dataSource.user = sa}</li>
+   *
+   * <li>{@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .dataSource.password = }</li>
+   *
+   * <li>{@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .dataSourceUrl =
+   * jdbc:h2:mem:}<em>{@code dataSourceName}</em></li>
+   *
+   * </ol></li>
+   *
+   * </ol>
+   *
+   * @param target a {@link Properties} instance that will be used as
+   * the basis of the {@link UCPServiceConfigurationLocalhost}
+   * implementation that will be returned by the {@link
+   * #create(Properties, System, Properties)} method and into which
+   * properties may be installed; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @param dataSourceName the data source name in question; may be
+   * {@code null}
+   *
+   * @exception NullPointerException if {@code target} is {@code null}
+   *
+   * @see
+   * UCPServiceConfigurationProvider#installDataSourceProperties(Properties,
+   * System, Properties, String)
+   */
+  @Override
+  protected void installDataSourceProperties(final Properties target,
+                                             final System system,
+                                             final Properties coordinates,
+                                             String dataSourceName) {
+    Objects.requireNonNull(target);
+    super.installDataSourceProperties(target, system, coordinates, dataSourceName);
+
+    if (!"true".equalsIgnoreCase(this.getDataSourceProperty(target,
+                                                            system,
+                                                            coordinates,
+                                                            dataSourceName,
+                                                            "explicitlyConfigured"))) {
+      final String prefix = this.getPrefix();
+      assert prefix != null;
+      assert !prefix.isEmpty();
+
+      final String dataSourceClassName;
+      final String description;
+      final String url;
+      final String urlValue;
+      final String user;
+      final String password;
+      if (dataSourceName == null) {
+        urlValue = "jdbc:h2:mem:test";
+        dataSourceClassName = prefix + ".dataSourceClassName";
+        description = prefix + ".dataSource.description";
+        url = prefix + ".dataSource.url";
+        user = prefix + ".dataSource.user";
+        password = prefix + ".dataSource.password";
+      } else {
+        dataSourceName = dataSourceName.trim();
+        if (dataSourceName.isEmpty()) {
+          urlValue = "jdbc:h2:mem:test";
+          dataSourceClassName = prefix + ".dataSourceClassName";
+          description = prefix + ".dataSource.description";
+          url = prefix + ".dataSource.url";
+          user = prefix + ".dataSource.user";
+          password = prefix + ".dataSource.password";
+        } else {
+          dataSourceClassName = prefix + "." + dataSourceName + ".dataSourceClassName";
+          description = prefix + "." + dataSourceName + ".dataSource.description";
+          url = prefix + "." + dataSourceName + ".dataSource.url";
+          urlValue = "jdbc:h2:mem:" + dataSourceName;
+          user = prefix + "." + dataSourceName + ".dataSource.user";
+          password = prefix + "." + dataSourceName + ".dataSource.password";
+        }
+      }
+
+      target.setProperty(dataSourceClassName, org.h2.jdbcx.JdbcDataSource.class.getName());
+      target.setProperty(url, urlValue);
+      target.setProperty(description, "A local, transient, in-memory H2 database");
+      target.setProperty(user, "sa");
+      target.setProperty(password, "");
+    }
+  }
+
+  final String extractDataSourceName(final String prefixedProperty) {
+    String returnValue = null;
+    if (prefixedProperty != null && !prefixedProperty.isEmpty()) {
+      final String prefix = this.getPrefix();
+      assert prefix != null;
+      assert !prefix.isEmpty();
+      final String prefixWithDot = prefix + ".";
+      final int prefixWithDotLength = prefixWithDot.length();
+      if (prefixedProperty.startsWith(prefixWithDot) && prefixedProperty.length() > prefixWithDotLength) {
+        final int dotIndex = prefixedProperty.indexOf('.', prefixWithDotLength);
+        if (dotIndex > 0) {
+          returnValue = prefixedProperty.substring(prefixWithDotLength, dotIndex);
+        }
+      }
+    }
+    return returnValue;
+  }
+
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/package-info.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/java/io/helidon/service/configuration/ucp/localhost/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces for automatically discovering
+ * service configuration information relevant to <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+ * target="_parent">Oracle Universal Connection Pool</a> componentry
+ * suitable for local testing environments.
+ *
+ * @see io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhost
+ *
+ * @see io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhostProvider
+ */
+package io.helidon.service.configuration.ucp.localhost;

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/javadoc/overview.html
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/javadoc/overview.html
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<body>
+  <p>Provides classes and interfaces for auto-discovering
+     configuration for
+     the <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+     target="_parent">Oracle Universal Connection Pool</a> suitable
+     for a local testing environment.</p>
+
+  @see io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhost
+
+  @see io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhostProvider
+</body>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
@@ -1,2 +1,14 @@
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhostProvider

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/main/resources/META-INF/services/io.helidon.service.configuration.api.ServiceConfigurationProvider
@@ -1,0 +1,2 @@
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+io.helidon.service.configuration.ucp.localhost.UCPServiceConfigurationLocalhostProvider

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/test/java/io/helidon/service/configuration/ucp/localhost/TestPropertiesScenarios.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-localhost/src/test/java/io/helidon/service/configuration/ucp/localhost/TestPropertiesScenarios.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp.localhost;
+
+import io.helidon.service.configuration.api.ServiceConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TestPropertiesScenarios {
+
+  public TestPropertiesScenarios() {
+    super();
+  }
+
+  @Test
+  public void testBareBones() {
+    final ServiceConfiguration sc = ServiceConfiguration.getInstance("ucp");
+    assertNotNull(sc);
+    assertEquals("jdbc:h2:mem:test", sc.getProperty("javax.sql.DataSource.dataSource.url"));
+  }
+
+  @Test
+  public void testJustInTimePropertyCreation() {
+    final ServiceConfiguration sc = ServiceConfiguration.getInstance("ucp");
+    assertNotNull(sc);
+    assertEquals("jdbc:h2:mem:fred", sc.getProperty("javax.sql.DataSource.fred.dataSource.url"));
+  }
+  
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/pom.xml
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.serviceconfiguration</groupId>
+        <artifactId>helidon-serviceconfiguration-project</artifactId>
+        <version>1.1.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-serviceconfiguration-ucp</artifactId>
+    <name>Helidon ServiceConfiguration UCP Implementation</name>
+
+    <dependencies>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>com.h2database</groupId>
+          <artifactId>h2</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>helidon-serviceconfiguration-api</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+      </dependency>
+  </dependencies>
+
+</project>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/UCPServiceConfiguration.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/UCPServiceConfiguration.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp;
+
+import java.util.Properties;
+import java.util.Set;
+
+import io.helidon.service.configuration.api.ServiceConfiguration;
+import io.helidon.service.configuration.api.ServiceConfigurationProvider; // for javadoc only
+import io.helidon.service.configuration.api.System;
+
+/**
+ * An abstract {@link ServiceConfiguration} implementation that
+ * provides configuration information for <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+ * target="_parent">Oracle Universal Connection Pool</a> componentry.
+ *
+ * @see #UCPServiceConfiguration(Properties, System, Properties)
+ *
+ * @see UCPServiceConfigurationProvider
+ */
+public class UCPServiceConfiguration extends ServiceConfiguration {
+
+
+  /*
+   * Instance fields.
+   */
+
+
+  /**
+   * A {@link Properties} instance supplied {@linkplain
+   * #UCPServiceConfiguration(Properties, System, Properties) at
+   * construction time} containing the property values that will
+   * ultimately be returned by the default implementation of the
+   * {@link #getPropertyNames()} and {@link #getProperty(String,
+   * String)} methods.
+   *
+   * <p>This field is never {@code null}.</p>
+   *
+   * @see #UCPServiceConfiguration(Properties, System,
+   * Properties)
+   */
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected final Properties properties;
+
+  /**
+   * The {@link System} that was determined to be the authoritative
+   * {@link System} at the time this {@link
+   * UCPServiceConfiguration} was {@linkplain
+   * #UCPServiceConfiguration(Properties, System, Properties)
+   * constructed}.
+   *
+   * <p>This field may be {@code null}.</p>
+   *
+   * @see #UCPServiceConfiguration(Properties, System,
+   * Properties)
+   *
+   * @see ServiceConfigurationProvider#buildFor(Set, Properties)
+   */
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected final System system;
+
+  /**
+   * A {@link Properties} instance representing the meta-properties in
+   * effect at the time this {@link UCPServiceConfiguration} was
+   * {@linkplain #UCPServiceConfiguration(Properties, System,
+   * Properties) constructed}.
+   *
+   * <p>This field may be {@code null}.</p>
+   *
+   * @see #UCPServiceConfiguration(Properties, System,
+   * Properties)
+   *
+   * @see ServiceConfigurationProvider#buildFor(Set, Properties)
+   */
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected final Properties coordinates;
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link UCPServiceConfiguration}.
+   *
+   * @param properties a {@link Properties} instance containing the
+   * property values that will ultimately be returned by the default
+   * implementation of the {@link #getPropertyNames()} and {@link
+   * #getProperty(String, String)} methods; may be {@code null}
+   *
+   * @param system the {@link System} that was determined to be the
+   * authoritative {@link System}; may be {@code null}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @see ServiceConfigurationProvider#buildFor(Set, Properties)
+   *
+   * @see ServiceConfigurationProvider#getAuthoritativeSystem(Set, Properties)
+   */
+  protected UCPServiceConfiguration(final Properties properties, final System system, final Properties coordinates) {
+    super("ucp");
+    if (properties == null) {
+      this.properties = new Properties();
+    } else {
+      this.properties = properties;
+    }
+    this.system = system;
+    this.coordinates = coordinates;
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * Returns an {@linkplain java.util.Collections#unmodifiableSet(Set)
+   * unmodifiable} and unchanging {@link Set} of {@link String}s
+   * representing the names of properties whose values may be
+   * retrieved with the {@link #getProperty(String, String)} method.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>Overrides of this method must not return {@code null}.</p>
+   *
+   * <p>Overrides of this method must ensure that the {@link Set}
+   * returned may be used without the end user having to peform
+   * explicit synchronization.</p>
+   *
+   * <p>This method and its overrides, if any, may return the same
+   * {@link Set} instance with each invocation, or different {@link
+   * Set} instances with different contents.</p>
+   *
+   * @return an {@linkplain java.util.Collections#unmodifiableSet(Set)
+   * unmodifiable} and unchanging {@link Set} of {@link String}s
+   * representing the names of properties whose values may be
+   * retrieved with the {@link #getProperty(String, String)} method
+   *
+   * @see #getProperty(String, String)
+   */
+  @Override
+  public Set<String> getPropertyNames() {
+    return this.properties.stringPropertyNames();
+  }
+
+  /**
+   * Returns a value for the property described by the supplied {@code
+   * propertyName}, or the value of the supplied {@code defaultValue}
+   * parameter if no such property value exists.
+   *
+   * <p>This method will return {@code null} if {@code defaultValue}
+   * is {@code null}.
+   *
+   * <p>Overrides of this method may return {@code null} if {@code
+   * defaultValue} is {@code null}.</p>
+   *
+   * <p>This method and its overrides, if any, may return the same or
+   * different values for each invocation with the same
+   * parameters.</p>
+   *
+   * @param propertyName the name of the property whose value should
+   * be returned; may be {@code null} in which case the value of the
+   * supplied {@code defaultValue} parameter will be returned instead
+   *
+   * @param defaultValue the value to return if a value for the named
+   * property could not be found; may be {@code null}
+   *
+   * @return a value for the property described by the supplied {@code
+   * propertyName}, or the value of the supplied {@code defaultValue}
+   * parameter
+   *
+   * @see #getPropertyNames()
+   */
+  @Override
+  public String getProperty(final String propertyName, final String defaultValue) {
+    return this.properties.getProperty(propertyName, defaultValue);
+  }
+
+
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/UCPServiceConfigurationProvider.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/UCPServiceConfigurationProvider.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.service.configuration.ucp;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.helidon.service.configuration.api.ServiceConfiguration;
+import io.helidon.service.configuration.api.ServiceConfigurationProvider;
+import io.helidon.service.configuration.api.System;
+
+/**
+ * An abstract {@link ServiceConfigurationProvider} implementation
+ * that provides {@link UCPServiceConfiguration} instances.
+ *
+ * @see #buildFor(Set, Properties)
+ *
+ * @see UCPServiceConfiguration
+ */
+public abstract class UCPServiceConfigurationProvider extends ServiceConfigurationProvider {
+
+
+  /*
+   * Static fields.
+   */
+
+
+  /**
+   * A {@link Pattern} used to split
+   * whitespace-and-comma-separated&mdash;or just
+   * comma-separated&mdash;tokens from a {@link String}.
+   *
+   * <p>This field is never {@code null}.</p>
+   */
+  private static final Pattern WHITESPACE_COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
+
+
+  /*
+   * Instance fields.
+   */
+
+
+  /**
+   * The prefix with which relevant property names will start.
+   *
+   * <p>This field is never {@code null}.</p>
+   *
+   * @see #getPrefix()
+   */
+  private final String prefix;
+
+
+  /*
+   * Constructors.
+   */
+
+
+  /**
+   * Creates a new {@link UCPServiceConfigurationProvider} whose
+   * {@linkplain
+   * ServiceConfigurationProvider#ServiceConfigurationProvider(String)
+   * service identifier} is {@code ucp}.
+   */
+  protected UCPServiceConfigurationProvider() {
+    super("ucp");
+    this.prefix = "javax.sql.DataSource";
+  }
+
+
+  /*
+   * Instance methods.
+   */
+
+
+  /**
+   * Returns the prefix with which relevant property names will start.
+   *
+   * <p>This method never returns {@code null}.</p>
+   *
+   * <p>Overrides of this method must not return {@code null}.</p>
+   *
+   * <p>The default implementation of this method returns {@code
+   * javax.sql.DataSource}.</p>
+   *
+   * <p>Undefined behavior will result if the return value of an
+   * override of this method is {@linkplain String#isEmpty()
+   * empty}.</p>
+   *
+   * @return the non-{@code null} {@code prefix} with which relevant
+   * property names will start
+   */
+  public String getPrefix() {
+    return this.prefix;
+  }
+
+  /**
+   * Creates and returns a new {@link UCPServiceConfiguration}.
+   *
+   * <p>Normally this method is invoked as a result of an invocation
+   * of the {@link #buildFor(Set, Properties)} method.  In these
+   * cases, the {@link #appliesTo(Properties, System, Properties)}
+   * method will have already been invoked and will have returned
+   * {@code true}.</p>
+   *
+   * <p>Overrides of this method must not call the {@link
+   * #buildFor(Set, Properties)} method, as an infinite loop may
+   * result.</p>
+   *
+   * @param properties a {@link Properties} instance that can be used
+   * as the basis of a {@link UCPServiceConfiguration}
+   * implementation; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return a new, non-{@code null} {@link UCPServiceConfiguration}
+   *
+   * @exception NullPointerException if {@code properties} is {@code
+   * null}
+   *
+   * @see
+   * UCPServiceConfiguration#UCPServiceConfiguration(Properties,
+   * System, Properties)
+   *
+   * @see #buildFor(Set, Properties)
+   *
+   * @see #appliesTo(Properties, System, Properties)
+   */
+  protected UCPServiceConfiguration create(final Properties properties, final System system, final Properties coordinates) {
+    Objects.requireNonNull(properties);
+    return new UCPServiceConfiguration(properties, system, coordinates);
+  }
+
+  /**
+   * Overrides the {@link ServiceConfigurationProvider#buildFor(Set,
+   * Properties)} method to ensure that there is an {@linkplain
+   * ServiceConfigurationProvider#getAuthoritativeSystem(Set,
+   * Properties) authoritative <code>System</code>} and then, if so,
+   * calls the {@link #appliesTo(Properties, System, Properties)}
+   * method, and, if that returns {@code true}, then calls the {@link
+   * #create(Properties, System, Properties)} method and returns its
+   * result.
+   *
+   * <p>This method may&mdash;and often does&mdash;return {@code
+   * null}.</p>
+   *
+   * @param systems a {@link Set} of {@link System}s that will help
+   * determine whether a {@link ServiceConfiguration} is in effect or
+   * not; may be {@code null}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return a new {@link ServiceConfiguration} instance suitable for
+   * the configuration space implied by the supplied {@link Set} of
+   * {@link System}s and coordinates, or {@code null}
+   *
+   * @see #appliesTo(Properties, System, Properties)
+   *
+   * @see #create(Properties, System, Properties)
+   */
+  @Override
+  public final ServiceConfiguration buildFor(final Set<? extends System> systems, final Properties coordinates) {
+    ServiceConfiguration returnValue = null;
+    final System system = getAuthoritativeSystem(systems, coordinates);
+    if (system != null && system.isEnabled()) {
+      final Properties properties = new Properties();
+      if (this.appliesTo(properties, system, coordinates)) {
+        returnValue = this.create(properties, system, coordinates);
+      }
+    }
+    return returnValue;
+  }
+
+  /**
+   * Returns {@code true} if this {@link
+   * UCPServiceConfigurationProvider} is relevant in the
+   * configuration space described by the supplied properties, {@link
+   * System} and coordinates.
+   *
+   * <p>The default implementation of this method:</p>
+   *
+   * <ol>
+   *
+   * <li>Looks for a property named {@code ucp.dataSourceNames}.
+   * The value of this property is a comma-separated {@link String}
+   * whose components are names of data sources that will ultimately
+   * have Hikari connection pools set up for them.</li>
+   *
+   * <li>If that property is not found, then all property names found
+   * in the supplied {@code properties}, {@code system} and {@code
+   * coordinates} are scanned for those starting with {@code
+   * javax.sql.DataSource.}, and for all names in that subset, the
+   * next period-separated component of the name is taken to be a data
+   * source name.  For example, a property named {@code
+   * javax.sql.DataSource.test.dataSourceClassName} will yield a data
+   * source name of {@code test}.</li>
+   *
+   * <li>For each such data source name discovered, the {@link
+   * #installDataSourceProperties(Properties, System, Properties,
+   * String)} method is called with the parameters supplied to this
+   * method and the data source name.</li>
+   *
+   * <li>After this installation step, a property named according to
+   * the following pattern is sought: {@code
+   * javax.sql.DataSource.}<em>{@code dataSourceName}</em>{@code
+   * .dataSourceClassName}.</li>
+   *
+   * <li>If that yields a class name and the corresponding class can
+   * be {@linkplain Class#forName(String) loaded}, then {@code true}
+   * is returned.</li>
+   *
+   * <li>If that does not yield a class name, then a property named
+   * according to the following pattern is sought: {@code
+   * javax.sql.DataSource.}<em>{@code dataSourceName}</em>{@code
+   * .jdbcUrl}.</li>
+   *
+   * <li>If that yields a non-{@code null} {@link String} then it is
+   * passed to the {@link DriverManager#getDriver(String)} method.  If
+   * that method invocation results in a non-{@code null} return
+   * value, then {@code true} is returned.</li>
+   *
+   * <li>In all other cases, {@code false} is returned.</li>
+   *
+   * </ol>
+   *
+   * @param properties a {@link Properties} instance that may be used
+   * later by the {@link #create(Properties, System, Properties)}
+   * method as the basis of a {@link UCPServiceConfiguration}
+   * implementation; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @return {@code true} if this {@link
+   * UCPServiceConfigurationProvider} applies to the
+   * configuration space implied by the supplied parameters; {@code
+   * false} otherwise
+   *
+   * @exception NullPointerException if {@code properties} is {@code
+   * null}
+   */
+  protected boolean appliesTo(final Properties properties, final System system, final Properties coordinates) {
+    Objects.requireNonNull(properties);
+    boolean returnValue = false;
+    if (system != null && system.isEnabled()) {
+      final Collection<? extends String> dataSourceNames = this.getDataSourceNames(properties, system, coordinates);
+      if (dataSourceNames != null && !dataSourceNames.isEmpty()) {
+        final String prefix = this.getPrefix();
+        assert prefix != null;
+        for (final String dataSourceName : dataSourceNames) {
+          installDataSourceProperties(properties, system, coordinates, dataSourceName);
+          final String dataSourceClassName =
+            this.getDataSourceProperty(properties, system, coordinates, dataSourceName, "dataSourceClassName");
+          if (dataSourceClassName == null) {
+            final String jdbcUrl = this.getDataSourceProperty(properties, system, coordinates, dataSourceName, "jdbcUrl");
+            if (jdbcUrl != null) {
+              try {
+                final Object driver = DriverManager.getDriver(jdbcUrl);
+                assert driver != null;
+                returnValue = true;
+              } catch (final SQLException ohWell) {
+                assert !returnValue;
+              }
+            }
+          } else {
+            try {
+              Class.forName(dataSourceClassName);
+              returnValue = true;
+            } catch (final ClassNotFoundException classNotFoundException) {
+              assert !returnValue;
+            }
+          }
+          if (!returnValue) {
+            break;
+          }
+        }
+      }
+    }
+    return returnValue;
+  }
+
+  private Set<String> getDataSourceNames(final Properties target, final System system, final Properties coordinates) {
+    Objects.requireNonNull(target);
+
+    Set<String> returnValue = new HashSet<>();
+
+    final String dataSourceNamesProperty =
+      getProperty(target, system, coordinates, this.getServiceIdentifier() + ".dataSourceNames", null);
+    if (dataSourceNamesProperty == null || dataSourceNamesProperty.trim().isEmpty()) {
+
+      final Set<String> allPropertyNames = getPropertyNames(target, system, coordinates);
+      assert allPropertyNames != null;
+
+      final String prefixWithDot = new StringBuilder(this.getPrefix()).append(".").toString();
+      final int prefixWithDotLength = prefixWithDot.length();
+
+      for (String propertyName : allPropertyNames) {
+        if (propertyName != null
+            && propertyName.length() > prefixWithDotLength
+            && propertyName.startsWith(prefixWithDot)) {
+          propertyName = propertyName.substring(prefixWithDotLength);
+          final int dotIndex = propertyName.indexOf('.');
+          if (dotIndex > 0) {
+            returnValue.add(propertyName.substring(0, dotIndex));
+          }
+        }
+      }
+
+      if (returnValue.isEmpty()) {
+        returnValue.add(null);
+      }
+    } else {
+      returnValue.addAll(Arrays.asList(WHITESPACE_COMMA_PATTERN.split(dataSourceNamesProperty)));
+    }
+
+    return returnValue;
+  }
+
+  /**
+   * Installs any discoverable properties that might exist that
+   * pertain to the data source identified by the supplied {@code
+   * dataSourceName} into the supplied {@code target} {@link
+   * Properties} object, optionally using the supplied {@code system}
+   * and {@code coordinates} objects in the process.
+   *
+   * <p>The default implementation of this method:</p>
+   *
+   * <ol>
+   *
+   * <li>Looks for a property named {@code ucp.}<em>{@code
+   * dataSourceName}</em>{@code .propertiesPath}.  If it is found,
+   * then it will be converted to a {@link Path} via the {@link
+   * Paths#get(String, String...)} method.</li>
+   *
+   * <li>If the resulting {@link Path} identifies a readable file,
+   * then the file is read into a temporary {@link Properties} object
+   * via the {@link Properties#load(Reader)} method.</li>
+   *
+   * <li>{@code target} will now contain a property named {@code
+   * javax.sql.DataSource.}<em>{@code dataSourceName}</em>{@code
+   * .explicitlyConfigured} with a {@link String} value of {@code
+   * true}.</li>
+   *
+   * <li>Every property that the temporary {@link Properties} object
+   * contains as a result of reading the file will be added to {@code
+   * target}, prefixed with {@code javax.sql.DataSource.}<em>{@code
+   * dataSourceName}</em>{@code .}.</li>
+   *
+   * </ol>
+   *
+   * <p>If the supplied {@code dataSourceName} is {@code null} or
+   * {@linkplain String#isEmpty() empty}, or if the property being
+   * read out of the temporary {@link Properties} object already
+   * starts with {@code javax.sql.DataSource.}, then it is copied into
+   * {@code target} without any prefix or modification.</p>
+   *
+   * @param target the {@link Properties} into which data source
+   * properties will be installed; must not be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @param dataSourceName the name of the data source for which
+   * properties should be installed; may be {@code null}
+   *
+   * @exception NullPointerException if {@code target} is {@code null}
+   */
+  protected void installDataSourceProperties(final Properties target,
+                                             final System system,
+                                             final Properties coordinates,
+                                             final String dataSourceName) {
+    Objects.requireNonNull(target);
+
+    final String hikariPropertiesPathString =
+      this.getDataSourceProperty(target,
+                                 system,
+                                 coordinates,
+                                 this.getServiceIdentifier(),
+                                 dataSourceName,
+                                 "propertiesPath");
+
+    if (hikariPropertiesPathString != null) {
+
+      final Properties temp = new Properties();
+      try (Reader reader = Files.newBufferedReader(Paths.get(hikariPropertiesPathString), StandardCharsets.UTF_8)) {
+        temp.load(reader);
+        this.setDataSourceProperty(target, dataSourceName, "explicitlyConfigured", "true");
+      } catch (final IOException ohWell) {
+
+      }
+
+      if (!temp.isEmpty()) {
+
+        // Now read each property out of temp, prefix its name with
+        // <prefix>.<dataSourceName>, and set it in target.
+        //
+        // So test.properties' jdbcUrl=jdbc:foo:bar becomes
+        // javax.sql.DataSource.test.jdbcUrl=jdbc:foo:bar.
+
+        final Collection<? extends String> names = temp.stringPropertyNames();
+        assert names != null;
+        assert !names.isEmpty();
+
+        final String prefix = this.getPrefix();
+        assert prefix != null;
+
+        for (final String unprefixedPropertyName : names) {
+          if (unprefixedPropertyName != null && !unprefixedPropertyName.isEmpty()) {
+            if (dataSourceName == null
+                || dataSourceName.isEmpty()
+                || unprefixedPropertyName.startsWith(prefix + "." + dataSourceName + ".")) {
+              target.setProperty(unprefixedPropertyName,
+                                 temp.getProperty(unprefixedPropertyName));
+            } else {
+              target.setProperty(prefix + "." + dataSourceName + "." + unprefixedPropertyName,
+                                 temp.getProperty(unprefixedPropertyName));
+            }
+          }
+        }
+
+      }
+
+    }
+  }
+
+  private Object setDataSourceProperty(final Properties properties,
+                                       String dataSourceName,
+                                       final String unprefixedPropertyName,
+                                       final String propertyValue) {
+    Objects.requireNonNull(properties);
+    final Object returnValue =
+      properties.setProperty(prefixDataSourcePropertyName(this.getPrefix(), dataSourceName, unprefixedPropertyName),
+                             propertyValue);
+    return returnValue;
+  }
+
+
+  /**
+   * Returns the value of a property found in the {@code properties}
+   * parameter value, or, failing that, in the supplied {@link
+   * System}'s {@linkplain System#getProperties() properties}, or,
+   * failing that, in the supplied {@code coordinates} parameter
+   * value, that applies to the data source identified by the supplied
+   * {@code dataSourceName} parameter, taking into account the
+   * {@linkplain #getPrefix() prefix}.
+   *
+   * <p>This method may return {@code null}.</p>
+   *
+   * @param properties the {@link Properties} to check first; must not
+   * be {@code null}
+   *
+   * @param system a {@link System} determined to be in effect; may,
+   * strictly speaking, be {@code null} but ordinarily is non-{@code
+   * null} and {@linkplain System#isEnabled() enabled}
+   *
+   * @param coordinates a {@link Properties} instance representing the
+   * meta-properties in effect; may be {@code null}
+   *
+   * @param dataSourceName the name of a data source; may be {@code
+   * null}
+   *
+   * @param unprefixedPropertyName the "simple" property name being
+   * sought; must not be {@code null}
+   *
+   * @return the value of the property, or {@code null} if no such
+   * property exists
+   *
+   * @exception NullPointerException if {@code properties} or {@code
+   * unprefixedPropertyName} is {@code null}
+   */
+  protected final String getDataSourceProperty(final Properties properties,
+                                               final System system,
+                                               final Properties coordinates,
+                                               String dataSourceName,
+                                               final String unprefixedPropertyName) {
+    return this.getDataSourceProperty(properties, system, coordinates, this.getPrefix(), dataSourceName, unprefixedPropertyName);
+  }
+
+  private String getDataSourceProperty(final Properties properties,
+                                       final System system,
+                                       final Properties coordinates,
+                                       final String prefix,
+                                       String dataSourceName,
+                                       final String unprefixedPropertyName) {
+    final String returnValue =
+      getProperty(properties,
+                  system,
+                  coordinates,
+                  prefixDataSourcePropertyName(prefix, dataSourceName, unprefixedPropertyName),
+                  null);
+    return returnValue;
+  }
+
+
+  /*
+   * Static methods.
+   */
+
+
+  private static String prefixDataSourcePropertyName(final String prefix,
+                                                     String dataSourceName,
+                                                     final String unprefixedPropertyName) {
+    Objects.requireNonNull(prefix);
+    if (prefix.isEmpty()) {
+      throw new IllegalArgumentException("prefix.isEmpty()");
+    }
+    Objects.requireNonNull(unprefixedPropertyName);
+
+    final String prefixedPropertyName;
+    if (dataSourceName == null) {
+      prefixedPropertyName = prefix + "." + unprefixedPropertyName;
+    } else {
+      dataSourceName = dataSourceName.trim();
+      if (dataSourceName.isEmpty()) {
+        prefixedPropertyName = prefix + "." + unprefixedPropertyName;
+      } else {
+        prefixedPropertyName = prefix + "." + dataSourceName + "." + unprefixedPropertyName;
+      }
+    }
+    return prefixedPropertyName;
+  }
+
+  private static Set<String> getPropertyNames(final Properties properties,
+                                              final System system,
+                                              final Properties coordinates) {
+    Objects.requireNonNull(properties);
+    final Set<String> returnValue = new HashSet<>();
+    final Properties systemProperties;
+    if (system == null || !system.isEnabled()) {
+      systemProperties = null;
+    } else {
+      systemProperties = system.getProperties();
+    }
+    if (systemProperties != null) {
+      returnValue.addAll(systemProperties.stringPropertyNames());
+    }
+    returnValue.addAll(properties.stringPropertyNames());
+    if (coordinates != null) {
+      returnValue.addAll(coordinates.stringPropertyNames());
+    }
+    return Collections.unmodifiableSet(returnValue);
+  }
+
+  private static String getProperty(final Properties properties,
+                                    final System system,
+                                    final Properties coordinates,
+                                    final String propertyName,
+                                    final String defaultValue) {
+    Objects.requireNonNull(properties);
+    Objects.requireNonNull(propertyName);
+    String returnValue = properties.getProperty(propertyName);
+    if (returnValue == null) {
+      if (coordinates != null) {
+        returnValue = coordinates.getProperty(propertyName);
+      }
+      if (returnValue == null) {
+        if (system == null || !system.isEnabled()) {
+          returnValue = java.lang.System.getProperty(propertyName, defaultValue);
+        } else {
+          final Properties systemProperties = system.getProperties();
+          if (systemProperties == null) {
+            returnValue = defaultValue;
+          } else {
+            returnValue = systemProperties.getProperty(propertyName, defaultValue);
+          }
+        }
+      }
+    }
+    return returnValue;
+  }
+
+}

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/package-info.java
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/java/io/helidon/service/configuration/ucp/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides classes and interfaces for automatically discovering
+ * service configuration information relevant to <a
+ * href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+ * target="_parent">Oracle Universal Connection Pool</a> componentry.
+ *
+ * @see io.helidon.service.configuration.ucp.UCPServiceConfiguration
+ */
+package io.helidon.service.configuration.ucp;

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/javadoc/overview.html
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp/src/main/javadoc/overview.html
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<body>
+  <p>Provides classes and interfaces for auto-discovering
+     configuration for
+     the <a href="https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html"
+     target="_parent">Oracle Universal Connection Pool</a>.</p>
+
+  @see io.helidon.service.configuration.ucp.UCPServiceConfiguration
+
+  @see io.helidon.service.configuration.ucp.UCPServiceConfigurationProvider
+</body>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -343,6 +343,21 @@
                 </dependency>
                 <dependency>
                     <groupId>io.helidon.serviceconfiguration</groupId>
+                    <artifactId>helidon-serviceconfiguration-ucp-accs</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.serviceconfiguration</groupId>
+                    <artifactId>helidon-serviceconfiguration-ucp-localhost</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.serviceconfiguration</groupId>
+                    <artifactId>helidon-serviceconfiguration-ucp</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.serviceconfiguration</groupId>
                     <artifactId>helidon-serviceconfiguration-system-kubernetes</artifactId>
                     <version>${project.version}</version>
                 </dependency>
@@ -353,7 +368,17 @@
                 </dependency>
                 <dependency>
                     <groupId>io.helidon.integrations.cdi</groupId>
+                    <artifactId>helidon-integrations-cdi-datasource</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.integrations.cdi</groupId>
                     <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.helidon.integrations.cdi</groupId>
+                    <artifactId>helidon-integrations-cdi-datasource-ucp</artifactId>
                     <version>${project.version}</version>
                 </dependency>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <version.lib.netty>4.1.34.Final</version.lib.netty>
         <version.netty.tcnative>2.0.22.Final</version.netty.tcnative>
         <version.lib.oci-java-sdk-objectstorage>1.5.2</version.lib.oci-java-sdk-objectstorage>
-        <version.lib.ojdbc8>12.2.0.1</version.lib.ojdbc8>
+        <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.31.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.0.12</version.lib.opentracing.grpc>
         <version.lib.persistence-api>2.2</version.lib.persistence-api>
@@ -174,6 +174,7 @@
         <version.lib.testng>6.13.1</version.lib.testng>
         <version.lib.transaction-api>1.2</version.lib.transaction-api>
         <version.lib.typesafe-config>1.3.3</version.lib.typesafe-config>
+        <version.lib.ucp>19.3.0.0</version.lib.ucp>
         <version.lib.validation-api>2.0.1.Final</version.lib.validation-api>
         <version.lib.weld>3.1.1.Final</version.lib.weld>
         <version.lib.zipkin>2.6.0</version.lib.zipkin>
@@ -1138,6 +1139,12 @@
                 <groupId>com.oracle.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${version.lib.ojdbc8}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.jdbc</groupId>
+                <artifactId>ucp</artifactId>
+                <version>${version.lib.ucp}</version>
+                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>mysql</groupId>


### PR DESCRIPTION
This PR:
* refactors the common bits out of the HikariCP support
* re-expresses the HikariCP support in terms of the common bits
* adds relevant `serviceconfiguration` implementations for UCP
* adds a CDI portable extension for UCP
* adds documentation and various `pom.xml` elements as needed

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>