### PR TITLE
Changes to content length optimization to handle flushes

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/DataChunk.java
+++ b/common/http/src/main/java/io/helidon/common/http/DataChunk.java
@@ -249,4 +249,14 @@ public interface DataChunk {
     default boolean isReadOnly() {
         return false;
     }
+
+    /**
+     * An empty data chunk with a flush flag can be used to force a connection
+     * flush. This method determines if this chunk is used for that purpose.
+     *
+     * @return Outcome of test.
+     */
+    default boolean isFlushChunk() {
+        return flush() && data().limit() == 0;
+    }
 }

--- a/tests/apps/bookstore/bookstore-mp/src/test/java/io/helidon/tests/apps/bookstore/mp/BookResourceTest.java
+++ b/tests/apps/bookstore/bookstore-mp/src/test/java/io/helidon/tests/apps/bookstore/mp/BookResourceTest.java
@@ -61,6 +61,7 @@ class BookResourceTest {
                 .request()
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+        assertNotNull(res.getHeaderString("content-length"));
 
         assertBookStoreSize(1);
 

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
@@ -136,7 +136,7 @@ class ResponseWriter implements ContainerResponseWriter {
 
         res.send(ReactiveStreamsAdapter.publisherToFlow(
                     ReactiveStreamsAdapter.publisherFromFlow(publisher)
-                        .map(byteBuffer -> DataChunk.create(doFlush(context, byteBuffer), byteBuffer))));
+                        .map(byteBuffer -> DataChunk.create(doFlush(context, byteBuffer), byteBuffer, true))));
 
         return publisher;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -263,6 +263,10 @@ class BareResponseImpl implements BareResponse {
             throw new IllegalStateException("Response is already closed!");
         }
         if (data != null) {
+            if (data.isFlushChunk()) {
+                ctx.flush();
+                return;
+            }
             if (lengthOptimization) {
                 if (firstChunk == null) {
                     firstChunk = data.isReadOnly() ? data : data.duplicate();      // cache first chunk


### PR DESCRIPTION
Changes to content length optimization to handle chunks used for flushing connections. ByteBuffer's created from Jersey data are freshly allocated so a DataChunk that wraps one of these can be marked as read only as well.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>