### PR TITLE
Revert "Update jackson databind to 2.9.9 (#797)"

### DIFF
--- a/3RD-PARTY.txt
+++ b/3RD-PARTY.txt
@@ -2313,7 +2313,7 @@ Version 2.0, January 2004
 http://www.apache.org/licenses/
 
 ========================================================================
-jackson-databind 2.9.9
+jackson-databind 2.9.8
 ========================================================================
 COPYRIGHT: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
@@ -2326,7 +2326,7 @@ It is currently developed by a community of developers, as well as supported
 commercially by FasterXML.com.
 
 ## Licensing
------------------jackson-core 2.9.9 -----------------------
+-----------------jackson-core 2.9.8 -----------------------
 COPYRIGHT: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
         <version.lib.hikaricp>2.7.8</version.lib.hikaricp>
         <version.lib.inject>1</version.lib.inject>
-        <version.lib.jackson>2.9.9</version.lib.jackson>
+        <version.lib.jackson>2.9.8</version.lib.jackson>
         <version.lib.jaegertracing>0.34.0</version.lib.jaegertracing>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>


### PR DESCRIPTION
This reverts commit 67a8fdd547a10f9f71a2be1dfe7ed6502c020749.

The pipeline is failing after the merge of PR #797 (pipeline passed in PR branch but failed after merge to master). It looks environmental  but it's causing other PRs to fail. This reverts us back to jackson 2.9.8 to get the building passing again.
