### PR TITLE
Change build pipeline to Java 11

### DIFF
--- a/config/config/etc/spotbugs/exclude.xml
+++ b/config/config/etc/spotbugs/exclude.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- False positive. See https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Class name="io.helidon.config.internal.PropertiesConfigParser"/>
+        <Method name="parse"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -33,6 +33,10 @@
         Configuration Core module.
     </description>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/config/git/etc/spotbugs/exclude.xml
+++ b/config/git/etc/spotbugs/exclude.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- False positive. See https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Class name="io.helidon.config.git.GitConfigSource"/>
+        <Method name="init"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/config/git/pom.xml
+++ b/config/git/pom.xml
@@ -33,6 +33,10 @@
         Git Config source.
     </description>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/javadoc/overview.html
+++ b/integrations/serviceconfiguration/serviceconfiguration-ucp-accs/src/main/javadoc/overview.html
@@ -24,5 +24,5 @@
      target="_parent">when running on the Oracle Application Container
      Cloud Service</a> system.</p>
 
-    @see com.oracle.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider
+    @see io.helidon.service.configuration.ucp.accs.UCPServiceConfigurationACCSProvider
 </body>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -101,12 +101,11 @@ public class IndexBuilder implements Extension {
 
     private IndexView existingIndexFileReader() throws IOException {
         try (InputStream jandexIS = getClass().getResourceAsStream(INDEX_PATH)) {
-            if (jandexIS == null) {
-                throw new IllegalArgumentException("Attempted to read from previously-located index file "
-                        + INDEX_PATH + " but the file cannot be found");
-            }
             LOGGER.log(Level.FINE, "Using Jandex index at {0}", INDEX_PATH);
             return new IndexReader(jandexIS).read();
+        } catch (IOException ex) {
+            throw new IOException("Attempted to read from previously-located index file "
+                    + INDEX_PATH + " but the file cannot be found", ex);
         }
     }
 
@@ -114,12 +113,11 @@ public class IndexBuilder implements Extension {
         Indexer indexer = new Indexer();
         for (Class<?> c : annotatedTypes) {
             try (InputStream is = contextClassLoader().getResourceAsStream(resourceNameForClass(c))) {
-                if (is == null) {
-                    throw new IllegalArgumentException("Cannot load bytecode from class "
-                            + c.getName() + " at " + resourceNameForClass(c)
-                            + " for annotation processing");
-                }
                 indexer.index(is);
+            } catch (IOException ex) {
+                throw new IOException("Cannot load bytecode from class "
+                        + c.getName() + " at " + resourceNameForClass(c)
+                        + " for annotation processing", ex);
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
                         <additionalJOptions combine.children="append">
                             <JOption>-J-Dhttp.agent=maven-javadoc-plugin</JOption>
                         </additionalJOptions>
+                        <additionalOptions>--frames</additionalOptions>
                         <sourceFileExcludes>
                             <sourceFileExclude>**/module-info.java</sourceFileExclude>
                             <sourceFileExclude>target/**/*.java</sourceFileExclude>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <version.lib.slf4j>1.7.25</version.lib.slf4j>
         <version.lib.smallrye-openapi>1.1.1</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.24</version.lib.snakeyaml>
-        <version.lib.spotbugs-annotations>3.1.3</version.lib.spotbugs-annotations>
+        <version.lib.spotbugs-annotations>3.1.12</version.lib.spotbugs-annotations>
         <version.lib.testng>6.13.1</version.lib.testng>
         <version.lib.transaction-api>1.2</version.lib.transaction-api>
         <version.lib.typesafe-config>1.3.3</version.lib.typesafe-config>
@@ -215,7 +215,7 @@
         <version.plugin.scm-publish-plugin>3.0.0</version.plugin.scm-publish-plugin>
         <version.plugin.site>3.7.1</version.plugin.site>
         <version.plugin.source>3.0.1</version.plugin.source>
-        <version.plugin.spotbugs>3.1.3.1</version.plugin.spotbugs>
+        <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.spotify-docker>1.0.0</version.plugin.spotify-docker>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
@@ -39,9 +39,7 @@ public final class LoggingTestUtils {
     public static void initializeLogging() {
         if (System.getProperty("java.util.logging.config.file") == null) {
             try (InputStream stream = LoggingTestUtils.class.getResourceAsStream("/logging-test.properties")) {
-                if (null != stream) {
-                    LogManager.getLogManager().readConfiguration(stream);
-                }
+                LogManager.getLogManager().readConfiguration(stream);
             } catch (IOException e) {
                 // ignored for now
             }

--- a/webserver/webserver/etc/spotbugs/exclude.xml
+++ b/webserver/webserver/etc/spotbugs/exclude.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- False positive. See https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Class name="io.helidon.webserver.ClassPathContentHandler"/>
+        <Method name="extractJarEntry"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <surefire.argLine>-Xmx128m -Dfile.encoding=UTF-8</surefire.argLine>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
 
     <build>

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/wercker.yml
+++ b/wercker.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-box: maven:3.5.4-jdk-9
+box: maven:3.6.1-jdk-11
 command-timeout: 60
 
 copyright:


### PR DESCRIPTION
Updates our build pipeline from Java 9 to Java 11. This required upgrading spotbugs and making some spotbugs and javadoc fixes.
