### PR TITLE
Pass maxContentLength to constructor of HttpServerUpgradeHandler

### DIFF
--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
@@ -90,4 +90,23 @@ public class Http2SslTest {
             Assertions.assertEquals(getNoBookRes.protocol(), Protocol.HTTP_2);
         }
     }
+
+    @Test
+    @DisabledOnJre(JRE.JAVA_8)
+    public void testHelloWorldHtt2SslPostFirst() throws Exception {
+        Request.Builder builder = TestServer.newRequestBuilder(webServer, "/books", true);
+        Request postBook = builder.post(
+                RequestBody.create(APPLICATION_JSON, TestServer.getBookAsJson())).build();
+        try (Response postBookRes = client.newCall(postBook).execute()) {
+            Assertions.assertEquals(postBookRes.code(), 200);
+            Assertions.assertEquals(postBookRes.protocol(), Protocol.HTTP_2);
+        }
+
+        builder = TestServer.newRequestBuilder(webServer, "/books/123456", true);
+        Request deleteBook = builder.delete().build();
+        try (Response deleteBookRes = client.newCall(deleteBook).execute()) {
+            Assertions.assertEquals(deleteBookRes.code(), 200);
+            Assertions.assertEquals(deleteBookRes.protocol(), Protocol.HTTP_2);
+        }
+    }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -90,7 +90,8 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
                     .maxContentLength(http2Config.maxContentLength()).build();
             HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(sourceCodec,
                     protocol -> AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)
-                            ? new Http2ServerUpgradeCodec(helidonHandler) : null);
+                            ? new Http2ServerUpgradeCodec(helidonHandler) : null,
+                    http2Config.maxContentLength());
 
             CleartextHttp2ServerUpgradeHandler cleartextHttp2ServerUpgradeHandler =
                     new CleartextHttp2ServerUpgradeHandler(sourceCodec, upgradeHandler, helidonHandler);


### PR DESCRIPTION
Pass maxContentLength to constructor of HttpServerUpgradeHandler or an initial (clear text) POST requesting an upgrade can fail. New POST test with TLS.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>