### PR TITLE
Update 09_jsonb-support.adoc

### DIFF
--- a/docs/src/main/docs/webserver/09_jsonb-support.adoc
+++ b/docs/src/main/docs/webserver/09_jsonb-support.adoc
@@ -36,6 +36,7 @@ Declare the following dependency in your project:
 <dependency>
     <groupId>io.helidon.media.jsonb</groupId>
     <artifactId>helidon-media-jsonb-server</artifactId>
+    <version>1.1.2</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Hi, 
Maven was having trouble pulling the dependency without the appropriate Helidon version, so I added it and it worked.