### PR TITLE
No longer using UUID to generate Context id.

### DIFF
--- a/common/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/src/main/java/io/helidon/common/context/Context.java
@@ -168,6 +168,8 @@ public interface Context {
      */
     class Builder implements io.helidon.common.Builder<Context> {
         private static final AtomicLong PARENT_CONTEXT_COUNTER = new AtomicLong(1);
+        // this will cycle through long values from 1 to Long.MAX_VALUE
+        private static final AtomicLong CHILD_CONTEXT_COUNTER = new AtomicLong(1);
         private Context parent;
         private String id;
 
@@ -184,12 +186,13 @@ public interface Context {
                 return String.valueOf(PARENT_CONTEXT_COUNTER.getAndIncrement());
             }
             if (parent instanceof ListContext) {
-                return parent.id() + ":" + ((ListContext) parent).contextCounter().getAndIncrement();
+                return parent.id() + ":" + ((ListContext) parent).nextChildId();
             }
-            // we cannot depend on the parent, so let's use UUID
-            return parent.id() + ":" + UUID.randomUUID();
-        }
 
+            // we cannot depend on the parent, so let's use a simple counter (across all contexts)
+            long nextId = CHILD_CONTEXT_COUNTER.getAndUpdate(operand -> (operand == Long.MAX_VALUE) ? 1 : (operand + 1));
+            return parent.id() + ":" + nextId;
+        }
 
         /**
          * Parent of the new context.

--- a/common/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/src/main/java/io/helidon/common/context/Context.java
@@ -17,7 +17,6 @@
 package io.helidon.common.context;
 
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 

--- a/common/context/src/main/java/io/helidon/common/context/ListContext.java
+++ b/common/context/src/main/java/io/helidon/common/context/ListContext.java
@@ -106,8 +106,8 @@ class ListContext implements Context {
         }
     }
 
-    AtomicLong contextCounter() {
-        return contextCounter;
+    long nextChildId() {
+        return contextCounter.getAndUpdate(operand -> (operand == Long.MAX_VALUE) ? 1 : (operand + 1));
     }
 
     private interface RegisteredItem<T> {

--- a/common/http/src/main/java/io/helidon/common/http/ContextualRegistry.java
+++ b/common/http/src/main/java/io/helidon/common/http/ContextualRegistry.java
@@ -45,16 +45,21 @@ import io.helidon.common.context.Context;
  * AuthenticatedInternalIdentity auth = registry.get(securityFrameworkInternalInstance, AuthenticatedInternalIdentity.class);
  * }</pre></li>
  * </ol>
+ *
+ * @deprecated This class will be replaced with {@link io.helidon.common.context.Context} in future Helidon versions
  */
+@Deprecated
 public interface ContextualRegistry extends Context {
 
     /**
      * Creates a new empty instance.
      *
      * @return new instance
+     * @deprecated use {@link io.helidon.common.context.Context#create()}
      */
+    @Deprecated
     static ContextualRegistry create() {
-        return new ListContextualRegistry();
+        return builder().build();
     }
 
     /**
@@ -64,8 +69,64 @@ public interface ContextualRegistry extends Context {
      *
      * @param parent a parent registry
      * @return new instance
+     * @deprecated use {@link io.helidon.common.context.Context#create(io.helidon.common.context.Context)}
      */
+    @Deprecated
     static ContextualRegistry create(Context parent) {
-        return new ListContextualRegistry(parent);
+        return builder().parent(parent).build();
+    }
+
+    /**
+     * Fluent API builder for advanced configuration.
+     *
+     * @return a new builder
+     * @deprecated used for backward compatibility only
+     */
+    @Deprecated
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent API builder for {@link io.helidon.common.http.ContextualRegistry}.
+     */
+    class Builder implements io.helidon.common.Builder<ContextualRegistry> {
+        private Context parent;
+        private String id;
+
+        @Override
+        public ContextualRegistry build() {
+            return new ListContextualRegistry(this);
+        }
+
+        /**
+         * Parent of the new context.
+         * @param parent parent context
+         *
+         * @return updated builder instance
+         */
+        public Builder parent(Context parent) {
+            this.parent = parent;
+            return this;
+        }
+
+        /**
+         * Identification of the new context, should be unique within this runtime.
+         *
+         * @param id context identification
+         * @return updated builder instance
+         */
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        Context parent() {
+            return parent;
+        }
+
+        String id() {
+            return id;
+        }
     }
 }

--- a/common/http/src/main/java/io/helidon/common/http/ListContextualRegistry.java
+++ b/common/http/src/main/java/io/helidon/common/http/ListContextualRegistry.java
@@ -27,24 +27,25 @@ import io.helidon.common.context.Context;
 class ListContextualRegistry implements ContextualRegistry {
     private final Context delegate;
 
-    /**
-     * Creates new instance with defined parent.
-     *
-     * @param parent a parent context or {@code null}.
-     */
-    ListContextualRegistry(Context parent) {
-        if (parent instanceof ListContextualRegistry) {
-            this.delegate = Context.create(((ListContextualRegistry) parent).delegate);
-        } else {
-            this.delegate = Context.create(parent);
-        }
-    }
+    ListContextualRegistry(ContextualRegistry.Builder builder) {
+        String configuredId = builder.id();
+        Context parent = builder.parent();
 
-    /**
-     * Creates new instance.
-     */
-    ListContextualRegistry() {
-        this(null);
+        Context.Builder delegateBuilder = Context.builder();
+
+        if (null != parent) {
+            if (parent instanceof ListContextualRegistry) {
+                delegateBuilder.parent(((ListContextualRegistry) parent).delegate);
+            } else {
+                delegateBuilder.parent(parent);
+            }
+        }
+
+        if (null != configuredId) {
+            delegateBuilder.id(configuredId);
+        }
+
+        this.delegate = delegateBuilder.build();
     }
 
     @Override

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.grpc.server;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import io.helidon.common.context.Context;
@@ -147,6 +148,8 @@ public interface GrpcServerConfiguration {
      * A {@link GrpcServerConfiguration} builder.
      */
     final class Builder implements io.helidon.common.Builder<GrpcServerConfiguration> {
+        private static final AtomicInteger GRPC_SERVER_COUNTER = new AtomicInteger(1);
+
         private String name = DEFAULT_NAME;
 
         private int port = DEFAULT_PORT;
@@ -318,7 +321,9 @@ public interface GrpcServerConfiguration {
             }
 
             if (context == null) {
-                context = Context.create();
+                context = Context.builder()
+                        .id("grpc-" + GRPC_SERVER_COUNTER.getAndIncrement())
+                        .build();
             }
 
             if (tracer == null) {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -87,6 +87,7 @@ public class ServerImpl implements Server {
 
         Routing.Builder routingBuilder = Routing.builder();
         Config serverConfig = config.get("server");
+
         ServerConfiguration.Builder serverConfigBuilder = ServerConfiguration.builder(serverConfig)
                 .context(this.context)
                 .port(builder.port())

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.helidon.common.Version;
+import io.helidon.common.context.Context;
 import io.helidon.common.http.ContextualRegistry;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -93,7 +94,14 @@ class NettyWebServer implements WebServer {
         LOGGER.info(() -> "Version: " + Version.VERSION);
         this.bossGroup = new NioEventLoopGroup(sockets.size());
         this.workerGroup = config.workersCount() <= 0 ? new NioEventLoopGroup() : new NioEventLoopGroup(config.workersCount());
-        this.contextualRegistry = ContextualRegistry.create(config.context());
+        // the contextual registry needs to be created as a different type is expected. Once we remove ContextualRegistry
+        // we can simply use the one from config
+        Context context = config.context();
+        if (context instanceof ContextualRegistry) {
+            this.contextualRegistry = (ContextualRegistry) context;
+        } else {
+            this.contextualRegistry = ContextualRegistry.create(config.context());
+        }
         this.configuration = config;
 
         for (Map.Entry<String, SocketConfiguration> entry : sockets) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.net.ssl.SSLContext;
 
 import io.helidon.common.context.Context;
+import io.helidon.common.http.ContextualRegistry;
 
 import io.opentracing.Tracer;
 
@@ -32,15 +33,12 @@ import io.opentracing.Tracer;
  * Basic implementation of the {@link ServerConfiguration}.
  */
 class ServerBasicConfig implements ServerConfiguration {
-
-    static final ServerConfiguration DEFAULT_CONFIGURATION = ServerConfiguration.builder().build();
-
     private final SocketConfiguration socketConfig;
     private final int workers;
     private final Tracer tracer;
     private final Map<String, SocketConfiguration> socketConfigs;
     private final ExperimentalConfiguration experimental;
-    private final Context context;
+    private final ContextualRegistry context;
 
     /**
      * Creates new instance.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -23,12 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
 
 import io.helidon.common.CollectionsHelper;
 import io.helidon.common.context.Context;
+import io.helidon.common.http.ContextualRegistry;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 
@@ -223,13 +225,13 @@ public interface ServerConfiguration extends SocketConfiguration {
      * A {@link ServerConfiguration} builder.
      */
     final class Builder implements io.helidon.common.Builder<ServerConfiguration> {
-
+        private static final AtomicInteger WEBSERVER_COUNTER = new AtomicInteger(1);
         private final SocketConfiguration.Builder defaultSocketBuilder = SocketConfiguration.builder();
         private final Map<String, SocketConfiguration> sockets = new HashMap<>();
         private int workers;
         private Tracer tracer;
         private ExperimentalConfiguration experimental;
-        private Context context;
+        private ContextualRegistry context;
 
         private Builder() {
         }
@@ -449,7 +451,12 @@ public interface ServerConfiguration extends SocketConfiguration {
          * @return an updated builder
          */
         public Builder context(Context context) {
-            this.context = context;
+            // backward compatibility only - in 2.0 we should use the context given to us
+            this.context = ContextualRegistry.builder()
+                    .id(context.id() + ":web-" + WEBSERVER_COUNTER.getAndIncrement())
+                    .parent(context)
+                    .build();
+
             return this;
         }
 
@@ -539,7 +546,12 @@ public interface ServerConfiguration extends SocketConfiguration {
         @Override
         public ServerConfiguration build() {
             if (null == context) {
-                context = Context.create();
+                // I do not expect "unlimited" number of webservers
+                // in case somebody spins a huge number up, the counter will cycle to negative numbers once
+                // Integer.MAX_VALUE is reached.
+                context = ContextualRegistry.builder()
+                        .id("web-" + WEBSERVER_COUNTER.getAndIncrement())
+                        .build();
             }
 
             Optional<Tracer> maybeTracer = context.get(Tracer.class);
@@ -583,7 +595,7 @@ public interface ServerConfiguration extends SocketConfiguration {
             return experimental;
         }
 
-        Context context() {
+        ContextualRegistry context() {
             return context;
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -311,7 +311,10 @@ public interface WebServer {
             }
 
             WebServer result = new NettyWebServer(configuration == null
-                                                          ? ServerBasicConfig.DEFAULT_CONFIGURATION
+                                                          // this is happening once per microservice, no need to store in a constant
+                                                          // also the configuration creates instances of context etc. that should
+                                                          // not be initialized unless needed
+                                                          ? ServerConfiguration.builder().build()
                                                           : configuration,
                                                   defaultRouting, routings);
             if (defaultRouting instanceof RequestRouting) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -311,9 +311,9 @@ public interface WebServer {
             }
 
             WebServer result = new NettyWebServer(configuration == null
-                                                          // this is happening once per microservice, no need to store in a constant
-                                                          // also the configuration creates instances of context etc. that should
-                                                          // not be initialized unless needed
+                                                          // this is happening once per microservice, no need to store in
+                                                          // a constant; also the configuration creates instances of context etc.
+                                                          // that should not be initialized unless needed
                                                           ? ServerConfiguration.builder().build()
                                                           : configuration,
                                                   defaultRouting, routings);


### PR DESCRIPTION
Refactored to use a meaningful id for parent contexts

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #829 