### PR TITLE
Implementation of Microprofile Health 2.0

### DIFF
--- a/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.helidon.health;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -24,6 +25,7 @@ import java.util.stream.Stream;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 
+import io.helidon.common.CollectionsHelper;
 import io.helidon.common.http.Http;
 
 import org.eclipse.microprofile.health.HealthCheck;
@@ -120,7 +122,7 @@ class HealthSupportTest {
                 .addIncluded(includedHealthChecks)
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(allChecks);
 
         // Test the JSON
         final JsonObject json = response.json();
@@ -136,7 +138,7 @@ class HealthSupportTest {
         HealthSupport support = HealthSupport.builder()
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(Collections.emptyList());
 
         assertThat(response.status(), is(Http.Status.OK_200));
 
@@ -149,13 +151,14 @@ class HealthSupportTest {
 
     @Test
     void checksAreSortedByName() {
+        List<HealthCheck> checks = CollectionsHelper.listOf(new GoodHealthCheck("g"),
+                                                            new GoodHealthCheck("a"),
+                                                            new GoodHealthCheck("v"));
         HealthSupport support = HealthSupport.builder()
-                .add(new GoodHealthCheck("g"))
-                .add(new GoodHealthCheck("a"))
-                .add(new GoodHealthCheck("v"))
+                .add(checks)
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(checks);
 
         // Test the JSON
         final JsonObject json = response.json();
@@ -171,7 +174,7 @@ class HealthSupportTest {
                 .add(goodChecks)
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(goodChecks);
 
         assertThat(response.status(), is(Http.Status.OK_200));
 
@@ -189,7 +192,7 @@ class HealthSupportTest {
                 .add(badChecks)
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(badChecks);
 
         assertThat(response.status(), is(Http.Status.SERVICE_UNAVAILABLE_503));
 
@@ -207,7 +210,7 @@ class HealthSupportTest {
                 .add(brokenChecks)
                 .build();
 
-        HealthSupport.HealthResponse response = support.callHealthChecks();
+        HealthSupport.HealthResponse response = support.callHealthChecks(brokenChecks);
 
         assertThat(response.status(), is(Http.Status.INTERNAL_SERVER_ERROR_500));
 

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCheckProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.microprofile.health;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.microprofile.health.HealthCheck;
@@ -31,7 +32,27 @@ public interface HealthCheckProvider {
     /**
      * Return the provided {@link org.eclipse.microprofile.health.HealthCheck}s.
      *
-     * @return  the {@link org.eclipse.microprofile.health.HealthCheck}s
+     * @return the {@link org.eclipse.microprofile.health.HealthCheck}s
+     * @deprecated in the new versions of MP Health, we use either {@link #readinessChecks()} or {@link #livenessChecks()}
      */
+    @Deprecated
     List<HealthCheck> healthChecks();
+
+    /**
+     * Return the provided readiness {@link org.eclipse.microprofile.health.HealthCheck}s.
+     *
+     * @return the {@link org.eclipse.microprofile.health.HealthCheck}s
+     */
+    default List<HealthCheck> readinessChecks() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Return the provided liveness {@link org.eclipse.microprofile.health.HealthCheck}s.
+     *
+     * @return the {@link org.eclipse.microprofile.health.HealthCheck}s
+     */
+    default List<HealthCheck> livenessChecks() {
+        return Collections.emptyList();
+    }
 }

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthMpService.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthMpService.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import javax.enterprise.inject.se.SeContainer;
+
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
@@ -28,29 +30,60 @@ import io.helidon.microprofile.server.spi.MpServiceContext;
 
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
 
 /**
  * Helidon Microprofile Server extension for Health checks.
  */
 public class HealthMpService implements MpService {
+    private static final Health HEALTH_LITERAL = new Health() {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Health.class;
+        }
+    };
+
+    private static final Readiness READINESS_LITERAL = new Readiness() {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Readiness.class;
+        }
+    };
+
+    private static final Liveness LIVENESS_LITERAL = new Liveness() {
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return Liveness.class;
+        }
+    };
+
     @Override
     public void configure(MpServiceContext mpServiceContext) {
         Config healthConfig = mpServiceContext.helidonConfig().get("health");
         HealthSupport.Builder builder = HealthSupport.builder()
                 .config(healthConfig);
 
-        mpServiceContext.cdiContainer()
-                .select(HealthCheck.class, new Health() {
-                    @Override
-                    public Class<? extends Annotation> annotationType() {
-                        return Health.class;
-                    }
-                })
+        SeContainer cdiContainer = mpServiceContext.cdiContainer();
+
+        cdiContainer.select(HealthCheck.class, HEALTH_LITERAL)
                 .stream()
                 .forEach(builder::add);
 
+        cdiContainer.select(HealthCheck.class, LIVENESS_LITERAL)
+                .stream()
+                .forEach(builder::addLiveness);
+
+        cdiContainer.select(HealthCheck.class, READINESS_LITERAL)
+                .stream()
+                .forEach(builder::addReadiness);
+
         HelidonServiceLoader.create(ServiceLoader.load(HealthCheckProvider.class))
-                .forEach(healthCheckProvider -> builder.add(healthCheckProvider.healthChecks()));
+                .forEach(healthCheckProvider -> {
+                    builder.add(healthCheckProvider.healthChecks());
+                    healthCheckProvider.livenessChecks().forEach(builder::addLiveness);
+                    healthCheckProvider.readinessChecks().forEach(builder::addReadiness);
+                });
 
         healthConfig.get("routing")
                 .asString()

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-tck</artifactId>
-            <version>${version.lib.microprofile-health-api}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <version.lib.junit>5.1.0</version.lib.junit>
         <version.lib.microprofile-config-api>1.3</version.lib.microprofile-config-api>
         <version.lib.microprofile-config-tck>1.3</version.lib.microprofile-config-tck>
-        <version.lib.microprofile-health-api>1.0</version.lib.microprofile-health-api>
+        <version.lib.microprofile-health>2.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>1.1</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
@@ -1012,7 +1012,12 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-api</artifactId>
-                <version>${version.lib.microprofile-health-api}</version>
+                <version>${version.lib.microprofile-health}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.health</groupId>
+                <artifactId>microprofile-health-tck</artifactId>
+                <version>${version.lib.microprofile-health}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>


### PR DESCRIPTION
This implementation is backward compatible with Heath 1.0 (I retained the original JSON structure with the new one - e.g. we get both `state` and `status` in the response.
We can safely merge this into master.
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

I have validated the backward compatibility by executing TCK of Health 1.0 against the current code base and all tests passed