### PR TITLE
Update examples and tests to use microprofile-2.2 bundle

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -281,7 +281,7 @@
             <dependency>
                 <groupId>io.helidon.microprofile.bundles</groupId>
                 <artifactId>helidon-microprofile-2.2</artifactId>
-                <version>${project.version{</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.microprofile</groupId>

--- a/docs/src/main/docs/sitegen.yaml
+++ b/docs/src/main/docs/sitegen.yaml
@@ -25,7 +25,7 @@ engine:
       helidon-version: "${project.version}"
       microprofile-openapi-version: "${version.lib.microprofile-openapi-api}"
       jandex-plugin-version: ${version.plugin.jandex}
-      mp-version: "1.2"
+      mp-version: "2.2"
       guides-dir: "${project.basedir}/../examples/guides"
 assets:
   - target: "/"

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -30,7 +30,7 @@
     <name>Helidon Microprofile Examples Explicit Hello World</name>
 
     <description>
-        Microprofile 1.1 example with explicit bootstrapping (Server.create(Application.class).start())
+        Microprofile 2.2 example with explicit bootstrapping (Server.create(Application.class).start())
     </description>
 
     <properties>
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -30,7 +30,7 @@
     <name>Helidon Microprofile Examples Implicit Hello World</name>
 
     <description>
-        Microprofile 1.2 example with implicit bootstrapping (server.Main(new String[0])
+        Microprofile 2.2 example with implicit bootstrapping (server.Main(new String[0])
     </description>
 
     <properties>
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -179,7 +179,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/examples/security/oidc/pom.xml
+++ b/examples/security/oidc/pom.xml
@@ -40,7 +40,7 @@
         <!-- Helidon MicroProfile -->
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- Helidon MicroProfile Security -->

--- a/examples/todo-app/demo-backend/pom.xml
+++ b/examples/todo-app/demo-backend/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile</groupId>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -164,7 +164,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile-2.2</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
This updates docs, examples and the bookstore test app to use the microprofile 2.2 bundle. Also fixes a typo in the bom pom.