### PR TITLE
Enables support of application.yaml use case in data source injection extensions

### DIFF
--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -34,6 +34,7 @@
     </properties>
 
     <dependencies>
+
       <!-- Compile-scoped dependencies. -->
         <dependency>
             <groupId>io.helidon.integrations.cdi</groupId>
@@ -127,6 +128,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>
@@ -134,8 +136,12 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>io.helidon.serviceconfiguration:helidon-serviceconfiguration-hikaricp-accs</classpathDependencyExclude>
+                        <classpathDependencyExclude>io.helidon.serviceconfiguration:helidon-serviceconfiguration-hikaricp-localhost</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
                     <systemPropertyVariables>
-                      <java.util.logging.config.file>${project.basedir}/src/test/logging.properties</java.util.logging.config.file>
+                        <java.util.logging.config.file>${project.basedir}/src/test/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -122,9 +122,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                      <java.util.logging.config.file>${project.basedir}/src/test/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
+++ b/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.integrations.datasource.hikaricp.cdi;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.sql.DataSource;
+
+import io.helidon.microprofile.config.MpConfig;
+import io.helidon.microprofile.server.Server;
+
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ApplicationScoped
+class TestConfiguration {
+
+    @Inject
+    @Named("test")
+    private DataSource test;
+    
+    private Server server;
+
+    TestConfiguration() {
+        super();
+    }
+
+    @BeforeEach
+    void startServer() {
+        this.stopServer();
+        // The sequence of calls here is the only way to supply a CDI
+        // container to Helidon's MicroProfile Server such that all of
+        // the normal configuration is loaded properly.
+        final Server.Builder builder = Server.builder();
+        assertNotNull(builder);
+        builder.config((MpConfig) ConfigProviderResolver.instance().getConfig(Thread.currentThread().getContextClassLoader()));
+        final SeContainerInitializer initializer = SeContainerInitializer.newInstance()
+            .addBeanClasses(TestConfiguration.class);
+        assertNotNull(initializer);
+        builder.cdiContainer(initializer.initialize());
+        this.server = builder.build();
+        assertNotNull(this.server);
+        this.server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (this.server != null) {
+            this.server.stop();
+            this.server = null;
+        }
+    }
+
+    private void onStartup(@Observes @Initialized(ApplicationScoped.class) final Object event) {
+        assertNotNull(this.test);
+        assertNotNull(this.test.toString());
+    }
+
+    @Test
+    void testConfiguration() {
+
+    }
+
+}

--- a/integrations/cdi/datasource-hikaricp/src/test/logging.properties
+++ b/integrations/cdi/datasource-hikaricp/src/test/logging.properties
@@ -1,0 +1,6 @@
+.level=INFO
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.level=FINEST
+
+io.helidon.level=FINER

--- a/integrations/cdi/datasource-hikaricp/src/test/logging.properties
+++ b/integrations/cdi/datasource-hikaricp/src/test/logging.properties
@@ -1,6 +1,17 @@
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 .level=INFO
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.ConsoleHandler.level=FINEST
-
-io.helidon.level=FINER

--- a/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
+++ b/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
@@ -1,10 +1,23 @@
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 javax:
    sql:
       DataSource:
          test:
-            dataSourceClassName: org.postgresql.ds.PGPoolingDataSource
+            dataSourceClassName: org.h2.jdbcx.JdbcDataSource
             dataSource:
-               url: jdbc:postgresql://127.0.0.1:5432/hello_world
-               user: benchmarkdbuser
-               password: benchmarkdbpass
+               url: jdbc:h2:mem:test
+               user: sa
+               password: ""
 

--- a/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
+++ b/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
@@ -1,0 +1,10 @@
+javax:
+   sql:
+      DataSource:
+         test:
+            dataSourceClassName: org.postgresql.ds.PGPoolingDataSource
+            dataSource:
+               url: jdbc:postgresql://127.0.0.1:5432/hello_world
+               user: benchmarkdbuser
+               password: benchmarkdbpass
+

--- a/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/io/helidon/integrations/datasource/ucp/cdi/UCPBackedDataSourceExtension.java
@@ -37,7 +37,6 @@ import io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension;
 
 import oracle.ucp.jdbc.PoolDataSource;
 import oracle.ucp.jdbc.PoolDataSourceFactory;
-import oracle.ucp.jdbc.PoolDataSourceImpl;
 
 /**
  * An {@link Extension} that arranges for named {@link DataSource}
@@ -97,7 +96,6 @@ public class UCPBackedDataSourceExtension extends AbstractDataSourceExtension {
         beanConfigurator
             .addQualifier(dataSourceName)
             .addTransitiveTypeClosure(PoolDataSource.class)
-            .beanClass(PoolDataSourceImpl.class)
             .scope(ApplicationScoped.class)
             .createWith(cc -> {
                     try {


### PR DESCRIPTION
This PR changes some internals of `AbstractDataSourceExtension` to acquire configuration so that Helidon-specific post-MicroProfile-Config-initialization property names are recognized, enabling a user to configure data sources out of the box using `application.yaml`.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>
