### PR TITLE
Use Zipkin quickstart script in READMEs

### DIFF
--- a/examples/grpc/opentracing/README.md
+++ b/examples/grpc/opentracing/README.md
@@ -14,9 +14,9 @@ Prerequisites:
     ```
     docker run -d -p 9411:9411 openzipkin/zipkin
     ```
-    or with Java 8:
+    or with Java 8+:
     ```
-    wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+    curl -sSL https://zipkin.io/quickstart.sh | bash -s
     java -jar zipkin.jar
     ```
 

--- a/examples/webserver/demo-translator-backend/README.md
+++ b/examples/webserver/demo-translator-backend/README.md
@@ -16,9 +16,9 @@ Prerequisites:
     ```
     docker run -d -p 9411:9411 openzipkin/zipkin
     ```
-    or with Java 8:
+    or with Java 8+:
     ```
-    wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+    curl -sSL https://zipkin.io/quickstart.sh | bash -s
     java -jar zipkin.jar
     ```
 

--- a/examples/webserver/demo-translator-frontend/README.md
+++ b/examples/webserver/demo-translator-frontend/README.md
@@ -16,9 +16,9 @@ Prerequisites:
     ```
     docker run -d -p 9411:9411 openzipkin/zipkin
     ```
-    or with Java 8:
+    or with Java 8+:
     ```
-    wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+    curl -sSL https://zipkin.io/quickstart.sh | bash -s
     java -jar zipkin.jar
     ```
 

--- a/examples/webserver/opentracing/README.md
+++ b/examples/webserver/opentracing/README.md
@@ -14,9 +14,9 @@ Prerequisites:
     ```
     docker run -d -p 9411:9411 openzipkin/zipkin
     ```
-    or with Java 8:
+    or with Java 8+:
     ```
-    wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+    curl -sSL https://zipkin.io/quickstart.sh | bash -s
     java -jar zipkin.jar
     ```
 


### PR DESCRIPTION
The group id of the Zipkin Server artifact recently changed, so the previous instructions were not downloading the latest version.
Zipkin provides a quickstart script to download the latest version.
Zipkin Server also runs with Java 8 or higher.

See https://github.com/openzipkin/openzipkin.github.io/issues/136