### PR TITLE
Change Netty workers default to equal available processors.

### DIFF
--- a/docs/src/main/docs/microprofile/02_server-configuration.adoc
+++ b/docs/src/main/docs/microprofile/02_server-configuration.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/docs/microprofile/02_server-configuration.adoc
+++ b/docs/src/main/docs/microprofile/02_server-configuration.adoc
@@ -27,7 +27,7 @@ By default, the server uses the MicroProfile Config, but you may also want to us
 There are 3 default MicroProfile Config sources:
 
 * `System.getProperties()`
-* `System.getenv()` 
+* `System.getenv()`
 * all `META-INF/microprofile-config.properties` files on the class path
 
 In this example, the configuration is in a file, and it includes Helidon configuration options.
@@ -48,7 +48,7 @@ server.backlog: 512
 server.receive-buffer: 256
 # Socket timeout milliseconds - defaults to 0 (infinite)
 server.timeout: 30000
-# Default is CPU_COUNT * 2
+# Defaults to Runtime.availableProcessors()
 server.workers=4
 # Default is not to use SSL
 ssl:

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -53,9 +53,9 @@ public interface ServerConfiguration extends SocketConfiguration {
     String DEFAULT_SOCKET_NAME = "@default";
 
     /**
-     * Returns a count of threads in s pool used to tryProcess HTTP requests.
+     * Returns the count of threads in the pool used to process HTTP requests.
      * <p>
-     * Default value is {@code CPU_COUNT * 2}.
+     * Default value is {@link Runtime#availableProcessors()}.
      *
      * @return a workers count
      */
@@ -565,7 +565,7 @@ public interface ServerConfiguration extends SocketConfiguration {
             }
 
             if (workers <= 0) {
-                workers = Runtime.getRuntime().availableProcessors() * 2;
+                workers = Runtime.getRuntime().availableProcessors();
             }
 
             if (null == experimental) {


### PR DESCRIPTION
Performance testing shows improvement when this default is used.