### PR TITLE
Fixing version in io.grpc/pom.xml

### DIFF
--- a/grpc/io.grpc/pom.xml
+++ b/grpc/io.grpc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.helidon.grpc</groupId>
         <artifactId>helidon-grpc-project</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>io.grpc</artifactId>


### PR DESCRIPTION
Fix build error on master by repairing version element in io.grpc/pom.xml.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>