### PR TITLE
Healthchecks moved to liveness checks.

### DIFF
--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.lang.management.ThreadMXBean;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
 
 /**
  * A health check that looks for thread deadlocks. Automatically created and registered via CDI.
@@ -31,7 +31,7 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
  * This health check can be referred to in properties as "deadlock". So for example, to exclude this
  * health check from being exposed, use "helidon.health.exclude: deadlock".
  */
-@Health
+@Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 public final class DeadlockHealthCheck implements HealthCheck {
     /**
@@ -50,7 +50,7 @@ public final class DeadlockHealthCheck implements HealthCheck {
      *
      * @param threadBean thread mx bean to get thread monitoring data from
      * @return a new health check to register with
-     *         {@link io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)}
+     *         {@link io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)}
      */
     public static DeadlockHealthCheck create(ThreadMXBean threadBean) {
         return new DeadlockHealthCheck(threadBean);

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -31,9 +31,9 @@ import javax.inject.Inject;
 import io.helidon.health.HealthCheckException;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
 
 /**
  * A health check that verifies whether the server is running out of disk space. This health check will
@@ -54,7 +54,7 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
  * This health check can be referred to in properties as "diskSpace". So for example, to exclude this
  * health check from being exposed, use "helidon.health.exclude: diskSpace".
  */
-@Health
+@Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 public final class DiskSpaceHealthCheck implements HealthCheck {
     /**

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
@@ -33,7 +33,7 @@ public final class HealthChecks {
      * Deadlock health check.
      *
      * @return deadlock health check
-     * @see io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)
+     * @see io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)
      */
     public static HealthCheck deadlockCheck() {
         return DeadlockHealthCheck.create(ManagementFactory.getThreadMXBean());
@@ -43,7 +43,7 @@ public final class HealthChecks {
      * Disk space health check.
      *
      * @return disk space health check with default configuration
-     * @see io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)
+     * @see io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)
      * @see DiskSpaceHealthCheck#builder()
      */
     public static HealthCheck diskSpaceCheck() {
@@ -54,7 +54,7 @@ public final class HealthChecks {
      * Memory health check.
      *
      * @return memory health check with default configuration
-     * @see io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)
+     * @see io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)
      * @see HeapMemoryHealthCheck#builder()
      */
     public static HeapMemoryHealthCheck heapMemoryCheck() {
@@ -65,7 +65,7 @@ public final class HealthChecks {
      * Built-in health checks.
      *
      * @return built-in health checks to be configured with {@link io.helidon.health.HealthSupport}
-     * @see io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)
+     * @see io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)
      */
     public static HealthCheck[] healthChecks() {
         if (IS_GRAAL_VM) {

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -23,9 +23,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
 
 /**
  * A health check that verifies whether the server is running out of Java heap space. If heap usage exceeds a
@@ -41,7 +41,7 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
  * This health check can be referred to in properties as "heapMemory". So for example, to exclude this
  * health check from being exposed, use "helidon.health.exclude: heapMemory".
  */
-@Health
+@Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 public final class HeapMemoryHealthCheck implements HealthCheck {
     /**
@@ -79,7 +79,7 @@ public final class HeapMemoryHealthCheck implements HealthCheck {
      * Create a new heap memory health check with default configuration.
      *
      * @return a new health check to register with
-     *         {@link io.helidon.health.HealthSupport.Builder#add(org.eclipse.microprofile.health.HealthCheck...)}
+     *         {@link io.helidon.health.HealthSupport.Builder#addLiveness(org.eclipse.microprofile.health.HealthCheck...)}
      * @see #DEFAULT_THRESHOLD
      */
     public static HeapMemoryHealthCheck create() {
@@ -97,7 +97,8 @@ public final class HeapMemoryHealthCheck implements HealthCheck {
         final long threshold = (long) ((thresholdPercent / 100) * maxMemory);
         return HealthCheckResponse.named("heapMemory")
                 .state(threshold >= usedMemory)
-                .withData("percentFree", formatter.format("%.2f%%", 100 * ((double) (maxMemory - usedMemory) / maxMemory)).toString())
+                .withData("percentFree",
+                          formatter.format("%.2f%%", 100 * ((double) (maxMemory - usedMemory) / maxMemory)).toString())
                 .withData("free", DiskSpaceHealthCheck.format(freeMemory))
                 .withData("freeBytes", freeMemory)
                 .withData("max", DiskSpaceHealthCheck.format(maxMemory))


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #897 

This change is backward compatible, as the response is still available on `/health`