### PR TITLE
Client executor service supporting Context

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -57,6 +57,12 @@
                 <artifactId>helidon-webserver-test-support</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <!-- WebClient -->
+            <dependency>
+                <groupId>io.helidon.webclient</groupId>
+                <artifactId>helidon-webclient-jaxrs</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- gRPC server -->
             <dependency>
                 <groupId>io.helidon.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
         <module>grpc</module>
         <module>openapi</module>
         <module>jersey</module>
+        <module>webclient</module>
     </modules>
 
     <build>

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -82,6 +82,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jersey</groupId>
             <artifactId>helidon-jersey-server</artifactId>
             <scope>provided</scope>

--- a/security/integration/jersey/src/main/java9/module-info.java
+++ b/security/integration/jersey/src/main/java9/module-info.java
@@ -31,6 +31,7 @@ module io.helidon.security.integration.jersey {
     requires io.helidon.common.context;
     requires io.helidon.jersey.common;
     requires io.helidon.security.integration.common;
+    requires io.helidon.webclient.jaxrs;
     requires jersey.common;
     requires jersey.server;
     requires jersey.client;

--- a/tracing/jersey-client/pom.xml
+++ b/tracing/jersey-client/pom.xml
@@ -58,6 +58,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.jersey</groupId>
             <artifactId>helidon-jersey-client</artifactId>
             <version>${project.version}</version>

--- a/webclient/jaxrs/pom.xml
+++ b/webclient/jaxrs/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-webclient-project</artifactId>
+        <groupId>io.helidon.webclient</groupId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-webclient-jaxrs</artifactId>
+    <name>Helidon WebClient JAX-RS</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-configurable</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JaxRsClient.java
+++ b/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JaxRsClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.jaxrs;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import io.helidon.common.configurable.ThreadPoolSupplier;
+import io.helidon.common.context.Contexts;
+import io.helidon.config.Config;
+
+import org.glassfish.jersey.spi.ExecutorServiceProvider;
+
+/**
+ * Point of access to {@link javax.ws.rs.client.ClientBuilder} to support Helidon features,
+ * such as propagation of tracing, correct handling of {@link io.helidon.common.context.Context}.
+ */
+public final class JaxRsClient {
+    private static final AtomicReference<Supplier<ExecutorService>> EXECUTOR_SUPPLIER =
+            new AtomicReference<>(ThreadPoolSupplier.create());
+
+    private JaxRsClient() {
+    }
+
+    /**
+     * Configure defaults for all clients created.
+     * Configuration options:
+     *
+     * <table>
+     * <caption>Configuration parameters</caption>
+     * <tr>
+     *     <th>key</th>
+     *     <th>default value</th>
+     *     <th>description</th>
+     * </tr>
+     * <tr>
+     *     <td>executor</td>
+     *     <td>{@link io.helidon.common.configurable.ThreadPoolSupplier#create(io.helidon.config.Config)}</td>
+     *     <td>Default executor service to use for asynchronous operations. For configuration options
+     *      of {@code executor}, please refer to
+     *      {@link io.helidon.common.configurable.ThreadPoolSupplier.Builder#config(io.helidon.config.Config)}</td>
+     * </tr>
+     * </table>
+     *
+     * @param config configuration to use to configure JAX-RS clients defaults
+     */
+    public static void configureDefaults(Config config) {
+        EXECUTOR_SUPPLIER.set(ThreadPoolSupplier.create(config));
+    }
+
+    /**
+     * Configure the default executor service supplier to be used for asynchronous requests when explicit supplier is not
+     * provided.
+     *
+     * @param executorServiceSupplier supplier that provides the executor service
+     */
+    public static void defaultExecutor(Supplier<ExecutorService> executorServiceSupplier) {
+        Supplier<ExecutorService> wrapped = () -> Contexts.wrap(executorServiceSupplier.get());
+
+        EXECUTOR_SUPPLIER.set(wrapped);
+    }
+
+    public static ClientBuilder newBuilder() {
+        ClientBuilder result = ClientBuilder.newBuilder();
+
+        result.register(new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService getExecutorService() {
+                return EXECUTOR_SUPPLIER.get().get();
+            }
+
+            @Override
+            public void dispose(ExecutorService executorService) {
+
+            }
+        });
+
+        return result;
+    }
+
+    public static Client newClient() {
+        return newClientBuilder().build();
+    }
+}

--- a/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JerseyClientAutoDiscoverable.java
+++ b/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JerseyClientAutoDiscoverable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webclient.jaxrs;
+
+import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Priority;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.FeatureContext;
+
+import org.glassfish.jersey.internal.spi.AutoDiscoverable;
+import org.glassfish.jersey.spi.ExecutorServiceProvider;
+
+/**
+ * Auto discoverable feature to use a custom executor service
+ * for all client asynchronous operations.
+ * This is needed to support {@link io.helidon.common.context.Context} for
+ * outbound calls.
+ */
+@ConstrainedTo(RuntimeType.CLIENT)
+@Priority(121)
+public class JerseyClientAutoDiscoverable implements AutoDiscoverable {
+    @Override
+    public void configure(FeatureContext context) {
+        context.register(new ExecutorServiceProvider() {
+            @Override
+            public ExecutorService getExecutorService() {
+                return JaxRsClient.executor().get();
+            }
+
+            @Override
+            public void dispose(ExecutorService executorService) {
+                // no-op, as we use a shared executor instance
+            }
+        });
+    }
+}

--- a/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/package-info.java
+++ b/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Helidon support for JAX-RS (Jersey) client.
+ * You can create the JAX-RS client as usual using {@link javax.ws.rs.client.ClientBuilder#newBuilder()}
+ * and {@link javax.ws.rs.client.ClientBuilder#newClient()}.
+ * <p>
+ * If you want to configure defaults for asynchronous executor service,
+ *  you can use {@link io.helidon.webclient.jaxrs.JaxRsClient#configureDefaults(io.helidon.config.Config)}
+ *  or {@link io.helidon.webclient.jaxrs.JaxRsClient#defaultExecutor(java.util.function.Supplier)}.
+ *
+ * @see io.helidon.webclient.jaxrs.JaxRsClient
+ */
+package io.helidon.webclient.jaxrs;

--- a/webclient/jaxrs/src/main/java9/module-info.java
+++ b/webclient/jaxrs/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,21 @@
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
 
 /**
- * Tracing integration with jersey (JAX-RS) client.
+ * Basic integration with JAX-RS client.
  */
-module io.helidon.tracing.jersey.client {
+module io.helidon.webclient.jaxrs {
     requires java.logging;
     requires java.annotation;
 
     requires java.ws.rs;
-    requires javax.inject;
     requires jersey.client;
     requires jersey.common;
 
-    requires opentracing.api;
-    requires opentracing.util;
-
-    requires io.helidon.tracing;
-    requires io.helidon.tracing.config;
     requires io.helidon.common;
+    requires io.helidon.common.configurable;
     requires io.helidon.common.context;
-    requires io.helidon.webclient.jaxrs;
 
-    exports io.helidon.tracing.jersey.client;
+    exports io.helidon.webclient.jaxrs;
 
-    // needed to propagate tracing context from server to client
-    opens io.helidon.tracing.jersey.client.internal to io.helidon.tracing.jersey,io.helidon.microprofile.tracing;
-    exports io.helidon.tracing.jersey.client.internal;
-
-    provides AutoDiscoverable with io.helidon.tracing.jersey.client.ClientTracingAutoDiscoverable;
+    provides AutoDiscoverable with io.helidon.webclient.jaxrs.JerseyClientAutoDiscoverable;
 }

--- a/webclient/jaxrs/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
+++ b/webclient/jaxrs/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.webclient.jaxrs.JerseyClientAutoDiscoverable

--- a/webclient/jaxrs/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
+++ b/webclient/jaxrs/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/webclient/pom.xml
+++ b/webclient/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon</groupId>
+        <artifactId>helidon-project</artifactId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.helidon.webclient</groupId>
+    <artifactId>helidon-webclient-project</artifactId>
+    <name>Helidon WebClient Project</name>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>jaxrs</module>
+    </modules>
+
+</project>


### PR DESCRIPTION
Support for Jersey client to automatically propagate context when using asynchronous operations.

Resolves #838 