### PR TITLE
Adds support for unitName-less PersistenceContext injection points

### DIFF
--- a/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/io/helidon/integrations/cdi/jpa/JpaExtension.java
@@ -126,6 +126,36 @@ public class JpaExtension implements Extension {
     private static final Logger LOGGER = Logger.getLogger(JpaExtension.class.getName(),
                                                           JpaExtension.class.getPackage().getName() + ".Messages");
 
+    /**
+     * The name used to designate the only persistence unit in the
+     * environment, when there is exactly one persistence unit in the
+     * environment, and there is at least one {@link
+     * PersistenceContext @PersistenceContext}-annotated injection
+     * point that does not specify a value for the {@link
+     * PersistenceContext#unitName() unitName} element.
+     *
+     * <p>In such a case, the injection point will be effectively
+     * rewritten such that it will appear to the CDI container as
+     * though there <em>were</em> a value specified for the {@link
+     * PersistenceContext#unitName() unitName} element&mdash;namely
+     * this field's value.  Additionally, a bean identical to the
+     * existing solitary {@link PersistenceUnitInfo}-typed bean will
+     * be added with this field's value as the {@linkplain
+     * Named#value() value of its <code>Named</code> qualifier}, thus
+     * serving as a kind of alias for the "real" bean.</p>
+     *
+     * <p>This is necessary because the empty string ({@code ""}) as
+     * the value of the {@link Named#value()} element has special
+     * semantics, so cannot be used to designate an unnamed
+     * persistence unit.</p>
+     *
+     * <p>The value of this field is subject to change without prior
+     * notice at any point.  In general the mechanics around injection
+     * point rewriting are also subject to change without prior notice
+     * at any point.</p>
+     */
+    private static final String DEFAULT_PERSISTENCE_UNIT_NAME = "__DEFAULT__";
+
 
     /*
      * Instance fields.
@@ -574,27 +604,29 @@ public class JpaExtension implements Extension {
             if (persistenceContexts != null && !persistenceContexts.isEmpty()) {
                 for (final PersistenceContext persistenceContext : persistenceContexts) {
                     if (persistenceContext != null) {
-                        final String name = persistenceContext.unitName(); // yes, unitName(), not name()
-                        if (!name.isEmpty()) {
-                            processed = true;
-                            addUnlistedManagedClass(name, c);
+                        String unitName = persistenceContext.unitName();
+                        if (unitName == null || unitName.isEmpty()) {
+                            unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
                         }
+                        processed = true;
+                        addUnlistedManagedClass(unitName, c);
                     }
                 }
             }
             if (persistenceUnits != null && !persistenceUnits.isEmpty()) {
                 for (final PersistenceUnit persistenceUnit : persistenceUnits) {
                     if (persistenceUnit != null) {
-                        final String name = persistenceUnit.unitName(); // yes, unitName(), not name()
-                        if (!name.isEmpty()) {
-                            processed = true;
-                            addUnlistedManagedClass(name, c);
+                        String unitName = persistenceUnit.unitName();
+                        if (unitName == null || unitName.isEmpty()) {
+                            unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
                         }
+                        processed = true;
+                        addUnlistedManagedClass(unitName, c);
                     }
                 }
             }
             if (!processed) {
-                addUnlistedManagedClass("", c);
+                addUnlistedManagedClass(DEFAULT_PERSISTENCE_UNIT_NAME, c);
             }
         }
 
@@ -609,8 +641,7 @@ public class JpaExtension implements Extension {
      * member of its list of governed classes.
      *
      * @param name the name of the persistence unit in question; may
-     * be {@code null} in which case the empty string ({@code ""})
-     * will be used instead
+     * be {@code null}
      *
      * @param managedClass the {@link Class} to associate; may be
      * {@code null} in which case no action will be taken
@@ -624,7 +655,10 @@ public class JpaExtension implements Extension {
             LOGGER.entering(cn, mn, new Object[] {name, managedClass});
         }
 
-        if (managedClass != null && name != null && !name.isEmpty()) {
+        if (managedClass != null) {
+            if (name == null || name.isEmpty()) {
+                name = DEFAULT_PERSISTENCE_UNIT_NAME;
+            }
             Set<Class<?>> unlistedManagedClasses = this.unlistedManagedClassesByPersistenceUnitNames.get(name);
             if (unlistedManagedClasses == null) {
                 unlistedManagedClasses = new HashSet<>();
@@ -803,7 +837,13 @@ public class JpaExtension implements Extension {
         final Enumeration<URL> urls = classLoader.getResources("META-INF/persistence.xml");
         if (urls != null && urls.hasMoreElements()) {
             processImplicits = false;
-            this.processPersistenceXmls(event, beanManager, classLoader, urls, providers);
+            this.processPersistenceXmls(event,
+                                        beanManager,
+                                        classLoader,
+                                        urls,
+                                        providers,
+                                        preexistingPersistenceUnitInfoBeans != null
+                                        && !preexistingPersistenceUnitInfoBeans.isEmpty());
         }
 
         // If we did not find any PersistenceUnitInfo instances via
@@ -1177,8 +1217,12 @@ public class JpaExtension implements Extension {
 
         Objects.requireNonNull(event);
 
+        PersistenceUnitInfoBean solePersistenceUnitInfoBean = null;
         for (final PersistenceUnitInfoBean persistenceUnitInfoBean : this.implicitPersistenceUnits.values()) {
-            final String persistenceUnitName = persistenceUnitInfoBean.getPersistenceUnitName();
+            String persistenceUnitName = persistenceUnitInfoBean.getPersistenceUnitName();
+            if (persistenceUnitName == null || persistenceUnitName.isEmpty()) {
+                persistenceUnitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+            }
             if (!persistenceUnitInfoBean.excludeUnlistedClasses()) {
                 final Collection<? extends Class<?>> unlistedManagedClasses =
                     this.unlistedManagedClassesByPersistenceUnitNames.get(persistenceUnitName);
@@ -1196,9 +1240,25 @@ public class JpaExtension implements Extension {
             event.addBean()
                 .types(Collections.singleton(PersistenceUnitInfo.class))
                 .scope(ApplicationScoped.class)
-                .addQualifiers(NamedLiteral.of(persistenceUnitName == null ? "" : persistenceUnitName))
+                .addQualifiers(NamedLiteral.of(persistenceUnitName))
                 .createWith(cc -> persistenceUnitInfoBean);
+            if (solePersistenceUnitInfoBean == null) {
+                solePersistenceUnitInfoBean = persistenceUnitInfoBean;
+            } else {
+                solePersistenceUnitInfoBean = null;
+            }
             maybeAddPersistenceProviderBean(event, persistenceUnitInfoBean, providers);
+        }
+        if (solePersistenceUnitInfoBean != null) {
+            final String name = solePersistenceUnitInfoBean.getPersistenceUnitName();
+            if (name != null && !name.isEmpty()) {
+                final PersistenceUnitInfoBean instance = solePersistenceUnitInfoBean;
+                event.addBean()
+                    .types(Collections.singleton(PersistenceUnitInfo.class))
+                    .scope(ApplicationScoped.class)
+                    .addQualifiers(NamedLiteral.of(DEFAULT_PERSISTENCE_UNIT_NAME))
+                    .createWith(cc -> instance);
+            }
         }
 
         if (LOGGER.isLoggable(Level.FINER)) {
@@ -1210,7 +1270,8 @@ public class JpaExtension implements Extension {
                                         final BeanManager beanManager,
                                         final ClassLoader classLoader,
                                         final Enumeration<URL> urls,
-                                        final Collection<? extends PersistenceProvider> providers)
+                                        final Collection<? extends PersistenceProvider> providers,
+                                        final boolean userSuppliedPersistenceUnitInfoBeans)
         throws IOException, JAXBException, ReflectiveOperationException, XMLStreamException {
         final String cn = JpaExtension.class.getName();
         final String mn = "processPersistenceXmls";
@@ -1259,6 +1320,7 @@ public class JpaExtension implements Extension {
             final Unmarshaller unmarshaller =
                 JAXBContext.newInstance(Persistence.class.getPackage().getName()).createUnmarshaller();
             final DataSourceProvider dataSourceProvider = new BeanManagerBackedDataSourceProvider(beanManager);
+            PersistenceUnitInfo solePersistenceUnitInfo = null;
             while (urls.hasMoreElements()) {
                 final URL url = urls.nextElement();
                 assert url != null;
@@ -1275,7 +1337,10 @@ public class JpaExtension implements Extension {
                 }
                 if (persistenceUnitInfos != null && !persistenceUnitInfos.isEmpty()) {
                     for (final PersistenceUnitInfo persistenceUnitInfo : persistenceUnitInfos) {
-                        final String persistenceUnitName = persistenceUnitInfo.getPersistenceUnitName();
+                        String persistenceUnitName = persistenceUnitInfo.getPersistenceUnitName();
+                        if (persistenceUnitName == null || persistenceUnitName.isEmpty()) {
+                            persistenceUnitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+                        }
                         // Provide support for, e.g.:
                         //   @Inject
                         //   @Named("test")
@@ -1283,10 +1348,26 @@ public class JpaExtension implements Extension {
                         event.addBean()
                             .types(Collections.singleton(PersistenceUnitInfo.class))
                             .scope(ApplicationScoped.class)
-                            .addQualifiers(NamedLiteral.of(persistenceUnitName == null ? "" : persistenceUnitName))
+                            .addQualifiers(NamedLiteral.of(persistenceUnitName))
                             .createWith(cc -> persistenceUnitInfo);
+                        if (solePersistenceUnitInfo == null) {
+                          solePersistenceUnitInfo = persistenceUnitInfo;
+                        } else {
+                          solePersistenceUnitInfo = null;
+                        }
                         maybeAddPersistenceProviderBean(event, persistenceUnitInfo, providers);
                     }
+                }
+            }
+            if (!userSuppliedPersistenceUnitInfoBeans && solePersistenceUnitInfo != null) {
+                final String name = solePersistenceUnitInfo.getPersistenceUnitName();
+                if (name != null && !name.isEmpty()) {
+                    final PersistenceUnitInfo instance = solePersistenceUnitInfo;
+                    event.addBean()
+                        .types(Collections.singleton(PersistenceUnitInfo.class))
+                        .scope(ApplicationScoped.class)
+                        .addQualifiers(NamedLiteral.of(DEFAULT_PERSISTENCE_UNIT_NAME))
+                        .createWith(cc -> instance);
                 }
             }
         }
@@ -1417,7 +1498,11 @@ public class JpaExtension implements Extension {
         } else {
             fc.add(Synchronized.Literal.INSTANCE);
         }
-        fc.add(NamedLiteral.of(pc.unitName().trim()));
+        String unitName = pc.unitName().trim();
+        if (unitName.isEmpty()) {
+            unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+        }
+        fc.add(NamedLiteral.of(unitName));
 
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.exiting(cn, mn);
@@ -1455,7 +1540,11 @@ public class JpaExtension implements Extension {
         }
         fc.add(InjectLiteral.INSTANCE);
         fc.add(ContainerManaged.Literal.INSTANCE);
-        fc.add(NamedLiteral.of(pu.unitName().trim()));
+        String unitName = pu.unitName().trim();
+        if (unitName.isEmpty()) {
+            unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+        }
+        fc.add(NamedLiteral.of(unitName));
 
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.exiting(cn, mn);
@@ -1606,7 +1695,11 @@ public class JpaExtension implements Extension {
                                 } else {
                                     apc.add(Synchronized.Literal.INSTANCE);
                                 }
-                                apc.add(NamedLiteral.of(pc.unitName().trim()));
+                                String unitName = pc.unitName().trim();
+                                if (unitName.isEmpty()) {
+                                    unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+                                }
+                                apc.add(NamedLiteral.of(unitName));
                             }
                         }
                     }
@@ -1650,7 +1743,11 @@ public class JpaExtension implements Extension {
                             if (parameterType instanceof Class
                                 && EntityManagerFactory.class.isAssignableFrom((Class<?>) parameterType)) {
                                 apc.add(ContainerManaged.Literal.INSTANCE);
-                                apc.add(NamedLiteral.of(pu.unitName().trim()));
+                                String unitName = pu.unitName().trim();
+                                if (unitName.isEmpty()) {
+                                    unitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+                                }
+                                apc.add(NamedLiteral.of(unitName));
                             }
                         }
                     }
@@ -1821,7 +1918,10 @@ public class JpaExtension implements Extension {
             if (add) {
                 // The PersistenceProvider class in question is not one we
                 // already loaded.  Add a bean for it too.
-                final String persistenceUnitName = persistenceUnitInfo.getPersistenceUnitName();
+                String persistenceUnitName = persistenceUnitInfo.getPersistenceUnitName();
+                if (persistenceUnitName == null || persistenceUnitName.isEmpty()) {
+                    persistenceUnitName = DEFAULT_PERSISTENCE_UNIT_NAME;
+                }
 
                 // Provide support for, e.g.:
                 //   @Inject
@@ -1830,7 +1930,7 @@ public class JpaExtension implements Extension {
                 event.addBean()
                     .types(PersistenceProvider.class)
                     .scope(ApplicationScoped.class)
-                    .addQualifiers(NamedLiteral.of(persistenceUnitName == null ? "" : persistenceUnitName))
+                    .addQualifiers(NamedLiteral.of(persistenceUnitName))
                     .createWith(cc -> {
                         try {
                             ClassLoader classLoader = persistenceUnitInfo.getClassLoader();

--- a/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
+++ b/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
@@ -57,7 +57,7 @@ public class TestIntegration {
     @Inject
     private Transaction transaction;
 
-    @PersistenceContext(unitName = "test")
+    @PersistenceContext
     private EntityManager entityManager;
   
     TestIntegration() {


### PR DESCRIPTION
Permits `@PersistenceContext`-annotated injection points where `unitName` is not specified and there is exactly one persistence unit in the environment, following the spirit of Java EE.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>