### PR TITLE
Fix use of deprecated add() method on HealthSupport in quickstart and bookstore test

### DIFF
--- a/docs/src/main/docs/health/01_health.adoc
+++ b/docs/src/main/docs/health/01_health.adoc
@@ -129,7 +129,7 @@ The HTTP response also contains a JSON payload that describes the statuses for
 .Create the health support service:
 ----
 HealthSupport health = HealthSupport.builder()
-    .add(hc)
+    .addLiveness(hc)
     .build();
 ----
 
@@ -142,7 +142,7 @@ NOTE: Health check requires the `JSON-P` support to be enabled. See the example
 .Register a custom health check:
 ----
 HealthSupport health = HealthSupport.builder()
-    .add(() -> HealthCheckResponse.named("exampleHealthCheck")
+    .addLiveness(() -> HealthCheckResponse.named("exampleHealthCheck")
                  .up()
                  .withData("time", System.currentTimeMillis())
                  .build()) // <1>
@@ -190,7 +190,7 @@ A set of built-in health checks can be optionally enabled to report various
 [source,java]
 ----
 HealthSupport health = HealthSupport.builder()
-    .add(HealthChecks.healthChecks()) // <1>
+    .addLiveness(HealthChecks.healthChecks()) // <1>
     .build();
 
 Routing.builder()

--- a/docs/src/main/docs/health/02_health_in_k8s.adoc
+++ b/docs/src/main/docs/health/02_health_in_k8s.adoc
@@ -130,11 +130,11 @@ Routing healthRouting = Routing.builder()
         .register(JsonSupport.create())
         .register(HealthSupport.builder()
                 .webContext("/live") // <1>
-                .add(HealthChecks.healthChecks()) // <2>
+                .addLiveness(HealthChecks.healthChecks()) // <2>
                 .build())
         .register(HealthSupport.builder()
                 .webContext("/ready") // <3>
-                .add(() -> HealthCheckResponse.named("database").up().build()) // <4>
+                .addReadiness(() -> HealthCheckResponse.named("database").up().build()) // <4>
                 .build())
         .build();
 

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -101,8 +101,8 @@ You can build a native executable in 2 different ways:
 
 ### Local build
 
-Download Graal VM at https://github.com/oracle/graal/releases, the version
- currently supported for Helidon is `19.0.0`.
+Download Graal VM at https://github.com/oracle/graal/releases, the versions
+ currently supported for Helidon is `19.1.1` and `19.2.0`.
 
 ```
 # Setup the environment

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -98,7 +98,7 @@ public final class Main {
         MetricsSupport metrics = MetricsSupport.create();
         GreetService greetService = new GreetService(config);
         HealthSupport health = HealthSupport.builder()
-                .add(HealthChecks.healthChecks())   // Adds a convenient set of checks
+                .addLiveness(HealthChecks.healthChecks())   // Adds a convenient set of checks
                 .build();
 
         return Routing.builder()

--- a/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
+++ b/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
@@ -130,7 +130,7 @@ public final class Main {
      */
     private static Routing createRouting(Config config) {
         HealthSupport health = HealthSupport.builder()
-                .add(HealthChecks.healthChecks())   // Adds a convenient set of checks
+                .addLiveness(HealthChecks.healthChecks())   // Adds a convenient set of checks
                 .build();
 
         JsonLibrary jsonLibrary = getJsonLibrary(config);


### PR DESCRIPTION
Use `addLiveness()` instead of `add()` (which has been deprecated) in quickstart se and bookstore test app. Also fix README to use correct graalvm version.
