### PR TITLE
TracerBuilder now uses Helidon service loader.

### DIFF
--- a/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingJavaMockTracerProvider.java
+++ b/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingJavaMockTracerProvider.java
@@ -1,11 +1,30 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.helidon.microprofile.opentracing.tck;
+
+import javax.annotation.Priority;
 
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.tracing.spi.TracerProvider;
 
 /**
- * Created by David Kral.
+ * Provider for opentracing TCK.
  */
+@Priority(100)
 public class OpentracingJavaMockTracerProvider implements TracerProvider {
     @Override
     public TracerBuilder<?> createBuilder() {

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -37,7 +37,8 @@ import io.opentracing.util.GlobalTracer;
  * The JaegerTracerBuilder is a convenience builder for {@link io.opentracing.Tracer} to use with Jaeger.
  * <p>
  * <b>Unless You want to explicitly depend on Jaeger in Your code, please
- * use {@link io.helidon.tracing.TracerBuilder#create(String)} or {@link io.helidon.tracing.TracerBuilder#create(io.helidon.config.Config)} that is abstracted.</b>
+ * use {@link io.helidon.tracing.TracerBuilder#create(String)} or
+ * {@link io.helidon.tracing.TracerBuilder#create(io.helidon.config.Config)} that is abstracted.</b>
  * <p>
  * The Jaeger tracer uses environment variables and system properties to override the defaults.
  * Except for {@code protocol} and {@code service} these are honored, unless overridden in configuration
@@ -148,7 +149,7 @@ import io.opentracing.util.GlobalTracer;
  *
  * @see <a href="https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/README.md">Jaeger configuration</a>
  */
-public final class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
+public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final Logger LOGGER = Logger.getLogger(JaegerTracerBuilder.class.getName());
 
     static final boolean DEFAULT_ENABLED = true;
@@ -175,7 +176,10 @@ public final class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuil
     private boolean enabled = DEFAULT_ENABLED;
     private boolean global = true;
 
-    private JaegerTracerBuilder() {
+    /**
+     * Default constructor, does not modify any state.
+     */
+    protected JaegerTracerBuilder() {
     }
 
     /**
@@ -328,7 +332,7 @@ public final class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuil
         config.get("flush-interval-ms").asLong().ifPresent(this::flushIntervalMs);
         config.get("sampler-type").asString().as(SamplerType::create).ifPresent(this::samplerType);
         config.get("sampler-param").asDouble().ifPresent(this::samplerParam);
-        config.get("sampler-manager").asString().ifPresent(this::samplerMananger);
+        config.get("sampler-manager").asString().ifPresent(this::samplerManager);
 
         config.get("tags").detach()
                 .asMap()
@@ -351,7 +355,6 @@ public final class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuil
                     });
                 });
 
-
         config.get("global").asBoolean().ifPresent(this::registerGlobal);
 
         return this;
@@ -362,8 +365,21 @@ public final class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuil
      *
      * @param samplerManagerHostPort host and port of the sampler manager
      * @return updated builder instance
+     * @deprecated typo, please use {@link #samplerManager(String)}
      */
+    @Deprecated
     public JaegerTracerBuilder samplerMananger(String samplerManagerHostPort) {
+        this.samplerManager = samplerManagerHostPort;
+        return this;
+    }
+
+    /**
+     * The host name and port when using the remote controlled sampler.
+     *
+     * @param samplerManagerHostPort host and port of the sampler manager
+     * @return updated builder instance
+     */
+    public JaegerTracerBuilder samplerManager(String samplerManagerHostPort) {
         this.samplerManager = samplerManagerHostPort;
         return this;
     }

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerProvider.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerProvider.java
@@ -15,12 +15,16 @@
  */
 package io.helidon.tracing.jaeger;
 
+import javax.annotation.Priority;
+
+import io.helidon.common.Prioritized;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.tracing.spi.TracerProvider;
 
 /**
  * Jaeger java service.
  */
+@Priority(Prioritized.DEFAULT_PRIORITY)
 public class JaegerTracerProvider implements TracerProvider {
     @Override
     public TracerBuilder<?> createBuilder() {

--- a/tracing/tracing/pom.xml
+++ b/tracing/tracing/pom.xml
@@ -39,6 +39,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-service-loader</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
             <version>${project.version}</version>

--- a/tracing/tracing/src/main/java/io/helidon/tracing/TracerBuilder.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/TracerBuilder.java
@@ -16,13 +16,10 @@
 package io.helidon.tracing;
 
 import java.net.URI;
-import java.util.Iterator;
 import java.util.Objects;
-import java.util.ServiceLoader;
 
 import io.helidon.common.Builder;
 import io.helidon.config.Config;
-import io.helidon.tracing.spi.TracerProvider;
 
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
@@ -99,7 +96,7 @@ import io.opentracing.util.GlobalTracer;
  * </pre>
  *
  * @param <T> type of the builder, used so that inherited builders returned by methods
- *           are of the correct type and contain all methods, even those not inheritec from this
+ *           are of the correct type and contain all methods, even those not inherited from this
  *           interface
  */
 @SuppressWarnings("rawtypes")
@@ -111,12 +108,8 @@ public interface TracerBuilder<T extends TracerBuilder> extends Builder<Tracer> 
      * @return a new builder instance
      */
     static TracerBuilder<?> create(String serviceName) {
-        Iterator<TracerProvider> iterator = ServiceLoader.load(TracerProvider.class).iterator();
-        if (iterator.hasNext()) {
-            return iterator.next().createBuilder().serviceName(serviceName);
-        } else {
-            return NoOpBuilder.create().serviceName(serviceName);
-        }
+        return TracerProviderHelper.findTracerBuilder()
+                .serviceName(serviceName);
     }
 
     /**
@@ -126,12 +119,8 @@ public interface TracerBuilder<T extends TracerBuilder> extends Builder<Tracer> 
      * @return a new builder instance
      */
     static TracerBuilder<?> create(Config config) {
-        Iterator<TracerProvider> iterator = ServiceLoader.load(TracerProvider.class).iterator();
-        if (iterator.hasNext()) {
-            return iterator.next().createBuilder().config(config);
-        } else {
-            return NoOpBuilder.create().config(config);
-        }
+        return TracerProviderHelper.findTracerBuilder()
+                .config(config);
     }
 
     /**
@@ -282,7 +271,10 @@ public interface TracerBuilder<T extends TracerBuilder> extends Builder<Tracer> 
      * Build and register as a global tracer.
      *
      * @return The {@link Tracer} built and registered
+     * @deprecated Use {@link #registerGlobal(boolean)} to control whether the resulting instance is
+     * registered as a {@link io.opentracing.util.GlobalTracer}.
      */
+    @Deprecated
     default Tracer buildAndRegister() {
         Tracer result = build();
         GlobalTracer.register(result);

--- a/tracing/tracing/src/main/java/io/helidon/tracing/TracerProviderHelper.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/TracerProviderHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tracing;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import io.helidon.common.serviceloader.HelidonServiceLoader;
+import io.helidon.tracing.spi.TracerProvider;
+
+/**
+ * Tracer provider helper to find implementation to use.
+ */
+final class TracerProviderHelper {
+    private static final ServiceLoader<TracerProvider> SYSTEM_LOADER = ServiceLoader.load(TracerProvider.class);
+    private static final HelidonServiceLoader<TracerProvider> SERVICE_LOADER = HelidonServiceLoader.create(SYSTEM_LOADER);
+
+    private TracerProviderHelper() {
+    }
+
+    static TracerBuilder<?> findTracerBuilder() {
+        Iterator<TracerProvider> iterator = SERVICE_LOADER.iterator();
+
+        if (iterator.hasNext()) {
+            return iterator.next().createBuilder();
+        } else {
+            return NoOpBuilder.create();
+        }
+    }
+}

--- a/tracing/tracing/src/main/java9/module-info.java
+++ b/tracing/tracing/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
  */
 module io.helidon.tracing {
     requires io.helidon.common;
+    requires io.helidon.common.serviceloader;
     requires io.helidon.config;
     requires transitive opentracing.api;
     requires opentracing.noop;

--- a/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerBuilder.java
+++ b/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerBuilder.java
@@ -106,7 +106,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
  * @see <a href="http://zipkin.io/pages/instrumenting.html#core-data-structures">Zipkin Attributes</a>
  * @see <a href="https://github.com/openzipkin/zipkin/issues/962">Zipkin Missing Service Name</a>
  */
-public final class ZipkinTracerBuilder implements TracerBuilder<ZipkinTracerBuilder> {
+public class ZipkinTracerBuilder implements TracerBuilder<ZipkinTracerBuilder> {
     static final Logger LOGGER = Logger.getLogger(ZipkinTracerBuilder.class.getName());
     static final String DEFAULT_PROTOCOL = "http";
     static final int DEFAULT_ZIPKIN_PORT = 9411;
@@ -126,7 +126,10 @@ public final class ZipkinTracerBuilder implements TracerBuilder<ZipkinTracerBuil
     private boolean enabled = DEFAULT_ENABLED;
     private boolean global = true;
 
-    private ZipkinTracerBuilder() {
+    /**
+     * Default constructor, does not modify state.
+     */
+    protected ZipkinTracerBuilder() {
     }
 
     /**

--- a/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerProvider.java
+++ b/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import javax.annotation.Priority;
+
 import io.helidon.common.CollectionsHelper;
+import io.helidon.common.Prioritized;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.tracing.spi.TracerProvider;
 
@@ -33,6 +36,7 @@ import static io.helidon.common.CollectionsHelper.listOf;
 /**
  * Zipkin java service.
  */
+@Priority(Prioritized.DEFAULT_PRIORITY)
 public class ZipkinTracerProvider implements TracerProvider {
     // original Zipkin headers (comes from old name of Zipkin - "BigBrotherBird", or "B3")
     static final String X_B3_TRACE_ID = "x-b3-traceid";


### PR DESCRIPTION
Zipkin and Jaeger providers use default priority.
Zipkin and Jaeger providers are extensible.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #963 