### PR TITLE
Set useBaseVersion to false when copying dependencies 

### DIFF
--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -114,6 +114,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
                             <excludeScope>test</excludeScope>
+                            <useBaseVersion>false</useBaseVersion>
                         </configuration>
                     </execution>
                 </executions>

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -114,6 +114,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
                             <excludeScope>test</excludeScope>
+                            <useBaseVersion>false</useBaseVersion>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -63,6 +63,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
                             <excludeScope>test</excludeScope>
+                            <useBaseVersion>false</useBaseVersion>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/apps/bookstore/bookstore-se/pom.xml
+++ b/tests/apps/bookstore/bookstore-se/pom.xml
@@ -64,6 +64,7 @@
                             <overWriteIfNewer>true</overWriteIfNewer>
                             <includeScope>runtime</includeScope>
                             <excludeScope>test</excludeScope>
+                            <useBaseVersion>false</useBaseVersion>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Narayan has some dependencies that use pinned snapshots. An example

```
<version.microprofile.lra.api>1.0-20190801.113716-482</version.microprofile.lra.api>
```
We have to tell the `maven-dependency-plugin`'s `copy-dependencies` goal to use this in the jar filename, and not use the version in the base snapshot artifact. To do that we need to set useBaseVersion to false.
