### PR TITLE
add missing default value for mainClass property

### DIFF
--- a/archetypes/mp/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/mp/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -27,6 +27,9 @@
         <requiredProperty key="artifactId"/>
         <requiredProperty key="version"/>
         <requiredProperty key="package"/>
+        <requiredProperty key="mainClass">
+            <defaultValue>no</defaultValue>
+        </requiredProperty>
         <requiredProperty key="applicationName">
             <defaultValue>ExampleApplication</defaultValue>
             <validationRegex>([$_a-zA-Z][$_a-zA-Z0-9]*)</validationRegex>


### PR DESCRIPTION
Fix the helidon-mp archetype: set the mainClass default value.