### PR TITLE
Make EtcdConfigSourceTest passable with whitespaces in file path

### DIFF
--- a/config/etcd/src/test/java/io/helidon/config/etcd/EtcdConfigSourceTest.java
+++ b/config/etcd/src/test/java/io/helidon/config/etcd/EtcdConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ public class EtcdConfigSourceTest {
     }
 
     private void putConfiguration(String resourcePath) throws Exception {
-        File file = new File(EtcdConfigSourceTest.class.getResource(resourcePath).getFile());
+        File file = new File(EtcdConfigSourceTest.class.getResource(resourcePath).toURI());
         etcdClient.put("configuration",
                        String.join("\n", Files.readAllLines(file.toPath(), Charset.defaultCharset())));
     }


### PR DESCRIPTION
 * Workaround for https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4466485

```
Tests run: 4, Failures: 0, Errors: 4, Skipped: 0, Time elapsed: 0.051 sec <<< FAILURE! - in io.helidon.config.etcd.EtcdConfigSourceTest                                          
testConfigSourceBuilder  Time elapsed: 0.032 sec  <<< ERROR!                                                                                                                     
java.nio.file.NoSuchFileException: /mnt/c/Users/Daniel%20Kec/IdeaProjects/helidon/config/etcd/target/test-classes/application.conf                                                       
. . .                                                                                                         
at io.helidon.config.etcd.EtcdConfigSourceTest.putConfiguration(EtcdConfigSourceTest.java:140)                                                                                   
at io.helidon.config.etcd.EtcdConfigSourceTest.before(EtcdConfigSourceTest.java:60)   
```

Signed-off-by: Daniel Kec <daniel@kecovi.cz>