### PR TITLE
Add some resiliency to various metrics tests 

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -48,6 +48,6 @@ inject_credentials
 mvn -f ${WS_DIR}/pom.xml \
     clean install -e \
     -B \
-    -Pexamples,integrations,archetypes,spotbugs,javadoc,docs,sources,tck,tests
+    -Pexamples,integrations,archetypes,spotbugs,javadoc,docs,sources,tck,tests,pipeline
 
 examples/quickstarts/archetypes/test-archetypes.sh

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -33,6 +33,25 @@
         Metrics APIs and implementation necessary for Java SE using Helidon Web Server
     </description>
 
+    <profiles>
+        <profile>
+            <id>pipeline</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables>
+                                    <helidon.histogram.tolerance>0.01</helidon.histogram.tolerance>
+                                </systemPropertyVariables>
+                            </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
     <build>
         <plugins>
             <plugin>
@@ -40,7 +59,8 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <executions>
                         <execution>
-                            <id>InternalBridgeTest with global tags set</id>
+                            <!-- Run this test in default-test and also here with an env var set -->
+                            <id>metrics-global-tags-set</id>
                             <goals>
                                 <goal>test</goal>
                             </goals>

--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
@@ -16,9 +16,19 @@
 
 package io.helidon.metrics;
 
+import static io.helidon.metrics.HelidonMetricsMatcher.withinTolerance;
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.StringReader;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -27,11 +37,11 @@ import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Snapshot;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -78,11 +88,37 @@ class HelidonHistogramTest {
             + "application:file_sizes_bytes{quantile=\"0.99\"} 98000\n"
             + "application:file_sizes_bytes{quantile=\"0.999\"} 99000\n";
 
+    /**
+     * Parses a {@code Stream| of text lines (presumably in Prometheus/OpenMetrics format) into a {@code Stream}
+     * of {@code Map.Entry}, with the key the value name and the value a {@code Number}
+     * representing the converted value.
+     *
+     * @param lines Prometheus-format text as a stream of lines
+     * @return stream of name/value pairs
+     */
+    private static Stream<Map.Entry<String, Number>> parsePrometheusText(Stream<String> lines) {
+        return lines
+                .filter(line -> !line.startsWith("#") && line.length() > 0)
+                .map(line -> {
+                    final int space = line.indexOf(" ");
+                    return new AbstractMap.SimpleImmutableEntry<String, Number>(
+                            line.substring(0, space),
+                            parseNumber(line.substring(space + 1)));
+                });
+    }
+
+    private static Stream<Map.Entry<String, Number>> parsePrometheusText(String promText) {
+        return parsePrometheusText(Arrays.stream(promText.split("\n")));
+    }
+
+    private static Map<String, Number> EXPECTED_PROMETHEUS_RESULTS;
+
     private static Metadata meta;
     private static HelidonHistogram histoInt;
     private static HelidonHistogram delegatingHistoInt;
     private static HelidonHistogram histoLong;
     private static HelidonHistogram delegatingHistoLong;
+    private static final NumberFormat NUMBER_FORMATTER = DecimalFormat.getNumberInstance();
 
     @BeforeAll
     static void initClass() {
@@ -108,8 +144,20 @@ class HelidonHistogramTest {
             histoLong.getDelegate().update(dato, now);
             delegatingHistoLong.getDelegate().update(dato, now);
         }
+
+        EXPECTED_PROMETHEUS_RESULTS = parsePrometheusText(EXPECTED_PROMETHEUS_OUTPUT)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    // Deals with the exception so this is usable from inside a stream.
+    private static Number parseNumber(String value) {
+        try {
+            return NUMBER_FORMATTER.parse(value);
+        } catch (ParseException ex) {
+            fail("Unable to parse value as Number", ex);
+            return null; // never executed - the preceding fail will see to that
+        }
+    }
     @Test
     void testCounts() {
         assertAll("All counts must be 200",
@@ -157,7 +205,11 @@ class HelidonHistogramTest {
 
     @Test
     void testPrometheus() {
-        assertThat(histoInt.prometheusData(), is(EXPECTED_PROMETHEUS_OUTPUT));
+        final StringBuilder sb = new StringBuilder();
+        parsePrometheusText(new LineNumberReader(new StringReader(histoInt.prometheusData())).lines())
+                .forEach(entry -> assertThat("Unexpected value checking " + entry.getKey(),
+                                    EXPECTED_PROMETHEUS_RESULTS.get(entry.getKey()),
+                                    is(withinTolerance(entry.getValue()))));
     }
 
     @Test
@@ -185,11 +237,6 @@ class HelidonHistogramTest {
     }
 
     private void withTolerance(String field, double actual, double expectedValue) {
-        double min = expectedValue * 0.999;
-        double max = expectedValue * 1.001;
-
-        if ((actual < min) || (actual > max)) {
-            fail(field + ": expected: <" + expectedValue + ">, but actual value was: <" + actual + ">");
-        }
+        assertThat(field, expectedValue, is(withinTolerance(actual)));
     }
 }

--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.metrics;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Hamcrest Matcher for Metrics-related value checking.
+ * <p>
+ * Includes:
+ * <ul>
+ * <li>{@link #withinTolerance(java.lang.Number)} for checking within a range (tolerance) either side of an expected value</li>
+ * </ul>
+ */
+class HelidonMetricsMatcher {
+
+    static final Double VARIANCE = Double.valueOf(System.getProperty("helidon.histogram.tolerance", "0.001"));
+
+    static TypeSafeMatcher<Number> withinTolerance(final Number expected) {
+        return new TypeSafeMatcher<Number>() {
+            @Override
+            protected boolean matchesSafely(Number item) {
+                return Math.abs(expected.doubleValue() - item.doubleValue()) <= expected.doubleValue() * VARIANCE;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("withinTolerance expected value in range [")
+                        .appendValue(expected.doubleValue() * (1.0 - VARIANCE))
+                        .appendText(", ")
+                        .appendValue(expected.doubleValue() * (1.0 + VARIANCE))
+                        .appendText("]");
+            }
+        };
+    }
+}

--- a/metrics2/metrics2/pom.xml
+++ b/metrics2/metrics2/pom.xml
@@ -47,8 +47,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
                                 <systemPropertyVariables>
-                                    <concurrentGauge.minRequiredSeconds>45</concurrentGauge.minRequiredSeconds>
-                                    <histogram.tolerance>0.01</histogram.tolerance>
+                                    <helidon.concurrentGauge.minRequiredSeconds>45</helidon.concurrentGauge.minRequiredSeconds>
+                                    <helidon.histogram.tolerance>0.01</helidon.histogram.tolerance>
                                 </systemPropertyVariables>
                             </configuration>
                     </plugin>

--- a/metrics2/metrics2/pom.xml
+++ b/metrics2/metrics2/pom.xml
@@ -37,6 +37,26 @@
         <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
     </properties>
     
+    <profiles>
+        <profile>
+            <id>pipeline</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables>
+                                    <concurrentGauge.minRequiredSeconds>45</concurrentGauge.minRequiredSeconds>
+                                    <histogram.tolerance>0.01</histogram.tolerance>
+                                </systemPropertyVariables>
+                            </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
     <build>
         <plugins>
             <plugin>
@@ -44,7 +64,8 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <executions>
                         <execution>
-                            <id>InternalBridgeTest with global tags set</id>
+                            <!-- Run this test in default-test and also here with an env var set -->
+                            <id>metrics-global-tags-set</id>
                             <goals>
                                 <goal>test</goal>
                             </goals>

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.core.Is.is;
  * message so that info is available easily in the test output.
  */
 public class HelidonConcurrentGaugeTest {
-    private static final long MIN_REQUIRED_SECONDS = Integer.getInteger("concurrentGauge.minRequiredSeconds", 10);
+    private static final long MIN_REQUIRED_SECONDS = Integer.getInteger("helidon.concurrentGauge.minRequiredSeconds", 10);
     private static final long SECONDS_THRESHOLD = 60 - MIN_REQUIRED_SECONDS;
 
     /*
@@ -51,7 +51,7 @@ public class HelidonConcurrentGaugeTest {
      * the final test of max and min to fail because the gauge will not have had
      * time to gather the info about the prev. minute.
      */
-    private static final boolean SHOULD_WAIT = Boolean.valueOf(System.getProperty("shouldWait", "true"));
+    private static final boolean SHOULD_WAIT = Boolean.valueOf(System.getProperty("helidon.concurrentGauge.shouldWait", "true"));
 
     private static Metadata meta;
 

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.metrics;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
@@ -31,11 +33,33 @@ import static org.hamcrest.core.Is.is;
 
 /**
  * Class HelidonConcurrentGaugeTest.
+ * <p>
+ * The test collects timestamps from important moments in the code and, in case of an
+ * assertion violation, formats all the collected timestamps into the assertion error
+ * message so that info is available easily in the test output.
  */
 public class HelidonConcurrentGaugeTest {
-    private static final long SECONDS_THRESHOLD = 50;
+    private static final long MIN_REQUIRED_SECONDS = Integer.getInteger("concurrentGauge.minRequiredSeconds", 10);
+    private static final long SECONDS_THRESHOLD = 60 - MIN_REQUIRED_SECONDS;
+
+    /*
+     * For debugging only, to speed up testing of the test. Setting this to
+     * false avoids the logic that normally waits for a new, "clean" minute to
+     * begin the test run and then waiting for the next minute to start before
+     * retrieving the min and max to let the gauge stabilize its view back of
+     * the previous minute. Setting shouldWait to false will almost always cause
+     * the final test of max and min to fail because the gauge will not have had
+     * time to gather the info about the prev. minute.
+     */
+    private static final boolean SHOULD_WAIT = Boolean.valueOf(System.getProperty("shouldWait", "true"));
 
     private static Metadata meta;
+
+    private Date preStart;
+    private Date start;
+    private Date afterIncrementsComplete;
+    private Date afterDecrementsComplete;
+    private Date afterQuiescing;
 
     @BeforeAll
     static void initClass() {
@@ -44,6 +68,8 @@ public class HelidonConcurrentGaugeTest {
                 "aConcurrentGauge",
                 MetricType.CONCURRENT_GAUGE,
                 MetricUnits.NONE);
+        System.out.println("Minimum required seconds within minute is " + MIN_REQUIRED_SECONDS
+                + ", so SECONDS_THRESHOLD is " + SECONDS_THRESHOLD);
     }
 
     @Test
@@ -56,7 +82,10 @@ public class HelidonConcurrentGaugeTest {
 
     @Test
     void testMaxAndMinConcurrent() throws InterruptedException {
+        preStart = new Date();
         ensureSecondsInMinute();
+
+        start = new Date();
         HelidonConcurrentGauge gauge = HelidonConcurrentGauge.create("base", meta);
         System.out.println("Calling inc() and dec() a few times concurrently ...");
 
@@ -69,9 +98,10 @@ public class HelidonConcurrentGaugeTest {
                 futuresInc[i].complete(null);
             });
         });
-        CompletableFuture.allOf(futuresInc).thenRun(() ->
-                assertThat(gauge.getCount(), is(5L))
-        );
+
+        CompletableFuture.allOf(futuresInc).join();
+        afterIncrementsComplete = new Date();
+        assertThat(formatErrorOutput("after increments"), gauge.getCount(), is(5L));
 
         // Decrement gauge 10 times
         CompletableFuture<?>[] futuresDec = new CompletableFuture<?>[10];
@@ -82,25 +112,34 @@ public class HelidonConcurrentGaugeTest {
                 futuresDec[i].complete(null);
             });
         });
-        CompletableFuture.allOf(futuresDec).thenRun(() ->
-                assertThat(gauge.getCount(), is(-5L))
-        );
-
+        CompletableFuture.allOf(futuresDec).join();
+        afterDecrementsComplete = new Date();
+        assertThat(formatErrorOutput("after decrements"), gauge.getCount(), is(-5L));
+        System.out.println("CompletableFutures all done at seconds within minute = " + currentTimeSeconds());
         waitUntilNextMinute();
+
+        afterQuiescing = new Date();
+
         System.out.println("Verifying max and min from last minute ...");
-        assertThat(gauge.getMax(), is(5L));
-        assertThat(gauge.getMin(), is(-5L));
+        assertThat(formatErrorOutput("checking max"), gauge.getMax(), is(5L));
+        assertThat(formatErrorOutput("checking min"), gauge.getMin(), is(-5L));
     }
 
     private static void ensureSecondsInMinute() throws InterruptedException {
         long currentSeconds = currentTimeSeconds();
         System.out.println("Seconds in minute are " + currentSeconds);
         if (currentSeconds > SECONDS_THRESHOLD) {
+            System.out.println("which is beyond the threshold " + SECONDS_THRESHOLD + "; waiting until the next minute");
             waitUntilNextMinute();
         }
+        System.out.println("Continuing");
     }
 
     private static void waitUntilNextMinute() throws InterruptedException {
+        if (!SHOULD_WAIT) {
+            System.out.println("Not waiting");
+            return;
+        }
         boolean displayMessage = true;
         long currentMinute = currentTimeMinute();
         while (currentMinute == currentTimeMinute()) {
@@ -118,5 +157,29 @@ public class HelidonConcurrentGaugeTest {
 
     private static long currentTimeSeconds() {
         return System.currentTimeMillis() / 1000 % 60;
+    }
+
+    private String formatErrorOutput(String note) {
+        return String.format("%s%n"
+                            + "           prestart: %s%n"
+                            + "              start: %s%n"
+                            + "   after increments: %s%n"
+                            + "   after decrements: %s%n"
+                            + "    after quiescing: %s%n",
+                note,
+                formatDate(preStart),
+                formatDate(start),
+                formatDate(afterIncrementsComplete),
+                formatDate(afterDecrementsComplete),
+                formatDate(afterQuiescing));
+    }
+
+    private static String formatDate(Date d) {
+        if (d == null) {
+            return "not reached";
+        }
+        Calendar c = Calendar.getInstance();
+        c.setTime(d);
+        return String.format("%1$tH:%1$tM:%1$tS.%1$tL", c);
     }
 }

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
@@ -29,7 +29,7 @@ import org.hamcrest.TypeSafeMatcher;
  */
 class HelidonMetricsMatcher {
 
-    static final Double VARIANCE = Double.valueOf(System.getProperty("histogram.tolerance", "0.001"));
+    static final Double VARIANCE = Double.valueOf(System.getProperty("helidon.histogram.tolerance", "0.001"));
 
     static TypeSafeMatcher<Number> withinTolerance(final Number expected) {
         return new TypeSafeMatcher<Number>() {

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMetricsMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.metrics;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Hamcrest Matcher for Metrics-related value checking.
+ * <p>
+ * Includes:
+ * <ul>
+ * <li>{@link #withinTolerance(java.lang.Number)} for checking within a range (tolerance) either side of an expected value</li>
+ * </ul>
+ */
+class HelidonMetricsMatcher {
+
+    static final Double VARIANCE = Double.valueOf(System.getProperty("histogram.tolerance", "0.001"));
+
+    static TypeSafeMatcher<Number> withinTolerance(final Number expected) {
+        return new TypeSafeMatcher<Number>() {
+            @Override
+            protected boolean matchesSafely(Number item) {
+                return Math.abs(expected.doubleValue() - item.doubleValue()) <= expected.doubleValue() * VARIANCE;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("withinTolerance expected value in range [")
+                        .appendValue(expected.doubleValue() * (1.0 - VARIANCE))
+                        .appendText(", ")
+                        .appendValue(expected.doubleValue() * (1.0 + VARIANCE))
+                        .appendText("]");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Variability in the pipeline environment leads to intermittent test failures. (issue #1009)

These changes add some robustness to some of the metrics tests to be less susceptible to timing issues from slower-running pipeline nodes.

A new maven profile, `pipeline`, is added. The `build.sh` script now activates that profile and the `metrics2` pom is sensitive to that profile, setting two system properties that give more leeway to two of the tests. 

These changes also address some issues with potential failing asserts being hidden because they were inside `CompletableFutures`.