### PR TITLE
Fully enforce reusability in MP Metrics 1.1. support

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/InternalMetadataBuilderImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/InternalMetadataBuilderImpl.java
@@ -104,7 +104,7 @@ class InternalMetadataBuilderImpl implements InternalBridge.Metadata.MetadataBui
         if (name == null) {
             throw new IllegalStateException("name must be assigned");
         }
-        return new InternalMetadataImpl(name, displayName, description, type, unit);
+        return new InternalMetadataImpl(name, displayName, description, type, unit, reusable, null);
     }
 
     static class FactoryImpl implements Metadata.MetadataBuilder.Factory {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -269,25 +269,25 @@ public final class MetricsSupport implements Service {
         String metricPrefix = (null == routingName ? "" : routingName + ".") + "requests.";
 
         Registry vendor = rf.getARegistry(MetricRegistry.Type.VENDOR);
-        Counter totalCount = vendor.counter(new Metadata(metricPrefix + "count",
+        Counter totalCount = vendor.counter(reusableMetadata(metricPrefix + "count",
                                                          "Total number of HTTP requests",
                                                          "Each request (regardless of HTTP method) will increase this counter",
                                                          MetricType.COUNTER,
                                                          MetricUnits.NONE));
 
-        Meter totalMeter = vendor.meter(new Metadata(metricPrefix + "meter",
+        Meter totalMeter = vendor.meter(reusableMetadata(metricPrefix + "meter",
                                                      "Meter for overall HTTP requests",
                                                      "Each request will mark the meter to see overall throughput",
                                                      MetricType.METERED,
                                                      MetricUnits.NONE));
 
-        vendor.counter(new Metadata("grpc.requests.count",
+        vendor.counter(reusableMetadata("grpc.requests.count",
                                     "Total number of gRPC requests",
                                     "Each gRPC request (regardless of the method) will increase this counter",
                                     MetricType.COUNTER,
                                     MetricUnits.NONE));
 
-        vendor.meter(new Metadata("grpc.requests.meter",
+        vendor.meter(reusableMetadata("grpc.requests.meter",
                                   "Meter for overall gRPC requests",
                                   "Each gRPC request will mark the meter to see overall throughput",
                                   MetricType.METERED,
@@ -351,6 +351,13 @@ public final class MetricsSupport implements Service {
     public void update(Routing.Rules rules) {
         configureVendorMetrics(null, rules);
         configureEndpoint(rules);
+    }
+
+    private Metadata reusableMetadata(String name, String displayName, String description,
+            MetricType type, String units) {
+        Metadata result = new Metadata(name, displayName, description, type, units);
+        result.setReusable(true);
+        return result;
     }
 
     private void getOne(ServerRequest req, ServerResponse res, Registry registry) {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -65,9 +65,11 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     static Metadata toMetadata(io.helidon.common.metrics.InternalBridge.Metadata metadata, Map<String, String> tags) {
-        return new Metadata(metadata.getName(), metadata.getDisplayName(),
+        Metadata result = new Metadata(metadata.getName(), metadata.getDisplayName(),
         metadata.getDescription().orElse(null), metadata.getTypeRaw(),
                 metadata.getUnit().orElse(null), tagsAsString(tags));
+        result.setReusable(metadata.isReusable());
+        return result;
     }
 
     Optional<HelidonMetric> getMetric(String metricName) {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -430,8 +430,6 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
         }
         return a.getName().equals(b.getName())
                 && a.getTypeRaw().equals(b.getTypeRaw())
-                && a.getDisplayName().equals(b.getDisplayName())
-                && Objects.equals(a.getDescription(), b.getDescription())
                 && Objects.equals(a.getUnit(), b.getUnit())
                 && a.getTags().equals(b.getTags())
                 && (a.isReusable() == b.isReusable());

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -419,6 +419,10 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
             if (metric.isReusable() != metadata.isReusable()) {
                 throw new IllegalArgumentException("Metadata not re-usable for metric " + metadata.getName());
             }
+            if (!metadata.isReusable()) {
+                throw new IllegalArgumentException("Attempt to re-register metric " + metric.getName()
+                        + " but reuse of this metric is not permitted by its metadata");
+            }
         } else {
             metric = newInstanceCreator.apply(metadata.getName());
             metric.setReusable(metadata.isReusable());

--- a/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
@@ -112,7 +112,7 @@ public class RegistryFactoryTest {
         assertNotSame(c1, c2);
 
         //replace c2 with a counter from the same registry
-        c2 = app.getCounters().get("new.counter");
+        c2 = app.counter("new.counter");
         assertSame(c1, c2);
     }
 

--- a/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
@@ -112,7 +112,7 @@ public class RegistryFactoryTest {
         assertNotSame(c1, c2);
 
         //replace c2 with a counter from the same registry
-        c2 = app.counter("new.counter");
+        c2 = app.getCounters().get("new.counter");
         assertSame(c1, c2);
     }
 

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -544,8 +545,8 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
                 && a.getTypeRaw().equals(b.getTypeRaw())
                 && (((isFlexible(a) || isFlexible(b))
                     || (a.getDisplayName().equals(b.getDisplayName())
-                        && a.getDescription().equals(b.getDescription())
-                        && a.getUnit().equals(b.getUnit())
+                        && Objects.equals(a.getDescription(), b.getDescription())
+                        && Objects.equals(a.getUnit(), b.getUnit())
                         && (a.isReusable() == b.isReusable())
                     ))
                    );

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceMetrics.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceMetrics.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.metrics.MetricUnits;
 import static io.helidon.common.metrics.InternalBridge.Metadata.newMetadata;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceExtension.getRealClass;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceExtension.isFaultToleranceMetricsEnabled;
+import java.util.Collections;
 
 /**
  * Class FaultToleranceMetrics.
@@ -303,7 +304,8 @@ class FaultToleranceMetrics {
      */
     private static Counter registerCounter(String name, String description) {
         return getMetricRegistry().counter(
-                newMetadata(name, name, description, MetricType.COUNTER, MetricUnits.NONE));
+                newMetadata(name, name, description, MetricType.COUNTER, MetricUnits.NONE,
+                        true, Collections.emptyMap()));
     }
 
     /**
@@ -315,7 +317,8 @@ class FaultToleranceMetrics {
      */
     static Histogram registerHistogram(String name, String description) {
         return getMetricRegistry().histogram(
-                newMetadata(name, name, description, MetricType.HISTOGRAM, MetricUnits.NANOSECONDS));
+                newMetadata(name, name, description, MetricType.HISTOGRAM, MetricUnits.NANOSECONDS,
+                        true, Collections.emptyMap()));
     }
 
     /**
@@ -335,7 +338,8 @@ class FaultToleranceMetrics {
         Gauge<T> existing = getMetricRegistry().getBridgeGauges().get(metricID);
         if (existing == null) {
             getMetricRegistry().register(
-                    newMetadata(metricID.getName(), metricID.getName(), description, MetricType.GAUGE, MetricUnits.NANOSECONDS),
+                    newMetadata(metricID.getName(), metricID.getName(), description, MetricType.GAUGE, MetricUnits.NANOSECONDS,
+                            true, Collections.emptyMap()),
                     gauge);
         }
         return existing;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceMetrics.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceMetrics.java
@@ -17,6 +17,7 @@
 package io.helidon.microprofile.faulttolerance;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 
 import javax.enterprise.inject.spi.CDI;
 
@@ -33,7 +34,6 @@ import org.eclipse.microprofile.metrics.MetricUnits;
 import static io.helidon.common.metrics.InternalBridge.Metadata.newMetadata;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceExtension.getRealClass;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceExtension.isFaultToleranceMetricsEnabled;
-import java.util.Collections;
 
 /**
  * Class FaultToleranceMetrics.

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
@@ -87,9 +87,8 @@ public class MetricsTest extends FaultToleranceTest {
                 .withType(MetricType.COUNTER)
                 .withUnit(MetricUnits.NONE)
                 .build());
-        MetricID metricID = InternalBridge.INSTANCE.getMetricIDFactory().newMetricID("dcounter");
-        metricRegistry.getBridgeCounters().get(metricID).inc();
-        assertThat(metricRegistry.getBridgeCounters().get(metricID).getCount(), is(1L));
+        metricRegistry.counter("dcounter").inc();
+        assertThat(metricRegistry.counter("dcounter").getCount(), is(1L));
     }
 
     @Test

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/MetricsTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Future;
 
 import io.helidon.common.metrics.InternalBridge;
 import io.helidon.common.metrics.InternalBridge.Metadata.MetadataBuilder;
+import io.helidon.common.metrics.InternalBridge.MetricID;
 import io.helidon.common.metrics.InternalBridge.MetricRegistry;
 
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
@@ -86,8 +87,9 @@ public class MetricsTest extends FaultToleranceTest {
                 .withType(MetricType.COUNTER)
                 .withUnit(MetricUnits.NONE)
                 .build());
-        metricRegistry.counter("dcounter").inc();
-        assertThat(metricRegistry.counter("dcounter").getCount(), is(1L));
+        MetricID metricID = InternalBridge.INSTANCE.getMetricIDFactory().newMetricID("dcounter");
+        metricRegistry.getBridgeCounters().get(metricID).inc();
+        assertThat(metricRegistry.getBridgeCounters().get(metricID).getCount(), is(1L));
     }
 
     @Test

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -88,7 +88,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Counter produceCounter(MetricRegistry registry, InjectionPoint ip) {
-        return processInjectionPoint(ip, registry::getCounters, registry::counter, Counter.class);
+        return produceMetric(ip, registry::getCounters, registry::counter, Counter.class);
     }
 
     @Produces
@@ -99,7 +99,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Meter produceMeter(MetricRegistry registry, InjectionPoint ip) {
-        return processInjectionPoint(ip, registry::getMeters, registry::meter, Meter.class);
+        return produceMetric(ip, registry::getMeters, registry::meter, Meter.class);
     }
 
     @Produces
@@ -110,7 +110,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Timer produceTimer(MetricRegistry registry, InjectionPoint ip) {
-        return processInjectionPoint(ip, registry::getTimers, registry::timer, Timer.class);
+        return produceMetric(ip, registry::getTimers, registry::timer, Timer.class);
     }
 
     @Produces
@@ -121,7 +121,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Histogram produceHistogram(MetricRegistry registry, InjectionPoint ip) {
-        return processInjectionPoint(ip, registry::getHistograms, registry::histogram, Histogram.class);
+        return produceMetric(ip, registry::getHistograms, registry::histogram, Histogram.class);
     }
 
     /**
@@ -157,7 +157,7 @@ public class MetricProducer {
         return produceGauge(registry, ip);
     }
 
-    private <T> T processInjectionPoint(InjectionPoint ip, Supplier<Map<String, T>> getTypedMetricsFn,
+    private <T> T produceMetric(InjectionPoint ip, Supplier<Map<String, T>> getTypedMetricsFn,
             Function<Metadata, T> registerFn, Class<T> clazz) {
 
         Metric metricAnno = ip.getAnnotated().getAnnotation(Metric.class);

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -17,7 +17,6 @@
 package io.helidon.microprofile.metrics;
 
 import java.lang.reflect.Constructor;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -17,6 +17,10 @@
 package io.helidon.microprofile.metrics;
 
 import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -38,6 +42,8 @@ import org.eclipse.microprofile.metrics.annotation.Metric;
  */
 @ApplicationScoped
 public class MetricProducer {
+
+    private final Map<InjectionPoint, Object> injectionPoints = new HashMap<>();
 
     private static Metadata newMetadata(InjectionPoint ip, Metric metric, MetricType metricType) {
         return metric == null ? new Metadata(getName(ip),
@@ -69,17 +75,12 @@ public class MetricProducer {
     }
 
     private static String getName(Metric metric, InjectionPoint ip) {
-        StringBuilder fullName =
-                new StringBuilder(metric.absolute() ? "" : ip.getMember().getDeclaringClass().getName() + ".");
-        if (metric.name().isEmpty()) {
-            fullName.append(ip.getMember().getName());
-            if (ip.getMember() instanceof Constructor) {
-                fullName.append(".new");
-            }
-        } else {
-            fullName.append(metric.name());
-        }
-        return fullName.toString();
+        boolean isAbsolute = metric != null && metric.absolute();
+        String prefix = isAbsolute ? "" : ip.getMember().getDeclaringClass().getName() + ".";
+        String shortName = metric != null && !metric.name().isEmpty() ? metric.name() : ip.getMember().getName();
+        String ctorSuffix = ip.getMember() instanceof Constructor ? ".new" : "";
+        String fullName = prefix + shortName + ctorSuffix;
+        return fullName;
     }
 
     @Produces
@@ -90,8 +91,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Counter produceCounter(MetricRegistry registry, InjectionPoint ip) {
-        Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
-        return registry.counter(newMetadata(ip, metric, MetricType.COUNTER));
+        return processInjectionPoint(ip, registry::getCounters, registry::counter, Counter.class);
     }
 
     @Produces
@@ -102,8 +102,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Meter produceMeter(MetricRegistry registry, InjectionPoint ip) {
-        Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
-        return registry.meter(newMetadata(ip, metric, MetricType.METERED));
+        return processInjectionPoint(ip, registry::getMeters, registry::meter, Meter.class);
     }
 
     @Produces
@@ -114,8 +113,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Timer produceTimer(MetricRegistry registry, InjectionPoint ip) {
-        Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
-        return registry.timer(newMetadata(ip, metric, MetricType.TIMER));
+        return processInjectionPoint(ip, registry::getTimers, registry::timer, Timer.class);
     }
 
     @Produces
@@ -126,8 +124,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     private Histogram produceHistogram(MetricRegistry registry, InjectionPoint ip) {
-        Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
-        return registry.histogram(newMetadata(ip, metric, MetricType.HISTOGRAM));
+        return processInjectionPoint(ip, registry::getHistograms, registry::histogram, Histogram.class);
     }
 
     /**
@@ -161,5 +158,28 @@ public class MetricProducer {
     @Produces
     private <T> Gauge<T> produceGaugeDefault(MetricRegistry registry, InjectionPoint ip) {
         return produceGauge(registry, ip);
+    }
+
+    private <T> T processInjectionPoint(InjectionPoint ip, Supplier<Map<String, T>> getTypedMetricsFn,
+            Function<Metadata, T> registerFn, Class<T> clazz) {
+        /*
+         * Some injection points are reported more than once. If the IP has
+         * previously been processed just return the metric that was created at
+         * that time, rather than trying to create a new metric again.
+         */
+        if (!injectionPoints.containsKey(ip)) {
+            Metric metricAnno = ip.getAnnotated().getAnnotation(Metric.class);
+            T result = getTypedMetricsFn.get().get(getName(metricAnno, ip));
+            /*
+             * For an injection point, refer to a previously-registered metric,
+             * if any. Register a new instance only if none is already present.
+             */
+            if (result == null) {
+                result = registerFn.apply(newMetadata(ip, metricAnno, MetricType.from(clazz)));
+            }
+            injectionPoints.put(ip, result);
+            return result;
+        }
+        return clazz.cast(injectionPoints.get(ip));
     }
 }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
@@ -79,6 +79,6 @@ public class MetricsMpServiceTest {
     }
 
     protected static Counter getCounter(String name) {
-        return registry.getCounters().get(name);
+        return registry.counter(name);
     }
 }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
@@ -19,13 +19,14 @@ package io.helidon.microprofile.metrics;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
-import io.helidon.common.metrics.InternalBridge.MetricRegistry;
 import io.helidon.config.Config;
+import io.helidon.metrics.RegistryFactory;
 import io.helidon.microprofile.config.MpConfig;
 import io.helidon.microprofile.server.Server;
 
 import org.eclipse.microprofile.metrics.Counter;
-import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.junit.jupiter.api.AfterAll;
@@ -53,8 +54,7 @@ public class MetricsMpServiceTest {
                 .build();
         server.start();
 
-        registry = io.helidon.common.metrics.InternalBridge.INSTANCE
-                .getRegistryFactory().getBridgeRegistry(Type.APPLICATION);
+        registry = registry = RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.APPLICATION);
 
         port = server.port();
         baseUri = "http://localhost:" + port;
@@ -70,8 +70,7 @@ public class MetricsMpServiceTest {
     }
 
     protected static void registerCounter(String name) {
-        io.helidon.common.metrics.InternalBridge.Metadata meta =
-                io.helidon.common.metrics.InternalBridge.Metadata.newMetadata(name,
+        Metadata meta = new Metadata(name,
                                      name,
                                      name,
                                      MetricType.COUNTER,
@@ -80,6 +79,6 @@ public class MetricsMpServiceTest {
     }
 
     protected static Counter getCounter(String name) {
-        return registry.counter(name);
+        return registry.getCounters().get(name);
     }
 }


### PR DESCRIPTION
The code that supports MP Metrics 1.1 does not fully enforce reusability. These changes correct that.

(This PR also addresses some unnecessary references to the internal bridging infrastructure which these classes did not need to use; they can and should depend directly on the MP metrics 1.1 artifacts.)

See issue #1046 