### PR TITLE
Allow config to disable all base metrics easily

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/BaseRegistry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/BaseRegistry.java
@@ -47,10 +47,13 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * </ul>
  *
  * Each metric can be disabled by using the following configuration property:
- * {@code helidon.metrics.base.${metric_name}.enabled=false}
+ * {@code helidon.metrics.base.${metric_name}.enabled=false}. Further, to suppress
+ * all base metrics set {@code helidon.metrics.base.enabled=false}.
  */
 final class BaseRegistry extends Registry {
     private static final String CONFIG_METRIC_ENABLED_BASE = "base.";
+    static final String BASE_ENABLED_KEY = CONFIG_METRIC_ENABLED_BASE + "enabled";
+
     private static final Metadata MEMORY_USED_HEAP = new Metadata("memory.usedHeap",
                                                                   "Used Heap Memory",
                                                                   "Displays the amount of used heap memory in bytes.",
@@ -182,6 +185,9 @@ final class BaseRegistry extends Registry {
 
         BaseRegistry result = new BaseRegistry(config);
 
+        if (!config.get(BASE_ENABLED_KEY).asBoolean().orElse(true)) {
+            return result;
+        }
         MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
 
         // load all base metrics

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -448,7 +448,9 @@ public final class MetricsSupport implements Service {
             // backward compatibility
             config.get("context").asString().ifPresent(this::context);
 
-
+            if (!config.get(BaseRegistry.BASE_ENABLED_KEY).asBoolean().orElse(true)) {
+                LOGGER.finest("Metrics support for base metrics is disabled in configuration");
+            }
             return this;
         }
 

--- a/metrics/metrics/src/test/java/io/helidon/metrics/MetricsSupportTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/MetricsSupportTest.java
@@ -16,10 +16,14 @@
 
 package io.helidon.metrics;
 
+import io.helidon.common.CollectionsHelper;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
 import javax.json.JsonObject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +35,9 @@ class MetricsSupportTest {
     private static Registry base;
     private static Registry vendor;
     private static Registry app;
+
+    private static final String METRIC_USED_HEAP = "memory.usedHeap";
+
 
     @BeforeAll
     static void initClass() {
@@ -77,5 +84,17 @@ class MetricsSupportTest {
     void testJsonMetaMultiple() {
         JsonObject jsonObject = MetricsSupport.toJsonMeta(app, base);
         System.out.println("jsonObject = " + jsonObject);
+    }
+
+    @Test
+    void testBaseMetricsDisabled() {
+        Config config = Config.builder()
+                .sources(ConfigSources.create(CollectionsHelper.mapOf(
+                        "base.enabled", "false")))
+                .build();
+        RegistryFactory myRF = RegistryFactory.create(config);
+        Registry myBase = myRF.getARegistry(MetricRegistry.Type.BASE);
+        assertFalse(myBase.getGauges().containsKey(METRIC_USED_HEAP), "Base registry incorrectly contains "
+                + METRIC_USED_HEAP + " when base was configured as disabled");
     }
 }

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
@@ -26,7 +26,6 @@ import java.lang.management.ThreadMXBean;
 import java.util.List;
 
 import io.helidon.config.Config;
-import java.util.logging.Logger;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
@@ -54,8 +53,6 @@ import org.eclipse.microprofile.metrics.Tag;
 final class BaseRegistry extends Registry {
 
     static final String BASE_ENABLED_KEY = "base.enabled";
-
-    private static final Logger LOGGER = Logger.getLogger(BaseRegistry.class.getName());
 
     private static final String CONFIG_METRIC_ENABLED_BASE = "base.";
 

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
@@ -48,13 +48,13 @@ import org.eclipse.microprofile.metrics.Tag;
  * </ul>
  *
  * Each metric can be disabled by using the following configuration property:
- * {@code helidon.metrics.base.${metric_name}.enabled=false}
+ * {@code helidon.metrics.base.${metric_name}.enabled=false}. Further, to suppress
+ * all base metrics set {@code helidon.metrics.base.enabled=false}.
  */
 final class BaseRegistry extends Registry {
 
-    static final String BASE_ENABLED_KEY = "base.enabled";
-
     private static final String CONFIG_METRIC_ENABLED_BASE = "base.";
+    static final String BASE_ENABLED_KEY = CONFIG_METRIC_ENABLED_BASE + "enabled";
 
     private static final Metadata MEMORY_USED_HEAP =
             new HelidonMetadata("memory.usedHeap",

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/BaseRegistry.java
@@ -26,6 +26,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.List;
 
 import io.helidon.config.Config;
+import java.util.logging.Logger;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
@@ -51,6 +52,10 @@ import org.eclipse.microprofile.metrics.Tag;
  * {@code helidon.metrics.base.${metric_name}.enabled=false}
  */
 final class BaseRegistry extends Registry {
+
+    static final String BASE_ENABLED_KEY = "base.enabled";
+
+    private static final Logger LOGGER = Logger.getLogger(BaseRegistry.class.getName());
 
     private static final String CONFIG_METRIC_ENABLED_BASE = "base.";
 
@@ -195,6 +200,9 @@ final class BaseRegistry extends Registry {
 
         BaseRegistry result = new BaseRegistry(config);
 
+        if (!config.get(BASE_ENABLED_KEY).asBoolean().orElse(true)) {
+            return result;
+        }
         MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
 
         // load all base metrics

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -500,6 +500,9 @@ public final class MetricsSupport implements Service {
             // backward compatibility
             config.get("context").asString().ifPresent(this::context);
 
+            if (!config.get(BaseRegistry.BASE_ENABLED_KEY).asBoolean().orElse(true)) {
+                LOGGER.finest("Metrics support for base metrics is disabled in configuration");
+            }
             return this;
         }
 


### PR DESCRIPTION
Addresses #958 

The config key `helidon.metrics.base.enable` can be set to `true` (the default) or `false` to control whether Helidon will create those metrics or not.

