### PR TITLE
Defer datasource configuration

### DIFF
--- a/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
+++ b/integrations/cdi/datasource-hikaricp/src/test/resources/application.yaml
@@ -20,4 +20,3 @@ javax:
                url: jdbc:h2:mem:test
                user: sa
                password: ""
-

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestExtendedSynchronizedEntityManager.java
@@ -51,10 +51,8 @@ import static org.junit.jupiter.api.Assertions.fail;
     name = "chirp",
     className = "org.h2.jdbcx.JdbcDataSource",
     url = "jdbc:h2:mem:chirp;INIT=RUNSCRIPT FROM 'classpath:chirp.ddl'",
-    serverName = "",
-    properties = {
-        "user=sa"
-    }
+    user = "sa",
+    serverName = ""
 )
 class TestExtendedSynchronizedEntityManager {
 

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedSynchronizedEntityManager.java
@@ -51,10 +51,8 @@ import static org.junit.jupiter.api.Assertions.fail;
     name = "chirp",
     className = "org.h2.jdbcx.JdbcDataSource",
     url = "jdbc:h2:mem:chirp;INIT=RUNSCRIPT FROM 'classpath:chirp.ddl'",
-    serverName = "",
-    properties = {
-        "user=sa"
-    }
+    user = "sa",
+    serverName = ""
 )
 class TestJpaTransactionScopedSynchronizedEntityManager {
 

--- a/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedUnsynchronizedEntityManager.java
+++ b/integrations/cdi/jpa-cdi/src/test/java/io/helidon/integrations/cdi/jpa/chirp/TestJpaTransactionScopedUnsynchronizedEntityManager.java
@@ -51,10 +51,8 @@ import static org.junit.jupiter.api.Assertions.fail;
     name = "chirp",
     className = "org.h2.jdbcx.JdbcDataSource",
     url = "jdbc:h2:mem:chirp;INIT=RUNSCRIPT FROM 'classpath:chirp.ddl'",
-    serverName = "",
-    properties = {
-        "user=sa"
-    }
+    user = "sa",
+    serverName = ""
 )
 class TestJpaTransactionScopedUnsynchronizedEntityManager {
 

--- a/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
+++ b/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
@@ -45,10 +45,8 @@ import static org.junit.jupiter.api.Assertions.fail;
     name = "test",
     className = "org.h2.jdbcx.JdbcDataSource",
     url = "jdbc:h2:mem:test",
+    user = "sa",
     serverName = "",
-    properties = {
-        "user=sa"
-    }
 )
 public class TestIntegration {
 

--- a/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
+++ b/integrations/cdi/jpa-weld/src/test/java/io/helidon/integrations/cdi/jpa/weld/TestIntegration.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.fail;
     className = "org.h2.jdbcx.JdbcDataSource",
     url = "jdbc:h2:mem:test",
     user = "sa",
-    serverName = "",
+    serverName = ""
 )
 public class TestIntegration {
 


### PR DESCRIPTION
Adds the ability to push data source configuration until the last possible minute to help with Graal VM.