### PR TITLE
WIP: Adapt to changes in MP Metrics 2.1.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -75,7 +75,7 @@
         <version.lib.microprofile-health>2.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
-        <version.lib.microprofile-metrics2-api>2.0.1</version.lib.microprofile-metrics2-api>
+        <version.lib.microprofile-metrics2-api>2.1.0</version.lib.microprofile-metrics2-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -321,7 +321,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
                 .map(Registry::toBridgeEntry);
     }
 
-    private synchronized static <T extends Metric> SortedMap<MetricID, T>
+    private static synchronized <T extends Metric> SortedMap<MetricID, T>
             getBridgeMetrics(SortedMap<String, T> metrics, Class<T> clazz) {
         return metrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -205,7 +205,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public void removeMatching(MetricFilter filter) {
+    public synchronized void removeMatching(MetricFilter filter) {
         allMetrics.entrySet().removeIf(entry -> filter.matches(entry.getKey(), entry.getValue()));
     }
 
@@ -275,7 +275,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
+    public synchronized Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
             Predicate<? super Map.Entry<? extends InternalBridge.MetricID, ? extends Metric>> predicate) {
         return allMetrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -321,7 +321,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
                 .map(Registry::toBridgeEntry);
     }
 
-    private static <T extends Metric> SortedMap<MetricID, T>
+    private synchronized static <T extends Metric> SortedMap<MetricID, T>
             getBridgeMetrics(SortedMap<String, T> metrics, Class<T> clazz) {
         return metrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -405,7 +405,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
         return type() + ": " + allMetrics.size() + " metrics";
     }
 
-    private <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
+    private synchronized <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
         Map<String, V> collected = allMetrics.entrySet()
                 .stream()
                 .filter(it -> metricClass.isAssignableFrom(it.getValue().getClass()))
@@ -470,7 +470,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if any) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(String metricName,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(String metricName,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
 
@@ -493,7 +493,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if matching the metadata) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
         return getOptionalMetric(metadata.getName(), clazz)

--- a/microprofile/metrics2/pom.xml
+++ b/microprofile/metrics2/pom.xml
@@ -54,6 +54,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <version>${version.lib.microprofile-metrics2-api}</version>  
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>internal-test-libs</artifactId>
             <scope>test</scope>

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  *
  * @param <T> data type reported by the underlying {@code Gauge}
  */
-public class DelegatingGauge<T> implements Gauge<T> {
+public class DelegatingGauge<T extends Number> implements Gauge<T> {
 
     private final Method method;
     private final Object obj;
@@ -50,15 +50,14 @@ public class DelegatingGauge<T> implements Gauge<T> {
      * @param clazz  type of the underlying gauge
      * @return {@code DelegatingGauge}
      */
-    public static <S> DelegatingGauge<S> newInstance(Method method, Object obj, Class<S> clazz) {
+    public static <S extends Number> DelegatingGauge<S> newInstance(Method method, Object obj, Class<S> clazz) {
         return new DelegatingGauge<>(method, obj, clazz);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public T getValue() {
         try {
-            return (T) method.invoke(obj);
+            return clazz.cast(method.invoke(obj));
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             throw new RuntimeException(ex);
         }

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -187,7 +187,7 @@ public class MetricProducer {
     @Produces
     @VendorDefined
     @SuppressWarnings("unchecked")
-    private <T> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
+    private <T extends Number> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
         Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
         return (Gauge<T>) registry.getGauges().entrySet().stream()
                 .filter(entry -> entry.getKey().getName().equals(metric.name()))
@@ -205,7 +205,7 @@ public class MetricProducer {
      * @return requested gauge
      */
     @Produces
-    private <T> Gauge<T> produceGaugeDefault(MetricRegistry registry, InjectionPoint ip) {
+    private <T extends Number> Gauge<T> produceGaugeDefault(MetricRegistry registry, InjectionPoint ip) {
         return produceGauge(registry, ip);
     }
 }

--- a/microprofile/tests/tck/tck-metrics2/pom.xml
+++ b/microprofile/tests/tck/tck-metrics2/pom.xml
@@ -71,6 +71,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
MP Metrics 2.1.0 brings a changes that affect us:
* Implementations need to be thread-safe, 
* a `Gauge`'s type must extend `Number`

