### PR TITLE
Add sync to metrics registry methods for thread safeness

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -205,7 +205,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public void removeMatching(MetricFilter filter) {
+    public synchronized void removeMatching(MetricFilter filter) {
         allMetrics.entrySet().removeIf(entry -> filter.matches(entry.getKey(), entry.getValue()));
     }
 
@@ -275,7 +275,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
+    public synchronized Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
             Predicate<? super Map.Entry<? extends InternalBridge.MetricID, ? extends Metric>> predicate) {
         return allMetrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -321,7 +321,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
                 .map(Registry::toBridgeEntry);
     }
 
-    private static <T extends Metric> SortedMap<MetricID, T>
+    private static synchronized <T extends Metric> SortedMap<MetricID, T>
             getBridgeMetrics(SortedMap<String, T> metrics, Class<T> clazz) {
         return metrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -405,7 +405,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
         return type() + ": " + allMetrics.size() + " metrics";
     }
 
-    private <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
+    private synchronized <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
         Map<String, V> collected = allMetrics.entrySet()
                 .stream()
                 .filter(it -> metricClass.isAssignableFrom(it.getValue().getClass()))
@@ -470,7 +470,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if any) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(String metricName,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(String metricName,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
 
@@ -493,7 +493,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if matching the metadata) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
         return getOptionalMetric(metadata.getName(), clazz)


### PR DESCRIPTION
Particularly (but not only) in the metrics 2.0 implementation, the code needs to update multiple data structures or otherwise take multiple steps as metrics are added or removed or processed.

This PR adds synchronization where multiple steps are involved in these operations.