### PR TITLE
Rationalize some metrics 1.1 and 2.0 support code; add sync to both impls

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -205,7 +205,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public void removeMatching(MetricFilter filter) {
+    public synchronized void removeMatching(MetricFilter filter) {
         allMetrics.entrySet().removeIf(entry -> filter.matches(entry.getKey(), entry.getValue()));
     }
 
@@ -275,7 +275,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
     }
 
     @Override
-    public Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
+    public synchronized Map<InternalBridge.MetricID, Metric> getBridgeMetrics(
             Predicate<? super Map.Entry<? extends InternalBridge.MetricID, ? extends Metric>> predicate) {
         return allMetrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -321,7 +321,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
                 .map(Registry::toBridgeEntry);
     }
 
-    private static <T extends Metric> SortedMap<MetricID, T>
+    private static synchronized <T extends Metric> SortedMap<MetricID, T>
             getBridgeMetrics(SortedMap<String, T> metrics, Class<T> clazz) {
         return metrics.entrySet().stream()
                 .map(Registry::toBridgeEntry)
@@ -405,7 +405,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
         return type() + ": " + allMetrics.size() + " metrics";
     }
 
-    private <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
+    private synchronized <V> SortedMap<String, V> getSortedMetrics(MetricFilter filter, Class<V> metricClass) {
         Map<String, V> collected = allMetrics.entrySet()
                 .stream()
                 .filter(it -> metricClass.isAssignableFrom(it.getValue().getClass()))
@@ -470,7 +470,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if any) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(String metricName,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(String metricName,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
 
@@ -493,7 +493,7 @@ class Registry extends MetricRegistry implements io.helidon.common.metrics.Inter
      * @param clazz class of the metric to find or create
      * @return the existing metric (if matching the metadata) or a newly-registered one
      */
-    private <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
+    private synchronized <T extends MetricImpl> T getOrRegisterMetric(Metadata metadata,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz) {
         return getOptionalMetric(metadata.getName(), clazz)

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonMetadata.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonMetadata.java
@@ -28,30 +28,6 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  */
 public class HelidonMetadata extends DefaultMetadata {
 
-    private boolean isFlexible = false;
-
-    /**
-     * Creates a new "flexible" metadata instance which, when used in comparison against other
-     * instances, will require matches on only the name and type. This is particularly
-     * useful for injection handling of {@code @Metric} which can specify metadata-related
-     * information to be used if the metadata has not been previously registered
-     * but need not mandate what that existing metadata must be.
-     *
-     * @param name name
-     * @param displayName display name
-     * @param description description
-     * @param type metric type
-     * @param unit unit
-     * @return new flexible {@code HelidonMetadata}
-     */
-    public static HelidonMetadata newFlexible(String name, String displayName, String description, MetricType type,
-                           String unit) {
-        final HelidonMetadata result = new HelidonMetadata(name, displayName, description,
-                type, unit, false);
-        result.isFlexible = true;
-        return result;
-    }
-
     /**
      * Construct immutable metadata.
      *
@@ -89,39 +65,4 @@ public class HelidonMetadata extends DefaultMetadata {
     public HelidonMetadata(String name, String displayName, String description, MetricType type, String unit) {
         super(name, displayName, description, type, unit, true);
     }
-
-    public boolean isFlexible() {
-        return isFlexible;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("%s, HelidonMetadata{isFlexible=%b}", super.toString(), isFlexible);
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = super.hashCode();
-        hash = 37 * hash + (this.isFlexible ? 1 : 0);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (!(obj instanceof HelidonMetadata)) {
-            return false;
-        }
-        final HelidonMetadata other = (HelidonMetadata) obj;
-        if (this.isFlexible != other.isFlexible) {
-            return false;
-        }
-        return super.equals(obj);
-    }
-
 }

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -83,11 +83,9 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         return new Registry(type);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public synchronized <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
-        Metadata metadata = getOrCreateMetadata(name, metric);
-        return (T) reuseOrRegisterMetric(new MetricID(name), toImpl(metadata, metric));
+    public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
+        return registerUniqueMetric(name, metric);
     }
 
     @Override
@@ -95,11 +93,9 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         return register(metadata, metric, NO_TAGS);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public synchronized <T extends Metric> T register(Metadata metadata, T metric, Tag... tags) throws IllegalArgumentException {
-        metadata = checkAgainstExistingMetadataOrRegister(metadata, tags);
-        return (T) reuseOrRegisterMetric(new MetricID(metadata.getName(), tags), toImpl(metadata, metric));
+    public <T extends Metric> T register(Metadata metadata, T metric, Tag... tags) throws IllegalArgumentException {
+        return registerUniqueMetric(metadata, metric, tags);
     }
 
     @Override
@@ -544,115 +540,179 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         }
         return a.getName().equals(b.getName())
                 && a.getTypeRaw().equals(b.getTypeRaw())
-                && (((isFlexible(a) || isFlexible(b))
-                    || (a.getDisplayName().equals(b.getDisplayName())
-                        && Objects.equals(a.getDescription(), b.getDescription())
-                        && Objects.equals(a.getUnit(), b.getUnit())
-                        && (a.isReusable() == b.isReusable())
-                    ))
-                   );
+                && (a.getDisplayName().equals(b.getDisplayName())
+                && Objects.equals(a.getDescription(), b.getDescription())
+                && Objects.equals(a.getUnit(), b.getUnit())
+                && (a.isReusable() == b.isReusable())
+            );
     }
 
     // -- Private methods -----------------------------------------------------
 
-    private void enforceConsistentMetadata(MetricID metricID, Metadata m1, Metadata m2) {
-
-        // Check that metadata is compatible.
-        if (!metadataMatches(m1, m2)) {
-            throw new IllegalArgumentException("New metric " + metricID
-                    + " with metadata " + m2
+    private static boolean enforceConsistentMetadata(Metadata existingMetadata, Metadata newMetadata,
+            Tag... tags) {
+        if (!metadataMatches(existingMetadata, newMetadata)) {
+            throw new IllegalArgumentException("New metric " + new MetricID(newMetadata.getName(), tags)
+                    + " with metadata " + newMetadata
                     + " conflicts with a metric already registered with metadata "
-                    + m1);
+                    + existingMetadata);
         }
+        return true;
     }
 
-    private void enforceReusabilityAllowed(MetricID metricID, Metadata m1, Metadata m2) {
-        if (!m1.isReusable()) {
-            throw new IllegalArgumentException("A metric " + metricID
-                    + " already registered as non-reusable");
-        } else if (!m2.isReusable()) {
-            throw new IllegalArgumentException("A metric " + metricID
-                    + " already registered as reusable but a new registration requires non-reusable");
-        }
+    private static <T extends HelidonMetric> boolean enforceConsistentMetadata(T existingMetric,
+            Metadata newMetadata, Tag... tags) {
+
+        return enforceConsistentMetadata(existingMetric.metadata(), newMetadata, tags);
     }
 
-    private synchronized <T extends HelidonMetric> T getOrRegisterMetric(Metadata metadata,
+    private static boolean enforceConsistentMetadataType(Metadata existingMetadata, MetricType newType, Tag... tags) {
+        if (!existingMetadata.getTypeRaw().equals(newType)) {
+            throw new IllegalArgumentException("Attempting to register a new metric "
+                    + new MetricID(existingMetadata.getName(), tags) + " of type " + newType.toString()
+                    + " found pre-existing metadata with conflicting type "
+                    + existingMetadata.getTypeRaw().toString());
+        }
+        return true;
+    }
+
+    /**
+     * Returns an existing metric (if one is already registered with the name
+     * from the metadata plus the tags, and if the existing metadata is
+     * consistent with the new metadata, and if reuse is permitted) or a new
+     * metric, registered using the metadata and tags.
+     *
+     * @param <T> type of the metric
+     * @param newMetadata metadata describing the metric
+     * @param metricFactory factory for creating a new instance of the metric
+     * type
+     * @param clazz class of the metric to find or create
+     * @param tags tags for refining the identity of the metric
+     * @return the existing or newly-created metric
+     * @throws IllegalArgumentException if the metadata is inconsistent with
+     * previously-registered metadata or if the metric is being reused and the
+     * metadata prohibits reuse
+     */
+    private synchronized <T extends HelidonMetric> T getOrRegisterMetric(Metadata newMetadata,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz,
-            Tag... tags) {
-        final Metadata metadataToUse = checkAgainstExistingMetadataOrRegister(metadata, tags);
-        return getOptionalMetric(metadata.getName(), clazz, tags)
-                .map(metric -> enforceReusability(metric, metadataToUse, metadata))
+            Tag... tags) throws IllegalArgumentException {
+        final String metricName = newMetadata.getName();
+        /*
+         * If there is an existing compatible metric then there's really nothing
+         * new to register; the existing registration is enough so return that
+         * previously-registered metric.
+         */
+        return getOptionalMetric(metricName, clazz, tags)
+                .filter(existingMetric -> enforceConsistentMetadata(existingMetric, newMetadata, tags))
+                .filter(existingMetric -> enforceReusability(existingMetric, newMetadata, tags))
                 .orElseGet(() -> {
-                    return reuseOrRegisterMetric(metadataToUse.getName(),
-                            metricFactory.apply(type.getName(), metadata),
-                            tags);
+                    final Metadata metadata = getOrRegisterMetadata(metricName, newMetadata, tags);
+                    return registerMetric(metricName,
+                                    metricFactory.apply(type.getName(), metadata),
+                                    tags);
                 });
     }
 
+    /**
+     * Returns an existing metric with the requested name and tags, or if none
+     * is already registered registers a new metric using the name and type. If
+     * metadata with the same name already exists it is used and checked for
+     * consistency with the metric type {@code T}.
+     *
+     * @param <T> type of the metric
+     * @param metricName name of the metric
+     * @param metricFactory factory for creating a new instance of the metric type
+     * @param clazz class of the metric to find or create
+     * @param tags tags for refining the identity of the metric
+     * @return the existing or newly-created metric
+     */
     private synchronized <T extends HelidonMetric> T getOrRegisterMetric(String metricName,
             BiFunction<String, Metadata, T> metricFactory,
             Class<T> clazz,
             Tag... tags) {
-        final T metric = getOptionalMetric(metricName, clazz, tags)
+        final MetricType newType = METRIC_TO_TYPE_MAP.get(clazz);
+        return getOptionalMetric(metricName, clazz, tags)
                 .orElseGet(() -> {
-                    Metadata metadata = getOrCreateMetadata(metricName, METRIC_TO_TYPE_MAP.get(clazz));
-                    return reuseOrRegisterMetric(metricName,
-                            metricFactory.apply(type.getName(), metadata),
+                    final Metadata metadata = getOrRegisterMetadata(metricName, newType,
+                            () ->  new HelidonMetadata(metricName, newType), tags);
+                    return registerMetric(metricName, metricFactory.apply(type.getName(), metadata),
                             tags);
                 });
+    }
+
+    /**
+     * Registers a new metric, using the specified name, using existing metadata
+     * or, if none, creating new metadata based on the metric's name and type,
+     * returning the metric itself. Throws an exception if the metric is already
+     * registered or if the metric and existing metadata are incompatible.
+     *
+     *
+     * @param <T> type of the metric
+     * @param metricName name of the metric
+     * @param metric the metric to register
+     * @return the newly-registered metric
+     * @throws IllegalArgumentException if the metric is already registered and
+     * its metadata prohibits reuse
+     */
+    private synchronized <T extends Metric> T registerUniqueMetric(String metricName, T metric) throws IllegalArgumentException {
+
+        enforceMetricUniqueness(metricName);
+        final MetricType metricType = MetricType.from(metric.getClass());
+
+        final Metadata metadata = getOrRegisterMetadata(metricName, metricType,
+                () -> new HelidonMetadata(metricName, metricType), NO_TAGS);
+        registerMetric(metricName, toImpl(metadata, metric), NO_TAGS);
         return metric;
     }
 
-    private synchronized Metadata getOrRegisterMetadata(String metricName, Supplier<HelidonMetadata> metadataSupplier) {
-        Metadata result = allMetadata.get(metricName);
-        if (result == null) {
-            result = metadataSupplier.get();
-            result = registerMetadata(result);
+
+    /**
+     * Registers a new metric, using the metadata's name and the tags, described
+     * by the given metadata, returning the metric itself. Throws an exception
+     * if the metric is already registered or if incompatible metadata is
+     * already registered.
+     *
+     * @param <T> type of the metric
+     * @param metadata metadata describing the metric
+     * @param metric the metric to register
+     * @param tags tags associated with the metric
+     * @return the newly-registered metric
+     * @throws IllegalArgumentException if the specified metadata is incompatible with previously-registered metadata
+     */
+    private synchronized <T extends Metric> T registerUniqueMetric(Metadata metadata, T metric, Tag... tags)
+            throws IllegalArgumentException {
+
+        final String metricName = metadata.getName();
+        enforceMetricUniqueness(metricName, tags);
+
+        metadata = getOrRegisterMetadata(metricName, metadata, tags);
+        registerMetric(metricName, toImpl(metadata, metric), tags);
+        return metric;
+    }
+
+    private boolean enforceMetricUniqueness(String metricName) {
+        return enforceMetricUniqueness(new MetricID(metricName));
+    }
+
+    private boolean enforceMetricUniqueness(String metricName, Tag... tags) {
+        return enforceMetricUniqueness(new MetricID(metricName, tags));
+    }
+
+    private boolean enforceMetricUniqueness(MetricID metricID) {
+        if (allMetrics.containsKey(metricID)) {
+            throw new IllegalArgumentException("Attempt to reregister the existing metric " + metricID);
         }
-        return result;
+        return true;
     }
 
-    private Metadata getOrCreateMetadata(String metricName, MetricType metricType) {
-        Metadata result = getOrRegisterMetadata(metricName, () -> {
-                return new HelidonMetadata(metricName, metricType);
-            });
-        // result might have been previously registered, so make sure the metric types match
-        if (metricType != result.getTypeRaw()) {
-            throw new IllegalArgumentException("Attempting to register a new metric "
-                    + metricName + " of type " + metricType.toString()
-                    + " found pre-existing metadata with conflicting type "
-                    + result.getTypeRaw().toString());
-        }
-        return result;
-    }
-
-    private Metadata getOrCreateMetadata(String metricName, Metric metric) {
-
-        Metadata result = getOrRegisterMetadata(metricName, () -> {
-                return toMetadata(metricName, metric);
-            });
-        return result;
-    }
-
-    private <T extends HelidonMetric> T enforceReusability(T metric, Metadata m1, Metadata m2) {
+    private static <T extends HelidonMetric> boolean enforceReusability(T metric, Metadata metadata, Tag... tags) {
         // We are here because a metric already exists during an attempt to register.
-        if (!metric.metadata().isReusable() && !isFlexible(m1) && !isFlexible(m2)) {
+        if (!metadata.isReusable()) {
             throw new IllegalArgumentException("Attempting to re-register metric "
                     + metric.getName() + " that is already registered as non-reusable");
         }
-        return metric;
-    }
-
-    private synchronized Metadata checkAgainstExistingMetadataOrRegister(Metadata metadata, Tag... tags) {
-        final String metricName = metadata.getName();
-        final Metadata existingMetadata = allMetadata.get(metricName);
-        if (existingMetadata != null) {
-            enforceConsistentMetadata(new MetricID(metadata.getName(), tags),
-                    existingMetadata, metadata);
-            return existingMetadata;
-        }
-        return registerMetadata(metadata);
+        return true;
     }
 
     private <T extends HelidonMetric, U extends HelidonMetric> U toType(T m1, Class<U> clazz) {
@@ -665,26 +725,54 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
                 + " and " + type2.toString() + " do not match");
     }
 
+    /**
+     * Returns an existing metadata instance with the requested name or, if there
+     * is none, registers the provided new metadata. Throws an exception if the
+     * provided new metadata is incompatible with any existing metadata
+     *
+     * @param metricName name of the metric
+     * @param newMetadata new metadata to register if none exists for this name
+     * @param tags tags associated with the metric being sought or created (for error messaging)
+     * @return existing metadata if any; otherwise the provided new metadata
+     */
+    private synchronized Metadata getOrRegisterMetadata(String metricName, Metadata newMetadata, Tag... tags) {
+
+        return getOptionalMetadata(metricName)
+                .filter(existingMetadata -> enforceConsistentMetadata(existingMetadata, newMetadata, tags))
+                .orElseGet(() -> registerMetadata(newMetadata));
+    }
+
+    /**
+     * Returns an existing metadata instance with the requested name or, if there is none,
+     * registers the metadata supplied by the provided metadata factory. Throws an exception
+     * if the provided new metric type is incompatible with any previously-registered
+     * metadata.
+     *
+     * @param metricName name of the metric
+     * @param newMetricType metric type of the new metric being created
+     * @param metadataFactory supplier for new metadata if none is found under the specified name
+     * @param tags tags associated with the metric being sought or created (for error messaging)
+     * @return existing metadata if any; otherwise the metadata from the provided supplier
+     */
+    private synchronized Metadata getOrRegisterMetadata(String metricName, MetricType newMetricType,
+            Supplier<Metadata> metadataFactory, Tag... tags) {
+
+        return getOptionalMetadata(metricName)
+                .filter(existingMetadata -> enforceConsistentMetadataType(existingMetadata, newMetricType, tags))
+                .orElseGet(() -> registerMetadata(metadataFactory.get()));
+    }
+
+    private Optional<Metadata> getOptionalMetadata(String name) {
+        return Optional.ofNullable(allMetadata.get(name));
+    }
+
     private Metadata registerMetadata(Metadata metadata) {
         allMetadata.put(metadata.getName(), metadata);
         return metadata;
     }
 
-    private <T extends HelidonMetric> T reuseOrRegisterMetric(String metricName, T metric, Tag... tags) {
-        return reuseOrRegisterMetric(new MetricID(metricName, tags), metric);
-    }
-
-    @SuppressWarnings("unchecked")
-    private synchronized <T extends HelidonMetric> T reuseOrRegisterMetric(MetricID metricID, T metric) {
-        HelidonMetric existingMetric = allMetrics.get(metricID);
-
-        if (existingMetric != null) {
-            enforceReusabilityAllowed(metricID, existingMetric.metadata(), metric.metadata());
-            if (metric.getClass().isAssignableFrom(existingMetric.getClass())) {
-                return (T) toType(existingMetric, metric.getClass());
-            }
-        }
-        final String metricName = metricID.getName();
+    private synchronized <T extends HelidonMetric> T registerMetric(String metricName, T metric, Tag... tags) {
+        final MetricID metricID = new MetricID(metricName, tags);
         allMetrics.put(metricID, metric);
         List<MetricID> metricIDsWithSameName = allMetricIDsByName.get(metricName);
         if (metricIDsWithSameName == null) {
@@ -697,7 +785,9 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
 
 
     private <T extends Metric> HelidonMetric toImpl(Metadata metadata, T metric) {
-        switch (metadata.getTypeRaw()) {
+
+        MetricType metricType = deriveType(metadata.getTypeRaw(), metric);
+        switch (metricType) {
             case COUNTER:
                 return HelidonCounter.create(type.getName(), metadata, (Counter) metric);
             case GAUGE:
@@ -712,9 +802,25 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
                 return HelidonConcurrentGauge.create(type.getName(), metadata, (ConcurrentGauge) metric);
             case INVALID:
             default:
-                throw new IllegalArgumentException("Unexpected metric type " + metadata.getType()
+                throw new IllegalArgumentException("Unexpected metric type " + metricType
                         + ": " + metric.getClass().getName());
         }
+    }
+
+    private static MetricType deriveType(MetricType candidateType, Metric metric) {
+        if (candidateType != MetricType.INVALID) {
+            return candidateType;
+        }
+         /*
+         * A metric could be passed as a lambda, in which case neither
+         * MetricType.from() nor, for example, Counter.class.isAssignableFrom,
+         * works. Check each specific metric class using instanceof.
+         */
+        return Stream.of(Counter.class, Gauge.class, Histogram.class, Meter.class, Timer.class, ConcurrentGauge.class)
+                .filter(clazz -> clazz.isInstance(metric))
+                .map(MetricType::from)
+                .findFirst()
+                .orElse(MetricType.INVALID);
     }
 
     private static <T extends Metric> HelidonMetadata toMetadata(String name, T metric) {
@@ -776,10 +882,5 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         result.put(HelidonMeter.class, MetricType.METERED);
         result.put(HelidonTimer.class, MetricType.TIMER);
         return result;
-    }
-
-    private static boolean isFlexible(Metadata metadata) {
-        return ((metadata instanceof HelidonMetadata)
-                && HelidonMetadata.class.cast(metadata).isFlexible());
     }
 }

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/RegistryTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/RegistryTest.java
@@ -119,31 +119,4 @@ public class RegistryTest {
         assertThat(ex.getMessage(), containsString("re-register"));
         assertThat(ex.getMessage(), containsString("already registered as non-reusable"));
     }
-
-    @Test
-    void testCompatibleFlexibleMetadata() {
-        Metadata flex1 = HelidonMetadata.newFlexible("counter7", "random DN", "random descr",
-                MetricType.TIMER, MetricUnits.MINUTES);
-        Metadata flex2 = HelidonMetadata.newFlexible("counter7", "other DN", "other descr",
-                MetricType.TIMER, MetricUnits.HOURS);
-        Metadata hard = new HelidonMetadata("counter7", "my DN", "my descr", MetricType.TIMER, MetricUnits.DAYS);
-
-        assertThat(Registry.metadataMatches(flex1, hard), is(true));
-        assertThat(Registry.metadataMatches(hard, flex1), is(true));
-        assertThat(Registry.metadataMatches(flex1, flex2), is(true));
-    }
-
-    @Test
-    void testIncompatibleFlexibleMetadata() {
-        Metadata flex1 = HelidonMetadata.newFlexible("differentName", "random DN", "random descr",
-                MetricType.TIMER, MetricUnits.MINUTES);
-        Metadata flex2 = HelidonMetadata.newFlexible("myMetric", "other DN", "other descr",
-                MetricType.COUNTER, MetricUnits.NONE);
-        Metadata hard = new HelidonMetadata("myMetric", "my DN", "my descr", MetricType.TIMER, MetricUnits.DAYS);
-
-        assertThat(Registry.metadataMatches(flex1, hard), is(false));
-        assertThat(Registry.metadataMatches(hard, flex1), is(false));
-        assertThat(Registry.metadataMatches(flex2, hard), is(false));
-        assertThat(Registry.metadataMatches(flex1, flex2), is(false));
-    }
 }


### PR DESCRIPTION
These changes bring the 1.1 and 2.0 metrics support code more closely in alignment, particularly the registry implementations. They also remove from `metrics2/metrics2` the `flexible` setting (and related code) added earlier to `HelidonMetadata`.

The resulting `Registry` code is clearer (I hope):

* The methods `getOrRegisterMetric` and `getOrRegisterMetadata`, as their names suggest, retrieve an existing and compatible instance if available and create one otherwise. Those methods are also refactored and simplified a bit.
* The methods 'registerMetric` and 'registerMetadata` do just that, without checking for pre-existing instances.

These changes also add thread-safeness to the 1.1 and 2.0 registries.