### PR TITLE
Clean up visibility and JavaDoc for metrics

### DIFF
--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -73,7 +73,12 @@
                             <destDir>classes</destDir>
                             <doclint>none</doclint>
                             <doctitle>Helidon ${project.version} API Documentation</doctitle>
-                            <excludePackageNames>*.internal:*.internal.*:*.config.testing.*</excludePackageNames>
+                            <!--
+                                io.helidon.common.metrics support compat. between MP metrics 1.1 and 2.0. The contents
+                                are not for use by developers using Helidon and will be removed if/when we stop supporting
+                                the 1.1 compatibility.
+                            -->
+                            <excludePackageNames>*.internal:*.internal.*:*.config.testing.*:io.helidon.common.metrics</excludePackageNames>
                             <groups>
                                 <group>
                                     <title>Microprofile</title>
@@ -142,6 +147,17 @@
                                   test, compilation roots.
                               -->
                               <sourceFileExclude>**/*_.java</sourceFileExclude>
+                              <!--
+                                  Exclude internal bridge classes for metrics which must be public for
+                                  service loader discovery.
+                              -->
+                              <sourceFileExclude>**/InternalBridgeImpl.java</sourceFileExclude>
+                              <!--
+                                  Exclude MP metrics classes that must be public for visibility but should not be
+                                  used by developers.
+                              -->
+                              <sourceFileExclude>**/MetricsCdiExtension.java</sourceFileExclude>
+                              <sourceFileExclude>**/MetricsMpService.java</sourceFileExclude>
                             </sourceFileExcludes>
                             <sourceFileIncludes>
                                 <sourceFileInclude>io/helidon/**/*.java</sourceFileInclude>

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Clock.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package io.helidon.metrics;
  * Clock interface to allow replacing system clock with
  * a custom one (e.g. for unit testing).
  */
-public interface Clock {
+interface Clock {
     /**
      * System clock. Please do not use directly, use {@link #system()}.
      * This is only visible as we cannot do private modifier in interfaces yet.

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Clock.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Clock.java
@@ -20,7 +20,7 @@ package io.helidon.metrics;
  * Clock interface to allow replacing system clock with
  * a custom one (e.g. for unit testing).
  */
-public interface Clock {
+interface Clock {
     /**
      * System clock. Please do not use directly, use {@link #system()}.
      * This is only visible as we cannot do private modifier in interfaces yet.

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  *
  * @param <T> data type reported by the underlying {@code Gauge}
  */
-public class DelegatingGauge<T> implements Gauge<T> {
+class DelegatingGauge<T> implements Gauge<T> {
 
     private final Method method;
     private final Object obj;

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -40,7 +40,7 @@ import org.eclipse.microprofile.metrics.annotation.Metric;
  * Class MetricProducer.
  */
 @ApplicationScoped
-public class MetricProducer {
+class MetricProducer {
 
     private static Metadata newMetadata(InjectionPoint ip, Metric metric, MetricType metricType) {
         return metric == null ? new Metadata(getName(ip),

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.metrics.annotation.RegistryType;
  * Producer of each type of registry.
  */
 @ApplicationScoped
-public final class RegistryProducer {
+final class RegistryProducer {
     private static final RegistryFactory REGISTRY_FACTORY =
             io.helidon.metrics.RegistryFactory.getInstance();
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/VendorDefined.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/VendorDefined.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Qualifier
-public @interface VendorDefined {
+@interface VendorDefined {
 
     /**
      * Literal.

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  *
  * @param <T> data type reported by the underlying {@code Gauge}
  */
-public class DelegatingGauge<T> implements Gauge<T> {
+class DelegatingGauge<T> implements Gauge<T> {
 
     private final Method method;
     private final Object obj;

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -47,7 +47,7 @@ import org.eclipse.microprofile.metrics.annotation.Metric;
  * Class MetricProducer.
  */
 @ApplicationScoped
-public class MetricProducer {
+class MetricProducer {
 
     private static Metadata newMetadata(InjectionPoint ip, Metric metric, MetricType metricType) {
         return metric == null ? new HelidonMetadata(getName(ip),

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/RegistryProducer.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.annotation.RegistryType;
  * Producer of each type of registry.
  */
 @ApplicationScoped
-public final class RegistryProducer {
+final class RegistryProducer {
 
     private static final io.helidon.metrics.RegistryFactory REGISTRY_FACTORY =
             io.helidon.metrics.RegistryFactory.getInstance();

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/VendorDefined.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/VendorDefined.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Qualifier
-public @interface VendorDefined {
+@interface VendorDefined {
 
     /**
      * Literal.


### PR DESCRIPTION
Some artifacts in metrics need to be public (for use from other modules) but developers should not use them. Others were defined as public but can be more restrictive.

This PR changes the visibility for some items and suppresses JavaDoc for ones that must remain public (such as `MetricsMpService` and `MetricsCdiExtension` which are loaded as Java services).

Fixes #1060 