### PR TITLE
 Inform Jersey of broken pipe by throwing exception

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/BaseProcessor.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/BaseProcessor.java
@@ -76,6 +76,8 @@ abstract class BaseProcessor<T, U> implements Processor<T, U>, Subscription {
             } catch (Throwable ex) {
                 onError(ex);
             }
+        } else {
+            throw new IllegalStateException("Subscriber is closed!");
         }
     }
 

--- a/common/reactive/src/main/java/io/helidon/common/reactive/BaseProcessor.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/BaseProcessor.java
@@ -70,14 +70,13 @@ abstract class BaseProcessor<T, U> implements Processor<T, U>, Subscription {
 
     @Override
     public final void onNext(T item) {
-        if (!subscriber.isClosed()) {
-            try {
-                hookOnNext(item);
-            } catch (Throwable ex) {
-                onError(ex);
-            }
-        } else {
+        if (subscriber.isClosed()) {
             throw new IllegalStateException("Subscriber is closed!");
+        }
+        try {
+            hookOnNext(item);
+        } catch (Throwable ex) {
+            onError(ex);
         }
     }
 

--- a/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
@@ -144,6 +144,9 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
         } catch (ExecutionException e) {
             complete(e.getCause());
             throw new IOException(e.getCause());
+        } catch (IllegalStateException e) {
+            complete(e);
+            throw new IOException(e);
         }
     }
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * {@link BaseProcessor} test.
@@ -80,11 +81,7 @@ public class BaseProcessorTest {
         processor.subscribe(subscriber);
         subscriber.request1();
         processor.onComplete();
-        try {
-            processor.onNext("foo");
-        } catch (Throwable t) {
-            assertThat(t, is(instanceOf(IllegalStateException.class)));
-        }
+        assertThrows(IllegalStateException.class, () -> processor.onNext("foo"));
         assertThat(subscriber.isComplete(), is(equalTo(true)));
         assertThat(subscriber.getItems(), is(empty()));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
@@ -80,7 +80,11 @@ public class BaseProcessorTest {
         processor.subscribe(subscriber);
         subscriber.request1();
         processor.onComplete();
-        processor.onNext("foo");
+        try {
+            processor.onNext("foo");
+        } catch (Throwable t) {
+            assertThat(t, is(instanceOf(IllegalStateException.class)));
+        }
         assertThat(subscriber.isComplete(), is(equalTo(true)));
         assertThat(subscriber.getItems(), is(empty()));
     }

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -95,5 +95,20 @@
             <artifactId>internal-test-libs</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.server;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+import javax.ws.rs.sse.SseEventSource;
+
+import io.helidon.common.CollectionsHelper;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Unit test for {@link ServerImpl} SSE.
+ */
+class ServerSseTest {
+    private static Client client;
+
+    private CompletableFuture<Void> connClosedFuture = new CompletableFuture<>();
+
+    @BeforeAll
+    static void initClass() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        client.close();
+    }
+
+    @Test
+    void testSse() throws Exception {
+        Server server = Server.builder()
+                .addApplication("/", new TestApplication1())
+                .build();
+        server.start();
+
+        try {
+            // Set up SSE event source
+            WebTarget target = client.target("http://localhost:" + server.port()).path("test1").path("sse");
+            SseEventSource sseEventSource = SseEventSource.target(target).build();
+            sseEventSource.register(event -> System.out.println(event.readData(String.class)));
+
+            // Open SSE source for a few millis and then close it
+            sseEventSource.open();
+            Thread.sleep(200);
+            sseEventSource.close();
+
+            // Wait for server to detect connection closed
+            try {
+                connClosedFuture.get(2000, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                fail("Closing of SSE connection not detected!");
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private final class TestApplication1 extends Application {
+        @Override
+        public Set<Object> getSingletons() {
+            return CollectionsHelper.setOf(new TestResource1());
+        }
+    }
+
+    @Path("/test1")
+    public final class TestResource1 {
+        @GET
+        @Path("sse")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void listenToEvents(@Context SseEventSink eventSink, @Context Sse sse) {
+            while (true) {
+                eventSink.send(sse.newEvent("hello")).thenAccept(t -> {
+                    if (t != null) {
+                        System.out.println(t);
+                        connClosedFuture.complete(null);
+                    }
+                });
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    // falls through
+                }
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -175,6 +175,7 @@ class BareResponseImpl implements BareResponse {
             responseFuture.complete(this);
         } else {
             LOGGER.log(Level.FINER, throwable, () -> log("Response completion failed!"));
+            internallyClosed.set(true);
             responseFuture.completeExceptionally(throwable);
         }
     }


### PR DESCRIPTION
Ensure exceptions are propagated so that Jersey can detect problems writing to a broken pipe. This is very useful when the server streams data in chunks, and possibly over a long period, such as when streaming SSE events. A new test that verifies the fix has been added.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>