### PR TITLE
Restore helidon-metrics2 as default metrics library

### DIFF
--- a/archetypes/se/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/se/src/main/resources/archetype-resources/pom.xml
@@ -49,7 +49,7 @@
 #if( $metricsSupport.matches("y|yes|true") )
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
 #end
 #if( $unitTest.matches("y|yes|true") )

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -417,6 +417,11 @@
                 <artifactId>helidon-metrics</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.metrics</groupId>
+                <artifactId>helidon-metrics2</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
             <!-- health checks -->
             <dependency>
                 <groupId>io.helidon.health</groupId>

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.media.jsonb</groupId>

--- a/examples/grpc/metrics/pom.xml
+++ b/examples/grpc/metrics/pom.xml
@@ -58,7 +58,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.grpc</groupId>

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.openapi</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/metrics2/metrics2/pom.xml
+++ b/metrics2/metrics2/pom.xml
@@ -120,6 +120,12 @@
             <groupId>io.helidon.microprofile.config</groupId>
             <artifactId>helidon-microprofile-config</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.helidon.config</groupId>
+                    <artifactId>helidon-config-object-mapping</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/tests/apps/bookstore/bookstore-se/pom.xml
+++ b/tests/apps/bookstore/bookstore-se/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.media.jsonb</groupId>

--- a/tests/integration/native-image/se-1/pom.xml
+++ b/tests/integration/native-image/se-1/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.security.integration</groupId>


### PR DESCRIPTION
Restore helidon-metrics2 as default metrics library, where it applies. This includes normal dependencies, some tests and archetypes. Exclude `helidon-config-object-mapping` from its pom to ensure compatibility with GraalVM in SE apps.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>