### PR TITLE
Throw JsonException when parser returns unexpected type

### DIFF
--- a/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonProcessing.java
+++ b/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonProcessing.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import javax.json.Json;
+import javax.json.JsonException;
 import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
 import javax.json.JsonStructure;
@@ -86,7 +87,11 @@ public final class JsonProcessing {
                             ? jsonReaderFactory.createReader(is)
                             : jsonReaderFactory.createReader(is, charset);
 
-                    return reader.read();
+                    JsonStructure json = reader.read();
+                    if (!clazz.isAssignableFrom(json.getClass())) {
+                        throw new JsonException("Unable to convert " + json.getClass() + " to " + clazz);
+                    }
+                    return json;
                 });
     }
 

--- a/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
+++ b/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
@@ -103,7 +103,7 @@ public final class JsonSupport extends JsonService {
         request.content()
                 .registerReader(JsonStructure.class::isAssignableFrom, (publisher, type) -> {
                     Charset charset = determineCharset(request.headers());
-                    return reader(charset).apply(publisher);
+                    return reader(charset).apply(publisher, type);
                 });
         // Writer
         response.registerWriter(json -> (json instanceof JsonStructure) && acceptsJson(request, response),

--- a/media/jsonp/server/src/test/java/io/helidon/media/jsonp/server/JsonContentReaderTest.java
+++ b/media/jsonp/server/src/test/java/io/helidon/media/jsonp/server/JsonContentReaderTest.java
@@ -64,12 +64,12 @@ public class JsonContentReaderTest {
 
         try {
             JsonArray array = stage.thenApply(o -> {
-                fail("Shouldn't occur because of a class cast exception!");
+                fail("Shouldn't occur because of JSON exception!");
                 return o;
             }).toCompletableFuture().get(10, TimeUnit.SECONDS);
             fail("Should have failed because an expected array is actually an object: " + array);
         } catch (ExecutionException e) {
-            assertThat(e.getCause(), IsInstanceOf.instanceOf(ClassCastException.class));
+            assertThat(e.getCause(), IsInstanceOf.instanceOf(JsonException.class));
         }
     }
 


### PR DESCRIPTION
Verify that the type returned by the JSON-P parser matches that requested by the application, and if does not, throw a JsonException instead of a low-level ClassCastException. See issue #991.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>