### PR TITLE
Jackson 2.10.0

### DIFF
--- a/3RD-PARTY.txt
+++ b/3RD-PARTY.txt
@@ -2389,7 +2389,7 @@ Version 2.0, January 2004
 http://www.apache.org/licenses/
 
 ========================================================================
-jackson-databind 2.9.9.3
+jackson-databind 2.10.0
 ========================================================================
 COPYRIGHT: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
@@ -2402,7 +2402,7 @@ It is currently developed by a community of developers, as well as supported
 commercially by FasterXML.com.
 
 ## Licensing
------------------jackson-core 2.9.9.3 -----------------------
+-----------------jackson-core 2.10.0 -----------------------
 COPYRIGHT: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
 
@@ -2416,7 +2416,10 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
------------------jackson-annotations 2.9.8 -----------------------
+-----------------jackson-annotations 2.10.0 -----------------------
+-----------------jackson-datatype-jdk8 2.10.0 -----------------------
+-----------------jackson-datatype-jsr310 2.10.0 -----------------------
+-----------------jackson-module-parameter-names 2.10.0 -----------------------
 COPYRIGHT: Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -55,8 +55,7 @@
         <version.lib.hikaricp>2.7.8</version.lib.hikaricp>
         <version.lib.inject>1</version.lib.inject>
         <!-- Jackson databind 2.9.9 has patch versions. This bom has databind 2.9.9.3 -->
-        <version.lib.jackson>2.9.9</version.lib.jackson>
-        <version.lib.jackson-bom>2.9.9.20190807</version.lib.jackson-bom>
+        <version.lib.jackson>2.10.0</version.lib.jackson>
         <version.lib.jaegertracing>0.34.0</version.lib.jaegertracing>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>
@@ -671,7 +670,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${version.lib.jackson-bom}</version>
+                <version>${version.lib.jackson}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -54,7 +54,6 @@
         <version.lib.hibernate>5.4.4.Final</version.lib.hibernate>
         <version.lib.hikaricp>2.7.8</version.lib.hikaricp>
         <version.lib.inject>1</version.lib.inject>
-        <!-- Jackson databind 2.9.9 has patch versions. This bom has databind 2.9.9.3 -->
         <version.lib.jackson>2.10.0</version.lib.jackson>
         <version.lib.jaegertracing>0.34.0</version.lib.jaegertracing>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -28,7 +28,7 @@
     <name>Helidon Microprofile Tests TCK Opentracing</name>
 
     <properties>
-        <jackson.tck.version>2.9.0</jackson.tck.version>
+        <jackson.tck.version>2.10.0</jackson.tck.version>
     </properties>
 
     <dependencies>

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -28,7 +28,9 @@
     <name>Helidon Microprofile Tests TCK Opentracing</name>
 
     <properties>
-        <jackson.tck.version>2.10.0</jackson.tck.version>
+        <!-- We force the version of jackson to 2.9.0 since that's -->
+        <!-- what the TCK test forces us to use (via shrinkwrap)   -->
+        <version.lib.jackson>2.9.0</version.lib.jackson>
     </properties>
 
     <dependencies>
@@ -90,31 +92,26 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>${jackson.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
-            <version>${jackson.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.tck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <version>${jackson.tck.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Upgrade Jackson to 2.10.0. This should reduce the stream of CVE patches. For more details see 

 https://medium.com/@cowtowncoder/jackson-2-10-features-cd880674d8a2
