### PR TITLE
Allow customization of top level span name using message format

### DIFF
--- a/docs/src/main/docs/tracing/01_tracing.adoc
+++ b/docs/src/main/docs/tracing/01_tracing.adoc
@@ -269,6 +269,7 @@ tracing:
         web-server:
           spans:
           - name: "content-read"
+            new-name: "read"
             enabled: false
 ----
 
@@ -288,3 +289,25 @@ routingBuilder.register(WebTracingConfig.builder()
         .build();
     .build());
 ----
+
+==== Renaming top level span using request properties
+To have a nicer overview in search pane of a tracer, you can customize the top-level span name using configuration.
+
+Example:
+[source,yaml]
+.Configuration in YAML
+----
+tracing:
+  components:
+    web-server:
+      spans:
+      - name: "HTTP Request"
+        new-name: "HTTP %1$s %2$s"
+----
+
+This is supported ONLY for the span named "HTTP Request" on component "web-server".
+
+Parameters provided:
+1. Method - HTTP method
+2. Path - path of the request (such as '/greet')
+3. Query - query of the request (may be null)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
@@ -289,6 +289,9 @@ public abstract class WebTracingConfig {
             }
 
             String spanName = spanConfig.newName().orElse(TRACING_SPAN_HTTP_REQUEST);
+            if (spanName.indexOf('%') > -1) {
+                spanName = String.format(spanName, req.method().name(), req.path(), req.query());
+            }
             // tracing is enabled, so we replace the parent span with web server parent span
             Tracer.SpanBuilder spanBuilder = tracer.buildSpan(spanName)
                     .withTag(Tags.COMPONENT.getKey(), "helidon-webserver")


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Customer request. Top level tracing span ("HTTP Request") can be renamed using a message format and parameters (method, path and query).
