### PR TITLE
Support for Health 2.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -433,6 +433,11 @@
                 <artifactId>helidon-health-checks</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.health</groupId>
+                <artifactId>helidon-health-common</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
 
             <!-- jwt -->
             <dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -72,7 +72,7 @@
         <version.lib.jsonp-impl>1.1.2</version.lib.jsonp-impl>
         <version.lib.junit>5.1.0</version.lib.junit>
         <version.lib.microprofile-config>1.3</version.lib.microprofile-config>
-        <version.lib.microprofile-health>2.0.1</version.lib.microprofile-health>
+        <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
         <version.lib.microprofile-metrics2-api>2.0.1</version.lib.microprofile-metrics2-api>

--- a/docs/src/main/docs/health/01_health.adoc
+++ b/docs/src/main/docs/health/01_health.adoc
@@ -248,7 +248,7 @@ Routing.builder()
 
 The JSON responses shown above contain properties `"status"` and `"outcome"` with the same
 values. Helidon reports both of these to maintain backward compatibility with older
-versions of the MicroProfile Metrics library. This behavior can be disabled by setting
+versions of MicroProfile Health. This behavior can be disabled by setting
 the property `health.backward-compatible` to `false`, in which case only `"status"`
-is reported. Future versions of Helidon will drop support for older versions of Metrics,
+is reported. Future versions of Helidon will drop support for older versions of Health,
 so it is recommended to rely on `"status"` instead of `"outcome"` in your applications.

--- a/docs/src/main/docs/health/01_health.adoc
+++ b/docs/src/main/docs/health/01_health.adoc
@@ -166,6 +166,7 @@ TIP: Balance collecting a lot of information with the need to avoid overloading
 ----
 {
     "outcome": "UP",
+    "status": "UP",
     "checks": [
         {
             "name": "exampleHealthCheck",
@@ -209,6 +210,7 @@ Routing.builder()
 ----
 {
     "outcome": "UP",
+    "status": "UP",
     "checks": [
         {
             "name": "deadlock",
@@ -241,3 +243,12 @@ Routing.builder()
     ]
 }
 ----
+
+=== Strict JSON Output
+
+The JSON responses shown above contain properties `"status"` and `"outcome"` with the same
+values. Helidon reports both of these to maintain backward compatibility with older
+versions of the MicroProfile Metrics library. This behavior can be disabled by setting
+the property `health.backward-compatible` to `false`, in which case only `"status"`
+is reported. Future versions of Helidon will drop support for older versions of Metrics,
+so it is recommended to rely on `"status"` instead of `"outcome"` in your applications.

--- a/health/common/pom.xml
+++ b/health/common/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-health-project</artifactId>
+        <groupId>io.helidon.health</groupId>
+        <version>1.3.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-health-common</artifactId>
+    <name>Helidon Health Common</name>
+
+    <dependencies>
+        <dependency>
+            <!-- only needed for compilation, not required in runtime -->
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/health/common/src/main/java/io/helidon/health/common/BuiltInHealthCheck.java
+++ b/health/common/src/main/java/io/helidon/health/common/BuiltInHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
+package io.helidon.health.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
 /**
- * Helidon health checks.
+ * Used to decorate Helidon built-in health checks for later processing.
  */
-module io.helidon.health.checks {
-    requires java.logging;
-    requires java.management;
-
-    requires static cdi.api;
-    requires static javax.inject;
-
-    requires io.helidon.common;
-    requires io.helidon.health;
-    requires io.helidon.health.common;
-    requires static microprofile.config.api;
-    requires microprofile.health.api;
-
-    exports io.helidon.health.checks;
+@Qualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BuiltInHealthCheck {
 }

--- a/health/common/src/main/java/io/helidon/health/common/package-info.java
+++ b/health/common/src/main/java/io/helidon/health/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,6 @@
  */
 
 /**
- * Helidon health checks.
+ * Health common package.
  */
-module io.helidon.health.checks {
-    requires java.logging;
-    requires java.management;
-
-    requires static cdi.api;
-    requires static javax.inject;
-
-    requires io.helidon.common;
-    requires io.helidon.health;
-    requires io.helidon.health.common;
-    requires static microprofile.config.api;
-    requires microprofile.health.api;
-
-    exports io.helidon.health.checks;
-}
+package io.helidon.health.common;

--- a/health/common/src/main/java9/module-info.java
+++ b/health/common/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,12 @@
  */
 
 /**
- * Helidon health checks.
+ * Helidon health common.
  */
-module io.helidon.health.checks {
-    requires java.logging;
-    requires java.management;
+module io.helidon.health.common {
 
     requires static cdi.api;
     requires static javax.inject;
 
-    requires io.helidon.common;
-    requires io.helidon.health;
-    requires io.helidon.health.common;
-    requires static microprofile.config.api;
-    requires microprofile.health.api;
-
-    exports io.helidon.health.checks;
+    exports io.helidon.health.common;
 }

--- a/health/health-checks/pom.xml
+++ b/health/health-checks/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>helidon-health</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-common</artifactId>
+        </dependency>
+        <dependency>
             <!-- only needed for compilation, not required in runtime -->
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -21,6 +21,8 @@ import java.lang.management.ThreadMXBean;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.helidon.health.common.BuiltInHealthCheck;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
@@ -33,6 +35,7 @@ import org.eclipse.microprofile.health.Liveness;
  */
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
+@BuiltInHealthCheck
 public final class DeadlockHealthCheck implements HealthCheck {
     /**
      * Used for detecting deadlocks. Injected in the constructor.

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -29,6 +29,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.helidon.health.HealthCheckException;
+import io.helidon.health.common.BuiltInHealthCheck;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -56,6 +57,7 @@ import org.eclipse.microprofile.health.Liveness;
  */
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
+@BuiltInHealthCheck
 public final class DiskSpaceHealthCheck implements HealthCheck {
     /**
      * Default path on the file system the health check will be executed for.

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -22,6 +22,8 @@ import java.util.Locale;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.helidon.health.common.BuiltInHealthCheck;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -43,6 +45,7 @@ import org.eclipse.microprofile.health.Liveness;
  */
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
+@BuiltInHealthCheck
 public final class HeapMemoryHealthCheck implements HealthCheck {
     /**
      * Default threshold percentage.

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -33,6 +33,7 @@
     <description>Health check support for Helidon SE</description>
 
     <modules>
+        <module>common</module>
         <module>health</module>
         <module>health-checks</module>
     </modules>

--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -57,6 +57,10 @@
             <artifactId>internal-test-libs</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-common</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile/health/src/main/java9/module-info.java
+++ b/microprofile/health/src/main/java9/module-info.java
@@ -24,6 +24,7 @@ module io.helidon.microprofile.health {
     requires io.helidon.common;
     requires io.helidon.common.serviceloader;
     requires io.helidon.health;
+    requires io.helidon.health.common;
     requires io.helidon.microprofile.server;
 
     requires cdi.api;

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -128,6 +128,7 @@ public class HealthMpServiceIT {
 
         JsonObject json = (JsonObject) Json.createReader(new StringReader(health)).read();
         assertThat(json, is(notNullValue()));
+        assertThat(json.getJsonString("outcome"), is(notNullValue()));      // backward compatibility default
         return json;
     }
 

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -53,6 +53,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
             <scope>test</scope>

--- a/microprofile/tests/tck/tck-health/src/test/resources/tck-application.yaml
+++ b/microprofile/tests/tck/tck-health/src/test/resources/tck-application.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+health:
+  backward-compatible: false        # For JSON schema validation

--- a/tests/apps/bookstore/bookstore-mp/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/apps/bookstore/bookstore-mp/src/main/resources/META-INF/microprofile-config.properties
@@ -23,3 +23,6 @@ app.greeting=Hello
 # Microprofile server properties
 server.port=8080
 server.host=0.0.0.0
+
+# Disable built-in health checks
+mp.health.disable-default-procedures=true

--- a/tests/functional/bookstore/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
+++ b/tests/functional/bookstore/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
@@ -233,6 +233,14 @@ class MainTest {
         jsonReader = Json.createReader(conn.getInputStream());
         jsonObject = jsonReader.readObject();
         assertThat("Checking health outcome", jsonObject.getString("outcome"), is("UP"));
+        assertThat("Checking health status", jsonObject.getString("status"), is("UP"));
+
+        // Verify that built-in health checks are disabled in MP according to
+        // 'microprofile-config.properties' setting in bookstore application
+        if (edition.equals("mp")) {
+            assertThat("Checking built-in health checks disabled",
+                    jsonObject.getJsonArray("checks").size(), is(0));
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Support for MP Health 2.1: (1) New backward compatible flag 'health.backward-compatible' to enable/disable Metrics 1.X JSON support; by default it is set to true. New Health 2.1 TCKs enforce schema validation, so this flag is required. (2) Support to disable all built-in health checks using 'mp.health.disable-default-procedures' property; built-in checks are decorated with a new qualifier for the purpose of filtering when this property is set.

Will update docs before removing WIP label.