### PR TITLE
Add support for form parameters

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/FormParams.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParams.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+/**
+ * Provides access to any form parameters present in the request entity.
+ */
+public interface FormParams extends Parameters {
+
+    /**
+     * Creates a new {@code FormParams} instance using the provided assignment string and media
+     * type.
+     *
+     * @param paramAssignments String containing the parameter assignments, formatted according
+     *                         to the media type specified (& separator for URL-encoded, NL for
+     *                         text/plain)
+     * @param mediaType MediaType for which the parameter conversion is occurring
+     * @return the new {@code FormParams} instance
+     */
+    static FormParams create(String paramAssignments, MediaType mediaType) {
+        return FormParamsImpl.create(paramAssignments, mediaType);
+    }
+}

--- a/common/http/src/main/java/io/helidon/common/http/FormParams.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParams.java
@@ -25,8 +25,8 @@ public interface FormParams extends Parameters {
      * type.
      *
      * @param paramAssignments String containing the parameter assignments, formatted according
-     *                         to the media type specified (& separator for URL-encoded, NL for
-     *                         text/plain)
+     *                         to the media type specified ({@literal &} separator for
+     *                         URL-encoded, NL for text/plain)
      * @param mediaType MediaType for which the parameter conversion is occurring
      * @return the new {@code FormParams} instance
      */

--- a/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.helidon.common.CollectionsHelper;
+
+/**
+ * Implementation of the {@link FormParams} interface.
+ */
+public class FormParamsImpl implements FormParams {
+
+    /*
+     * For form params represented in text/plain (uncommon), newlines appear between name=value
+     * assignments. When urlencoded, ampersands separate the name=value assignments.
+     */
+    private static final Map<MediaType, Pattern> PATTERNS = CollectionsHelper.mapOf(
+            MediaType.APPLICATION_FORM_URLENCODED, preparePattern("&"),
+            MediaType.TEXT_PLAIN, preparePattern("\n"));
+
+    private static Pattern preparePattern(String assignmentSeparator) {
+        return Pattern.compile(String.format("([^=]+)=([^%1$s]+)%1$s?", assignmentSeparator));
+    }
+
+    private Map<String, List<String>> params;
+
+    static FormParams create(String paramAssignments, MediaType mediaType) {
+        final Map<String, List<String>> params = new HashMap<>();
+        Matcher m = PATTERNS.get(mediaType).matcher(paramAssignments);
+        while (m.find()) {
+            final String key = m.group(1);
+            final String value = m.group(2);
+            List<String> values = params.compute(key, (k, v) -> {
+                        if (v == null) {
+                            v = new ArrayList<>();
+                        }
+                        v.add(value);
+                        return v;
+            });
+        }
+        return new FormParamsImpl(params);
+    }
+
+    private FormParamsImpl(Map<String, List<String>> params) {
+        this.params = params;
+    }
+
+    @Override
+    public Optional<String> first(String name) {
+        return Optional.ofNullable(params.get(name)).filter(list -> !list.isEmpty()).map(list -> list.get(0));
+    }
+
+    @Override
+    public List<String> all(String name) {
+        List<String> result = params.get(name);
+        return result == null ? Collections.emptyList() : Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public List<String> put(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> put(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> putIfAbsent(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> putIfAbsent(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> computeIfAbsent(String key, Function<String, Iterable<String>> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> computeSingleIfAbsent(String key, Function<String, String> value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Parameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(String key, String... values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(String key, Iterable<String> values) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAll(Parameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> remove(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, List<String>> toMap() {
+        return Collections.unmodifiableMap(params);
+    }
+}

--- a/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/FormParamsImpl.java
@@ -16,12 +16,9 @@
 package io.helidon.common.http;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,7 +27,7 @@ import io.helidon.common.CollectionsHelper;
 /**
  * Implementation of the {@link FormParams} interface.
  */
-public class FormParamsImpl implements FormParams {
+class FormParamsImpl extends ReadOnlyParameters implements FormParams {
 
     /*
      * For form params represented in text/plain (uncommon), newlines appear between name=value
@@ -43,8 +40,6 @@ public class FormParamsImpl implements FormParams {
     private static Pattern preparePattern(String assignmentSeparator) {
         return Pattern.compile(String.format("([^=]+)=([^%1$s]+)%1$s?", assignmentSeparator));
     }
-
-    private Map<String, List<String>> params;
 
     static FormParams create(String paramAssignments, MediaType mediaType) {
         final Map<String, List<String>> params = new HashMap<>();
@@ -64,77 +59,6 @@ public class FormParamsImpl implements FormParams {
     }
 
     private FormParamsImpl(Map<String, List<String>> params) {
-        this.params = params;
-    }
-
-    @Override
-    public Optional<String> first(String name) {
-        return Optional.ofNullable(params.get(name)).filter(list -> !list.isEmpty()).map(list -> list.get(0));
-    }
-
-    @Override
-    public List<String> all(String name) {
-        List<String> result = params.get(name);
-        return result == null ? Collections.emptyList() : Collections.unmodifiableList(result);
-    }
-
-    @Override
-    public List<String> put(String key, String... values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> put(String key, Iterable<String> values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> putIfAbsent(String key, String... values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> putIfAbsent(String key, Iterable<String> values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> computeIfAbsent(String key, Function<String, Iterable<String>> values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> computeSingleIfAbsent(String key, Function<String, String> value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void putAll(Parameters parameters) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void add(String key, String... values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void add(String key, Iterable<String> values) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void addAll(Parameters parameters) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> remove(String key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<String, List<String>> toMap() {
-        return Collections.unmodifiableMap(params);
+        super(params);
     }
 }

--- a/common/http/src/test/java/io/helidon/common/http/FormParamsTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/FormParamsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.http;
+
+import io.helidon.common.CollectionsHelper;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+import java.util.List;
+import java.util.Optional;
+
+public class FormParamsTest {
+
+    private static final String KEY1 = "key1";
+    private static final String VAL1 = "value1";
+
+    private static final String KEY2 = "key2";
+    private static final String VAL2_1 = "value2.1";
+    private static final String VAL2_2 = "value2.2";
+
+
+    @Test
+    void testOneLineSingleAssignment() {
+        FormParams fp = FormParams.create(KEY1 + "=" + VAL1, MediaType.TEXT_PLAIN);
+
+        checkKey1(fp);
+    }
+
+    @Test
+    void testTwoDifferentAssignments() {
+        String assignments = String.format("%s=%s\n%s=%s\n%s=%s", KEY1, VAL1,
+                KEY2, VAL2_1, KEY2, VAL2_2);
+
+        FormParams fp = FormParams.create(assignments, MediaType.TEXT_PLAIN);
+
+        checkKey1(fp);
+        checkKey2(fp);
+    }
+
+    @Test
+    void testTwoDifferentAssignmentsURLEncoded() {
+        String assignments = String.format("%s=%s&%s=%s&%s=%s", KEY1, VAL1, KEY2, VAL2_1, KEY2, VAL2_2);
+
+        FormParams fp = FormParams.create(assignments, MediaType.APPLICATION_FORM_URLENCODED);
+
+        checkKey1(fp);
+        checkKey2(fp);
+    }
+
+    @Test
+    void testAbsentKey() {
+        FormParams fp = FormParams.create(KEY1 + "=" + VAL1, MediaType.TEXT_PLAIN);
+
+        Optional<String> shouldNotExist = fp.first(KEY2);
+        assertThat(shouldNotExist.isPresent(), is(false));
+
+        List<String> shouldBeEmpty = fp.all(KEY2);
+        assertThat(shouldBeEmpty.size(), is(0));
+
+        assertThrows(UnsupportedOperationException.class, () -> fp.computeSingleIfAbsent(KEY2, k -> "replacement"));
+    }
+
+    private static void checkKey1(FormParams fp) {
+        Optional<String> result = fp.first(KEY1);
+        assertThat(result.orElse("missing"), is(equalTo(VAL1)));
+
+        List<String> listResult = fp.all(KEY1);
+        assertThat(listResult, hasItem(VAL1));
+        assertThat(listResult.size(), is(1));
+    }
+
+    private static void checkKey2(FormParams fp) {
+        Optional<String> result = fp.first(KEY2);
+        assertThat(result.orElse("missing"), is(equalTo(VAL2_1)));
+
+        List<String> listResult = fp.all(KEY2);
+        assertThat(listResult, hasItems(VAL2_1, VAL2_2));
+    }
+
+}

--- a/media/common/src/test/java/io/helidon/media/common/ContentReadersTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/ContentReadersTest.java
@@ -17,6 +17,7 @@
 package io.helidon.media.common;
 
 import java.io.InputStream;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
@@ -73,5 +74,20 @@ class ContentReadersTest {
         InputStream inputStream = future.get(10, TimeUnit.SECONDS);
         byte[] actualBytes = InputStreamHelper.readAllBytes(inputStream);
         assertThat(actualBytes, is(bytes));
+    }
+
+    @Test
+    void testURLDecodingReader() throws Exception {
+        String original = "myParam=\"Now@is'the/time";
+        String encoded = URLEncoder.encode(original, "UTF-8");
+        Multi<DataChunk> chunks = Multi.just(DataChunk.create(encoded.getBytes(StandardCharsets.UTF_8)));
+
+        CompletableFuture<? extends String> future =
+                ContentReaders.urlEncodedStringReader(StandardCharsets.UTF_8)
+                        .apply(chunks)
+                        .toCompletableFuture();
+
+        String s = future.get(10, TimeUnit.SECONDS);
+        assertThat(s, is(original));
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FormParamsSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FormParamsSupport.java
@@ -16,6 +16,7 @@
 package io.helidon.webserver;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.FormParams;
@@ -54,7 +55,7 @@ public class FormParamsSupport implements Service, Handler {
     @Override
     public void accept(ServerRequest req, ServerResponse res) {
         MediaType reqMediaType = req.headers().contentType().orElse(MediaType.TEXT_PLAIN);
-        Charset charset = reqMediaType.charset().map(Charset::forName).orElse(Charset.defaultCharset());
+        Charset charset = reqMediaType.charset().map(Charset::forName).orElse(StandardCharsets.UTF_8);
 
         req.content().registerReader(FormParams.class,
                 (chunks, type) -> readContent(reqMediaType, charset, chunks)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FormParamsSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FormParamsSupport.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.nio.charset.Charset;
+
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.FormParams;
+import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.Flow.Publisher;
+import io.helidon.common.reactive.Single;
+import io.helidon.media.common.ContentReaders;
+
+/**
+ * Provides support for form parameters in requests, adding a reader for URL-encoded text
+ * (if the request's media type so indicates) and also adding a reader for {@code FormParams}.
+ * <p>
+ * Developers will typically add this support to routing:
+ * <pre>{@code
+ * Routing.builder()
+ *        .register(FormParamSupport.create())
+ *        . ... // any other handlers
+ * }</pre>
+ * <p>
+ * When responding to a request, the developer can use
+ * <pre>{@code
+ *     request.content().as(FormParams.class).thenApply(fp -> ...)
+ * }</pre>
+ * and use all the methods defined on {@link FormParams} (which extends
+ * {@link io.helidon.common.http.Parameters}).
+ */
+public class FormParamsSupport implements Service, Handler {
+
+    private static final FormParamsSupport INSTANCE = new FormParamsSupport();
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.any(this);
+    }
+
+    @Override
+    public void accept(ServerRequest req, ServerResponse res) {
+        MediaType reqMediaType = req.headers().contentType().orElse(MediaType.TEXT_PLAIN);
+        Charset charset = reqMediaType.charset().map(Charset::forName).orElse(Charset.defaultCharset());
+
+        req.content().registerReader(FormParams.class,
+                (chunks, type) -> readContent(reqMediaType, charset, chunks)
+                        .map(s -> FormParams.create(s, reqMediaType)).toStage());
+
+        req.next();
+    }
+
+    /**
+     *
+     * @return the singleton instance of {@code FormParamSupport}
+     */
+    public static FormParamsSupport create() {
+        return INSTANCE;
+    }
+
+    private static Single<String> readContent(MediaType mediaType, Charset charset,
+            Publisher<DataChunk> chunks) {
+        return mediaType.equals(MediaType.APPLICATION_FORM_URLENCODED)
+                ? ContentReaders.readURLEncodedString(chunks, charset)
+                : ContentReaders.readString(chunks, charset);
+    }
+}

--- a/webserver/webserver/src/main/java9/module-info.java
+++ b/webserver/webserver/src/main/java9/module-info.java
@@ -21,6 +21,7 @@ module io.helidon.webserver {
     requires io.helidon.common;
     requires transitive io.helidon.media.common;
     requires transitive io.helidon.common.http;
+    requires transitive io.helidon.common.mapper;
     requires transitive io.helidon.common.pki;
     requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.common.context;

--- a/webserver/webserver/src/main/java9/module-info.java
+++ b/webserver/webserver/src/main/java9/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.webserver {
     requires io.helidon.common;
     requires transitive io.helidon.media.common;
     requires transitive io.helidon.common.http;
-    requires transitive io.helidon.common.mapper;
+    requires io.helidon.common.mapper;
     requires transitive io.helidon.common.pki;
     requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.common.context;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/FormParamsSupportTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/FormParamsSupportTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.http.FormParams;
+import io.helidon.common.http.MediaType;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+
+
+
+
+public class FormParamsSupportTest {
+
+    private static WebServer testServer;
+
+    @BeforeAll
+    public static void startup() throws InterruptedException, ExecutionException, TimeoutException {
+        testServer = WebServer.create(ServerConfiguration.builder()
+                        .port(0)
+                        .build(),
+                    Routing.builder()
+                        .register(FormParamsSupport.create())
+                        .put("/params", (req, resp) -> {
+                            req.content().as(FormParams.class).thenAccept(fp ->
+                                    resp.send(fp.toMap().toString()));
+                        })
+                        .build())
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        testServer.shutdown();
+    }
+
+    @Test
+    public void urlEncodedTest() throws Exception {
+        HttpURLConnection cnx = getURLConnection(testServer.port(),
+                "PUT", "/params", MediaType.APPLICATION_FORM_URLENCODED);
+        stringToRequest(cnx, "key1=val+1&key2=val2_1&key2=val2_2");
+        String response = stringFromResponse(cnx, MediaType.TEXT_PLAIN);
+
+        assertThat(response, containsString("key1=[val 1]"));
+        assertThat(response, containsString("key2=[val2_1, val2_2]"));
+    }
+
+    @Test
+    public void plainTextTest() throws Exception{
+        HttpURLConnection cnx = getURLConnection(testServer.port(),
+                "PUT", "/params", MediaType.TEXT_PLAIN);
+        stringToRequest(cnx, "key1=val 1\nkey2=val2_1\nkey2=val2_2");
+        String response = stringFromResponse(cnx, MediaType.TEXT_PLAIN);
+
+        assertThat(response, containsString("key1=[val 1]"));
+        assertThat(response, containsString("key2=[val2_1, val2_2]"));
+    }
+
+    private static HttpURLConnection getURLConnection(
+            int port,
+            String method,
+            String path,
+            MediaType mediaType) throws Exception {
+        URL url = new URL("http://localhost:" + port + path);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(method);
+        conn.setReadTimeout(20000 /* ms */);
+        if (mediaType != null) {
+            conn.setRequestProperty("Content-Type", mediaType.toString());
+        }
+        System.out.println("Connecting: " + method + " " + url);
+        return conn;
+    }
+
+    private static void stringToRequest(HttpURLConnection cnx, String payload) throws IOException {
+        cnx.setDoOutput(true);
+        OutputStreamWriter osw = new OutputStreamWriter(cnx.getOutputStream());
+        osw.write(payload);
+        osw.flush();
+        osw.close();
+    }
+
+    private static String stringFromResponse(HttpURLConnection cnx, MediaType mediaType) throws IOException {
+        try (final InputStreamReader isr = new InputStreamReader(
+                cnx.getInputStream(), mediaType.charset().orElse(StandardCharsets.UTF_8.name()))) {
+            StringBuilder sb = new StringBuilder();
+            CharBuffer cb = CharBuffer.allocate(1024);
+            while (isr.read(cb) != -1) {
+                cb.flip();
+                sb.append(cb);
+            }
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for form parameters in the entity, either as plain text or as URL-encoded text.

Developers will register the new `FormParamsSupport` with their `Routing` which will subsequently allow them to use `request.content().as(FormParams.class)` to get convenient access to the form parameters. `FormParams` extends `Parameters` for consistency with retrieving other types of parameters.

This is _not_ full form data support, which will probably need to wait for the multipart support.

Resolves #784 