### PR TITLE
Implement MP Metrics 2.1.0: Add restriction that gauges are Gauge<? extends Number>

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -75,7 +75,7 @@
         <version.lib.microprofile-health>2.0.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
-        <version.lib.microprofile-metrics2-api>2.0.1</version.lib.microprofile-metrics2-api>
+        <version.lib.microprofile-metrics2-api>2.1.0</version.lib.microprofile-metrics2-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
@@ -19,6 +19,12 @@ package io.helidon.metrics;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 import javax.json.JsonObjectBuilder;
@@ -30,7 +36,7 @@ import org.eclipse.microprofile.metrics.MetricID;
 /**
  * Gauge implementation.
  */
-final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
+final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T> {
     private final Supplier<T> value;
 
     private HelidonGauge(String registryType, Metadata metadata, Gauge<T> metric) {
@@ -63,20 +69,34 @@ final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
         T value = getValue();
         String nameWithTags = jsonFullKey(metricID);
 
-        if (value instanceof String) {
-            builder.add(nameWithTags, (String) value);
-        } else if (value instanceof BigInteger) {
-            builder.add(nameWithTags, (BigInteger) value);
+        if (value instanceof AtomicInteger) {
+            builder.add(nameWithTags, value.doubleValue());
+        } else if (value instanceof AtomicLong) {
+            builder.add(nameWithTags, value.longValue());
         } else if (value instanceof BigDecimal) {
             builder.add(nameWithTags, (BigDecimal) value);
+        } else if (value instanceof BigInteger) {
+            builder.add(nameWithTags, (BigInteger) value);
+        } else if (value instanceof Byte) {
+            builder.add(nameWithTags, value.intValue());
+        } else if (value instanceof Double) {
+            builder.add(nameWithTags, (Double) value);
+        } else if (value instanceof DoubleAccumulator) {
+            builder.add(nameWithTags, value.doubleValue());
+        } else if (value instanceof DoubleAdder) {
+            builder.add(nameWithTags, value.doubleValue());
+        } else if (value instanceof Float) {
+            builder.add(nameWithTags, value.floatValue());
         } else if (value instanceof Integer) {
             builder.add(nameWithTags, (Integer) value);
         } else if (value instanceof Long) {
             builder.add(nameWithTags, (Long) value);
-        } else if (value instanceof Double) {
-            builder.add(nameWithTags, (Double) value);
-        } else if (value instanceof Boolean) {
-            builder.add(nameWithTags, (Boolean) value);
+        } else if (value instanceof LongAccumulator) {
+            builder.add(nameWithTags, value.longValue());
+        } else if (value instanceof LongAdder) {
+            builder.add(nameWithTags, value.longValue());
+        } else if (value instanceof Short) {
+            builder.add(nameWithTags, value.intValue());
         } else {
             builder.add(nameWithTags, String.valueOf(value));
         }

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
@@ -45,7 +45,8 @@ final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T
         value = metric::getValue;
     }
 
-    static HelidonGauge<?> create(String registryType, Metadata metadata, Gauge<?> metric) {
+    static <S extends Number> HelidonGauge<S> create(String registryType, Metadata metadata,
+            Gauge<S> metric) {
         return new HelidonGauge<>(registryType, metadata, metric);
     }
 

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
@@ -98,7 +98,8 @@ final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T
         } else if (value instanceof Short) {
             builder.add(nameWithTags, value.intValue());
         } else {
-            builder.add(nameWithTags, String.valueOf(value));
+            // Might be a developer-provided class which extends Number.
+            builder.add(nameWithTags, value.doubleValue());
         }
     }
 

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -485,10 +485,11 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         final MetadataBuilder builder = new MetadataBuilder();
         builder.withName(metadata.getName())
                 .withDisplayName(metadata.getDisplayName())
-                .withType(metadata.getTypeRaw());
+                .withType(metadata.getTypeRaw())
+                .reusable(metadata.isReusable());
         metadata.getDescription().ifPresent(builder::withDescription);
         metadata.getUnit().ifPresent(builder::withUnit);
-        return (metadata.isReusable() ? builder.reusable() : builder.notReusable()).build();
+        return builder.build();
     }
 
     synchronized Optional<Map.Entry<MetricID, HelidonMetric>> getOptionalMetricEntry(String metricName) {

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonGaugeTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonGaugeTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+
+public class HelidonGaugeTest {
+
+    private static final int EXPECTED_VALUE = 1;
+    private static final Pattern JSON_RESULT_PATTERN = Pattern.compile("\\{\"myValue[^\"]*\":1.0\\}");
+
+    private static final JsonBuilderFactory FACTORY = Json.createBuilderFactory(Collections.emptyMap());
+
+    private static Metadata meta;
+
+    @BeforeAll
+    static void initClass() {
+        meta = new HelidonMetadata("aGauge",
+                "aGauge",
+                "aGauge",
+                MetricType.GAUGE,
+                MetricUnits.NONE);
+    }
+
+    @Test
+    void testJson() {
+        MyValue myValue = new MyValue(EXPECTED_VALUE);
+        Gauge<MyValue> myGauge = new Gauge<MyValue>() {
+
+            @Override
+            public MyValue getValue() {
+                return myValue;
+            }
+        };
+
+        HelidonGauge<?> gauge = HelidonGauge.create("base", meta, myGauge);
+        JsonObjectBuilder builder = FACTORY.createObjectBuilder();
+        gauge.jsonData(builder, new MetricID("myValue"));
+        JsonObject json = builder.build();
+
+        String s = json.toString();
+        assertThat("JSON string " + s + " does not match pattern " + JSON_RESULT_PATTERN.toString(),
+                JSON_RESULT_PATTERN.matcher(s).matches());
+    }
+
+    public static class MyValue extends Number {
+
+        private final Double value;
+
+        public MyValue(double value) {
+            this.value = Double.valueOf(value);
+        }
+
+        @Override
+        public int intValue() {
+            return value.intValue();
+        }
+
+        @Override
+        public long longValue() {
+            return value.longValue();
+        }
+
+        @Override
+        public float floatValue() {
+            return value.floatValue();
+        }
+
+        @Override
+        public double doubleValue() {
+            return value.doubleValue();
+        }
+    }
+}

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  *
  * @param <T> data type reported by the underlying {@code Gauge}
  */
-class DelegatingGauge<T> implements Gauge<T> {
+class DelegatingGauge<T extends Number> implements Gauge<T> {
 
     private final Method method;
     private final Object obj;
@@ -50,7 +50,8 @@ class DelegatingGauge<T> implements Gauge<T> {
      * @param clazz  type of the underlying gauge
      * @return {@code DelegatingGauge}
      */
-    public static <S> DelegatingGauge<S> newInstance(Method method, Object obj, Class<S> clazz) {
+    public static <S extends Number> DelegatingGauge<S> newInstance(Method method, Object obj,
+            Class<S> clazz) {
         return new DelegatingGauge<>(method, obj, clazz);
     }
 

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -181,7 +181,7 @@ class MetricProducer {
     @Produces
     @VendorDefined
     @SuppressWarnings("unchecked")
-    private <T> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
+    private <T extends Number> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
         Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
         return (Gauge<T>) registry.getGauges().entrySet().stream()
                 .filter(entry -> entry.getKey().getName().equals(metric.name()))
@@ -199,7 +199,8 @@ class MetricProducer {
      * @return requested gauge
      */
     @Produces
-    private <T> Gauge<T> produceGaugeDefault(MetricRegistry registry, InjectionPoint ip) {
+    private <T extends Number> Gauge<T> produceGaugeDefault(MetricRegistry registry,
+            InjectionPoint ip) {
         return produceGauge(registry, ip);
     }
 

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -33,7 +33,6 @@ import java.util.logging.Logger;
 
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
-import javax.enterprise.inject.InjectionException;
 import javax.enterprise.inject.spi.AfterDeploymentValidation;
 import javax.enterprise.inject.spi.AnnotatedMember;
 import javax.enterprise.inject.spi.AnnotatedType;
@@ -409,8 +408,8 @@ public class MetricsCdiExtension implements Extension {
                 LOGGER.log(Level.FINE, () -> String.format("Registering gauge with metadata %s", md.toString()));
                 registry.register(md, dg, gaugeID.getTagsAsList().toArray(new Tag[0]));
             } catch (Throwable t) {
-                adv.addDeploymentProblem(new IllegalArgumentException("Error processing @Gauge " +
-                        "annotation on " + site.getAnnotated().getJavaMember().getDeclaringClass().getName()
+                adv.addDeploymentProblem(new IllegalArgumentException("Error processing @Gauge "
+                        + "annotation on " + site.getAnnotated().getJavaMember().getDeclaringClass().getName()
                         + ":" + site.getAnnotated().getJavaMember().getName(), t));
             }
         });

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import org.hamcrest.Matchers;
+import org.jboss.weld.exceptions.DeploymentException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BadGaugeTest  {
+
+    @Test
+    public void testBadBean() {
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance();
+        assertThat(initializer, Matchers.is(Matchers.notNullValue()));
+        initializer.addBeanClasses(BadGaugedBean.class);
+        DeploymentException ex = assertThrows(DeploymentException.class, () -> {
+            SeContainer cdiContainer = initializer.initialize();
+            cdiContainer.close();
+        });
+
+        Throwable cause = ex.getCause();
+        assertThat(cause, notNullValue());
+        assertThat(cause, is(instanceOf(IllegalArgumentException.class)));
+
+        assertThat(cause.getMessage(), containsString("Error processing @Gauge"));
+        assertThat(cause.getMessage(), containsString(BadGaugedBean.class.getName() + ":notAllowed"));
+
+        Throwable subCause = cause.getCause();
+        assertThat(subCause, notNullValue());
+        assertThat(subCause, is(instanceOf(IllegalArgumentException.class)));
+        assertThat(subCause.getMessage(), containsString("assignment-compatible with Number"));
+
+    }
+}

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugedBean.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugedBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+
+import javax.enterprise.context.ApplicationScoped;
+
+public class BadGaugedBean {
+
+    @Gauge(unit = MetricUnits.NONE)
+    public boolean notAllowed() {
+        return true;
+    }
+}

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/GaugedBean.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/GaugedBean.java
@@ -52,4 +52,38 @@ public class GaugedBean {
         return measuredValue;
     }
 
+    @Gauge(unit = MetricUnits.HOURS)
+    public MyValue getMyValue() {
+        return new MyValue(measuredValue);
+    }
+
+    public static class MyValue extends Number {
+
+        private Double value;
+
+        public MyValue(double value) {
+            this.value = Double.valueOf(value);
+        }
+
+        @Override
+        public int intValue() {
+            return value.intValue();
+        }
+
+        @Override
+        public long longValue() {
+            return value.longValue();
+        }
+
+        @Override
+        public float floatValue() {
+            return value.floatValue();
+        }
+
+        @Override
+        public double doubleValue() {
+            return value.doubleValue();
+        }
+    }
+
 }

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
@@ -115,6 +115,10 @@ public class MetricsTest extends MetricsBaseTest {
         Gauge<Integer> otherGauge = getMetric(bean, "retrieveValue");
         valueViaGauge = otherGauge.getValue();
         assertThat(valueViaGauge, is(EXPECTED_VALUE));
+
+        Gauge<GaugedBean.MyValue> customTypeGauge = getMetric(bean, "getMyValue");
+        GaugedBean.MyValue valueViaCustomGauge = customTypeGauge.getValue();
+        assertThat(valueViaCustomGauge, is(EXPECTED_VALUE));
     }
 
     @Test

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
@@ -118,7 +118,7 @@ public class MetricsTest extends MetricsBaseTest {
 
         Gauge<GaugedBean.MyValue> customTypeGauge = getMetric(bean, "getMyValue");
         GaugedBean.MyValue valueViaCustomGauge = customTypeGauge.getValue();
-        assertThat(valueViaCustomGauge, is(EXPECTED_VALUE));
+        assertThat(valueViaCustomGauge.intValue(), is(EXPECTED_VALUE));
     }
 
     @Test

--- a/microprofile/tests/tck/tck-metrics2/pom.xml
+++ b/microprofile/tests/tck/tck-metrics2/pom.xml
@@ -71,6 +71,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Metrics 2.1.0 clarifies that `Gauge` metrics apply to values assignable to or ("boxable" to) `Number`. 

These changes incorporate that restriction and thereby implement MP Metrics 2.1.0. This PR introduces no syntactic incompatibilities for developers of Helidon apps; those are hidden inside the Helidon code. A potential semantic incompatibility is that the Helidon annotation processing code for `@Gauge` now makes sure that the data type of the annotation site is assignable or boxable to `Number` and throws an exception if not.

It is unlikely that developers would have used `@Gauge` to annotate non-`Number` types, but if they did then those apps will fail to run now.

One other very minor change is that this PR simplifies a few lines by using the new `MetadataBuilder.reusable(boolean)` method; previously there were only `MetadataBuilder.reusable()` and `MetadataBuilder.notReusable()`.

Resolves #1018 