### PR TITLE
Support for mutable vendor registry

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/RegistryFactory.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/RegistryFactory.java
@@ -56,7 +56,7 @@ public final class RegistryFactory implements io.helidon.common.metrics.Internal
 
         registry = Registry.create(Type.VENDOR);
         registries.put(Type.VENDOR, registry);
-        publicRegistries.put(Type.VENDOR, FinalRegistry.create(registry));
+        publicRegistries.put(Type.VENDOR, registry);
 
         this.config = new AtomicReference<>(config);
     }
@@ -143,8 +143,8 @@ public final class RegistryFactory implements io.helidon.common.metrics.Internal
 
     /**
      * Get a registry based on its type.
-     * For {@link Type#APPLICATION} returns a modifiable registry, for other types
-     * returns a final registry (cannot register new metrics).
+     * For {@link Type#APPLICATION} and {@link Type#VENDOR} returns a modifiable registry,
+     * for {@link Type#BASE} returns a final registry (cannot register new metrics).
      *
      * @param type type of registry
      * @return Registry for the type defined.

--- a/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
@@ -97,9 +97,17 @@ public class RegistryFactoryTest {
     }
 
     @Test
-    void testVendorFinal() {
-        assertThrows(UnsupportedOperationException.class, () -> vendor.counter("another.counter"));
-        assertThrows(UnsupportedOperationException.class, () -> vendorUn.counter("another.counter"));
+    void testVendorModifiable() {
+        Counter c1 = vendor.counter("new.counter");
+        Counter c2 = vendorUn.counter("new.counter");
+
+        assertThat(c1, notNullValue());
+        assertThat(c2, notNullValue());
+        assertNotSame(c1, c2);
+
+        //replace c2 with a counter from the same registry
+        c2 = vendor.counter("new.counter");
+        assertSame(c1, c2);
     }
 
     @Test

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/RegistryFactory.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/RegistryFactory.java
@@ -56,7 +56,7 @@ public final class RegistryFactory implements io.helidon.common.metrics.Internal
 
         registry = Registry.create(Type.VENDOR);
         registries.put(Type.VENDOR, registry);
-        publicRegistries.put(Type.VENDOR, FinalRegistry.create(registry));
+        publicRegistries.put(Type.VENDOR, registry);
 
         this.config = new AtomicReference<>(config);
     }
@@ -143,8 +143,8 @@ public final class RegistryFactory implements io.helidon.common.metrics.Internal
 
     /**
      * Get a registry based on its type.
-     * For {@link Type#APPLICATION} returns a modifiable registry, for other types
-     * returns a final registry (cannot register new metrics).
+     * For {@link Type#APPLICATION} and {@link Type#VENDOR} returns a modifiable registry,
+     * for {@link Type#BASE} returns a final registry (cannot register new metrics).
      *
      * @param type type of registry
      * @return MetricRegistry for the type defined.

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/RegistryFactoryTest.java
@@ -88,9 +88,17 @@ public class RegistryFactoryTest {
     }
 
     @Test
-    void testVendorFinal() {
-        assertThrows(UnsupportedOperationException.class, () -> vendor.counter("another.counter"));
-        assertThrows(UnsupportedOperationException.class, () -> vendorUn.counter("another.counter"));
+    void testVendorModifiable() {
+        Counter c1 = vendor.counter("new.counter");
+        Counter c2 = vendorUn.counter("new.counter");
+
+        assertThat(c1, notNullValue());
+        assertThat(c2, notNullValue());
+        assertNotSame(c1, c2);
+
+        //replace c2 with a counter from the same registry
+        c2 = vendor.counter("new.counter");
+        assertSame(c1, c2);
     }
 
     @Test


### PR DESCRIPTION
Making publicly exposed vendor registry mutable in both Metrics 1 and Metrics 2, per discussion with @tomas-langer at OOW.

We need to be able to register Coherence metrics with the vendor registry when running inside/alongside Helidon, and the current implementation does not allow us to do that. Other products/frameworks that bundle Helidon may need to do the same thing as well in the future, and there is no real benefit to vendor registry being immutable anyway, not is it required by the spec. 