### PR TITLE
Minimally-invasive refinement to start-up time calculation

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -148,7 +148,11 @@ public interface Server {
      * Builder to build {@link Server} instance.
      */
     final class Builder {
-        private static final long STARTUP_TIME = ServerImpl.STARTUP_TIME;
+
+        {
+            // Load the initialization start time as early as possible from non-public code.
+            ServerImpl.recordInitStart(System.nanoTime());
+        }
 
         // there should only be one
         private static final AtomicInteger MP_SERVER_COUNTER = new AtomicInteger(1);

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -148,6 +148,8 @@ public interface Server {
      * Builder to build {@link Server} instance.
      */
     final class Builder {
+        private static final long STARTUP_TIME = ServerImpl.STARTUP_TIME;
+
         // there should only be one
         private static final AtomicInteger MP_SERVER_COUNTER = new AtomicInteger(1);
         private static final Logger LOGGER = Logger.getLogger(Builder.class.getName());

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -484,11 +484,11 @@ public class ServerImpl implements Server {
 
                             if ("0.0.0.0".equals(host)) {
                                 // listening on all addresses
-                                LOGGER.info(() -> "Server initialized on http://localhost:" + port + " (and all other host addresses); "
-                                        + "in " + initializationElapsedTime + " milliseconds.");
+                                LOGGER.info(() -> "Server initialized on http://localhost:" + port + " (and all other host addresses)"
+                                        + " in " + initializationElapsedTime + " milliseconds.");
                             } else {
                                 LOGGER.info(() -> "Server initialized on http://" + host + ":" + port
-                                        + "in " + initializationElapsedTime + " milliseconds.");
+                                        + " in " + initializationElapsedTime + " milliseconds.");
                             }
                         }
                     }

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -67,6 +67,7 @@ import org.glassfish.jersey.server.ResourceConfig;
  * Server to handle lifecycle of microprofile implementation.
  */
 public class ServerImpl implements Server {
+    static final long STARTUP_TIME = System.nanoTime();
     private static final Logger LOGGER = Logger.getLogger(ServerImpl.class.getName());
     private static final Logger JERSEY_LOGGER = Logger.getLogger(ServerImpl.class.getName() + ".jersey");
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
@@ -446,14 +447,13 @@ public class ServerImpl implements Server {
         CountDownLatch cdl = new CountDownLatch(1);
         AtomicReference<Throwable> throwRef = new AtomicReference<>();
 
-        long beforeT = System.nanoTime();
         server.start()
                 .whenComplete((webServer, throwable) -> {
                     if (null != throwable) {
                         STARTUP_LOGGER.log(Level.FINEST, "Startup failed", throwable);
                         throwRef.set(throwable);
                     } else {
-                        long t = TimeUnit.MILLISECONDS.convert(System.nanoTime() - beforeT, TimeUnit.NANOSECONDS);
+                        long t = TimeUnit.MILLISECONDS.convert(System.nanoTime() - STARTUP_TIME, TimeUnit.NANOSECONDS);
 
                         port = webServer.port();
                         STARTUP_LOGGER.finest("Started up");


### PR DESCRIPTION
Addresses #1099 

The end-of-startup log message understated the actual start-up time for the MP server.

This PR simply captures the current system time at class-load-time of `ServerImpl` (which we now also trigger as early as possible in `Server.Builder`). This does not include all of the JVM and class loading time but it greatly improves the accuracy of the start-up log message. For example:

```
2019.10.14 12:43:08 INFO org.jboss.weld.Version Thread[main,5,main]: WELD-000900: 3.1.1 (Final)
...
2019.10.14 12:43:12 INFO io.helidon.microprofile.server.ServerImpl Thread[nioEventLoopGroup-2-1,10,main]: Server started on http://localhost:8080 (and all other host addresses) in 4284 milliseconds.
```
The reported start-up time in ms much more closely aligns with the log message timestamps. 

Another option (I looked into this and @batsatt also mentioned it in slack) would have been to use the `RuntimeMXBean` which reports the JVM start-up time. In some informal measurements I was seeing a 40-50 ms cost for that. 

Yet another option (thanks to @spericas) would have collected the start-up time in the built-in `Main` class, but users can provide their own `Main` which would skip that (as Santiago also mentioned).

The changes in the PR give a timing that matches up with the log message timestamps and also gives a reasonable approximation to the full start-up time. The `Server.Builder` and `ServerImpl` classes are loaded early during start-up.