### PR TITLE
New bundle for MP 3.1

### DIFF
--- a/archetypes/mp/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/mp/src/main/resources/archetype-resources/pom.xml
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -358,6 +358,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.microprofile.bundles</groupId>
+                <artifactId>helidon-microprofile-3.1</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.bundles</groupId>
                 <artifactId>internal-test-libs</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -41,7 +41,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -67,7 +67,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/microprofile/bundles/helidon-microprofile-3.1/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-3.1/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.bundles</groupId>
+        <artifactId>bundles-project</artifactId>
+        <version>1.3.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-microprofile-3.1</artifactId>
+    <name>Helidon Microprofile Bundles 3.1</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-3.0</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/bundles/helidon-microprofile-3.1/src/main/java9/module-info.java
+++ b/microprofile/bundles/helidon-microprofile-3.1/src/main/java9/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aggregator module for microprofile 3.1.
+ */
+module io.helidon.microprofile.v3_1 {
+    requires transitive io.helidon.microprofile.config.cdi;
+    requires transitive io.helidon.microprofile.config;
+    requires transitive io.helidon.microprofile.server;
+    requires transitive io.helidon.microprofile.health;
+    requires transitive io.helidon.microprofile.metrics;
+    requires transitive io.helidon.microprofile.faulttolerance;
+    requires transitive io.helidon.microprofile.jwt.auth.cdi;
+    requires transitive io.helidon.microprofile.tracing;
+    requires transitive io.helidon.microprofile.restclient;
+    requires transitive io.helidon.microprofile.openapi;
+
+    requires io.helidon.health.checks;
+}

--- a/microprofile/bundles/pom.xml
+++ b/microprofile/bundles/pom.xml
@@ -44,6 +44,7 @@
         <module>helidon-microprofile-1.2</module>
         <module>helidon-microprofile-2.2</module>
         <module>helidon-microprofile-3.0</module>
+        <module>helidon-microprofile-3.1</module>
     </modules>
 
     <profiles>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.health</groupId>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -38,7 +38,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.microprofile.bundles</groupId>
-                    <artifactId>helidon-microprofile-3.0</artifactId>
+                    <artifactId>helidon-microprofile-3.1</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -38,7 +38,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.microprofile.bundles</groupId>
-                    <artifactId>helidon-microprofile-3.0</artifactId>
+                    <artifactId>helidon-microprofile-3.1</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/tests/functional/context-propagation/pom.xml
+++ b/tests/functional/context-propagation/pom.xml
@@ -31,7 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/functional/jax-rs-subresource/pom.xml
+++ b/tests/functional/jax-rs-subresource/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/functional/multiport/pom.xml
+++ b/tests/functional/multiport/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId>
+            <artifactId>helidon-microprofile-3.1</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
New bundle for MP 3.1. No new APIs, so just a dependency with MP 3.0.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>