### PR TITLE
Fix for Issue #1106

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsApplication.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsApplication.java
@@ -126,7 +126,7 @@ public final class JaxRsApplication {
          * @return updated builder instance
          */
         public Builder contextRoot(String contextRoot) {
-            this.contextRoot = contextRoot;
+            this.contextRoot = normalize(contextRoot);
             return this;
         }
 
@@ -222,8 +222,19 @@ public final class JaxRsApplication {
             }
             ApplicationPath path = clazz.getAnnotation(ApplicationPath.class);
             if (null != path) {
-                contextRoot = path.value();
+                contextRoot = normalize(path.value());
             }
+        }
+
+        /**
+         * Normalizes a context root by stripping off a trailing slash.
+         *
+         * @param contextRoot Context root to normalize.
+         * @return Normalized context root.
+         */
+        private static String normalize(String contextRoot) {
+            int length = contextRoot.length();
+            return length > 1 && contextRoot.endsWith("/") ? contextRoot.substring(0, length - 1) : contextRoot;
         }
 
         private void routingName(Class<?> clazz) {

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/JaxRsApplicationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.server;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Class JaxRsApplicationTest.
+ */
+public class JaxRsApplicationTest {
+
+    @ApplicationPath("/foo/bar/")
+    static class MyApplication extends Application {
+    }
+
+    @Test
+    public void testContextRootNormalization() {
+        JaxRsApplication app1 = JaxRsApplication.builder().contextRoot("/").build();
+        assertThat(app1.contextRoot(), is("/"));
+        JaxRsApplication app2 = JaxRsApplication.builder().contextRoot("/foo").build();
+        assertThat(app2.contextRoot(), is("/foo"));
+        JaxRsApplication app3 = JaxRsApplication.builder().contextRoot("/foo/").build();
+        assertThat(app3.contextRoot(), is("/foo"));
+        JaxRsApplication app4 = JaxRsApplication.builder().contextRoot("/foo/bar/").build();
+        assertThat(app4.contextRoot(), is("/foo/bar"));
+        JaxRsApplication app5 = JaxRsApplication.builder().application(MyApplication.class).build();
+        assertThat(app5.contextRoot(), is("/foo/bar"));
+    }
+}

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
@@ -89,7 +89,7 @@ class ServerImplTest {
     void testTwoApps() {
         Server server = Server.builder()
                 .addApplication("/app1", new TestApplication1())
-                .addApplication("/app2", new TestApplication2())
+                .addApplication("/app2/", new TestApplication2())       // trailing slash ignored
                 .build();
 
         server.start();

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -41,6 +41,7 @@ import io.helidon.common.configurable.ServerThreadPoolSupplier;
 import io.helidon.common.configurable.ThreadPool;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.common.http.HttpRequest;
 import io.helidon.config.Config;
 import io.helidon.webserver.Handler;
 import io.helidon.webserver.Routing;
@@ -171,16 +172,16 @@ public class JerseySupport implements Service {
     private static URI baseUri(ServerRequest req) {
         try {
             return new URI(req.isSecure() ? "https" : "http", null, req.localAddress(),
-                           req.localPort(), basePath(req), null, null);
+                           req.localPort(), basePath(req.path()), null, null);
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Unable to create a base URI from the request info.", e);
         }
     }
 
-    private static String basePath(ServerRequest req) {
-        String reqPath = req.path().toString();
-        String absPath = req.path().absolute().toString();
-        String basePath = absPath.substring(0, absPath.length() - reqPath.length());
+    static String basePath(HttpRequest.Path path) {
+        String reqPath = path.toString();
+        String absPath = path.absolute().toString();
+        String basePath = absPath.substring(0, absPath.length() - reqPath.length() + 1);
 
         if (absPath.isEmpty() || basePath.isEmpty()) {
             return "/";

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URLConnection;
+import java.util.Collections;
+import java.util.List;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Entity;
@@ -29,14 +31,17 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.helidon.common.http.HttpRequest;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.webserver.jersey.JerseySupport.basePath;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The JerseySupportTest.
@@ -313,6 +318,55 @@ public class JerseySupportTest {
             while ((n = is.read(buffer)) > 0) {
                 // consume rest of stream
             }
+        }
+    }
+
+    @Test
+    public void testBasePath() {
+        assertThat(basePath(new PathMockup(null, "/")),
+                is("/"));
+        assertThat(basePath(new PathMockup("/my/application/path", "/")),
+                is("/my/application/path/"));
+        assertThat(basePath(new PathMockup("/my/application/path", "/path")),
+                is("/my/application/"));
+        assertThat(basePath(new PathMockup("/my/application/path", "/application/path")),
+                is("/my/"));
+        assertThat(basePath(new PathMockup("/my/application/path", "/my/application/path")),
+                is("/"));
+    }
+
+    static class PathMockup implements HttpRequest.Path {
+        private final String absolutePath;
+        private final String path;
+
+        PathMockup(String absolutePath, String path) {
+            this.absolutePath = absolutePath;
+            this.path = path;
+        }
+
+        @Override
+        public String param(String name) {
+            return "";
+        }
+
+        @Override
+        public List<String> segments() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String toRawString() {
+            return toString();
+        }
+
+        @Override
+        public HttpRequest.Path absolute() {
+            return absolutePath == null ? this : new PathMockup(null, absolutePath);
+        }
+
+        @Override
+        public String toString() {
+            return path;
         }
     }
 


### PR DESCRIPTION
Details:

1. Fixed problem calculating the base URI that is passed to Jersey and is available to applications via injection of UriInfo. 

2. Normalize an application's path that is specified programmatically or via an `@ApplicationPath` annotation. Trailing slashes can cause problems.

3. New tests for (1) and (2).

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>