### PR TITLE
Changes to metrics to work with MP metrics 2.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -73,7 +73,7 @@
         <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
-        <version.lib.microprofile-metrics2-api>2.2-RC1</version.lib.microprofile-metrics2-api>
+        <version.lib.microprofile-metrics2-api>2.2</version.lib.microprofile-metrics2-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -73,7 +73,7 @@
         <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
-        <version.lib.microprofile-metrics2-api>2.0.2</version.lib.microprofile-metrics2-api>
+        <version.lib.microprofile-metrics2-api>2.2-RC1</version.lib.microprofile-metrics2-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -73,7 +73,7 @@
         <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics1-api>1.1</version.lib.microprofile-metrics1-api>
-        <version.lib.microprofile-metrics2-api>2.1.0</version.lib.microprofile-metrics2-api>
+        <version.lib.microprofile-metrics2-api>2.0.2</version.lib.microprofile-metrics2-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
@@ -36,7 +36,8 @@ import org.eclipse.microprofile.metrics.MetricID;
 /**
  * Gauge implementation.
  */
-final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
+final class HelidonGauge<T /* extends Number */> extends MetricImpl implements Gauge<T> {
+    // TODO uncomment above once MP metrics enforces the Number restriction
     private final Supplier<T> value;
 
     private HelidonGauge(String registryType, Metadata metadata, Gauge<T> metric) {
@@ -45,8 +46,9 @@ final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
         value = metric::getValue;
     }
 
-    static <S> HelidonGauge<S> create(String registryType, Metadata metadata,
+    static <S /* extends Number */> HelidonGauge<S> create(String registryType, Metadata metadata,
             Gauge<S> metric) {
+        // TODO uncomment above once MP metrics enforces the Number restriction
         return new HelidonGauge<>(registryType, metadata, metric);
     }
 
@@ -67,9 +69,13 @@ final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
 
     @Override
     public void jsonData(JsonObjectBuilder builder, MetricID metricID) {
+        // TODO uncomment 'value' declaration below and remove 'untypedValue' once MP metrics enforces restriction
+        // T value = getValue();
         T untypedValue = getValue();
         String nameWithTags = jsonFullKey(metricID);
 
+        // TODO remove following 'if' and 'value' assignment once MP metrics enforces restriction,
+        // promoting the nested 'if' one level.
         if (untypedValue instanceof Number) {
             Number value = (Number) untypedValue;
             if (value instanceof AtomicInteger) {
@@ -104,6 +110,7 @@ final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
                 // Might be a developer-provided class which extends Number.
                 builder.add(nameWithTags, value.doubleValue());
             }
+        // TODO remove following 'else' and 'builder.add' once MP metrics enforces restriction
         } else {
             builder.add(nameWithTags, String.valueOf(value));
         }

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/HelidonGauge.java
@@ -36,7 +36,7 @@ import org.eclipse.microprofile.metrics.MetricID;
 /**
  * Gauge implementation.
  */
-final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T> {
+final class HelidonGauge<T> extends MetricImpl implements Gauge<T> {
     private final Supplier<T> value;
 
     private HelidonGauge(String registryType, Metadata metadata, Gauge<T> metric) {
@@ -45,7 +45,7 @@ final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T
         value = metric::getValue;
     }
 
-    static <S extends Number> HelidonGauge<S> create(String registryType, Metadata metadata,
+    static <S> HelidonGauge<S> create(String registryType, Metadata metadata,
             Gauge<S> metric) {
         return new HelidonGauge<>(registryType, metadata, metric);
     }
@@ -67,40 +67,45 @@ final class HelidonGauge<T extends Number> extends MetricImpl implements Gauge<T
 
     @Override
     public void jsonData(JsonObjectBuilder builder, MetricID metricID) {
-        T value = getValue();
+        T untypedValue = getValue();
         String nameWithTags = jsonFullKey(metricID);
 
-        if (value instanceof AtomicInteger) {
-            builder.add(nameWithTags, value.doubleValue());
-        } else if (value instanceof AtomicLong) {
-            builder.add(nameWithTags, value.longValue());
-        } else if (value instanceof BigDecimal) {
-            builder.add(nameWithTags, (BigDecimal) value);
-        } else if (value instanceof BigInteger) {
-            builder.add(nameWithTags, (BigInteger) value);
-        } else if (value instanceof Byte) {
-            builder.add(nameWithTags, value.intValue());
-        } else if (value instanceof Double) {
-            builder.add(nameWithTags, (Double) value);
-        } else if (value instanceof DoubleAccumulator) {
-            builder.add(nameWithTags, value.doubleValue());
-        } else if (value instanceof DoubleAdder) {
-            builder.add(nameWithTags, value.doubleValue());
-        } else if (value instanceof Float) {
-            builder.add(nameWithTags, value.floatValue());
-        } else if (value instanceof Integer) {
-            builder.add(nameWithTags, (Integer) value);
-        } else if (value instanceof Long) {
-            builder.add(nameWithTags, (Long) value);
-        } else if (value instanceof LongAccumulator) {
-            builder.add(nameWithTags, value.longValue());
-        } else if (value instanceof LongAdder) {
-            builder.add(nameWithTags, value.longValue());
-        } else if (value instanceof Short) {
-            builder.add(nameWithTags, value.intValue());
+        if (untypedValue instanceof Number) {
+            Number value = (Number) untypedValue;
+            if (value instanceof AtomicInteger) {
+                builder.add(nameWithTags, value.doubleValue());
+            } else if (value instanceof AtomicLong) {
+                builder.add(nameWithTags, value.longValue());
+            } else if (value instanceof BigDecimal) {
+                builder.add(nameWithTags, (BigDecimal) value);
+            } else if (value instanceof BigInteger) {
+                builder.add(nameWithTags, (BigInteger) value);
+            } else if (value instanceof Byte) {
+                builder.add(nameWithTags, value.intValue());
+            } else if (value instanceof Double) {
+                builder.add(nameWithTags, (Double) value);
+            } else if (value instanceof DoubleAccumulator) {
+                builder.add(nameWithTags, value.doubleValue());
+            } else if (value instanceof DoubleAdder) {
+                builder.add(nameWithTags, value.doubleValue());
+            } else if (value instanceof Float) {
+                builder.add(nameWithTags, value.floatValue());
+            } else if (value instanceof Integer) {
+                builder.add(nameWithTags, (Integer) value);
+            } else if (value instanceof Long) {
+                builder.add(nameWithTags, (Long) value);
+            } else if (value instanceof LongAccumulator) {
+                builder.add(nameWithTags, value.longValue());
+            } else if (value instanceof LongAdder) {
+                builder.add(nameWithTags, value.longValue());
+            } else if (value instanceof Short) {
+                builder.add(nameWithTags, value.intValue());
+            } else {
+                // Might be a developer-provided class which extends Number.
+                builder.add(nameWithTags, value.doubleValue());
+            }
         } else {
-            // Might be a developer-provided class which extends Number.
-            builder.add(nameWithTags, value.doubleValue());
+            builder.add(nameWithTags, String.valueOf(value));
         }
     }
 

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -485,15 +485,11 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         final MetadataBuilder builder = new MetadataBuilder();
         builder.withName(metadata.getName())
                 .withDisplayName(metadata.getDisplayName())
-                .withType(metadata.getTypeRaw());
-        // TODO - restore to original code here once new MP module is avl
-//                .reusable(metadata.isReusable());
+                .reusable(metadata.isReusable());
 
         metadata.getDescription().ifPresent(builder::withDescription);
         metadata.getUnit().ifPresent(builder::withUnit);
-// TODO - restore original return once new MP module is avl
-//        return builder.build();
-        return (metadata.isReusable() ? builder.reusable() : builder.notReusable()).build();
+        return builder.build();
     }
 
     synchronized Optional<Map.Entry<MetricID, HelidonMetric>> getOptionalMetricEntry(String metricName) {

--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -485,11 +485,15 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         final MetadataBuilder builder = new MetadataBuilder();
         builder.withName(metadata.getName())
                 .withDisplayName(metadata.getDisplayName())
-                .withType(metadata.getTypeRaw())
-                .reusable(metadata.isReusable());
+                .withType(metadata.getTypeRaw());
+        // TODO - restore to original code here once new MP module is avl
+//                .reusable(metadata.isReusable());
+
         metadata.getDescription().ifPresent(builder::withDescription);
         metadata.getUnit().ifPresent(builder::withUnit);
-        return builder.build();
+// TODO - restore original return once new MP module is avl
+//        return builder.build();
+        return (metadata.isReusable() ? builder.reusable() : builder.notReusable()).build();
     }
 
     synchronized Optional<Map.Entry<MetricID, HelidonMetric>> getOptionalMetricEntry(String metricName) {

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  *
  * @param <T> data type reported by the underlying {@code Gauge}
  */
-class DelegatingGauge<T extends Number> implements Gauge<T> {
+class DelegatingGauge<T /* extends Number */> implements Gauge<T> {
 
     private final Method method;
     private final Object obj;
@@ -50,7 +50,7 @@ class DelegatingGauge<T extends Number> implements Gauge<T> {
      * @param clazz  type of the underlying gauge
      * @return {@code DelegatingGauge}
      */
-    public static <S extends Number> DelegatingGauge<S> newInstance(Method method, Object obj,
+    public static <S /* extends Number */> DelegatingGauge<S> newInstance(Method method, Object obj,
             Class<S> clazz) {
         return new DelegatingGauge<>(method, obj, clazz);
     }

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/DelegatingGauge.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.metrics.Gauge;
  * @param <T> data type reported by the underlying {@code Gauge}
  */
 class DelegatingGauge<T /* extends Number */> implements Gauge<T> {
+    // TODO uncomment preceding clause once MP metrics enforces restriction
 
     private final Method method;
     private final Object obj;
@@ -52,6 +53,7 @@ class DelegatingGauge<T /* extends Number */> implements Gauge<T> {
      */
     public static <S /* extends Number */> DelegatingGauge<S> newInstance(Method method, Object obj,
             Class<S> clazz) {
+        // TODO uncomment preceding clause once MP metrics enforces restriction
         return new DelegatingGauge<>(method, obj, clazz);
     }
 

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -190,6 +190,7 @@ class MetricProducer {
     @VendorDefined
     @SuppressWarnings("unchecked")
     private <T /* extends Number */> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
+        // TODO uncomment preceding clause once MP metrics enforces restriction
         Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
         return (Gauge<T>) registry.getGauges().entrySet().stream()
                 .filter(entry -> entry.getKey().getName().equals(metric.name()))
@@ -209,6 +210,7 @@ class MetricProducer {
     @Produces
     private <T /* extends Number */> Gauge<T> produceGaugeDefault(MetricRegistry registry,
             InjectionPoint ip) {
+        // TODO uncomment preceding clause once MP metrics enforces restrictions
         return produceGauge(registry, ip);
     }
 

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricProducer.java
@@ -189,7 +189,7 @@ class MetricProducer {
     @Produces
     @VendorDefined
     @SuppressWarnings("unchecked")
-    private <T extends Number> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
+    private <T /* extends Number */> Gauge<T> produceGauge(MetricRegistry registry, InjectionPoint ip) {
         Metric metric = ip.getAnnotated().getAnnotation(Metric.class);
         return (Gauge<T>) registry.getGauges().entrySet().stream()
                 .filter(entry -> entry.getKey().getName().equals(metric.name()))
@@ -207,7 +207,7 @@ class MetricProducer {
      * @return requested gauge
      */
     @Produces
-    private <T extends Number> Gauge<T> produceGaugeDefault(MetricRegistry registry,
+    private <T /* extends Number */> Gauge<T> produceGaugeDefault(MetricRegistry registry,
             InjectionPoint ip) {
         return produceGauge(registry, ip);
     }

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -394,7 +394,7 @@ public class MetricsCdiExtension implements Extension {
             MetricID gaugeID = gaugeSite.getKey();
 
             AnnotatedMethodConfigurator<?> site = gaugeSite.getValue();
-            DelegatingGauge<? extends Number> dg;
+            DelegatingGauge<? /* extends Number */> dg;
             try {
                 dg = buildDelegatingGauge(gaugeID.getName(), site,
                         bm);
@@ -417,7 +417,7 @@ public class MetricsCdiExtension implements Extension {
         annotatedGaugeSites.clear();
     }
 
-    private DelegatingGauge<? extends Number> buildDelegatingGauge(String gaugeName,
+    private DelegatingGauge<? /* extends Number */> buildDelegatingGauge(String gaugeName,
             AnnotatedMethodConfigurator<?> site, BeanManager bm) {
         Bean<?> bean = bm.getBeans(site.getAnnotated().getJavaMember().getDeclaringClass())
                 .stream()
@@ -425,12 +425,13 @@ public class MetricsCdiExtension implements Extension {
                 .orElseThrow(() -> new IllegalArgumentException("Cannot find bean for annotated gauge " + gaugeName));
 
         Class<?> returnType = site.getAnnotated().getJavaMember().getReturnType();
-        Class<? extends Number> narrowedReturnType = typeToNumber(returnType);
+//        Class<? extends Number> narrowedReturnType = typeToNumber(returnType);
 
         return DelegatingGauge.newInstance(
                 site.getAnnotated().getJavaMember(),
                 getReference(bm, bean.getBeanClass(), bean),
-                narrowedReturnType);
+                // TODO - use narrowedReturnType once MP metrics restores Gauge<T extends Number> restriction.
+                returnType);
     }
 
     @SuppressWarnings("unchecked")

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -394,6 +394,7 @@ public class MetricsCdiExtension implements Extension {
             MetricID gaugeID = gaugeSite.getKey();
 
             AnnotatedMethodConfigurator<?> site = gaugeSite.getValue();
+            // TODO uncomment following clause once MP metrics enforces restriction
             DelegatingGauge<? /* extends Number */> dg;
             try {
                 dg = buildDelegatingGauge(gaugeID.getName(), site,
@@ -419,18 +420,20 @@ public class MetricsCdiExtension implements Extension {
 
     private DelegatingGauge<? /* extends Number */> buildDelegatingGauge(String gaugeName,
             AnnotatedMethodConfigurator<?> site, BeanManager bm) {
+        // TODO uncomment preceding clause once MP metrics enforces restriction
         Bean<?> bean = bm.getBeans(site.getAnnotated().getJavaMember().getDeclaringClass())
                 .stream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Cannot find bean for annotated gauge " + gaugeName));
 
         Class<?> returnType = site.getAnnotated().getJavaMember().getReturnType();
+        // TODO uncomment following line once MP metrics enforces restriction
 //        Class<? extends Number> narrowedReturnType = typeToNumber(returnType);
 
         return DelegatingGauge.newInstance(
                 site.getAnnotated().getJavaMember(),
                 getReference(bm, bean.getBeanClass(), bean),
-                // TODO - use narrowedReturnType once MP metrics restores Gauge<T extends Number> restriction.
+                // TODO use narrowedReturnType instead of returnType below once MP metrics enforces restriction
                 returnType);
     }
 

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BadGaugeTest  {
 
-    // TODO - re-enable once MP metrics reinstates the Gauge<T extends Number> restriction.
+    // TODO - remove following Disabled line once MP metrics enforces restriction
     @org.junit.jupiter.api.Disabled
     @Test
     public void testBadBean() {

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/BadGaugeTest.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BadGaugeTest  {
 
+    // TODO - re-enable once MP metrics reinstates the Gauge<T extends Number> restriction.
+    @org.junit.jupiter.api.Disabled
     @Test
     public void testBadBean() {
         SeContainerInitializer initializer = SeContainerInitializer.newInstance();


### PR DESCRIPTION
MicroProfile is working on releasing metrics 2.2. Its only change is to fix the backward-incompatible change that restricted gauges. According to their current PR this is the only change they are reverting; other compatible changes added in 2.1.0 will remain in 2.2.

This PR adapts Helidon to that change.

The initial set of changes alters the dependencies to refer to MP metrics 2.0.2. That release has the same restriction on gauges that 2.2 will but also lacks some minor (compatible!) changes from 2.1.0 which 2.2 will also have. In a future commit (once metrics 2.2 is available) I will update the dependency and fix a few temporary TODO items that work around the temporarily-missing enhancements that will return in 2.2.

Until then this PR will remain WIP and will not be merged.

Addresses #1116 