### PR TITLE
Remove com.google.code.findbugs:jsr305

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <version.lib.checkstyle>8.18</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <version.lib.jgit>4.9.0.201710071750-r</version.lib.jgit>
-        <version.lib.jsr305>3.0.2</version.lib.jsr305>
         <version.lib.netty.tcnative>2.0.25.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
@@ -710,11 +709,6 @@
                 <groupId>org.reactivestreams</groupId>
                 <artifactId>reactive-streams-tck</artifactId>
                 <version>${version.lib.reactivestreams}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${version.lib.jsr305}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.weld</groupId>

--- a/security/providers/google-login/pom.xml
+++ b/security/providers/google-login/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>


### PR DESCRIPTION
As far as I can tell we don't need this. We don't use the annotations, and it is already excluded from transient dependencies. 
