### PR TITLE
Use static factory methods instead of constructors wherever possible for gRPC classes

### DIFF
--- a/grpc/client/src/main/java/io/helidon/grpc/client/ClientMethodDescriptor.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/ClientMethodDescriptor.java
@@ -300,7 +300,7 @@ public final class ClientMethodDescriptor {
         private io.grpc.MethodDescriptor.Builder descriptor;
         private Class<?> requestType;
         private Class<?> responseType;
-        private PriorityBag<ClientInterceptor> interceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        private PriorityBag<ClientInterceptor> interceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
         private MarshallerSupplier defaultMarshallerSupplier = MarshallerSupplier.defaultInstance();
         private MarshallerSupplier marshallerSupplier;
         private CallCredentials callCredentials;

--- a/grpc/client/src/main/java/io/helidon/grpc/client/ClientProxy.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/ClientProxy.java
@@ -39,9 +39,20 @@ class ClientProxy
      * @param client  the {@link io.helidon.grpc.client.GrpcServiceClient} to use
      * @param names   a map of Java method names to gRPC method names
      */
-    ClientProxy(GrpcServiceClient client, Map<String, String> names) {
+    private ClientProxy(GrpcServiceClient client, Map<String, String> names) {
         this.client = client;
         this.names = names;
+    }
+
+    /**
+     * Create a {@link ClientProxy} instance.
+     *
+     * @param client  the {@link io.helidon.grpc.client.GrpcServiceClient} to use
+     * @param names   a map of Java method names to gRPC method names
+     * @return a {@link ClientProxy} instance for the specified service client
+     */
+    static ClientProxy create(GrpcServiceClient client, Map<String, String> names) {
+        return new ClientProxy(client, names);
     }
 
     @Override

--- a/grpc/client/src/main/java/io/helidon/grpc/client/ClientServiceDescriptor.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/ClientServiceDescriptor.java
@@ -362,7 +362,7 @@ public class ClientServiceDescriptor {
     public static final class Builder
             implements Rules, io.helidon.common.Builder<ClientServiceDescriptor> {
         private String name;
-        private PriorityBag<ClientInterceptor> interceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        private PriorityBag<ClientInterceptor> interceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
         private Class<?> serviceClass;
         private Descriptors.FileDescriptor proto;
         private MarshallerSupplier marshallerSupplier = MarshallerSupplier.defaultInstance();

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcServiceClient.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcServiceClient.java
@@ -86,7 +86,7 @@ public class GrpcServiceClient {
         for (ClientMethodDescriptor methodDescriptor : clientServiceDescriptor.methods()) {
             GrpcMethodStub methodStub = new GrpcMethodStub(channel, callOptions, methodDescriptor);
 
-            PriorityBag<ClientInterceptor> priorityInterceptors = new PriorityBag<>(InterceptorPriorities.USER);
+            PriorityBag<ClientInterceptor> priorityInterceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
             priorityInterceptors.addAll(clientServiceDescriptor.interceptors());
             priorityInterceptors.addAll(methodDescriptor.interceptors());
             List<ClientInterceptor> interceptors = priorityInterceptors.stream().collect(Collectors.toList());
@@ -185,7 +185,7 @@ public class GrpcServiceClient {
             proxyTypes[0] = type;
             System.arraycopy(extraTypes, 0, proxyTypes, 1, extraTypes.length);
         }
-        return (T) Proxy.newProxyInstance(type.getClassLoader(), proxyTypes, new ClientProxy(this, names));
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), proxyTypes, ClientProxy.create(this, names));
     }
 
     /**

--- a/grpc/core/src/main/java/io/helidon/grpc/core/PriorityBag.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/PriorityBag.java
@@ -50,27 +50,6 @@ public class PriorityBag<T> implements Iterable<T> {
 
     private final int defaultPriority;
 
-    /**
-     * Create a new {@link PriorityBag} where elements
-     * added with no priority will be last in the order.
-     */
-    public PriorityBag() {
-        this(new TreeMap<>(), new ArrayList<>(), -1);
-    }
-
-    /**
-     * Create a new {@link PriorityBag} where elements
-     * added with no priority will be be given a default
-     * priority value.
-     *
-     * @param defaultPriority  the default priority value to assign
-     *                         to elements added with no priority
-     */
-    public PriorityBag(int defaultPriority) {
-        this(new TreeMap<>(), new ArrayList<>(), defaultPriority);
-    }
-
-
     private PriorityBag(Map<Integer, List<T>> contents, List<T> noPriorityList, int defaultPriority) {
         this.contents = contents;
         this.noPriorityList = noPriorityList;
@@ -78,12 +57,43 @@ public class PriorityBag<T> implements Iterable<T> {
     }
 
     /**
+     * Create a new {@link PriorityBag} where elements
+     * added with no priority will be last in the order.
+     *
+     * @param <T> the type of elements in the bag
+     * @return a new {@link PriorityBag} where elements
+     *         dded with no priority will be last in the
+     *         order
+     */
+    public static <T> PriorityBag<T> create() {
+        return new PriorityBag<>(new TreeMap<>(), new ArrayList<>(), -1);
+    }
+
+    /**
+     * Create a new {@link PriorityBag} where elements
+     * added with no priority will be be given a default
+     * priority value.
+     *
+     * @param priority  the default priority value to assign
+     *                  to elements added with no priority
+     * @param <T>       the type of elements in the bag
+     *
+     * @return a new {@link PriorityBag} where elements
+     *         added with no priority will be be given
+     *         a default priority value
+     */
+    public static <T> PriorityBag<T> withDefaultPriority(int priority) {
+        return new PriorityBag<>(new TreeMap<>(), new ArrayList<>(), priority);
+    }
+
+
+    /**
      * Obtain a copy of this {@link PriorityBag}.
      *
      * @return a copy of this {@link PriorityBag}
      */
     public PriorityBag<T> copyMe() {
-        PriorityBag<T> copy = new PriorityBag<>();
+        PriorityBag<T> copy = PriorityBag.create();
         copy.merge(this);
         return copy;
     }

--- a/grpc/core/src/main/java/io/helidon/grpc/core/SafeStreamObserver.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/SafeStreamObserver.java
@@ -36,7 +36,7 @@ public class SafeStreamObserver<T>
      *
      * @param streamObserver  the {@link io.grpc.stub.StreamObserver} to wrap
      */
-    public SafeStreamObserver(StreamObserver<? super T> streamObserver) {
+    private SafeStreamObserver(StreamObserver<? super T> streamObserver) {
         delegate = streamObserver;
     }
 

--- a/grpc/core/src/test/java/io/helidon/grpc/core/PriorityBagTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/PriorityBagTest.java
@@ -32,7 +32,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldReturnElementsInOrder() {
-        PriorityBag<String> bag = new PriorityBag<>();
+        PriorityBag<String> bag = PriorityBag.create();
         bag.add("Three", 3);
         bag.add("Two", 2);
         bag.add("One", 1);
@@ -42,7 +42,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldReturnElementsInOrderWithinSamePriority() {
-        PriorityBag<String> bag = new PriorityBag<>();
+        PriorityBag<String> bag = PriorityBag.create();
         bag.add("Two", 2);
         bag.add("TwoToo", 2);
 
@@ -51,7 +51,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldReturnNoPriorityElementsLast() {
-        PriorityBag<String> bag = new PriorityBag<>();
+        PriorityBag<String> bag = PriorityBag.create();
         bag.add("Three", 3);
         bag.add("Last");
         bag.add("One", 1);
@@ -61,7 +61,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldGetPriorityFromAnnotation() {
-        PriorityBag<Object> bag = new PriorityBag<>();
+        PriorityBag<Object> bag = PriorityBag.create();
         Value value = new Value();
         bag.add("One", 1);
         bag.add("Three", 3);
@@ -72,7 +72,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldGetPriorityFromPrioritized() {
-        PriorityBag<Object> bag = new PriorityBag<>();
+        PriorityBag<Object> bag = PriorityBag.create();
         PrioritizedValue value = new PrioritizedValue();
         bag.add("One", 1);
         bag.add("Three", 3);
@@ -83,7 +83,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldUsePriorityFromPrioritizedOverAnnotation() {
-        PriorityBag<Object> bag = new PriorityBag<>();
+        PriorityBag<Object> bag = PriorityBag.create();
         AnnotatedPrioritizedValue value = new AnnotatedPrioritizedValue();
         bag.add("One", 1);
         bag.add("Three", 3);
@@ -94,7 +94,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldUseDefaultPriority() {
-        PriorityBag<Object> bag = new PriorityBag<>(2);
+        PriorityBag<Object> bag = PriorityBag.withDefaultPriority(2);
         bag.add("One", 1);
         bag.add("Three", 3);
         bag.add("Two");
@@ -104,7 +104,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldAddAll() {
-        PriorityBag<Object> bag = new PriorityBag<>();
+        PriorityBag<Object> bag = PriorityBag.create();
         bag.addAll(Arrays.asList("One", "Two", "Three"));
 
         assertThat(bag, contains("One", "Two", "Three"));
@@ -112,7 +112,7 @@ public class PriorityBagTest {
 
     @Test
     public void shouldAddAllWithPriority() {
-        PriorityBag<Object> bag = new PriorityBag<>();
+        PriorityBag<Object> bag = PriorityBag.create();
         bag.add("First", 1);
         bag.add("Last", 3);
         bag.addAll(Arrays.asList("One", "Two", "Three"), 2);
@@ -122,8 +122,8 @@ public class PriorityBagTest {
 
     @Test
     public void shouldMerge() {
-        PriorityBag<Object> bagOne = new PriorityBag<>();
-        PriorityBag<Object> bagTwo = new PriorityBag<>();
+        PriorityBag<Object> bagOne = PriorityBag.create();
+        PriorityBag<Object> bagTwo = PriorityBag.create();
 
         bagOne.add("A", 1);
         bagOne.add("B", 2);

--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -253,7 +253,7 @@ public class GrpcMetrics
          *
          * @param delegate the call to time
          */
-        MetricServerCall(MetricT metric, ServerCall<ReqT, RespT> delegate) {
+        private MetricServerCall(MetricT metric, ServerCall<ReqT, RespT> delegate) {
             super(delegate);
 
             this.metric = metric;
@@ -287,7 +287,7 @@ public class GrpcMetrics
          *
          * @param delegate the call to time
          */
-        TimedServerCall(Timer timer, ServerCall<ReqT, RespT> delegate) {
+        private TimedServerCall(Timer timer, ServerCall<ReqT, RespT> delegate) {
             super(timer, delegate);
 
             this.startNanos = System.nanoTime();
@@ -328,7 +328,7 @@ public class GrpcMetrics
          *
          * @param delegate the call to time
          */
-        CountedServerCall(Counter counter, ServerCall<ReqT, RespT> delegate) {
+        private CountedServerCall(Counter counter, ServerCall<ReqT, RespT> delegate) {
             super(counter, delegate);
         }
 
@@ -353,7 +353,7 @@ public class GrpcMetrics
          *
          * @param delegate the call to time
          */
-        MeteredServerCall(Meter meter, ServerCall<ReqT, RespT> delegate) {
+        private MeteredServerCall(Meter meter, ServerCall<ReqT, RespT> delegate) {
             super(meter, delegate);
         }
 
@@ -378,7 +378,7 @@ public class GrpcMetrics
          *
          * @param delegate the call to time
          */
-        HistogramServerCall(Histogram histogram, ServerCall<ReqT, RespT> delegate) {
+        private HistogramServerCall(Histogram histogram, ServerCall<ReqT, RespT> delegate) {
             super(histogram, delegate);
         }
 

--- a/grpc/server/src/main/java/io/helidon/grpc/server/BindableServiceImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/BindableServiceImpl.java
@@ -50,10 +50,21 @@ class BindableServiceImpl implements BindableService {
      */
     private final PriorityBag<ServerInterceptor> globalInterceptors;
 
-
-    BindableServiceImpl(ServiceDescriptor descriptor, PriorityBag<ServerInterceptor> interceptors) {
+    private BindableServiceImpl(ServiceDescriptor descriptor, PriorityBag<ServerInterceptor> interceptors) {
         this.descriptor = descriptor;
         this.globalInterceptors = interceptors.copyMe();
+    }
+
+    /**
+     * Create a {@link BindableServiceImpl} for a gRPC service.
+     *
+     * @param descriptor    the service descriptor
+     * @param interceptors  the bag of interceptors to apply to the service
+     *
+     * @return a {@link BindableServiceImpl} for the gRPC service
+     */
+    static BindableServiceImpl create(ServiceDescriptor descriptor, PriorityBag<ServerInterceptor> interceptors) {
+        return new BindableServiceImpl(descriptor, interceptors);
     }
 
     // ---- BindableService implementation ----------------------------------
@@ -74,7 +85,7 @@ class BindableServiceImpl implements BindableService {
     private <ReqT, RespT> ServerCallHandler<ReqT, RespT> wrapCallHandler(MethodDescriptor<ReqT, RespT> method) {
         ServerCallHandler<ReqT, RespT> handler = method.callHandler();
 
-        PriorityBag<ServerInterceptor> priorityServerInterceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        PriorityBag<ServerInterceptor> priorityServerInterceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
         priorityServerInterceptors.addAll(globalInterceptors);
         priorityServerInterceptors.addAll(descriptor.interceptors());
         priorityServerInterceptors.addAll(method.interceptors());

--- a/grpc/server/src/main/java/io/helidon/grpc/server/ContextSettingServerInterceptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/ContextSettingServerInterceptor.java
@@ -45,6 +45,18 @@ class ContextSettingServerInterceptor
      */
     private ServiceDescriptor serviceDescriptor;
 
+    private ContextSettingServerInterceptor() {
+    }
+
+    /**
+     * Create a {@link ContextSettingServerInterceptor}.
+     *
+     * @return a {@link ContextSettingServerInterceptor} instance.
+     */
+    static ContextSettingServerInterceptor create() {
+        return new ContextSettingServerInterceptor();
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRouting.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRouting.java
@@ -97,7 +97,7 @@ public interface GrpcRouting {
          * The {@link List} of the global {@link io.grpc.ServerInterceptor}s that should be
          * applied to all services.
          */
-        private PriorityBag<ServerInterceptor> interceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        private PriorityBag<ServerInterceptor> interceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
 
         /**
          * Add one or more global {@link ServerInterceptor} instances that will intercept calls
@@ -206,7 +206,7 @@ public interface GrpcRouting {
          * @return a new {@link GrpcRouting} instance
          */
         public GrpcRouting build() {
-            return new GrpcRoutingImpl(services.values(), interceptors);
+            return GrpcRoutingImpl.create(services.values(), interceptors);
         }
 
         // ---- helpers -----------------------------------------------------

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRoutingImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRoutingImpl.java
@@ -49,9 +49,22 @@ public class GrpcRoutingImpl
      * @param interceptors  the {@link List} of the global {@link io.grpc.ServerInterceptor}s that should
      *                      be applied to all services
      */
-    GrpcRoutingImpl(Collection<ServiceDescriptor> services, PriorityBag<ServerInterceptor> interceptors) {
+    private GrpcRoutingImpl(Collection<ServiceDescriptor> services, PriorityBag<ServerInterceptor> interceptors) {
         this.services = new ArrayList<>(Objects.requireNonNull(services));
         this.interceptors = interceptors.copyMe();
+    }
+
+    /**
+     * Create a {@link GrpcRoutingImpl}.
+     *
+     * @param services      the {@link List} of registered {@link ServiceDescriptor} instances
+     * @param interceptors  the {@link List} of the global {@link io.grpc.ServerInterceptor}s that should
+     *                      be applied to all services
+     *
+     * @return a {@link GrpcRoutingImpl} for the specified gRPC services with interceptors
+     */
+    static GrpcRouting create(Collection<ServiceDescriptor> services, PriorityBag<ServerInterceptor> interceptors) {
+        return new GrpcRoutingImpl(services, interceptors);
     }
 
     @Override

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
@@ -287,14 +287,14 @@ public interface GrpcServer {
          */
         @Override
         public GrpcServer build() {
-            PriorityBag<ServerInterceptor> interceptors = new PriorityBag<>();
-            GrpcServerImpl server = new GrpcServerImpl(configuration);
+            PriorityBag<ServerInterceptor> interceptors = PriorityBag.create();
+            GrpcServerImpl server = GrpcServerImpl.create(configuration);
 
-            interceptors.add(new ContextSettingServerInterceptor());
+            interceptors.add(ContextSettingServerInterceptor.create());
 
             Tracer tracer = configuration.tracer();
             if (tracer != null) {
-                interceptors.add(new GrpcTracing(tracer, configuration.tracingConfig()));
+                interceptors.add(GrpcTracing.create(tracer, configuration.tracingConfig()));
             }
 
             // add the global interceptors from the routing AFTER the tracing interceptor

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerBasicConfig.java
@@ -49,7 +49,7 @@ public class GrpcServerBasicConfig
      * @param builder the {@link GrpcServerConfiguration.Builder} to use to configure
      *                this {@link GrpcServerBasicConfig}.
      */
-    GrpcServerBasicConfig(GrpcServerConfiguration.Builder builder) {
+    private GrpcServerBasicConfig(GrpcServerConfiguration.Builder builder) {
         this.name = builder.name();
         this.port = builder.port();
         this.context = builder.context();
@@ -58,6 +58,18 @@ public class GrpcServerBasicConfig
         this.tracingConfig = builder.tracingConfig();
         this.workers = builder.workers();
         this.tlsConfig = builder.tlsConfig();
+    }
+
+    /**
+     * Create a {@link GrpcServerBasicConfig} instance using the specified builder.
+     *
+     * @param builder the {@link GrpcServerConfiguration.Builder} to use to configure
+     *                this {@link GrpcServerBasicConfig}
+     *
+     * @return a {@link GrpcServerBasicConfig} instance
+     */
+    static GrpcServerBasicConfig create(GrpcServerConfiguration.Builder builder) {
+        return new GrpcServerBasicConfig(builder);
     }
 
     // ---- accessors ---------------------------------------------------

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
@@ -342,7 +342,7 @@ public interface GrpcServerConfiguration {
                 workers = DEFAULT_WORKER_COUNT;
             }
 
-            return new GrpcServerBasicConfig(this);
+            return GrpcServerBasicConfig.create(this);
         }
     }
 }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerImpl.java
@@ -107,7 +107,7 @@ public class GrpcServerImpl implements GrpcServer {
     /**
      * The health status manager.
      */
-    private HealthServiceImpl healthService = new HealthServiceImpl();
+    private HealthServiceImpl healthService = HealthServiceImpl.create();
 
     /**
      * The {@link HandlerRegistry} to register services.
@@ -133,10 +133,20 @@ public class GrpcServerImpl implements GrpcServer {
      *
      * @param config the configuration for this server
      */
-    GrpcServerImpl(GrpcServerConfiguration config) {
+    private GrpcServerImpl(GrpcServerConfiguration config) {
         this.config = config;
         this.context = config.context();
 
+    }
+
+    /**
+     * Create a {@link GrpcServerImpl} with the specified configuration.
+     *
+     * @param config the configuration for this server
+     * @return a {@link GrpcServerImpl} with the specified configuration
+     */
+    static GrpcServerImpl create(GrpcServerConfiguration config) {
+        return new GrpcServerImpl(config);
     }
 
     // ---- GrpcServer interface --------------------------------------------

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcTracing.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcTracing.java
@@ -47,18 +47,25 @@ import io.opentracing.propagation.TextMapExtractAdapter;
 @Priority(InterceptorPriorities.TRACING)
 public class GrpcTracing
         implements ServerInterceptor {
-    /**
-     * public constructor.
-     *
-     * @param tracer        the Open Tracing {@link Tracer}
-     * @param tracingConfig the tracing configuration
-     */
-    GrpcTracing(Tracer tracer, GrpcTracingConfig tracingConfig) {
+
+    private GrpcTracing(Tracer tracer, GrpcTracingConfig tracingConfig) {
         this.tracer = tracer;
         operationNameConstructor = tracingConfig.operationNameConstructor();
         streaming = tracingConfig.isStreaming();
         verbose = tracingConfig.isVerbose();
         tracedAttributes = tracingConfig.tracedAttributes();
+    }
+
+    /**
+     * Create a {@link GrpcTracing} interceptor.
+     *
+     * @param tracer the Open Tracing {@link Tracer}
+     * @param config the tracing configuration
+     *
+     * @return a {@link GrpcTracing} interceptor instance
+     */
+    static GrpcTracing create(Tracer tracer, GrpcTracingConfig config) {
+        return new GrpcTracing(tracer, config);
     }
 
     @Override

--- a/grpc/server/src/main/java/io/helidon/grpc/server/HealthServiceImpl.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/HealthServiceImpl.java
@@ -40,14 +40,18 @@ class HealthServiceImpl
      */
     private final Map<String, HealthCheck> mapHealthChecks = new ConcurrentHashMap<>();
 
-    /**
-     * Create a {@link HealthServiceImpl}.
-     */
-    HealthServiceImpl() {
+    private HealthServiceImpl() {
         // register the empty service name to represent the global health check
         // see: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
         mapHealthChecks.put(HealthStatusManager.SERVICE_NAME_ALL_SERVICES,
                             ConstantHealthCheck.up(HealthStatusManager.SERVICE_NAME_ALL_SERVICES));
+    }
+
+    /**
+     * Create a {@link HealthServiceImpl}.
+     */
+    static HealthServiceImpl create() {
+        return new HealthServiceImpl();
     }
 
     /**

--- a/grpc/server/src/main/java/io/helidon/grpc/server/MethodDescriptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/MethodDescriptor.java
@@ -234,7 +234,7 @@ public class MethodDescriptor<ReqT, ResT> {
         private final io.grpc.MethodDescriptor.Builder<ReqT, ResT> descriptor;
         private final ServerCallHandler<ReqT, ResT> callHandler;
 
-        private final PriorityBag<ServerInterceptor> interceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        private final PriorityBag<ServerInterceptor> interceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
 
         private final Map<Context.Key, Object> context = new HashMap<>();
 

--- a/grpc/server/src/main/java/io/helidon/grpc/server/ServiceDescriptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/ServiceDescriptor.java
@@ -120,7 +120,7 @@ public class ServiceDescriptor {
     }
 
     BindableService bindableService(PriorityBag<ServerInterceptor> interceptors) {
-        return new BindableServiceImpl(this, interceptors);
+        return BindableServiceImpl.create(this, interceptors);
     }
 
     @Override
@@ -431,7 +431,7 @@ public class ServiceDescriptor {
         private Descriptors.FileDescriptor proto;
         private MarshallerSupplier marshallerSupplier = MarshallerSupplier.defaultInstance();
         private Map<String, MethodDescriptor.Builder> methodBuilders = new LinkedHashMap<>();
-        private PriorityBag<ServerInterceptor> interceptors = new PriorityBag<>(InterceptorPriorities.USER);
+        private PriorityBag<ServerInterceptor> interceptors = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
         private Map<Context.Key<?>, Object> context = new HashMap<>();
         private HealthCheck healthCheck;
 

--- a/grpc/server/src/test/java/io/helidon/grpc/server/BindableServiceImplTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/BindableServiceImplTest.java
@@ -54,7 +54,7 @@ public class BindableServiceImplTest {
         ServerInterceptor interceptorFive = spy(new InterceptorStub());
         ServerInterceptor interceptorSix = spy(new InterceptorStub());
 
-        PriorityBag<ServerInterceptor> global = new PriorityBag<>(InterceptorPriorities.USER);
+        PriorityBag<ServerInterceptor> global = PriorityBag.withDefaultPriority(InterceptorPriorities.USER);
         global.addAll(CollectionsHelper.listOf(interceptorOne, interceptorTwo, interceptorThree));
 
         ServiceDescriptor descriptor = ServiceDescriptor.builder(new Service())
@@ -64,7 +64,7 @@ public class BindableServiceImplTest {
                 .unary("foo", this::unary, rules -> rules.intercept(interceptorThree, interceptorFour, interceptorSix))
                 .build();
 
-        BindableServiceImpl bindableService = new BindableServiceImpl(descriptor, global);
+        BindableServiceImpl bindableService = BindableServiceImpl.create(descriptor, global);
         ServerServiceDefinition definition = bindableService.bindService();
         ServerMethodDefinition<?, ?> method = definition.getMethod("Service/foo");
         ServerCallHandler<?, ?> callHandler = method.getServerCallHandler();

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ContextSettingServerInterceptorTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ContextSettingServerInterceptorTest.java
@@ -43,7 +43,7 @@ public class ContextSettingServerInterceptorTest {
                 .unary("test", this::dummyUnary)
                 .build();
 
-        ContextSettingServerInterceptor interceptor = new ContextSettingServerInterceptor();
+        ContextSettingServerInterceptor interceptor = ContextSettingServerInterceptor.create();
 
         Metadata headers = new Metadata();
         ServerCall<String, String> call = mock(ServerCall.class);
@@ -72,7 +72,7 @@ public class ContextSettingServerInterceptorTest {
                 .unary("test", this::dummyUnary)
                 .build();
 
-        ContextSettingServerInterceptor interceptor = new ContextSettingServerInterceptor();
+        ContextSettingServerInterceptor interceptor = ContextSettingServerInterceptor.create();
 
         Metadata headers = new Metadata();
         ServerCall<String, String> call = mock(ServerCall.class);
@@ -105,7 +105,7 @@ public class ContextSettingServerInterceptorTest {
                 .unary("test", this::dummyUnary, cfg -> cfg.addContextValue(key2, "test-method-value"))
                 .build();
 
-        ContextSettingServerInterceptor interceptor = new ContextSettingServerInterceptor();
+        ContextSettingServerInterceptor interceptor = ContextSettingServerInterceptor.create();
 
         Metadata headers = new Metadata();
         ServerCall<String, String> call = mock(ServerCall.class);
@@ -138,7 +138,7 @@ public class ContextSettingServerInterceptorTest {
                 .unary("test", this::dummyUnary, cfg -> cfg.addContextValue(key, "test-method-value"))
                 .build();
 
-        ContextSettingServerInterceptor interceptor = new ContextSettingServerInterceptor();
+        ContextSettingServerInterceptor interceptor = ContextSettingServerInterceptor.create();
 
         Metadata headers = new Metadata();
         ServerCall<String, String> call = mock(ServerCall.class);

--- a/grpc/server/src/test/java/io/helidon/grpc/server/HealthServiceImplTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/HealthServiceImplTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class HealthServiceImplTest {
     @Test
     public void shouldRequestCheckForUpService() {
-        HealthServiceImpl healthService = new HealthServiceImpl();
+        HealthServiceImpl healthService = HealthServiceImpl.create();
         String serviceName = "foo";
         HealthCheck check = ConstantHealthCheck.up(serviceName);
         HealthCheckRequest request = HealthCheckRequest.newBuilder().setService(serviceName).build();
@@ -57,7 +57,7 @@ public class HealthServiceImplTest {
 
     @Test
     public void shouldRequestCheckForDownService() {
-        HealthServiceImpl healthService = new HealthServiceImpl();
+        HealthServiceImpl healthService = HealthServiceImpl.create();
         String serviceName = "foo";
         HealthCheck check = ConstantHealthCheck.down(serviceName);
         HealthCheckRequest request = HealthCheckRequest.newBuilder().setService(serviceName).build();
@@ -81,7 +81,7 @@ public class HealthServiceImplTest {
 
     @Test
     public void shouldRequestCheckForGlobalService() {
-        HealthServiceImpl healthService = new HealthServiceImpl();
+        HealthServiceImpl healthService = HealthServiceImpl.create();
         String serviceName = "";
         HealthCheck check = ConstantHealthCheck.up(serviceName);
         HealthCheckRequest request = HealthCheckRequest.newBuilder().setService(serviceName).build();
@@ -105,7 +105,7 @@ public class HealthServiceImplTest {
 
     @Test
     public void shouldRequestCheckWithoutServiceName() {
-        HealthServiceImpl healthService = new HealthServiceImpl();
+        HealthServiceImpl healthService = HealthServiceImpl.create();
         String serviceName = "";
         HealthCheck check = ConstantHealthCheck.up(serviceName);
         HealthCheckRequest request = HealthCheckRequest.newBuilder().build();
@@ -129,7 +129,7 @@ public class HealthServiceImplTest {
 
     @Test
     public void shouldRequestCheckForUnknownService() {
-        HealthServiceImpl healthService = new HealthServiceImpl();
+        HealthServiceImpl healthService = HealthServiceImpl.create();
         String serviceName = "unknown";
         HealthCheckRequest request = HealthCheckRequest.newBuilder().setService(serviceName).build();
         TestStreamObserver<HealthCheckResponse> observer = new TestStreamObserver<>();

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
@@ -462,7 +462,7 @@ public class ServiceDescriptorTest {
                 .unary("bar", this::dummyUnary)
                 .build();
 
-        io.grpc.MethodDescriptor<?, ?> methodDescriptor = descriptor.bindableService(new PriorityBag<>())
+        io.grpc.MethodDescriptor<?, ?> methodDescriptor = descriptor.bindableService(PriorityBag.create())
                 .bindService()
                 .getMethod("foo/bar")
                 .getMethodDescriptor();
@@ -481,7 +481,7 @@ public class ServiceDescriptorTest {
 
         assertThat(descriptor.name(), is(grpcDescriptor.getName()));
 
-        BindableService bindableService = descriptor.bindableService(new PriorityBag<>());
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
         assertThat(bindableService, is(notNullValue()));
 
         ServerServiceDefinition ssd = bindableService.bindService();
@@ -512,7 +512,7 @@ public class ServiceDescriptorTest {
 
         assertThat(descriptor.name(), is("Foo"));
 
-        BindableService bindableService = descriptor.bindableService(new PriorityBag<>());
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
         assertThat(bindableService, is(notNullValue()));
 
         ServerServiceDefinition ssd = bindableService.bindService();
@@ -544,7 +544,7 @@ public class ServiceDescriptorTest {
 
         assertThat(descriptor.name(), is("EchoService"));
 
-        BindableService bindableService = descriptor.bindableService(new PriorityBag<>());
+        BindableService bindableService = descriptor.bindableService(PriorityBag.create());
         assertThat(bindableService, is(notNullValue()));
 
         ServerServiceDefinition ssd = bindableService.bindService();

--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/DelegatingBeanAttributes.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/DelegatingBeanAttributes.java
@@ -40,11 +40,21 @@ class DelegatingBeanAttributes<T> implements BeanAttributes<T> {
      * @param delegate  the {@link BeanAttributes} to delegate to
      * @param types the {@link Type}s for this bean
      */
-    DelegatingBeanAttributes(BeanAttributes<?> delegate, Set<Type> types) {
+    private DelegatingBeanAttributes(BeanAttributes<?> delegate, Set<Type> types) {
         super();
         Objects.requireNonNull(delegate);
         this.delegate = delegate;
         this.types = Collections.unmodifiableSet(types);
+    }
+
+    /**
+     * Create a {@link DelegatingBeanAttributes}.
+     *
+     * @param delegate  the {@link BeanAttributes} to delegate to
+     * @param types the {@link Type}s for this bean
+     */
+    static <T> DelegatingBeanAttributes<T> create(BeanAttributes<?> delegate, Set<Type> types) {
+        return new DelegatingBeanAttributes<>(delegate, types);
     }
 
     @Override

--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientBuilder.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientBuilder.java
@@ -90,7 +90,7 @@ class GrpcClientBuilder
         checkForNonPublicMethodIssues();
 
         Class<?> annotatedServiceClass = annotatedServiceClass();
-        AnnotatedMethodList methodList = new AnnotatedMethodList(annotatedServiceClass);
+        AnnotatedMethodList methodList = AnnotatedMethodList.create(annotatedServiceClass);
         String name = determineServiceName(annotatedServiceClass);
 
         ClientServiceDescriptor.Builder builder = ClientServiceDescriptor.builder(serviceClass())

--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientCdiExtension.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientCdiExtension.java
@@ -110,7 +110,7 @@ public class GrpcClientCdiExtension implements Extension {
         BeanAttributes<?> producerAttributes = beanManager.createBeanAttributes(producerMethod);
         ProducerFactory<GrpcProxyProducer> factory = beanManager.getProducerFactory(producerMethod, null);
         Set<Type> types = CollectionsHelper.setOf(Object.class, type);
-        BeanAttributes<?> beanAttributes = new DelegatingBeanAttributes<>(producerAttributes, types);
+        BeanAttributes<?> beanAttributes = DelegatingBeanAttributes.create(producerAttributes, types);
         event.addBean(beanManager.createBean(beanAttributes, GrpcProxyProducer.class, factory));
     }
 }

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
@@ -76,7 +76,7 @@ public abstract class AbstractServiceBuilder {
      * Obtain the service class.
      * @return  the service class
      */
-    public Class<?> serviceClass() {
+    protected Class<?> serviceClass() {
         return serviceClass;
     }
 
@@ -84,7 +84,7 @@ public abstract class AbstractServiceBuilder {
      * Obtain the actual annotated class.
      * @return  the actual annotated class
      */
-    public Class<?> annotatedServiceClass() {
+    protected Class<?> annotatedServiceClass() {
         return annotatedServiceClass;
     }
 
@@ -119,7 +119,7 @@ public abstract class AbstractServiceBuilder {
      * Verify that there are no non-public annotated methods.
      */
     protected void checkForNonPublicMethodIssues() {
-        AnnotatedMethodList allDeclaredMethods = new AnnotatedMethodList(getAllDeclaredMethods(serviceClass));
+        AnnotatedMethodList allDeclaredMethods = AnnotatedMethodList.create(getAllDeclaredMethods(serviceClass));
 
         // log warnings for all non-public annotated methods
         allDeclaredMethods.withMetaAnnotation(RpcMethod.class).isNotPublic()

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethod.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethod.java
@@ -87,10 +87,9 @@ public class AnnotatedMethod implements AnnotatedElement {
      * Create annotated method instance from a {@link Method Java method}.
      *
      * @param method the Java method
-     * @throws java.lang.NullPointerException if the method parameter is null
      */
-    public AnnotatedMethod(Method method) {
-        this.declaredMethod = Objects.requireNonNull(method);
+    private AnnotatedMethod(Method method) {
+        this.declaredMethod = method;
         this.actualMethod = findAnnotatedMethod(method);
 
         if (method.equals(actualMethod)) {
@@ -101,6 +100,17 @@ public class AnnotatedMethod implements AnnotatedElement {
             parameterAnnotations = mergeParameterAnnotations(method, actualMethod);
         }
     }
+
+    /**
+     * Create an {@link AnnotatedMethod} instance from a {@link Method Java method}.
+     *
+     * @param method the Java method
+     * @throws java.lang.NullPointerException if the method parameter is null
+     * @return an {@link AnnotatedMethod} instance representing the Java method
+     */
+     public static AnnotatedMethod create(Method method) {
+         return new AnnotatedMethod(Objects.requireNonNull(method));
+     }
 
     /**
      * Get the underlying Java method.

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethodList.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethodList.java
@@ -37,62 +37,71 @@ public class AnnotatedMethodList implements Iterable<AnnotatedMethod> {
     private final AnnotatedMethod[] methods;
 
     /**
-     * Create new method list for a class.
-     *
-     * The method list contains {@link Class#getMethods() all methods} available
-     * on the class.
-     *
-     * The {@link java.lang.reflect.Method#isBridge() bridge methods} and methods declared directly
-     * on the {@link Object} class are filtered out.
-     *
-     * @param cls class from which the method list is created.
-     */
-    public AnnotatedMethodList(Class<?> cls) {
-        this(cls, false);
-    }
-
-    /**
-     * Create new method list for a class.
-     *
-     * The method list contains {@link Class#getMethods() all methods} available
-     * on the class or {@link Class#getDeclaredMethods() declared methods} only,
-     * depending on the value of the {@code declaredMethods} parameter.
-     *
-     * The {@link java.lang.reflect.Method#isBridge() bridge methods} and methods declared directly
-     * on the {@link Object} class are filtered out.
-     *
-     * @param cls             class from which the method list is created.
-     * @param declaredMethods if {@code true} only the {@link Class#getDeclaredMethods()
-     *                        declared methods} will be included in the method list; otherwise
-     *                        {@link Class#getMethods() all methods} will be listed.
-     */
-    public AnnotatedMethodList(Class<?> cls, boolean declaredMethods) {
-        this(declaredMethods ? allDeclaredMethods(cls) : methodList(cls));
-    }
-
-    /**
-     * Create new method list from the given collection of methods.
-     *
-     * The {@link Method#isBridge() bridge methods} and methods declared directly
-     * on the {@link Object} class are filtered out.
-     *
-     * @param methods methods to be included in the method list.
-     */
-    public AnnotatedMethodList(Collection<Method> methods) {
-        this.methods = methods.stream()
-                .filter(m -> !m.isBridge() && m.getDeclaringClass() != Object.class)
-                .map(AnnotatedMethod::new)
-                .toArray(AnnotatedMethod[]::new);
-    }
-
-    /**
      * Create new method list from the given array of {@link AnnotatedMethod
      * annotated methods}.
      *
      * @param methods methods to be included in the method list.
      */
-    public AnnotatedMethodList(AnnotatedMethod... methods) {
+    private AnnotatedMethodList(AnnotatedMethod... methods) {
         this.methods = methods;
+    }
+
+    /**
+     * Create an annotated method list for a class.
+     * <p>
+     * The method list contains {@link Class#getMethods() all methods} available
+     * on the class.
+     * <p>
+     * The {@link java.lang.reflect.Method#isBridge() bridge methods} and methods declared directly
+     * on the {@link Object} class are filtered out.
+     *
+     * @param cls class from which the method list is created
+     * @return an {@link AnnotatedMethodList} containing {@link AnnotatedMethod} instances for
+     *         all of the methods of the specified class
+     */
+    public static AnnotatedMethodList create(Class<?> cls) {
+        return create(cls, false);
+    }
+
+    /**
+     * Create an annotated method list for a class.
+     * <p>
+     * The method list contains {@link Class#getMethods() all methods} available
+     * on the class or {@link Class#getDeclaredMethods() declared methods} only,
+     * depending on the value of the {@code declaredMethods} parameter.
+     * <p>
+     * The {@link java.lang.reflect.Method#isBridge() bridge methods} and methods declared directly
+     * on the {@link Object} class are filtered out.
+     *
+     * @param cls             class from which the method list is created
+     * @param declaredMethods if {@code true} only the {@link Class#getDeclaredMethods()
+     *                        declared methods} will be included in the method list; otherwise
+     *                        {@link Class#getMethods() all methods} will be listed
+     * @return an {@link AnnotatedMethodList} containing {@link AnnotatedMethod} instances for
+     *         the methods of the specified class
+     */
+    public static AnnotatedMethodList create(Class<?> cls, boolean declaredMethods) {
+        return create(declaredMethods ? allDeclaredMethods(cls) : methodList(cls));
+    }
+
+    /**
+     * Create an annotated method list from the given collection of methods.
+     * <p>
+     * The {@link Method#isBridge() bridge methods} and methods declared directly
+     * on the {@link Object} class are filtered out.
+     *
+     * @param methods methods to be included in the method list.
+     * @return an {@link AnnotatedMethodList} containing {@link AnnotatedMethod} instances for
+     *         the methods of the specified class
+     */
+    public static AnnotatedMethodList create(Collection<Method> methods) {
+        AnnotatedMethod[] annotatedMethods
+                = methods.stream()
+                         .filter(m -> !m.isBridge() && m.getDeclaringClass() != Object.class)
+                         .map(AnnotatedMethod::create)
+                         .toArray(AnnotatedMethod[]::new);
+
+        return new AnnotatedMethodList(annotatedMethods);
     }
 
     /**

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/BidirectionalMethodHandlerSupplier.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/BidirectionalMethodHandlerSupplier.java
@@ -37,6 +37,7 @@ public class BidirectionalMethodHandlerSupplier
     /**
      * Create a supplier of handlers for bi-directional streaming methods.
      */
+    // method is public because it is loaded via ServiceLoader
     public BidirectionalMethodHandlerSupplier() {
         super(MethodDescriptor.MethodType.BIDI_STREAMING);
     }

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ClientStreamingMethodHandlerSupplier.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ClientStreamingMethodHandlerSupplier.java
@@ -40,6 +40,7 @@ public class ClientStreamingMethodHandlerSupplier
     /**
      * Create a supplier of handlers for client streaming methods.
      */
+    // method is public because it is loaded via ServiceLoader
     public ClientStreamingMethodHandlerSupplier() {
         super(MethodDescriptor.MethodType.CLIENT_STREAMING);
     }

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ServerStreamingMethodHandlerSupplier.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ServerStreamingMethodHandlerSupplier.java
@@ -44,6 +44,7 @@ public class ServerStreamingMethodHandlerSupplier
     /**
      * Create a supplier of handlers for server streaming methods.
      */
+    // method is public because it is loaded via ServiceLoader
     public ServerStreamingMethodHandlerSupplier() {
         super(MethodDescriptor.MethodType.SERVER_STREAMING);
     }

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/UnaryMethodHandlerSupplier.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/UnaryMethodHandlerSupplier.java
@@ -40,6 +40,7 @@ public class UnaryMethodHandlerSupplier
     /**
      * Create a supplier of handlers for server streaming methods.
      */
+    // method is public because it is loaded via ServiceLoader
     public UnaryMethodHandlerSupplier() {
         super(MethodDescriptor.MethodType.UNARY);
     }

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AbstractMethodHandlerSupplierTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AbstractMethodHandlerSupplierTest.java
@@ -44,7 +44,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleBidirectionalInvocationError() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getClientStreamingMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getClientStreamingMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         BadHandlerStub<String, String> stub = new BadHandlerStub<>(method,
@@ -60,7 +60,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleClientStreamingInvocationError() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getClientStreamingMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getClientStreamingMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         BadHandlerStub<String, String> stub = new BadHandlerStub<>(method,
@@ -76,7 +76,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleServerStreamingInvocationError() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getServerStreamingMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getServerStreamingMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         BadHandlerStub<String, String> stub = new BadHandlerStub<>(method,
@@ -95,7 +95,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleUnaryInvocationError() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getUnaryMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getUnaryMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         BadHandlerStub<String, String> stub = new BadHandlerStub<>(method, () -> instance, MethodDescriptor.MethodType.UNARY);
@@ -112,7 +112,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleFutureCompletion() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getUnaryMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getUnaryMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         HandlerStub<String, String> stub = new HandlerStub<>(method, () -> instance, MethodDescriptor.MethodType.UNARY);
@@ -126,7 +126,7 @@ public class AbstractMethodHandlerSupplierTest {
 
     @Test
     public void shouldHandleFutureExceptionalCompletion() throws Exception {
-        AnnotatedMethod method = new AnnotatedMethod(getUnaryMethod());
+        AnnotatedMethod method = AnnotatedMethod.create(getUnaryMethod());
         AbstractMethodHandlerSupplierTest instance = mock(AbstractMethodHandlerSupplierTest.class);
         StreamObserver observer = mock(StreamObserver.class);
         HandlerStub<String, String> stub = new HandlerStub<>(method, () -> instance, MethodDescriptor.MethodType.UNARY);

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AnnotatedMethodListTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AnnotatedMethodListTest.java
@@ -35,7 +35,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldFindAllDeclaredMethods() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         List<String> names = list.stream()
                 .map(am -> am.method().getName())
                 .collect(Collectors.toList());
@@ -45,7 +45,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldFindAllMethods() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class);
         List<String> names = list.stream()
                 .map(am -> am.method().getName())
                 .collect(Collectors.toList());
@@ -55,7 +55,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldIterateAllMethods() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         List<String> names = new ArrayList<>();
         Iterator<AnnotatedMethod> iterator = list.iterator();
         while (iterator.hasNext()) {
@@ -67,7 +67,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetNonePublicMethods() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.isNotPublic();
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -78,7 +78,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithParameterCount() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.hasParameterCount(2);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -89,7 +89,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithWithReturnType() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.hasReturnType(String.class);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -100,7 +100,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithWithNamePrefix() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.nameStartsWith("t");
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -111,7 +111,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithWithAnnotation() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.withAnnotation(Unary.class);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -122,7 +122,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithoutAnnotation() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.withoutAnnotation(Unary.class);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -133,7 +133,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithMetaAnnotation() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.withMetaAnnotation(RpcMethod.class);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())
@@ -144,7 +144,7 @@ public class AnnotatedMethodListTest {
 
     @Test
     public void shouldGetMethodsWithoutMetaAnnotation() {
-        AnnotatedMethodList list = new AnnotatedMethodList(Stub.class, true);
+        AnnotatedMethodList list = AnnotatedMethodList.create(Stub.class, true);
         AnnotatedMethodList methods = list.withoutMetaAnnotation(RpcMethod.class);
         List<String> names = methods.stream()
                 .map(am -> am.method().getName())

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AnnotatedMethodTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/AnnotatedMethodTest.java
@@ -38,13 +38,13 @@ public class AnnotatedMethodTest {
 
     @Test
     public void shouldNotAllowNullMethod() {
-        assertThrows(NullPointerException.class, () -> new AnnotatedMethod(null));
+        assertThrows(NullPointerException.class, () -> AnnotatedMethod.create(null));
     }
 
     @Test
     public void shouldHaveSameDeclaredAndActualAnnotatedMethodsIfNoSuperClass() throws Exception {
         Method method = GrandParent.class.getDeclaredMethod("one");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(method);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(method);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(method)));
         assertThat(annotatedMethod.method(), is(method));
@@ -53,7 +53,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldHaveSameDeclaredAndActualNonAnnotatedMethodsIfNoSuperClass() throws Exception {
         Method method = GrandParent.class.getDeclaredMethod("two");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(method);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(method);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(method)));
         assertThat(annotatedMethod.method(), is(method));
@@ -63,7 +63,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromSuperClass() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("one");
         Method method = GrandParent.class.getDeclaredMethod("one");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -72,7 +72,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldHaveNonAnnotatedMethodOverridingSuperClass() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("two");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(declaredMethod));
@@ -81,7 +81,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldHaveAnnotatedMethodOverridingAnnotatedMethodInSuperClass() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("three");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(declaredMethod));
@@ -90,7 +90,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldHaveAnnotatedMethodNotOverridingMethodInSuperClass() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("four");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(declaredMethod));
@@ -99,7 +99,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldHaveNonAnnotatedMethodNotOverridingMethodInSuperClass() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("five");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(declaredMethod));
@@ -109,7 +109,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromGrandParent() throws Exception {
         Method declaredMethod = Child.class.getDeclaredMethod("one");
         Method method = GrandParent.class.getDeclaredMethod("one");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -119,7 +119,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromParentNotFromInterface() throws Exception {
         Method declaredMethod = Child.class.getDeclaredMethod("three");
         Method method = Parent.class.getDeclaredMethod("three");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -129,7 +129,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromInterface() throws Exception {
         Method declaredMethod = Child.class.getDeclaredMethod("six");
         Method method = InterfaceOne.class.getDeclaredMethod("six");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -139,7 +139,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromFirstDeclaredInterface() throws Exception {
         Method declaredMethod = Multi.class.getDeclaredMethod("three");
         Method method = InterfaceOne.class.getDeclaredMethod("three");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -149,7 +149,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromSuperInterface() throws Exception {
         Method declaredMethod = Service.class.getDeclaredMethod("three");
         Method method = InterfaceOne.class.getDeclaredMethod("three");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -159,7 +159,7 @@ public class AnnotatedMethodTest {
     public void shouldHaveAnnotatedMethodFromParentsInterface() throws Exception {
         Method declaredMethod = Child.class.getDeclaredMethod("seven");
         Method method = InterfaceFour.class.getDeclaredMethod("seven");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
 
         assertThat(annotatedMethod.declaredMethod(), is(sameInstance(declaredMethod)));
         assertThat(annotatedMethod.method(), is(method));
@@ -168,7 +168,7 @@ public class AnnotatedMethodTest {
     @Test
     public void shouldMergeAnnotations() throws Exception {
         Method declaredMethod = Parent.class.getDeclaredMethod("one");
-        AnnotatedMethod annotatedMethod = new AnnotatedMethod(declaredMethod);
+        AnnotatedMethod annotatedMethod = AnnotatedMethod.create(declaredMethod);
         Annotation[] annotations = annotatedMethod.getAnnotations();
 
         assertThat(annotations.length, is(3));

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/BidirectionalMethodHandlerSupplierTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/BidirectionalMethodHandlerSupplierTest.java
@@ -193,7 +193,7 @@ public class BidirectionalMethodHandlerSupplierTest {
 
     private AnnotatedMethod getMethod(String name, Class<?>... args) {
         try {
-            return new AnnotatedMethod(Service.class.getMethod(name, args));
+            return AnnotatedMethod.create(Service.class.getMethod(name, args));
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/ClientStreamingMethodHandlerSupplierTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/ClientStreamingMethodHandlerSupplierTest.java
@@ -418,7 +418,7 @@ public class ClientStreamingMethodHandlerSupplierTest {
 
     private AnnotatedMethod getMethod(String name, Class<?>... args) {
         try {
-            return new AnnotatedMethod(Service.class.getMethod(name, args));
+            return AnnotatedMethod.create(Service.class.getMethod(name, args));
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/ServerStreamingMethodHandlerSupplierTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/ServerStreamingMethodHandlerSupplierTest.java
@@ -389,7 +389,7 @@ public class ServerStreamingMethodHandlerSupplierTest {
 
     private AnnotatedMethod getMethod(String name, Class<?>... args) {
         try {
-            return new AnnotatedMethod(Service.class.getMethod(name, args));
+            return AnnotatedMethod.create(Service.class.getMethod(name, args));
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/UnaryMethodHandlerSupplierTest.java
+++ b/microprofile/grpc/core/src/test/java/io/helidon/microprofile/grpc/core/UnaryMethodHandlerSupplierTest.java
@@ -758,7 +758,7 @@ public class UnaryMethodHandlerSupplierTest {
 
     private AnnotatedMethod getMethod(String name, Class<?>... args) {
         try {
-            return new AnnotatedMethod(UnaryService.class.getMethod(name, args));
+            return AnnotatedMethod.create(UnaryService.class.getMethod(name, args));
         } catch (NoSuchMethodException e) {
             throw new AssertionError(e);
         }

--- a/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/GrpcMetricsCdiExtension.java
+++ b/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/GrpcMetricsCdiExtension.java
@@ -85,7 +85,7 @@ public class GrpcMetricsCdiExtension
      * @return {@code true} if the method is a timed gRPC method
      */
     private boolean isRpcMethod(AnnotatedMethodConfigurator<?> configurator, Class<? extends Annotation> type) {
-        AnnotatedMethod method = new AnnotatedMethod(configurator.getAnnotated().getJavaMember());
+        AnnotatedMethod method = AnnotatedMethod.create(configurator.getAnnotated().getJavaMember());
         RpcMethod rpcMethod = method.firstAnnotationOrMetaAnnotation(RpcMethod.class);
         if (rpcMethod != null) {
             Annotation annotation = method.firstAnnotationOrMetaAnnotation(type);

--- a/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/MetricsConfigurer.java
+++ b/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/MetricsConfigurer.java
@@ -55,7 +55,7 @@ public class MetricsConfigurer
     @Override
     public void accept(Class<?> serviceClass, Class<?> annotatedClass, ServiceDescriptor.Builder builder) {
 
-        AnnotatedMethodList methodList = new AnnotatedMethodList(serviceClass);
+        AnnotatedMethodList methodList = AnnotatedMethodList.create(serviceClass);
 
         methodList.withAnnotation(Timed.class)
                 .stream()

--- a/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilder.java
+++ b/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilder.java
@@ -126,7 +126,7 @@ public class GrpcServiceBuilder
         checkForNonPublicMethodIssues();
 
         Class<?> annotatedServiceClass = annotatedServiceClass();
-        AnnotatedMethodList methodList = new AnnotatedMethodList(annotatedServiceClass);
+        AnnotatedMethodList methodList = AnnotatedMethodList.create(annotatedServiceClass);
         String name = determineServiceName(annotatedServiceClass);
 
         ServiceDescriptor.Builder builder = ServiceDescriptor.builder(serviceClass(), name)


### PR DESCRIPTION
Wherever possible constructors in classes in gRPC modules have been replaced with static factory methods. Classes where this could not be done are predominantly those that are discovered using a ServiceLoader.