### PR TITLE
Make package protected gRPC classes public

### DIFF
--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/ChannelProducer.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/ChannelProducer.java
@@ -36,7 +36,7 @@ import io.grpc.Channel;
  * A producer of gRPC {@link io.grpc.Channel Channels}.
  */
 @ApplicationScoped
-class ChannelProducer {
+public class ChannelProducer {
 
     private final GrpcChannelsProvider provider;
 

--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientProxyBuilder.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcClientProxyBuilder.java
@@ -27,8 +27,10 @@ import io.grpc.Channel;
 
 /**
  * A builder for gRPC clients dynamic proxies.
+ *
+ * @param <T> the type of the interface to be proxied
  */
-class GrpcClientProxyBuilder<T>
+public class GrpcClientProxyBuilder<T>
         implements Builder<T> {
 
     private static final Map<Class<?>, ClientServiceDescriptor> DESCRIPTORS = new ConcurrentHashMap<>();


### PR DESCRIPTION
The  `io.helidon.microprofile.grpc.client.GrpcClientProxyBuilder` class is package protected even though its methods are public. This class is a builder and has a private constructor but is not usable in client code unless the class itself is made public.

The `io.helidon.microprofile.grpc.client.ChannelProducer` class is package protected so even though it is a CDI bean it cannot be injected into any other beans in client code.