### PR TITLE
Add property to exit the process when server has started.

### DIFF
--- a/microprofile/server/etc/spotbugs/exclude.xml
+++ b/microprofile/server/etc/spotbugs/exclude.xml
@@ -21,18 +21,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://github.com/spotbugs/filter/3.0.0"
         xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
-
-    <Match>
-        <!-- False positive. See https://github.com/spotbugs/spotbugs/issues/756 -->
-        <Class name="io.helidon.webserver.ClassPathContentHandler"/>
-        <Method name="extractJarEntry"/>
-        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    </Match>
     <Match>
         <!-- Desired behavior -->
-        <Class name="io.helidon.webserver.NettyWebServer"/>
-        <Method name="started"/>
+        <Class name="io.helidon.microprofile.server"/>
+        <Method name="exitOnStarted"/>
         <Bug pattern="DM_EXIT"/>
     </Match>
-
 </FindBugsFilter>

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -70,6 +70,8 @@ public class ServerImpl implements Server {
     private static final Logger LOGGER = Logger.getLogger(ServerImpl.class.getName());
     private static final Logger JERSEY_LOGGER = Logger.getLogger(ServerImpl.class.getName() + ".jersey");
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
+    private static final String EXIT_ON_STARTED_KEY = "exit.on.started";
+    private static final boolean EXIT_ON_STARTED = System.getProperty(EXIT_ON_STARTED_KEY) != null;
     private static final StartedServers STARTED_SERVERS = new StartedServers();
 
     private static long initStartupTime = System.nanoTime();
@@ -503,11 +505,14 @@ public class ServerImpl implements Server {
         }
 
         if (throwRef.get() == null) {
+            if (EXIT_ON_STARTED) {
+                LOGGER.info(String.format("Exiting, -D%s set.",  EXIT_ON_STARTED_KEY));
+                System.exit(0);
+            }
             return this;
         } else {
             throw new MpException("Failed to start server", throwRef.get());
         }
-
     }
 
     @Override

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -71,7 +71,7 @@ public class ServerImpl implements Server {
     private static final Logger JERSEY_LOGGER = Logger.getLogger(ServerImpl.class.getName() + ".jersey");
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
     private static final String EXIT_ON_STARTED_KEY = "exit.on.started";
-    private static final boolean EXIT_ON_STARTED = System.getProperty(EXIT_ON_STARTED_KEY) != null;
+    private static final boolean EXIT_ON_STARTED = "✅".equals(System.getProperty(EXIT_ON_STARTED_KEY));
     private static final StartedServers STARTED_SERVERS = new StartedServers();
 
     private static long initStartupTime = System.nanoTime();
@@ -506,13 +506,17 @@ public class ServerImpl implements Server {
 
         if (throwRef.get() == null) {
             if (EXIT_ON_STARTED) {
-                LOGGER.info(String.format("Exiting, -D%s set.",  EXIT_ON_STARTED_KEY));
-                System.exit(0);
+                exitOnStarted();
             }
             return this;
         } else {
             throw new MpException("Failed to start server", throwRef.get());
         }
+    }
+
+    private void exitOnStarted() {
+        LOGGER.info(String.format("Exiting, -D%s set.",  EXIT_ON_STARTED_KEY));
+        System.exit(0);
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -61,7 +61,7 @@ class NettyWebServer implements WebServer {
 
     private static final Logger LOGGER = Logger.getLogger(NettyWebServer.class.getName());
     private static final String EXIT_ON_STARTED_KEY = "exit.on.started";
-    private static final boolean EXIT_ON_STARTED = System.getProperty(EXIT_ON_STARTED_KEY) != null;
+    private static final boolean EXIT_ON_STARTED = "✅".equals(System.getProperty(EXIT_ON_STARTED_KEY));
 
     private final EventLoopGroup bossGroup;
     private final EventLoopGroup workerGroup;


### PR DESCRIPTION
Causes either server to do `System.exit(0)` when `-Dexit.on.started=✅`. Use of the special character rather than `true` is an attempt to reduce false positives in the unlikely event that other code uses the same property.