### PR TITLE
Support MP 3.2; add full and core MP bundles and deprecate existing numbered ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ It also includes a number of additional bug fixes and enhancements.
 - Remove com.google.code.findbugs:jsr305 [1119](https://github.com/oracle/helidon/pull/1119)
 - Documentation [1075](https://github.com/oracle/helidon/pull/1075) [1123](https://github.com/oracle/helidon/pull/1123) [1118](https://github.com/oracle/helidon/pull/1118) [1105](https://github.com/oracle/helidon/pull/1105) [1079](https://github.com/oracle/helidon/pull/1079)
 
+### Deprecations
+
+- The following MicroProfile bundles are deprecated: `helidon-microprofile-3.0`,
+  `helidon-microprofile-2.2`, `helidon-microprofile-1.2`, `helidon-microprofile-1.1`,
+  `helidon-microprofile-1.0`. Use `helidon-microprofile` or
+  `helidon-microprofile-core` instead.
+
+
 ## Experimental
 
 The following enhancements are experimental. They should be considered unstable and subject

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Project Helidon is a set of Java Libraries for writing microservices.
 Helidon supports two programming models:
 
-* Helidon MP: [MicroProfile](https://microprofile.io/) 3.0
+* Helidon MP: [MicroProfile](https://microprofile.io/) 3.2
 * Helidon SE: a small, functional style API
 
 In either case your application is just a Java SE program.

--- a/archetypes/mp/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/mp/src/main/resources/archetype-resources/pom.xml
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -383,6 +383,16 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.microprofile.bundles</groupId>
+                <artifactId>helidon-microprofile-core</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.bundles</groupId>
+                <artifactId>helidon-microprofile</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.bundles</groupId>
                 <artifactId>internal-test-libs</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/docs/src/main/docs/guides/91_mp-tutorial.adoc
+++ b/docs/src/main/docs/guides/91_mp-tutorial.adoc
@@ -67,7 +67,7 @@ Create a new Maven POM file (called `pom.xml`) and add the following
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.0</artifactId> <4>
+            <artifactId>helidon-microprofile</artifactId> <4>
         </dependency>
     </dependencies>
 
@@ -107,8 +107,8 @@ The POM file contains the basic project information and configurations
 <3> Sets the `mainClass` which will be used later
     when building a JAR file.  The class will be created later in this
     tutorial.
-<4> Adds a dependency for the MicroProfile 3.0 bundle which allows the
-    use of MicroProfile 3.0 features in the application. The helidon-mp
+<4> Adds a dependency for the MicroProfile bundle which allows the
+    use of MicroProfile features in the application. The helidon-mp
     parent pom includes dependency management, so you don't need to
     include a version number here. You will automatically use the
     version of Helidon that matches the version of the parent pom
@@ -119,10 +119,10 @@ The POM file contains the basic project information and configurations
     loading. The Helidon parent pom handles the details of configuring
     these plugins. But you can modify the configuration here.
 
-TIP: MicroProfile 3.0 contains features like Metrics, Health Check,
+TIP: MicroProfile contains features like Metrics, Health Check,
  Streams Operators, Open Tracing, OpenAPI, REST client, and fault
- tolerance. You can find detailed information about MicroProfile 3.0 on the
- https://projects.eclipse.org/projects/technology.microprofile/releases/microprofile-3.0[Eclipse MicroProfile 3.0] site.
+ tolerance. You can find detailed information about MicroProfile on the
+ https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile] site.
 
 With this `pom.xml`, the application can be built successfully with Maven:
 
@@ -1217,7 +1217,7 @@ There were several links to more detailed information included in the
 
 ==== Related links
 
-* https://projects.eclipse.org/projects/technology.microprofile/releases/microprofile-3.0[Eclipse MicroProfile 3.0]
+* https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile]
 * https://docs.jboss.org/cdi/api/2.0/index.html[Contexts and Dependency Injection Specification]
 * <<guides/30_dockerfile.adoc,Creating Docker Images>>
 * <<microprofile/02_server-configuration.adoc,Configuring the Server>>

--- a/docs/src/main/docs/microprofile/01_introduction.adoc
+++ b/docs/src/main/docs/microprofile/01_introduction.adoc
@@ -47,11 +47,27 @@ how you should declare dependency management for Helidon applications.
 Then declare the following dependency in your project:
 
 [source,xml]
-.Maven Dependency
+.Maven Dependency for full MicroProfile
 ----
 <dependency>
   <groupId>io.helidon.microprofile.bundles</groupId>
-  <artifactId>helidon-microprofile-3.0</artifactId>
+  <artifactId>helidon-microprofile</artifactId>
+</dependency>
+----
+
+The above dependency adds all the features available in MicroProfile. If you
+want to start with a smaller core set of features then you can use the
+`core` bundle instead. This bundle includes the base feature in MicroProfile
+(such as JAX-RS, CDI, JSON-P/B, and Config) and leaves out some of the
+additional features such as Metrics and Tracing. You can add those dependencies
+individually if you choose.
+
+[source,xml]
+.Maven Dependency for MicroProfile core features only
+----
+<dependency>
+  <groupId>io.helidon.microprofile.bundles</groupId>
+  <artifactId>helidon-microprofile-core</artifactId>
 </dependency>
 ----
 

--- a/docs/src/main/docs/sitegen.yaml
+++ b/docs/src/main/docs/sitegen.yaml
@@ -25,7 +25,7 @@ engine:
       helidon-version: "${project.version}"
       microprofile-openapi-version: "${version.lib.microprofile-openapi-api}"
       jandex-plugin-version: ${version.plugin.jandex}
-      mp-version: "3.0"
+      mp-version: "3.2"
       guides-dir: "${project.basedir}/../examples/guides"
 assets:
   - target: "/"

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -41,7 +41,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/hello-world-explicit/pom.xml
+++ b/examples/microprofile/hello-world-explicit/pom.xml
@@ -41,7 +41,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-core</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-core</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -32,13 +32,13 @@
     <name>Helidon Microprofile Examples Implicit Hello World</name>
 
     <description>
-        Microprofile 2.2 example with implicit bootstrapping (server.Main(new String[0])
+        Microprofile example with implicit bootstrapping (server.Main(new String[0])
     </description>
 
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -38,11 +38,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.openapi</groupId>
-            <artifactId>microprofile-openapi-api</artifactId>
+            <groupId>io.helidon.microprofile.openapi</groupId>
+            <artifactId>helidon-microprofile-openapi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>

--- a/examples/microprofile/openapi-basic/src/test/java/io/helidon/microprofile/examples/openapi/basic/MainTest.java
+++ b/examples/microprofile/openapi-basic/src/test/java/io/helidon/microprofile/examples/openapi/basic/MainTest.java
@@ -76,18 +76,6 @@ class MainTest {
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");
 
-        r = client
-                .target(getConnectionString("/metrics"))
-                .request()
-                .get();
-        Assertions.assertEquals(200, r.getStatus(), "GET metrics status code");
-
-        r = client
-                .target(getConnectionString("/health"))
-                .request()
-                .get();
-        Assertions.assertEquals(200, r.getStatus(), "GET health status code");
-
         client.close();
     }
 

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -38,7 +38,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -67,7 +67,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/javadocs/pom.xml
+++ b/javadocs/pom.xml
@@ -326,7 +326,7 @@
         <!-- microprofile -->
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-1.2</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile</groupId>

--- a/microprofile/bundles/helidon-microprofile-core/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-core/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.bundles</groupId>
+        <artifactId>bundles-project</artifactId>
+        <version>1.3.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-microprofile-core</artifactId>
+    <name>Helidon Microprofile Core Bundle</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.interceptor</groupId>
+                    <artifactId>javax.interceptor-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/bundles/helidon-microprofile-core/src/main/java9/module-info.java
+++ b/microprofile/bundles/helidon-microprofile-core/src/main/java9/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aggregator module for microprofile core.
+ */
+module io.helidon.microprofile.bundle.core {
+    requires transitive io.helidon.microprofile.config.cdi;
+    requires transitive io.helidon.microprofile.config;
+    requires transitive io.helidon.microprofile.server;
+
+}

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.bundles</groupId>
+        <artifactId>bundles-project</artifactId>
+        <version>1.3.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-microprofile</artifactId>
+    <name>Helidon Microprofile Full Bundle</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-checks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.jwt</groupId>
+            <artifactId>helidon-microprofile-jwt-auth-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security.integration</groupId>
+            <artifactId>helidon-security-integration-jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.openapi</groupId>
+            <artifactId>helidon-microprofile-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.rest-client</groupId>
+            <artifactId>helidon-microprofile-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tracing</groupId>
+            <artifactId>helidon-microprofile-tracing</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/bundles/helidon-microprofile/src/main/java9/module-info.java
+++ b/microprofile/bundles/helidon-microprofile/src/main/java9/module-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Aggregator module for microprofile full bundle.
+ */
+module io.helidon.microprofile.bundle {
+    requires transitive io.helidon.microprofile.bundle.core;
+
+    requires transitive io.helidon.microprofile.health;
+    requires transitive io.helidon.microprofile.metrics;
+    requires transitive io.helidon.microprofile.faulttolerance;
+    requires transitive io.helidon.microprofile.jwt.auth.cdi;
+    requires transitive io.helidon.microprofile.tracing;
+    requires transitive io.helidon.microprofile.restclient;
+    requires transitive io.helidon.microprofile.openapi;
+
+    requires io.helidon.health.checks;
+}

--- a/microprofile/bundles/pom.xml
+++ b/microprofile/bundles/pom.xml
@@ -45,6 +45,8 @@
         <module>helidon-microprofile-2.2</module>
         <module>helidon-microprofile-3.0</module>
         <module>helidon-microprofile-3.1</module>
+        <module>helidon-microprofile-core</module>
+        <module>helidon-microprofile</module>
     </modules>
 
     <profiles>

--- a/microprofile/security/pom.xml
+++ b/microprofile/security/pom.xml
@@ -50,6 +50,16 @@
             <groupId>io.helidon.security.integration</groupId>
             <artifactId>helidon-security-integration-webserver</artifactId>
         </dependency>
+        <!--
+            The following dependency simplifies developers' poms so they can add
+            dependencies on this artifact without having to depend on the
+            security jersey client integration themselves.
+        -->
+        <dependency>
+            <groupId>io.helidon.security.integration</groupId>
+            <artifactId>helidon-security-integration-jersey-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>internal-test-libs</artifactId>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.health</groupId>

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -38,7 +38,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.microprofile.bundles</groupId>
-                    <artifactId>helidon-microprofile-3.1</artifactId>
+                    <artifactId>helidon-microprofile</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -38,7 +38,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.helidon.microprofile.bundles</groupId>
-                    <artifactId>helidon-microprofile-3.1</artifactId>
+                    <artifactId>helidon-microprofile</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -38,6 +38,18 @@
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
+        <!--
+            The metrics and health dependencies are needed so the functional bookstore
+            tests which use this artifact will find the expected metrics and health endpoints to probe.
+        -->
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-binding</artifactId>

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/tests/functional/context-propagation/pom.xml
+++ b/tests/functional/context-propagation/pom.xml
@@ -31,7 +31,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/functional/context-propagation/pom.xml
+++ b/tests/functional/context-propagation/pom.xml
@@ -31,11 +31,19 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/functional/jax-rs-subresource/pom.xml
+++ b/tests/functional/jax-rs-subresource/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/functional/jax-rs-subresource/pom.xml
+++ b/tests/functional/jax-rs-subresource/pom.xml
@@ -30,11 +30,15 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/functional/multiport/pom.xml
+++ b/tests/functional/multiport/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/tests/functional/multiport/pom.xml
+++ b/tests/functional/multiport/pom.xml
@@ -30,11 +30,19 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -32,7 +32,11 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/mp-security-client/pom.xml
+++ b/tests/integration/mp-security-client/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile</artifactId>
+            <artifactId>helidon-microprofile-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/mp-ws-services/pom.xml
+++ b/tests/integration/mp-ws-services/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-3.1</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
As part of support for MicroProfile 3.2 we are adding two new MP bundles: `helidon-microprofile-core` (basically what's needed for the server) and `helidon-microprofile` (everything).

We are also deprecating (but not yet removing) the bundles numbered after the MP version numbers.

The coding changes add the new bundles and also update all dependencies in Helidon that used to refer to the 3.1 MP bundle. The javadoc component had a dependency on the 1.2 bundle that has also been updated.

There are a few components (not included in this PR) which currently depend on some earlier (pre-3.1) MP bundle. We will need to decide for each what to do when we actually remove the numbered bundles in a future Helidon release:

- ./tests/integration/health/mp-disabled/pom.xml
- ./tests/integration/zipkin-mp-2.2/pom.xml
- ./examples/grpc/microprofile/metrics/pom.xml
- ./examples/grpc/microprofile/basic-client/pom.xml
- ./examples/grpc/microprofile/basic-server-implicit/pom.xml
- ./examples/security/attribute-based-access-control/pom.xml
- ./examples/security/idcs-login/pom.xml
- ./examples/security/oidc/pom.xml
- ./examples/microprofile/idcs/pom.xml
- ./examples/microprofile/mp1_1-static-content/pom.xml
- ./examples/microprofile/mp1_1-security/pom.xml
- ./examples/todo-app/backend/pom.xml
- ./microprofile/tests/tck/tck-fault-tolerance/pom.xml
- ./microprofile/tests/tck/tck-metrics/pom.xml
