### PR TITLE
Changes default logging to write to System.out. 

### DIFF
--- a/archetypes/mp/src/main/resources/archetype-resources/src/main/resources/logging.properties.vm
+++ b/archetypes/mp/src/main/resources/archetype-resources/src/main/resources/logging.properties.vm
@@ -2,18 +2,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/archetypes/se/src/main/resources/archetype-resources/src/main/resources/logging.properties.vm
+++ b/archetypes/se/src/main/resources/archetype-resources/src/main/resources/logging.properties.vm
@@ -2,18 +2,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/common/common/src/main/java/io/helidon/common/HelidonConsoleHandler.java
+++ b/common/common/src/main/java/io/helidon/common/HelidonConsoleHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import java.util.regex.Pattern;
+
+/**
+ * Logging handler that writes to {@link System#out} and uses a formatter that will replace {@code "!thread!"} substrings
+ * with the current thread.
+ */
+public class HelidonConsoleHandler extends StreamHandler {
+
+    /**
+     * Constructor.
+     */
+    public HelidonConsoleHandler() {
+        setOutputStream(System.out);
+        setLevel(Level.ALL); // Handlers should not filter, loggers should
+        setFormatter(new ThreadFormatter());
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        super.publish(record);
+        flush();
+    }
+
+    @Override
+    public void close() {
+        flush();
+    }
+
+    private static class ThreadFormatter extends SimpleFormatter {
+        private static final Pattern THREAD_PATTERN = Pattern.compile("!thread!");
+
+        @Override
+        public String format(LogRecord record) {
+            final String message = super.format(record);
+            return THREAD_PATTERN.matcher(message).replaceAll(Thread.currentThread().toString());
+        }
+    }
+}

--- a/docs/src/main/docs/guides/24_jpa.adoc
+++ b/docs/src/main/docs/guides/24_jpa.adoc
@@ -521,9 +521,7 @@ Add the following file under `src/main/resources`:
 .`src/main/resources/logging.properties`
 ----
 .level=INFO
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
-java.util.logging.ConsoleHandler.level=FINEST
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 com.zaxxer.hikari.level=INFO

--- a/docs/src/main/docs/guides/91_mp-tutorial.adoc
+++ b/docs/src/main/docs/guides/91_mp-tutorial.adoc
@@ -682,29 +682,20 @@ Create a `logging.properties` file in `src/main/resources` with
 .Example logging.properties file
 ----
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler <1>
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO <2>
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter <3>
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n <4>
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
 ----
 
-<1> The console logging handler is configured.
-<2> The default logging level is set to `INFO`.
-<3> The Helidon custom log formatter is used, this formatter extends the 
- `SimpleFormatter`.
-<4> The format string is set using the standard options to include the timestamp,
+<1> The Helidon console logging handler is configured. This handler writes to `System.out`, does not filter by level
+and uses a custom `SimpleFormatter` that supports thread names.
+<2> The format string is set using the standard options to include the timestamp,
  thread name and message.
-
-TIP: Remember that when you set the default level to `INFO`, if you set an 
- individual logger to a higher level (like `FINER`) you will still only get
- `INFO` level messages.  A common practice is to set the default level higher
- and set the individual loggers to `INFO`.
+<3> The global logging level is set to `INFO`.
 
 Update the main class to configure logging as shown below:
 

--- a/examples/employee-app/src/main/resources/logging.properties
+++ b/examples/employee-app/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/grpc/basics/src/main/resources/logging.properties
+++ b/examples/grpc/basics/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/grpc/metrics/src/main/resources/logging.properties
+++ b/examples/grpc/metrics/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/grpc/microprofile/basic-client/src/main/resources/logging.properties
+++ b/examples/grpc/microprofile/basic-client/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 io.helidon.microprofile.config.level=FINEST

--- a/examples/grpc/microprofile/basic-server-implicit/src/main/resources/logging.properties
+++ b/examples/grpc/microprofile/basic-server-implicit/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 io.helidon.microprofile.config.level=FINEST

--- a/examples/grpc/microprofile/metrics/src/main/resources/logging.properties
+++ b/examples/grpc/microprofile/metrics/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 io.helidon.microprofile.config.level=FINEST

--- a/examples/grpc/opentracing/src/main/resources/logging.properties
+++ b/examples/grpc/opentracing/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/grpc/security-abac/src/main/resources/logging.properties
+++ b/examples/grpc/security-abac/src/main/resources/logging.properties
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/grpc/security-outbound/src/main/resources/logging.properties
+++ b/examples/grpc/security-outbound/src/main/resources/logging.properties
@@ -18,20 +18,16 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-AUDIT.level=FINEST
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+AUDIT.level=FINEST
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/grpc/security/src/main/resources/logging.properties
+++ b/examples/grpc/security/src/main/resources/logging.properties
@@ -18,20 +18,16 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-AUDIT.level=FINEST
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+AUDIT.level=FINEST
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/microprofile/hello-world-explicit/src/main/resources/logging.properties
+++ b/examples/microprofile/hello-world-explicit/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/hello-world-explicit/src/main/resources/logging.properties
+++ b/examples/microprofile/hello-world-explicit/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL] %4$s %3$s : %5$s%6$s%n
 #All log level details
 .level=INFO

--- a/examples/microprofile/hello-world-implicit/src/main/resources/logging.properties
+++ b/examples/microprofile/hello-world-implicit/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/hello-world-implicit/src/main/resources/logging.properties
+++ b/examples/microprofile/hello-world-implicit/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 io.helidon.microprofile.config.level=FINEST

--- a/examples/microprofile/idcs/src/main/resources/logging.properties
+++ b/examples/microprofile/idcs/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/idcs/src/main/resources/logging.properties
+++ b/examples/microprofile/idcs/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/microprofile/mp1_1-security/src/main/resources/logging.properties
+++ b/examples/microprofile/mp1_1-security/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/mp1_1-security/src/main/resources/logging.properties
+++ b/examples/microprofile/mp1_1-security/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=INFO
 io.helidon.microprofile.config.level=FINEST

--- a/examples/microprofile/mp1_1-static-content/src/main/resources/logging.properties
+++ b/examples/microprofile/mp1_1-static-content/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/mp1_1-static-content/src/main/resources/logging.properties
+++ b/examples/microprofile/mp1_1-static-content/src/main/resources/logging.properties
@@ -15,9 +15,7 @@
 #
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL] %4$s %3$s : %5$s%6$s%n
 #All log level details
 .level=INFO

--- a/examples/microprofile/mp1_1-static-content/src/test/resources/logging.properties
+++ b/examples/microprofile/mp1_1-static-content/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/microprofile/mp1_1-static-content/src/test/resources/logging.properties
+++ b/examples/microprofile/mp1_1-static-content/src/test/resources/logging.properties
@@ -14,12 +14,10 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 java.util.logging.FileHandler.pattern=%h/java%u.log
 java.util.logging.FileHandler.limit=50000
 java.util.logging.FileHandler.count=1
 java.util.logging.FileHandler.formatter=java.util.logging.XMLFormatter
-java.util.logging.ConsoleHandler.level=FINER
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 org.jboss.weld.level=INFO

--- a/examples/microprofile/openapi-basic/src/main/resources/logging.properties
+++ b/examples/microprofile/openapi-basic/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/openapi/src/main/resources/logging.properties
+++ b/examples/openapi/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=FINER
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-mp/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/main/resources/logging.properties
@@ -17,19 +17,16 @@
 # Example Logging Configuration File
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
-# Send messages to the console
-handlers=java.util.logging.ConsoleHandler
-
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-
-#Component specific log levels
+## Send messages to the console
+#handlers=io.helidon.common.HelidonConsoleHandler
+#
+## HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+#java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+#
+## Global logging level. Can be overridden by specific loggers
+#.level=INFO
+#
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/examples/security/attribute-based-access-control/src/main/resources/logging.properties
+++ b/examples/security/attribute-based-access-control/src/main/resources/logging.properties
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/security/attribute-based-access-control/src/main/resources/logging.properties
+++ b/examples/security/attribute-based-access-control/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/security/google-login/src/main/resources/logging.properties
+++ b/examples/security/google-login/src/main/resources/logging.properties
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/security/google-login/src/main/resources/logging.properties
+++ b/examples/security/google-login/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/security/idcs-login/src/main/resources/logging.properties
+++ b/examples/security/idcs-login/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/security/idcs-login/src/main/resources/logging.properties
+++ b/examples/security/idcs-login/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST
 io.helidon.security.providers.oidc.level=FINEST

--- a/examples/security/jersey/src/main/resources/logging.properties
+++ b/examples/security/jersey/src/main/resources/logging.properties
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/security/jersey/src/main/resources/logging.properties
+++ b/examples/security/jersey/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/security/nohttp-programmatic/src/main/resources/logging.properties
+++ b/examples/security/nohttp-programmatic/src/main/resources/logging.properties
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 AUDIT.level=FINEST

--- a/examples/security/nohttp-programmatic/src/main/resources/logging.properties
+++ b/examples/security/nohttp-programmatic/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/security/webserver-digest-auth/src/main/resources/logging.properties
+++ b/examples/security/webserver-digest-auth/src/main/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 #All log level details
 .level=WARNING

--- a/examples/todo-app/backend/src/main/resources/logging.properties
+++ b/examples/todo-app/backend/src/main/resources/logging.properties
@@ -15,9 +15,7 @@
 #
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/examples/todo-app/frontend/src/main/resources/logging.properties
+++ b/examples/todo-app/frontend/src/main/resources/logging.properties
@@ -15,9 +15,7 @@
 #
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/examples/translator-app/backend/src/main/resources/logging.properties
+++ b/examples/translator-app/backend/src/main/resources/logging.properties
@@ -16,9 +16,7 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/examples/translator-app/frontend/src/main/resources/logging.properties
+++ b/examples/translator-app/frontend/src/main/resources/logging.properties
@@ -16,9 +16,7 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/examples/webserver/jersey/src/main/resources/logging.properties
+++ b/examples/webserver/jersey/src/main/resources/logging.properties
@@ -16,9 +16,7 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/examples/webserver/opentracing/src/main/resources/logging.properties
+++ b/examples/webserver/opentracing/src/main/resources/logging.properties
@@ -16,9 +16,7 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details

--- a/grpc/client/src/test/resources/logging.properties
+++ b/grpc/client/src/test/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/grpc/core/src/test/resources/logging.properties
+++ b/grpc/core/src/test/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/grpc/metrics/src/test/resources/logging.properties
+++ b/grpc/metrics/src/test/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/grpc/server/src/test/resources/logging.properties
+++ b/grpc/server/src/test/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/integrations/cdi/datasource-hikaricp/src/test/logging.properties
+++ b/integrations/cdi/datasource-hikaricp/src/test/logging.properties
@@ -12,6 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 .level=INFO
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.ConsoleHandler.level=FINEST
+handlers=io.helidon.common.HelidonConsoleHandler

--- a/integrations/cdi/datasource-ucp/src/test/logging.properties
+++ b/integrations/cdi/datasource-ucp/src/test/logging.properties
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 .level=INFO
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.ConsoleHandler.level=FINEST
+handlers=io.helidon.common.HelidonConsoleHandler
 oracle.ucp.level=FINE

--- a/integrations/cdi/jpa-cdi/src/test/logging.properties
+++ b/integrations/cdi/jpa-cdi/src/test/logging.properties
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 .level=INFO
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.ConsoleHandler.level=FINEST
+handlers=io.helidon.common.HelidonConsoleHandler
 
 io.helidon.integrations.cdi.jpa.level=FINER

--- a/integrations/cdi/jpa-weld/src/test/java/logging.properties
+++ b/integrations/cdi/jpa-weld/src/test/java/logging.properties
@@ -16,9 +16,7 @@
 .level=WARNING
 com.arjuna.level=WARNING
 com.zaxxer.hikari.level=WARNING
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 io.helidon.integrations.cdi.jpa.level=WARNING
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.ConsoleHandler.level=FINEST
 org.eclipse.persistence.level=WARNING
 org.jboss.weld.level=WARNING

--- a/microprofile/grpc/metrics/src/test/resources/logging.properties
+++ b/microprofile/grpc/metrics/src/test/resources/logging.properties
@@ -18,16 +18,13 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 io.helidon.microprofile.grpc.metrics.level=FINEST

--- a/microprofile/grpc/server/src/test/resources/logging.properties
+++ b/microprofile/grpc/server/src/test/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/microprofile/health/src/test/resources/logging.properties
+++ b/microprofile/health/src/test/resources/logging.properties
@@ -18,13 +18,10 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO

--- a/microprofile/tests/tck/tck-config/src/test/resources/logging.properties
+++ b/microprofile/tests/tck/tck-config/src/test/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=[%1$tc] %4$s: %2$s - %5$s %6$s%n
 .level=WARNING
 io.helidon.microprofile.config.level=INFO

--- a/security/integration/grpc/src/test/resources/logging.properties
+++ b/security/integration/grpc/src/test/resources/logging.properties
@@ -18,20 +18,16 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-AUDIT.level=FINEST
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+AUDIT.level=FINEST
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/security/providers/oidc-common/src/test/resources/logging.properties
+++ b/security/providers/oidc-common/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/security/providers/oidc-common/src/test/resources/logging.properties
+++ b/security/providers/oidc-common/src/test/resources/logging.properties
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 io.helidon.security.level=FINEST
 AUDIT.level=FINEST

--- a/security/providers/oidc/src/test/resources/logging.properties
+++ b/security/providers/oidc/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/security/providers/oidc/src/test/resources/logging.properties
+++ b/security/providers/oidc/src/test/resources/logging.properties
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 .level=INFO
 io.helidon.security.level=FINEST
 AUDIT.level=FINEST

--- a/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
+++ b/tests/apps/bookstore/bookstore-mp/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/tests/apps/bookstore/bookstore-se/src/main/resources/logging.properties
+++ b/tests/apps/bookstore/bookstore-se/src/main/resources/logging.properties
@@ -18,18 +18,15 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/tests/functional/context-propagation/src/test/resources/logging.properties
+++ b/tests/functional/context-propagation/src/test/resources/logging.properties
@@ -18,16 +18,13 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 AUDIT.level=FINEST

--- a/tests/functional/jax-rs-subresource/src/test/resources/logging.properties
+++ b/tests/functional/jax-rs-subresource/src/test/resources/logging.properties
@@ -18,16 +18,13 @@
 # For more information see $JAVA_HOME/jre/lib/logging.properties
 
 # Send messages to the console
-handlers=java.util.logging.ConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=INFO
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 AUDIT.level=FINEST

--- a/tests/integration/native-image/se-1/src/main/resources/logging.properties
+++ b/tests/integration/native-image/se-1/src/main/resources/logging.properties
@@ -16,18 +16,17 @@
 
 # Example Logging Configuration File
 # For more information see $JAVA_HOME/jre/lib/logging.properties
-# Send messages to the console
-handlers=java.util.logging.ConsoleHandler
 
-# Global default logging level. Can be overriden by specific handlers and loggers
-.level=INFO
-# Helidon Web Server has a custom log formatter that extends SimpleFormatter.
-# It replaces "!thread!" with the current thread name
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
-#Component specific log levels
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
 #io.helidon.webserver.level=INFO
 #io.helidon.config.level=INFO
 #io.helidon.security.level=INFO

--- a/webserver/jersey/src/test/resources/logging-test.properties
+++ b/webserver/jersey/src/test/resources/logging-test.properties
@@ -16,12 +16,8 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-
-#All log level details
 .level=WARNING
 
 io.helidon.webserver.level=FINE

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServerLogFormatter.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServerLogFormatter.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 /**
  * The WebServerLogFormatter provides a way to customize logging messages.
  */
+@Deprecated
 public class WebServerLogFormatter extends SimpleFormatter {
 
     private static final Pattern THREAD_PATTERN = Pattern.compile("!thread!");

--- a/webserver/webserver/src/test/resources/logging-test.properties
+++ b/webserver/webserver/src/test/resources/logging-test.properties
@@ -16,9 +16,7 @@
 
 
 #All attributes details
-handlers=java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level=FINEST
-java.util.logging.ConsoleHandler.formatter=io.helidon.webserver.WebServerLogFormatter
+handlers=io.helidon.common.HelidonConsoleHandler
 java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
 
 #All log level details


### PR DESCRIPTION
Fixes #1144.

Note that by setting the level in the handler to `Level.ALL,` the only levels that matter are those on the loggers, which is what nearly everyone expects.