### PR TITLE
Update io.grpc dependency to 1.25.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.etcd4j>2.16.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.23.0</version.lib.google-api-client>
         <version.lib.graalvm>19.2.0</version.lib.graalvm>
-        <version.lib.grpc>1.22.1</version.lib.grpc>
+        <version.lib.grpc>1.25.0</version.lib.grpc>
         <version.lib.guava>25.0-jre</version.lib.guava>
         <version.lib.h2>1.4.197</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.lib.checkstyle>8.18</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <version.lib.jgit>4.9.0.201710071750-r</version.lib.jgit>
-        <version.lib.netty.tcnative>2.0.25.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.26.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.0.8</version.lib.rxjava>


### PR DESCRIPTION
Update the io.grpc dependency to 1.25.0 and corresponding test dependency netty-tcnative-boringssl-static to 2.0.26.Final