### PR TITLE
Map metric type in metadata

### DIFF
--- a/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics2/metrics2/src/main/java/io/helidon/metrics/Registry.java
@@ -485,6 +485,7 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
         final MetadataBuilder builder = new MetadataBuilder();
         builder.withName(metadata.getName())
                 .withDisplayName(metadata.getDisplayName())
+                .withType(metadata.getTypeRaw())
                 .reusable(metadata.isReusable());
 
         metadata.getDescription().ifPresent(builder::withDescription);


### PR DESCRIPTION
Metric type was being dropped by this mapping method.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>