### PR TITLE
Compile package-info.java always, so rebuild does not trigger recompile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,10 @@
                         <release>11</release>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
+                            <!--
+                            https://issues.apache.org/jira/browse/MCOMPILER-368
+                             -->
+                            <arg>-Xpkginfo:always</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>