### PR TITLE
Better recovery for invalid URLs and content types

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -41,9 +41,11 @@ import io.helidon.common.configurable.ServerThreadPoolSupplier;
 import io.helidon.common.configurable.ThreadPool;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
+import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpRequest;
 import io.helidon.config.Config;
 import io.helidon.webserver.Handler;
+import io.helidon.webserver.HttpException;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
@@ -165,7 +167,7 @@ public class JerseySupport implements Service {
             }
             return new URI(sb.toString());
         } catch (URISyntaxException | MalformedURLException e) {
-            throw new IllegalStateException("Unable to create a request URI from the request info.", e);
+            throw new HttpException("Unable to parse request URL", Http.Status.BAD_REQUEST_400, e);
         }
     }
 
@@ -174,7 +176,7 @@ public class JerseySupport implements Service {
             return new URI(req.isSecure() ? "https" : "http", null, req.localAddress(),
                            req.localPort(), basePath(req.path()), null, null);
         } catch (URISyntaxException e) {
-            throw new IllegalStateException("Unable to create a base URI from the request info.", e);
+            throw new HttpException("Unable to parse request URL", Http.Status.BAD_REQUEST_400, e);
         }
     }
 

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -184,21 +184,21 @@ public class JerseySupportTest {
     public void errorThrownError() throws Exception {
         Response response = get("jersey/first/error/thrown/error");
 
-        doAssert(response, "", 500);
+        doAssert(response, null, 500);
     }
 
     @Test
     public void errorThrownUnhandled() throws Exception {
         Response response = get("jersey/first/error/thrown/unhandled");
 
-        doAssert(response, "", 500);
+        doAssert(response, null, 500);
     }
 
     @Test
     public void simplePostNotFound() throws Exception {
         Response response = post("jersey/first/non-existent-resource");
 
-        doAssert(response, "", Response.Status.NOT_FOUND);
+        doAssert(response, null, Response.Status.NOT_FOUND);
     }
 
     @Test
@@ -245,7 +245,7 @@ public class JerseySupportTest {
     public void simpleGetNotFound() throws Exception {
         Response response = get("jersey/first/non-existent-resource");
 
-        doAssert(response, "", Response.Status.NOT_FOUND);
+        doAssert(response, null, Response.Status.NOT_FOUND);
     }
 
     @Test
@@ -410,7 +410,9 @@ public class JerseySupportTest {
         try {
             assertEquals(expectedStatusCode, response.getStatus(),
                     "Unexpected error: " + response.getStatus());
-            assertEquals(expectedContent, response.readEntity(String.class));
+            if (expectedContent != null) {
+                assertEquals(expectedContent, response.readEntity(String.class));
+            }
         } finally {
             response.close();
         }

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -225,7 +225,7 @@ public class JerseySupportTest {
             return;
         }
         assertNotNull(response);
-        doAssert(response, "", Response.Status.NOT_FOUND);
+        doAssert(response, null, Response.Status.NOT_FOUND);
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -138,7 +138,13 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 send100Continue(ctx);
             }
 
-            routing.route(bareRequest, bareResponse);
+            // If a problem during routing, return 400 response
+            try {
+                routing.route(bareRequest, bareResponse);
+            } catch (IllegalArgumentException e) {
+                send400BadRequest(ctx, e.getMessage());
+                return;
+            }
         }
 
         if (msg instanceof HttpContent) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -365,6 +365,7 @@ class RequestRouting implements Routing {
                                                         "handler.class", "DEFAULT-ERROR-HANDLER",
                                                         "handled.error.message", t.toString()));
             }
+            String message = null;
             try {
                 if (t instanceof HttpException) {
                     response.status(((HttpException) t).status());
@@ -380,17 +381,14 @@ class RequestRouting implements Routing {
 
                     response.status(Http.Status.INTERNAL_SERVER_ERROR_500);
                 }
-                String message = t.getMessage();
-                if (message != null) {
-                    response.send(message);
-                }
+                message = t.getMessage();
             } catch (AlreadyCompletedException e) {
                 LOGGER.log(Level.WARNING,
                            "Cannot perform error handling of the throwable (see cause of this exception) because headers "
                                    + "were already sent",
                            new IllegalStateException("Headers already sent. Cannot handle the cause of this exception.", t));
             }
-            response.send().exceptionally(throwable -> {
+            response.send(message).exceptionally(throwable -> {
                 LOGGER.log(Level.WARNING, "Default error handler: Response wasn't successfully sent.", throwable);
                 return null;
             });

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -380,6 +380,10 @@ class RequestRouting implements Routing {
 
                     response.status(Http.Status.INTERNAL_SERVER_ERROR_500);
                 }
+                String message = t.getMessage();
+                if (message != null) {
+                    response.send(message);
+                }
             } catch (AlreadyCompletedException e) {
                 LOGGER.log(Level.WARNING,
                            "Cannot perform error handling of the throwable (see cause of this exception) because headers "

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -375,6 +375,18 @@ public class PlainTest {
         assertThat(headers, IsMapContaining.hasKey("content-length"));
     }
 
+    @Test
+    public void testBadContentType() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/",
+                Http.Method.GET,
+                null,
+                CollectionsHelper.listOf("Content-Type: %", "Connection: close"),
+                webServer);
+        assertThat(s, containsString("400 Bad Request"));
+        Map<String, String> headers = cutHeaders(s);
+        assertThat(headers, IsMapContaining.hasKey("content-type"));
+        assertThat(headers, IsMapContaining.hasKey("content-length"));
+    }
 
     private Map<String, String> cutHeaders(String response) {
         assertThat(response, notNullValue());


### PR DESCRIPTION
See Issue #1218. Return HTTP 400 when appropriate; there are some cases now where we either return an empty response or a 500 error. Exceptions are still logged for further analysis.