### PR TITLE
Helidon Features

### DIFF
--- a/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
+++ b/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
@@ -17,9 +17,11 @@
 package io.helidon.common;
 
 import java.util.EnumMap;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
@@ -29,10 +31,10 @@ import java.util.logging.Logger;
  */
 public final class HelidonFeatures {
     private static final Logger LOGGER = Logger.getLogger(HelidonFeatures.class.getName());
-
-    private static final Map<HelidonFlavor, Set<String>> FEATURES = new EnumMap<>(HelidonFlavor.class);
-    private static final AtomicReference<HelidonFlavor> CURRENT_FLAVOR = new AtomicReference<>();
     private static final AtomicBoolean PRINTED = new AtomicBoolean();
+    private static final AtomicReference<HelidonFlavor> CURRENT_FLAVOR = new AtomicReference<>();
+    private static final Map<HelidonFlavor, Set<String>> FEATURES = new EnumMap<>(HelidonFlavor.class);
+    private static final Map<HelidonFlavor, Map<String, Node>> ROOT_FEATURE_NODES = new EnumMap<>(HelidonFlavor.class);
 
     private HelidonFeatures() {
     }
@@ -43,12 +45,70 @@ public final class HelidonFeatures {
      * class. In SE this would be one of the *Support classes or similar,
      * in MP most likely a CDI extension class.
      *
+     * <p>Example for security providers (SE) - application with Oidc provider:
+     * <ul>
+     *     <li>Security calls {@code register(SE, "security")}</li>
+     *     <li>OIDC provider calls {@code register(SE, "security", "authentication", "OIDC"}</li>
+     *     <li>OIDC provider calls {@code register(SE, "security", "outbound", "OIDC"} if outbound is enabled</li>
+     * </ul>
+     *
      * @param flavor flavor to register a feature for
-     * @param name name of the feature
+     * @param path path of the feature (single value for root level features)
      */
-    public static void register(HelidonFlavor flavor, String name) {
-        FEATURES.computeIfAbsent(flavor, key -> new HashSet<>())
-                .add(name);
+    public static void register(HelidonFlavor flavor, String... path) {
+        if (path.length == 0) {
+            throw new IllegalArgumentException("At least the root feature name must be provided, but path was empty");
+        }
+        if (path.length == 1) {
+            FEATURES.computeIfAbsent(flavor, key -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER))
+                    .add(path[0]);
+        }
+
+        var rootFeatures = ROOT_FEATURE_NODES.computeIfAbsent(flavor, it -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+        ensureNode(rootFeatures, path);
+    }
+
+    /**
+     * Register a feature for all flavors.
+     *
+     * <p>Example for security providers (SE) - application with Oidc provider:
+     * <ul>
+     *     <li>Security calls {@code register(SE, "security")}</li>
+     *     <li>OIDC provider calls {@code register("security", "authentication", "OIDC"}</li>
+     *     <li>OIDC provider calls {@code register("security", "outbound", "OIDC"} if outbound is enabled</li>
+     * </ul>
+     *
+     * @param path path of the feature (single value for root level features)
+     */
+    public static void register(String... path) {
+        for (HelidonFlavor value : HelidonFlavor.values()) {
+            register(value, path);
+        }
+    }
+
+    static Node ensureNode(Map<String, Node> rootFeatureNodes, String... path) {
+        // last part of the path is the name
+        if (path.length == 1) {
+            return rootFeatureNodes.computeIfAbsent(path[0], Node::new);
+        }
+        // we have a path, let's go through it
+
+        // start with root
+        Node lastNode = ensureNode(rootFeatureNodes, path[0]);
+        for (int i = 1; i < path.length; i++) {
+            String pathElement = path[i];
+            lastNode = ensureNode(pathElement, lastNode);
+        }
+        return lastNode;
+    }
+
+    static Node ensureNode(String name, Node parent) {
+        return parent.children.computeIfAbsent(name, it -> new Node(name));
+    }
+
+    // testing only
+    static Map<String, Node> rootFeatureNodes(HelidonFlavor flavor) {
+        return ROOT_FEATURE_NODES.computeIfAbsent(flavor, it -> new HashMap<>());
     }
 
     /**
@@ -58,9 +118,11 @@ public final class HelidonFeatures {
      * This is to make sure we do not print SE flavors in MP, and at the
      * same time can have this method used from Web Server.
      * This method only prints feature the first time it is called.
+     *
      * @param flavor flavor to print features for
+     * @param details set to {@code true} to print the tree structure of sub-features
      */
-    public static void print(HelidonFlavor flavor) {
+    public static void print(HelidonFlavor flavor, boolean details) {
         CURRENT_FLAVOR.compareAndSet(null, HelidonFlavor.SE);
 
         HelidonFlavor currentFlavor = CURRENT_FLAVOR.get();
@@ -69,23 +131,56 @@ public final class HelidonFeatures {
             return;
         }
 
-        if (PRINTED.compareAndSet(false, true)) {
-            Set<String> strings = FEATURES.get(currentFlavor);
-            if (null == strings) {
-                LOGGER.info("Helidon " + currentFlavor + " " + Version.VERSION + " has no registered features");
-            } else {
-                LOGGER.info("Helidon " + currentFlavor + " " + Version.VERSION + " features: " + strings);
-            }
+        if (!PRINTED.compareAndSet(false, true)) {
+            return;
         }
+        Set<String> strings = FEATURES.get(currentFlavor);
+        if (null == strings) {
+            LOGGER.info("Helidon " + currentFlavor + " " + Version.VERSION + " has no registered features");
+        } else {
+            LOGGER.info("Helidon " + currentFlavor + " " + Version.VERSION + " features: " + strings);
+        }
+        if (details) {
+            LOGGER.info("Detailed feature tree:");
+            FEATURES.get(currentFlavor)
+                    .forEach(name -> printDetails(name, ROOT_FEATURE_NODES.get(currentFlavor).get(name), 0));
+        }
+    }
+
+    private static void printDetails(String name, Node node, int level) {
+
+        System.out.println("  ".repeat(level) + name);
+
+        node.children.forEach((childName, childNode) -> printDetails(childName, childNode, level + 1));
     }
 
     /**
      * Set the current Helidon flavor. Features will only be printed for the
      * flavor configured.
      *
+     * The first flavor configured wins.
+     *
      * @param flavor current flavor
      */
     public static void flavor(HelidonFlavor flavor) {
         CURRENT_FLAVOR.compareAndSet(null, flavor);
+    }
+
+    static final class Node {
+        private final Map<String, Node> children = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        private final String name;
+
+        Node(String name) {
+            this.name = name;
+        }
+
+        String name() {
+            return name;
+        }
+
+        // for tests
+        Map<String, Node> children() {
+            return children;
+        }
     }
 }

--- a/common/common/src/main/java/io/helidon/common/HelidonFlavor.java
+++ b/common/common/src/main/java/io/helidon/common/HelidonFlavor.java
@@ -21,7 +21,7 @@ package io.helidon.common;
  */
 public enum HelidonFlavor {
     /**
-     * The "standard edition" flavor.
+     * The "Standard Edition" flavor.
      */
     SE,
     /**

--- a/common/common/src/test/java/io/helidon/common/HelidonFeaturesTest.java
+++ b/common/common/src/test/java/io/helidon/common/HelidonFeaturesTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.common.HelidonFeatures.register;
+import static io.helidon.common.HelidonFlavor.SE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Unit test for {@link HelidonFeatures}.
+ */
+class HelidonFeaturesTest {
+    @Test
+    void testFeatureTree() {
+        register(SE, "security");
+        register(SE, "security", "authorization", "ABAC");
+        register(SE, "security", "authentication", "OIDC");
+        register(SE, "security", "outbound", "OIDC");
+        register(SE, "tracing");
+        register(SE, "tracing", "zipkin");
+        register(SE, "complex");
+        register(SE, "complex", "first");
+        register(SE, "complex", "first", "second");
+        register(SE, "complex", "first", "second", "third");
+        register(SE, "complex", "first", "second", "third2");
+
+        Map<String, HelidonFeatures.Node> features = HelidonFeatures.rootFeatureNodes(SE);
+
+        assertThat(features.keySet(), containsInAnyOrder("security", "tracing", "complex"));
+
+        HelidonFeatures.Node security = features.get("security");
+        assertThat(security.name(), is("security"));
+
+        Map<String, HelidonFeatures.Node> children = security.children();
+        assertThat(children.keySet(), containsInAnyOrder("authorization", "authentication", "outbound"));
+        HelidonFeatures.Node node = children.get("authentication");
+        assertThat(node.name(), is("authentication"));
+        HelidonFeatures.Node oidc = node.children().get("OIDC");
+        assertThat(oidc.name(), is("OIDC"));
+        assertThat(oidc.children(), is(Map.of()));
+
+        HelidonFeatures.Node second = features.get("complex").children().get("first").children().get("second");
+        Map<String, HelidonFeatures.Node> secondChildren = second.children();
+        assertThat(secondChildren.keySet(), containsInAnyOrder("third", "third2"));
+
+        HelidonFeatures.print(SE, true);
+    }
+}

--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Priority;
 
 import io.helidon.common.GenericType;
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.Prioritized;
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.common.serviceloader.Priorities;
@@ -64,6 +66,10 @@ import org.eclipse.microprofile.config.spi.Converter;
  */
 class BuilderImpl implements Config.Builder {
     static final Executor DEFAULT_CHANGES_EXECUTOR = Executors.newCachedThreadPool(new ConfigThreadFactory("config"));
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "Config");
+    }
 
     /*
      * Config sources

--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.pki.KeyConfig;
 import io.helidon.config.Config;
 import io.helidon.config.MissingValueException;
@@ -65,6 +66,10 @@ public final class EncryptionFilter implements ConfigFilter {
     private static final Logger LOGGER = Logger.getLogger(EncryptionFilter.class.getName());
     private static final String PREFIX_ALIAS = "${ALIAS=";
     private static final String PREFIX_CLEAR = "${CLEAR=";
+
+    static {
+        HelidonFeatures.register("Config", "Encryption");
+    }
 
     private final PrivateKey privateKey;
     private final char[] masterPassword;

--- a/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSource.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigHelper;
@@ -42,6 +43,10 @@ import io.helidon.config.spi.ConfigParser;
 public class EtcdConfigSource extends AbstractParsableConfigSource<Long> {
 
     private static final Logger LOGGER = Logger.getLogger(EtcdConfigSource.class.getName());
+
+    static {
+        HelidonFeatures.register("Config", "etcd");
+    }
 
     private final EtcdEndpoint endpoint;
     private final EtcdClient client;

--- a/config/git/src/main/java/io/helidon/config/git/GitConfigSource.java
+++ b/config/git/src/main/java/io/helidon/config/git/GitConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigHelper;
@@ -60,6 +61,10 @@ import static java.util.Collections.singleton;
 public class GitConfigSource extends AbstractParsableConfigSource<byte[]> {
 
     private static final Logger LOGGER = Logger.getLogger(GitConfigSource.class.getName());
+
+    static {
+        HelidonFeatures.register("Config", "git");
+    }
 
     private final URI uri;
     private final String branch;

--- a/config/hocon/src/main/java/io/helidon/config/hocon/internal/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/internal/HoconConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigHelper;
 import io.helidon.config.spi.ConfigNode.ListNode;
@@ -70,6 +71,10 @@ public class HoconConfigParser implements ConfigParser {
 
     private static final Set<String> SUPPORTED_MEDIA_TYPES =
             Set.of(MEDIA_TYPE_APPLICATION_HOCON, MEDIA_TYPE_APPLICATION_JSON);
+
+    static {
+        HelidonFeatures.register("Config", "HOCON");
+    }
 
     private final boolean resolvingEnabled;
     private final ConfigResolveOptions resolveOptions;

--- a/config/object-mapping/src/main/java/io/helidon/config/objectmapping/ObjectConfigMappers.java
+++ b/config/object-mapping/src/main/java/io/helidon/config/objectmapping/ObjectConfigMappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.function.Function;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigMappingException;
 import io.helidon.config.MissingValueException;
@@ -29,6 +30,11 @@ import io.helidon.config.objectmapping.ReflectionUtil.PropertyAccessor;
  * Various mappers used in {@link ObjectConfigMapperProvider}.
  */
 class ObjectConfigMappers {
+
+    static {
+        HelidonFeatures.register("Config", "Object Mapping");
+    }
+
     abstract static class MethodHandleConfigMapper<T, P> implements Function<Config, T> {
         private final Class<T> type;
         private final String methodName;

--- a/config/yaml/src/main/java/io/helidon/config/yaml/internal/YamlConfigParser.java
+++ b/config/yaml/src/main/java/io/helidon/config/yaml/internal/YamlConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigHelper;
 import io.helidon.config.spi.ConfigNode.ListNode;
@@ -58,6 +59,10 @@ public class YamlConfigParser implements ConfigParser {
     public static final int PRIORITY = ConfigParser.PRIORITY + 100;
 
     private static final Set<String> SUPPORTED_MEDIA_TYPES = Set.of(MEDIA_TYPE_APPLICATION_YAML);
+
+    static {
+        HelidonFeatures.register("Config", "YAML");
+    }
 
     /**
      * Default constructor needed by Java Service loader.

--- a/grpc/client/src/main/java/io/helidon/grpc/client/GrpcServiceClient.java
+++ b/grpc/client/src/main/java/io/helidon/grpc/client/GrpcServiceClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.core.MethodHandler;
 import io.helidon.grpc.core.PriorityBag;
@@ -45,6 +47,9 @@ import io.grpc.stub.StreamObserver;
  * A gRPC Client for a specific gRPC service.
  */
 public class GrpcServiceClient {
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "gRPC Client");
+    }
 
     private final HashMap<String, GrpcMethodStub> methodStubs;
 

--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.metrics.InternalBridge;
 import io.helidon.common.metrics.InternalBridge.Metadata.MetadataBuilder;
 import io.helidon.grpc.core.GrpcHelper;
@@ -51,6 +52,11 @@ import org.eclipse.microprofile.metrics.Timer;
 @Priority(InterceptorPriorities.TRACING + 1)
 public class GrpcMetrics
         implements ServerInterceptor, ServiceDescriptor.Configurer, MethodDescriptor.Configurer {
+
+    static {
+        HelidonFeatures.register("gRPC Server", "Metrics");
+        HelidonFeatures.register("gRPC Client", "Metrics");
+    }
 
     /**
      * The registry of vendor metrics.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.context.Context;
 import io.helidon.grpc.core.PriorityBag;
 
@@ -242,6 +244,10 @@ public interface GrpcServer {
      */
     final class Builder
             implements io.helidon.common.Builder<GrpcServer> {
+
+        static {
+            HelidonFeatures.register(HelidonFlavor.SE, "gRPC Server");
+        }
 
         private final GrpcRouting routing;
 

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HealthChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package io.helidon.health.checks;
 
 import java.lang.management.ManagementFactory;
 
+import io.helidon.common.HelidonFeatures;
+
 import org.eclipse.microprofile.health.HealthCheck;
 
 /**
@@ -26,6 +28,11 @@ import org.eclipse.microprofile.health.HealthCheck;
  */
 public final class HealthChecks {
     private static final boolean IS_GRAAL_VM = Boolean.getBoolean("com.oracle.graalvm.isaot");
+
+    static {
+        HelidonFeatures.register("Health", "Built-ins");
+    }
+
     private HealthChecks() {
     }
 

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.server.JsonSupport;
@@ -60,6 +62,10 @@ public final class HealthSupport implements Service {
     private static final Logger LOGGER = Logger.getLogger(HealthSupport.class.getName());
 
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "Health");
+    }
 
     private final boolean enabled;
     private final String webContext;

--- a/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
+++ b/media/jackson/server/src/main/java/io/helidon/media/jackson/server/JacksonSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.media.jackson.server;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.media.jackson.common.JacksonProcessing;
 import io.helidon.webserver.Handler;
 import io.helidon.webserver.JsonService;
@@ -37,6 +39,10 @@ import static io.helidon.media.common.ContentTypeCharset.determineCharset;
  * support to Helidon.
  */
 public final class JacksonSupport extends JsonService {
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "WebServer", "Jackson");
+    }
+
     private final BiFunction<? super ServerRequest, ? super ServerResponse, ? extends ObjectMapper> objectMapperProvider;
 
     /**

--- a/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
+++ b/media/jsonb/server/src/main/java/io/helidon/media/jsonb/server/JsonBindingSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.function.BiFunction;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.media.jsonb.common.JsonBinding;
 import io.helidon.webserver.Handler;
 import io.helidon.webserver.JsonService;
@@ -36,12 +38,15 @@ import static io.helidon.media.common.ContentTypeCharset.determineCharset;
  * href="http://json-b.net/">JSON-B</a> support to Helidon.
  */
 public final class JsonBindingSupport extends JsonService {
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "WebServer", "JSON-B");
+    }
 
     private final BiFunction<? super ServerRequest, ? super ServerResponse, ? extends Jsonb> jsonbProvider;
 
     private JsonBindingSupport(final BiFunction<? super ServerRequest,
-                                                ? super ServerResponse,
-                                                ? extends Jsonb> jsonbProvider) {
+            ? super ServerResponse,
+            ? extends Jsonb> jsonbProvider) {
         super();
         this.jsonbProvider = Objects.requireNonNull(jsonbProvider);
     }

--- a/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
+++ b/media/jsonp/server/src/main/java/io/helidon/media/jsonp/server/JsonSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import javax.json.JsonReader;
 import javax.json.JsonStructure;
 import javax.json.JsonWriter;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.Content;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Reader;
@@ -75,6 +77,10 @@ import static io.helidon.media.common.ContentTypeCharset.determineCharset;
  */
 public final class JsonSupport extends JsonService {
     private static final JsonSupport INSTANCE = new JsonSupport(JsonProcessing.create());
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "WebServer", "JSON-P");
+    }
 
     private final JsonProcessing processingSupport;
 

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -41,6 +41,8 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
@@ -94,6 +96,11 @@ public final class MetricsSupport implements Service {
 
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
     private static final String DEFAULT_CONTEXT = "/metrics";
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "Metrics");
+    }
+
     private final String context;
     private final RegistryFactory rf;
 

--- a/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/PrometheusSupport.java
+++ b/metrics/prometheus/src/main/java/io/helidon/metrics/prometheus/PrometheusSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.MediaType;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
@@ -42,6 +44,9 @@ import io.prometheus.client.CollectorRegistry;
  * It is possible to use
  */
 public final class PrometheusSupport implements Service {
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "WebServer", "Prometheus");
+    }
 
     /**
      * Standard path of Prometheus client resource: {@code /metrics}.

--- a/microprofile/access-log/src/main/java/io/helidon/microprofile/accesslog/AccessLogCdiExtension.java
+++ b/microprofile/access-log/src/main/java/io/helidon/microprofile/accesslog/AccessLogCdiExtension.java
@@ -34,7 +34,7 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
  */
 public class AccessLogCdiExtension implements Extension {
     static {
-        HelidonFeatures.register(HelidonFlavor.MP, "AccessLog");
+        HelidonFeatures.register(HelidonFlavor.MP, "Server", "AccessLog");
     }
 
     private void setUpAccessLog(@Observes @Priority(PLATFORM_BEFORE + 10) @RuntimeStart Config config,

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -299,7 +299,8 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
         now = System.currentTimeMillis() - now;
         LOGGER.fine("Container started in " + now + " millis (this excludes the initialization time)");
 
-        HelidonFeatures.print(HelidonFlavor.MP);
+        HelidonFeatures.print(HelidonFlavor.MP, config.get("features.print-details").asBoolean().orElse(false));
+
         return this;
     }
 

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/main/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,9 @@ import javax.json.JsonObject;
 import javax.json.JsonString;
 import javax.json.JsonValue;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
+
 import org.eclipse.microprofile.jwt.Claim;
 import org.eclipse.microprofile.jwt.ClaimValue;
 import org.eclipse.microprofile.jwt.Claims;
@@ -67,6 +70,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * JWT Authentication CDI extension class.
  */
 public class JwtAuthCdiExtension implements Extension {
+    static {
+        HelidonFeatures.register(HelidonFlavor.MP, "Security", "MP", "JWT-Auth");
+    }
 
     private final List<ClaimIP> qualifiers = new LinkedList<>();
 

--- a/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcCdiExtension.java
+++ b/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcCdiExtension.java
@@ -22,6 +22,8 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.config.Config;
 import io.helidon.microprofile.cdi.RuntimeStart;
 import io.helidon.microprofile.server.ServerCdiExtension;
@@ -31,6 +33,10 @@ import io.helidon.security.providers.oidc.OidcSupport;
  * Microprofile extension that brings support for Open ID Connect.
  */
 public final class OidcCdiExtension implements Extension {
+    static {
+        HelidonFeatures.register(HelidonFlavor.MP, "Security", "MP", "OIDC");
+    }
+
     private Config config;
 
     private void configure(@Observes @RuntimeStart Config config) {

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
@@ -82,6 +84,10 @@ public class OpenAPISupport implements Service {
     private static final String DEFAULT_STATIC_FILE_PATH_PREFIX = "META-INF/openapi.";
     private static final String OPENAPI_EXPLICIT_STATIC_FILE_LOG_MESSAGE_FORMAT = "Using specified OpenAPI static file %s";
     private static final String OPENAPI_DEFAULTED_STATIC_FILE_LOG_MESSAGE_FORMAT = "Using default OpenAPI static file %s";
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "OpenAPI");
+    }
 
     private final String webContext;
 

--- a/security/abac/policy-el/src/main/java/io/helidon/security/abac/policy/el/JavaxElPolicyExecutor.java
+++ b/security/abac/policy-el/src/main/java/io/helidon/security/abac/policy/el/JavaxElPolicyExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import javax.el.ValueExpression;
 import javax.el.VariableMapper;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.ProviderRequest;
 import io.helidon.security.SecurityContext;
@@ -46,6 +47,11 @@ import io.helidon.security.abac.policy.spi.PolicyExecutor;
 public final class JavaxElPolicyExecutor implements PolicyExecutor {
     private static final Logger LOGGER = Logger.getLogger(JavaxElPolicyExecutor.class.getName());
     private static final AttributeResolver ATTRIBUTE_RESOLVER = new AttributeResolver();
+
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC", "Policy", "EL");
+    }
+
     private final ExpressionFactory ef;
     private final List<CustomFunction> customMethods = new LinkedList<>();
 

--- a/security/abac/policy/src/main/java/io/helidon/security/abac/policy/PolicyValidator.java
+++ b/security/abac/policy/src/main/java/io/helidon/security/abac/policy/PolicyValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.ProviderRequest;
@@ -59,6 +60,11 @@ import io.helidon.security.providers.abac.spi.AbacValidator;
  */
 public final class PolicyValidator implements AbacValidator<PolicyValidator.PolicyConfig> {
     private static final Logger LOGGER = Logger.getLogger(PolicyValidator.class.getName());
+
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC", "Policy");
+    }
+
     private final List<PolicyExecutor> executors = new LinkedList<>();
 
     private PolicyValidator(Builder builder) {

--- a/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidator.java
+++ b/security/abac/role/src/main/java/io/helidon/security/abac/role/RoleValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.ProviderRequest;
@@ -60,6 +61,10 @@ import io.helidon.security.providers.abac.spi.AbacValidator;
  * This validator supports both {@link RolesAllowed} and {@link Roles} annotations.
  */
 public final class RoleValidator implements AbacValidator<RoleValidator.RoleConfig> {
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC", "Role");
+    }
+
     private RoleValidator() {
     }
 

--- a/security/abac/scope/src/main/java/io/helidon/security/abac/scope/ScopeValidator.java
+++ b/security/abac/scope/src/main/java/io/helidon/security/abac/scope/ScopeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.Grant;
@@ -50,6 +51,11 @@ public final class ScopeValidator implements AbacValidator<ScopeValidator.Scopes
      * Use this type when constructing a {@link Grant}, so this validator can accept it as a scope.
      */
     public static final String SCOPE_GRANT_TYPE = "scope";
+
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC", "Scope");
+    }
+
     private final boolean useOrOperator;
 
     private ScopeValidator(Builder builder) {

--- a/security/abac/time/src/main/java/io/helidon/security/abac/time/TimeValidator.java
+++ b/security/abac/time/src/main/java/io/helidon/security/abac/time/TimeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.ProviderRequest;
@@ -54,6 +55,11 @@ import io.helidon.security.providers.abac.spi.AbacValidator;
  */
 public final class TimeValidator implements AbacValidator<TimeValidator.TimeConfig> {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC", "Time");
+    }
+
     private TimeValidator() {
     }
 

--- a/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcClientSecurity.java
+++ b/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcClientSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityClientBuilder;
 import io.helidon.security.OutboundSecurityResponse;
@@ -51,6 +52,10 @@ public final class GrpcClientSecurity
      * {@link GrpcClientSecurity.Builder#property(String, Object)}.
      */
     public static final String PROPERTY_PROVIDER = "io.helidon.security.integration.grpc.GrpcClientSecurity.explicitProvider";
+
+    static {
+        HelidonFeatures.register("Security", "Integration", "gRPC Client");
+    }
 
     private final SecurityContext context;
 

--- a/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
+++ b/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.grpc.core.InterceptorPriorities;
@@ -151,6 +152,10 @@ public final class GrpcSecurity
     private static final String KEY_GRPC_CONFIG = "grpc-server";
 
     private static final AtomicInteger SECURITY_COUNTER = new AtomicInteger();
+
+    static {
+        HelidonFeatures.register("Security", "Integration", "gRPC Server");
+    }
 
     private final Security security;
     private final Optional<Config> config;

--- a/security/integration/jersey-client/src/main/java/io/helidon/security/integration/jersey/client/ClientSecurityFilter.java
+++ b/security/integration/jersey-client/src/main/java/io/helidon/security/integration/jersey/client/ClientSecurityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.context.Contexts;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityClientBuilder;
@@ -53,6 +54,10 @@ import io.helidon.security.integration.common.SecurityTracing;
 public class ClientSecurityFilter implements ClientRequestFilter {
 
     private static final Logger LOGGER = Logger.getLogger(ClientSecurityFilter.class.getName());
+
+    static {
+        HelidonFeatures.register("Security", "Integration", "Jersey Client");
+    }
 
     /**
      * Create an instance of this filter (used by Jersey or for unit tests, do not use explicitly in your production code).

--- a/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityFilterCommon.java
+++ b/security/integration/jersey/src/main/java/io/helidon/security/integration/jersey/SecurityFilterCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.AuthorizationResponse;
@@ -51,6 +52,10 @@ import org.glassfish.jersey.server.ContainerRequest;
  */
 abstract class SecurityFilterCommon {
     static final String PROP_FILTER_CONTEXT = "io.helidon.security.jersey.FilterContext";
+
+    static {
+        HelidonFeatures.register("Security", "Integration", "Jersey");
+    }
 
     @Context
     private Security security;

--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
@@ -93,6 +94,10 @@ public final class WebSecurity implements Service {
     public static final String CONTEXT_ADD_HEADERS = "security.addHeaders";
 
     private static final AtomicInteger SECURITY_COUNTER = new AtomicInteger();
+
+    static {
+        HelidonFeatures.register("Security", "Integration", "WebServer");
+    }
 
     private final Security security;
     private final Config config;

--- a/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
+++ b/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthorizationResponse;
 import io.helidon.security.EndpointConfig;
@@ -54,6 +55,10 @@ import io.helidon.security.spi.SynchronousProvider;
  * @see #create(Config)
  */
 public final class AbacProvider extends SynchronousProvider implements AuthorizationProvider {
+    static {
+        HelidonFeatures.register("Security", "Authorization", "ABAC");
+    }
+
     private final List<AbacValidator<? extends AbacValidatorConfig>> validators = new ArrayList<>();
     private final Set<Class<? extends Annotation>> supportedAnnotations;
     private final Set<String> supportedConfigKeys;

--- a/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenProvider.java
+++ b/security/providers/google-login/src/main/java/io/helidon/security/providers/google/login/GoogleTokenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
@@ -75,6 +76,11 @@ public final class GoogleTokenProvider extends SynchronousProvider implements Au
     private static final String HEADER_AUTHENTICATION_REQUIRED = "WWW-Authenticate";
 
     static final long TIME_SKEW_SECONDS = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "Google-Login");
+        HelidonFeatures.register("Security", "Outbound", "Google-Login");
+    }
 
     private final EvictableCache<String, CachedRecord> subjectCache = EvictableCache.<String, CachedRecord>builder()
             .evictor((key, record) -> record.getValidSupplier().get())

--- a/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnProvider.java
+++ b/security/providers/header/src/main/java/io/helidon/security/providers/header/HeaderAtnProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
@@ -40,6 +41,10 @@ import io.helidon.security.util.TokenHandler;
  * This provider also supports propagation of identity through a header.
  */
 public class HeaderAtnProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
+    static {
+        HelidonFeatures.register("Security", "Authentication", "Header");
+    }
+
     private final boolean optional;
     private final boolean authenticate;
     private final boolean propagate;
@@ -54,6 +59,10 @@ public class HeaderAtnProvider extends SynchronousProvider implements Authentica
         this.subjectType = builder.subjectType;
         this.atnTokenHandler = builder.atnTokenHandler;
         this.outboundTokenHandler = builder.outboundTokenHandler;
+
+        if (propagate) {
+            HelidonFeatures.register("Security", "Outbound", "Header");
+        }
     }
 
     /**

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
@@ -66,6 +67,11 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
     private static final Logger LOGGER = Logger.getLogger(HttpBasicAuthProvider.class.getName());
     private static final Pattern CREDENTIAL_PATTERN = Pattern.compile("(.*):(.*)");
     private static final char[] EMPTY_PASSWORD = new char[0];
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "Basic-Auth");
+        HelidonFeatures.register("Security", "Outbound", "Basic-Auth");
+    }
 
     private final List<SecureUserStore> userStores;
     private final String realm;

--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpDigestAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import javax.crypto.Cipher;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.Principal;
@@ -56,6 +57,11 @@ public final class HttpDigestAuthProvider extends SynchronousProvider implements
     private static final int SALT_LENGTH = 16;
     private static final int AES_NONCE_LENGTH = 12;
     private static final Logger LOGGER = Logger.getLogger(HttpDigestAuthProvider.class.getName());
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "Digest-Auth");
+    }
+
     private final List<HttpDigest.Qop> digestQopOptions = new LinkedList<>();
     private final SecureUserStore userStore;
     private final String realm;

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
@@ -68,6 +69,11 @@ public final class HttpSignProvider implements AuthenticationProvider, OutboundS
                             List.of("authorization")))
             .build();
     static final String ATTRIB_NAME_KEY_ID = HttpSignProvider.class.getName() + ".keyId";
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "Http-Sign");
+        HelidonFeatures.register("Security", "Outbound", "Http-Sign");
+    }
 
     private final boolean optional;
     private final String realm;

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsMtRoleMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.Grant;
@@ -65,6 +66,10 @@ public class IdcsMtRoleMapperProvider extends IdcsRoleMapperProviderBase {
     private static final Logger LOGGER = Logger
             .getLogger(IdcsMtRoleMapperProvider.class.getName());
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    static {
+        HelidonFeatures.register("Security", "Role-Mapper", "IDCS-Multitenant");
+    }
 
     private final TokenHandler idcsTenantTokenHandler;
     private final TokenHandler idcsAppNameTokenHandler;

--- a/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
+++ b/security/providers/idcs-mapper/src/main/java/io/helidon/security/providers/idcs/mapper/IdcsRoleMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.Grant;
@@ -47,6 +48,10 @@ import io.helidon.security.spi.SubjectMappingProvider;
  */
 public class IdcsRoleMapperProvider extends IdcsRoleMapperProviderBase implements SubjectMappingProvider {
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    static {
+        HelidonFeatures.register("Security", "Role-Mapper", "IDCS");
+    }
 
     private final EvictableCache<String, List<Grant>> roleCache;
     private final WebTarget assertEndpoint;

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.configurable.Resource;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
@@ -67,6 +68,10 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
      * Configure this for outbound requests to override user to use.
      */
     public static final String EP_PROPERTY_OUTBOUND_USER = "io.helidon.security.outbound.user";
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "JWT");
+    }
 
     private final boolean optional;
     private final boolean authenticate;
@@ -115,6 +120,10 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
 
         if (!verifySignature) {
             LOGGER.info("JWT Signature validation is disabled. Any JWT will be accepted.");
+        }
+
+        if (propagate) {
+            HelidonFeatures.register("Security", "Outbound", "JWT");
         }
     }
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
 
 import io.helidon.common.Errors;
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
@@ -87,6 +88,10 @@ import io.helidon.security.util.TokenHandler;
  */
 public final class OidcProvider extends SynchronousProvider implements AuthenticationProvider, OutboundSecurityProvider {
     private static final Logger LOGGER = Logger.getLogger(OidcProvider.class.getName());
+
+    static {
+        HelidonFeatures.register("Security", "Authentication", "OIDC");
+    }
 
     private final OidcConfig oidcConfig;
     private final TokenHandler paramHeaderHandler;
@@ -154,6 +159,10 @@ public final class OidcProvider extends SynchronousProvider implements Authentic
                                             .readEntity(String.class));
                 }
             };
+        }
+
+        if (propagate) {
+            HelidonFeatures.register("Security", "Outbound", "OIDC");
         }
     }
 

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -40,6 +40,8 @@ import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.configurable.ThreadPoolSupplier;
 import io.helidon.config.Config;
 import io.helidon.security.internal.SecurityAuditEvent;
@@ -91,6 +93,10 @@ public class Security {
     );
 
     private static final Logger LOGGER = Logger.getLogger(Security.class.getName());
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "Security");
+    }
 
     private final Collection<Class<? extends Annotation>> annotations = new LinkedList<>();
     private final List<Consumer<AuditProvider.TracedAuditEvent>> auditors = new LinkedList<>();

--- a/tests/integration/native-image/mp-1/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/native-image/mp-1/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@
 app.message=Properties message
 app.jaxrs.message=JAX-RS MP message
 app.jaxrs.number=42
-
+features.print-details=true

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.tracing.TracerBuilder;
 
@@ -154,6 +155,10 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
     static final String DEFAULT_HTTP_HOST = "localhost";
     static final int DEFAULT_HTTP_PORT = 14268;
     static final String DEFAULT_HTTP_PATH = "/api/traces";
+
+    static {
+        HelidonFeatures.register("Tracing", "Jaeger");
+    }
 
     private final Map<String, String> tags = new HashMap<>();
     private final List<Configuration.Propagation> propagations = new ArrayList<>();

--- a/tracing/jersey-client/src/main/java/io/helidon/tracing/jersey/client/ClientTracingFilter.java
+++ b/tracing/jersey-client/src/main/java/io/helidon/tracing/jersey/client/ClientTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.context.Contexts;
 import io.helidon.tracing.config.SpanTracingConfig;
 import io.helidon.tracing.config.TracingConfigUtil;
@@ -134,12 +135,15 @@ public class ClientTracingFilter implements ClientRequestFilter, ClientResponseF
      */
     public static final String X_REQUEST_ID = "x-request-id";
 
-
     static final String SPAN_PROPERTY_NAME = ClientTracingFilter.class.getName() + ".span";
 
     private static final List<String> PROPAGATED_HEADERS = List.of(X_REQUEST_ID, X_OT_SPAN_CONTEXT);
     private static final int HTTP_STATUS_ERROR_THRESHOLD = 400;
     private static final int HTTP_STATUS_SERVER_ERROR_THRESHOLD = 500;
+
+    static {
+        HelidonFeatures.register("Tracing", "Integration", "Jersey Client");
+    }
 
     private final Optional<TracerProvider> tracerProvider;
 

--- a/tracing/jersey/src/main/java/io/helidon/tracing/jersey/AbstractTracingFilter.java
+++ b/tracing/jersey/src/main/java/io/helidon/tracing/jersey/AbstractTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.tracing.config.SpanTracingConfig;
@@ -50,6 +51,10 @@ public abstract class AbstractTracingFilter implements ContainerRequestFilter, C
 
     private static final String SPAN_PROPERTY = AbstractTracingFilter.class.getName() + ".span";
     private static final String SPAN_SCOPE_PROPERTY = AbstractTracingFilter.class.getName() + ".spanScope";
+
+    static {
+        HelidonFeatures.register("Tracing", "Integration", "Jersey");
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {

--- a/tracing/tracing/src/main/java/io/helidon/tracing/TracerProviderHelper.java
+++ b/tracing/tracing/src/main/java/io/helidon/tracing/TracerProviderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package io.helidon.tracing;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 import io.helidon.tracing.spi.TracerProvider;
 
@@ -27,6 +29,10 @@ import io.helidon.tracing.spi.TracerProvider;
 final class TracerProviderHelper {
     private static final ServiceLoader<TracerProvider> SYSTEM_LOADER = ServiceLoader.load(TracerProvider.class);
     private static final HelidonServiceLoader<TracerProvider> SERVICE_LOADER = HelidonServiceLoader.create(SYSTEM_LOADER);
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "Tracing");
+    }
 
     private TracerProviderHelper() {
     }

--- a/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerBuilder.java
+++ b/tracing/zipkin/src/main/java/io/helidon/tracing/zipkin/ZipkinTracerBuilder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import io.helidon.common.HelidonFeatures;
 import io.helidon.config.Config;
 import io.helidon.tracing.Tag;
 import io.helidon.tracing.TracerBuilder;
@@ -112,6 +113,10 @@ public class ZipkinTracerBuilder implements TracerBuilder<ZipkinTracerBuilder> {
     static final String DEFAULT_ZIPKIN_HOST = "127.0.0.1";
     static final Version DEFAULT_VERSION = Version.V2;
     static final boolean DEFAULT_ENABLED = true;
+
+    static {
+        HelidonFeatures.register("Tracing", "Zipkin");
+    }
 
     private final List<Tag<?>> tags = new LinkedList<>();
     private String serviceName;

--- a/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogSupport.java
+++ b/webserver/access-log/src/main/java/io/helidon/webserver/accesslog/AccessLogSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
@@ -44,6 +46,11 @@ public final class AccessLogSupport implements Service {
      */
     public static final String DEFAULT_LOGGER_NAME = "io.helidon.webserver.AccessLog";
     private static final Pattern HEADER_ENTRY_PATTERN = Pattern.compile("%\\{(.*?)}i");
+
+    static {
+        HelidonFeatures.register(HelidonFlavor.SE, "WebServer", "AccessLog");
+    }
+
     private final List<AccessLogEntry> logFormat;
     private final Logger logger;
     private final boolean enabled;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -94,7 +94,7 @@ class NettyWebServer implements WebServer {
                    Map<String, Routing> namedRoutings) {
         Set<Map.Entry<String, SocketConfiguration>> sockets = config.sockets().entrySet();
 
-        HelidonFeatures.print(HelidonFlavor.SE);
+        HelidonFeatures.print(HelidonFlavor.SE, config.printFeatureDetails());
         this.bossGroup = new NioEventLoopGroup(sockets.size());
         this.workerGroup = config.workersCount() <= 0 ? new NioEventLoopGroup() : new NioEventLoopGroup(config.workersCount());
         // the contextual registry needs to be created as a different type is expected. Once we remove ContextualRegistry

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerBasicConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class ServerBasicConfig implements ServerConfiguration {
     private final Map<String, SocketConfiguration> socketConfigs;
     private final ExperimentalConfiguration experimental;
     private final ContextualRegistry context;
+    private final boolean printFeatureDetails;
 
     /**
      * Creates new instance.
@@ -51,6 +52,7 @@ class ServerBasicConfig implements ServerConfiguration {
         this.tracer = builder.tracer();
         this.experimental = builder.experimental();
         this.context = builder.context();
+        this.printFeatureDetails = builder.printFeatureDetails();
 
         HashMap<String, SocketConfiguration> map = new HashMap<>(builder.sockets());
         map.put(ServerConfiguration.DEFAULT_SOCKET_NAME, this.socketConfig);
@@ -115,6 +117,11 @@ class ServerBasicConfig implements ServerConfiguration {
     @Override
     public Context context() {
         return context;
+    }
+
+    @Override
+    public boolean printFeatureDetails() {
+        return printFeatureDetails;
     }
 
     static class SocketConfig implements SocketConfiguration {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,6 +182,13 @@ public interface ServerConfiguration extends SocketConfiguration {
     ExperimentalConfiguration experimental();
 
     /**
+     * Whether to print details of {@link io.helidon.common.HelidonFeatures}.
+     *
+     * @return whether to print details
+     */
+    boolean printFeatureDetails();
+
+    /**
      * Checks if HTTP/2 is enabled in config.
      *
      * @return Outcome of test.
@@ -231,6 +238,7 @@ public interface ServerConfiguration extends SocketConfiguration {
         private Tracer tracer;
         private ExperimentalConfiguration experimental;
         private ContextualRegistry context;
+        private boolean printFeatureDetails;
 
         private Builder() {
         }
@@ -445,6 +453,18 @@ public interface ServerConfiguration extends SocketConfiguration {
         }
 
         /**
+         * Set to {@code true} to print detailed feature information on startup.
+         *
+         * @param print whether to print details or not
+         * @return updated builder instance
+         * @see io.helidon.common.HelidonFeatures
+         */
+        public Builder printFeatureDetails(boolean print) {
+            this.printFeatureDetails = print;
+            return this;
+        }
+
+        /**
          * Configure the application scoped context to be used as a parent for webserver request contexts.
          * @param context top level context
          * @return an updated builder
@@ -485,6 +505,7 @@ public interface ServerConfiguration extends SocketConfiguration {
             configureSocket(config, defaultSocketBuilder);
 
             config.get("workers").asInt().ifPresent(this::workersCount);
+            config.get("features.print-details").asBoolean().ifPresent(this::printFeatureDetails);
 
             // sockets
             Config socketsConfig = config.get("sockets");
@@ -596,6 +617,10 @@ public interface ServerConfiguration extends SocketConfiguration {
 
         ContextualRegistry context() {
             return context;
+        }
+
+        boolean printFeatureDetails() {
+            return printFeatureDetails;
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.helidon.common.HelidonFeatures;
+import io.helidon.common.HelidonFlavor;
 import io.helidon.common.http.ContextualRegistry;
 
 /**
@@ -216,6 +218,9 @@ public interface WebServer {
      * sockets and optional multiple routings.
      */
     final class Builder implements io.helidon.common.Builder<WebServer> {
+        static {
+            HelidonFeatures.register(HelidonFlavor.SE, "WebServer");
+        }
 
         private final Map<String, Routing> routings = new HashMap<>();
         private final Routing defaultRouting;


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #1215 

You can control what is printed using configuration option:
`features.print-details`

In SE, this must be on the Config node you present to `ServerConfiguration`, for MP, this must be in the root of configuration.

Default output (`print-details=false`), MP:
~~2019.12.17 19:45:09 INFO io.helidon.common.HelidonFeatures Thread[main,5,main]: Helidon MP 2.0 features: [Config, Fault Tolerance, Health, JWT-Auth, Metrics, OpenAPI, Security, Server, Tracing~~

new:
`2019.12.17 22:54:09 INFO io.helidon.common.HelidonFeatures Thread[main,5,main]: Helidon MP 2.0-SNAPSHOT features: [Config, Fault Tolerance, Health, Metrics, OpenAPI, Security, Server, Tracing]`

Detailed output, MP (updated):
```
2019.12.17 19:45:09 INFO io.helidon.common.HelidonFeatures Thread[main,5,main]: Detailed feature tree:
Config
  Encryption
  YAML
Fault Tolerance
Health
Metrics
OpenAPI
Security
  Authorization
    ABAC
      Policy
      Role
      Scope
      Time
  Integration
    Jersey
  MP
    JWT-Auth
Server
Tracing
  Integration
    Jersey
  Jaeger
```