### PR TITLE
Change interceptor so it uses MetricID, not just name, during look-up

### DIFF
--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorConcurrentGauge.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorConcurrentGauge.java
@@ -40,6 +40,7 @@ final class InterceptorConcurrentGauge
         super(registry,
                 ConcurrentGauge.class,
                 ConcurrentGauge::name,
+                ConcurrentGauge::tags,
                 ConcurrentGauge::absolute,
                 MetricRegistry::getConcurrentGauges,
                 CONCURRENT_GAUGE.toString());

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorCounted.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorCounted.java
@@ -38,6 +38,7 @@ final class InterceptorCounted extends InterceptorBase<Counter, Counted> {
         super(registry,
               Counted.class,
               Counted::name,
+              Counted::tags,
               Counted::absolute,
               MetricRegistry::getCounters,
               "counter");

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorMetered.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorMetered.java
@@ -38,6 +38,7 @@ final class InterceptorMetered extends InterceptorBase<Meter, Metered> {
         super(registry,
               Metered.class,
               Metered::name,
+              Metered::tags,
               Metered::absolute,
               MetricRegistry::getMeters,
               "meter");

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorTimed.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/InterceptorTimed.java
@@ -38,6 +38,7 @@ final class InterceptorTimed extends InterceptorBase<Timer, Timed> {
         super(registry,
               Timed.class,
               Timed::name,
+              Timed::tags,
               Timed::absolute,
               MetricRegistry::getTimers,
               "timer");

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricUtil.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricUtil.java
@@ -21,9 +21,13 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.Tag;
 
 /**
  * Class MetricUtil.
@@ -48,6 +52,12 @@ final class MetricUtil {
             annotation = (A) clazz.getAnnotation(annotClass);
         }
         return annotation == null ? null : new LookupResult<>(MatchingType.CLASS, annotation);
+    }
+
+    static <E extends Member & AnnotatedElement>
+    MetricID getMetricID(E element, Class<?> clazz, MatchingType matchingType, String explicitName, String[] tags,
+            boolean absolute) {
+        return new MetricID(getMetricName(element, clazz, matchingType, explicitName, absolute), tags(tags));
     }
 
     static <E extends Member & AnnotatedElement>
@@ -91,6 +101,19 @@ final class MetricUtil {
     static <E extends Member & AnnotatedElement>
     String getElementName(E element, Class<?> clazz) {
         return element instanceof Constructor ? clazz.getSimpleName() : element.getName();
+    }
+
+    static Tag[] tags(String[] tagStrings) {
+        final List<Tag> result = new ArrayList<>();
+        for (int i = 0; i < tagStrings.length; i++) {
+            final int eq = tagStrings[i].indexOf("=");
+            if (eq > 0) {
+                final String tagName = tagStrings[i].substring(0, eq);
+                final String tagValue = tagStrings[i].substring(eq + 1);
+                result.add(new Tag(tagName, tagValue));
+            }
+        }
+        return result.toArray(new Tag[result.size()]);
     }
 
     enum MatchingType {

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +70,7 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 import static io.helidon.microprofile.metrics.MetricUtil.LookupResult;
 import static io.helidon.microprofile.metrics.MetricUtil.getMetricName;
 import static io.helidon.microprofile.metrics.MetricUtil.lookupAnnotation;
+import static io.helidon.microprofile.metrics.MetricUtil.tags;
 
 /**
  * MetricsCdiExtension class.
@@ -141,19 +141,6 @@ public class MetricsCdiExtension implements Extension {
             registry.concurrentGauge(meta, tags(concurrentGauge.tags()));
             LOGGER.log(Level.FINE, () -> "Registered concurrent gauge " + metricName);
         }
-    }
-
-    private static Tag[] tags(String[] tagStrings) {
-        final List<Tag> result = new ArrayList<>();
-        for (int i = 0; i < tagStrings.length; i++) {
-            final int eq = tagStrings[i].indexOf("=");
-            if (eq > 0) {
-                final String tagName = tagStrings[i].substring(0, eq);
-                final String tagValue = tagStrings[i].substring(eq + 1);
-                result.add(new Tag(tagName, tagValue));
-            }
-        }
-        return result.toArray(new Tag[result.size()]);
     }
 
     /**
@@ -380,7 +367,7 @@ public class MetricsCdiExtension implements Extension {
                             : javaMethod.getName());
                     String gaugeName = (gaugeAnnotation.absolute() ? gaugeNameSuffix
                             : String.format("%s.%s", clazz.getName(), gaugeNameSuffix));
-                    annotatedGaugeSites.put(new MetricID(gaugeName, tags(gaugeAnnotation.tags())), method);
+                    annotatedGaugeSites.put(new MetricID(gaugeName, MetricUtil.tags(gaugeAnnotation.tags())), method);
                     LOGGER.log(Level.FINE, () -> String.format("Recorded annotated gauge with name %s", gaugeName));
                 });
     }

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ResourceWithReusedMetricForInvocation.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ResourceWithReusedMetricForInvocation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+import javax.enterprise.context.Dependent;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Dependent
+public class ResourceWithReusedMetricForInvocation {
+
+    private static final String TAG_1 = "tag_1=value_1";
+    private static final String TAG_2 = "tag_2=value_2";
+    private static final String OTHER_REUSED_NAME = "reusedRetrieveDelay";
+
+    @GET
+    @Path("method1")
+    @Counted(name = OTHER_REUSED_NAME, absolute=true,reusable = true, tags = {TAG_1, TAG_2})
+    public String method1() {return "Hi from method 1";}
+
+    @GET
+    @Path("method2")
+    @Counted(name = OTHER_REUSED_NAME, absolute=true, reusable = true, tags = {TAG_1, TAG_2})
+    public String method2() {return "Hi from method 2";}
+}

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ReusabilityInterceptorTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ReusabilityInterceptorTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import org.junit.jupiter.api.Test;
+
+public class ReusabilityInterceptorTest extends MetricsBaseTest {
+
+    @Test
+    public void testReusedMetricWithInterceptor() {
+        ResourceWithReusedMetricForInvocation resource = newBean(ResourceWithReusedMetricForInvocation.class);
+        resource.method1();
+
+    }
+}

--- a/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ReusabilityMpServiceTest.java
+++ b/microprofile/metrics2/src/test/java/io/helidon/microprofile/metrics/ReusabilityMpServiceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ReusabilityMpServiceTest {
 
-    private Server initServer(Class<?> resourceClass) {
+    static Server initServer(Class<?> resourceClass) {
         return Server.builder()
                 .addResourceClass(resourceClass)
                 .config(MpConfig.builder().config(Config.create()).build())


### PR DESCRIPTION
The interceptors must use the full metric ID, not just the name, in locating metrics for intercepted methods.

The changes include some mild refactoring of a utility method for converting an array of tag-formatted strings into an array of `Tag` objects and the addition of a unit test.

Resolves #1238 

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>