### PR TITLE
Change exit.on.started value.

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -69,7 +69,7 @@ public class ServerImpl implements Server {
     private static final Logger JERSEY_LOGGER = Logger.getLogger(ServerImpl.class.getName() + ".jersey");
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
     private static final String EXIT_ON_STARTED_KEY = "exit.on.started";
-    private static final boolean EXIT_ON_STARTED = "✅".equals(System.getProperty(EXIT_ON_STARTED_KEY));
+    private static final boolean EXIT_ON_STARTED = "!".equals(System.getProperty(EXIT_ON_STARTED_KEY));
     private static final StartedServers STARTED_SERVERS = new StartedServers();
 
     private static long initStartupTime = System.nanoTime();

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -61,7 +61,7 @@ class NettyWebServer implements WebServer {
 
     private static final Logger LOGGER = Logger.getLogger(NettyWebServer.class.getName());
     private static final String EXIT_ON_STARTED_KEY = "exit.on.started";
-    private static final boolean EXIT_ON_STARTED = "✅".equals(System.getProperty(EXIT_ON_STARTED_KEY));
+    private static final boolean EXIT_ON_STARTED = "!".equals(System.getProperty(EXIT_ON_STARTED_KEY));
 
     private final EventLoopGroup bossGroup;
     private final EventLoopGroup workerGroup;


### PR DESCRIPTION
Replace use of unicode character with `'!'` since it doesn't work on some systems. 