### PR TITLE
Missing requires of JAX-RS API

### DIFF
--- a/microprofile/rest-client/src/main/java/module-info.java
+++ b/microprofile/rest-client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/rest-client/src/main/java/module-info.java
+++ b/microprofile/rest-client/src/main/java/module-info.java
@@ -22,6 +22,7 @@ module io.helidon.microprofile.restclient {
     requires transitive microprofile.rest.client.api;
     requires io.helidon.common.context;
     requires jersey.mp.rest.client;
+    requires java.ws.rs;
 
     provides org.eclipse.microprofile.rest.client.spi.RestClientListener
             with io.helidon.microprofile.restclient.MpRestClientListener;


### PR DESCRIPTION
Missing requires, fails compilation under IntelliJ.

Signed-off-by: Santiago Pericas-Geertsen <santiago.pericasgeertsen@oracle.com>