### PR TITLE
Minor gRPC changes

### DIFF
--- a/grpc/client/src/test/resources/test-client-config.yaml
+++ b/grpc/client/src/test/resources/test-client-config.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,3 +38,6 @@ grpc:
         tls-key-resource-path: "ssl/clientKey.pem"
         tls-cert-resource-path: "ssl/clientCert.pem"
         tls-ca-cert-resource-path: "ssl/ca.pem"
+    with_target:
+      target: "dns://localhost:1408"
+      load-balancer-policy: "round-robin"

--- a/microprofile/grpc/metrics/pom.xml
+++ b/microprofile/grpc/metrics/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>io.helidon.microprofile.metrics</groupId>
             <artifactId>helidon-microprofile-metrics</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.enterprise</groupId>

--- a/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtension.java
+++ b/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtension.java
@@ -18,6 +18,8 @@ package io.helidon.microprofile.grpc.server;
 
 import java.lang.annotation.Annotation;
 import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -73,8 +75,10 @@ public class GrpcServerCdiExtension
 
         Config config = resolveConfig(beanManager);
         GrpcServerConfiguration.Builder serverConfiguration = GrpcServerConfiguration.builder(config.get("grpc"));
+        CompletableFuture<GrpcServer> startedFuture = new CompletableFuture<>();
+        CompletableFuture<GrpcServer> shutdownFuture = new CompletableFuture<>();
 
-        loadExtensions(beanManager, config, routingBuilder, serverConfiguration);
+        loadExtensions(beanManager, config, routingBuilder, serverConfiguration, startedFuture, shutdownFuture);
         server = GrpcServer.create(serverConfiguration.build(), routingBuilder.build());
         long beforeT = System.nanoTime();
 
@@ -82,6 +86,7 @@ public class GrpcServerCdiExtension
                 .whenComplete((grpcServer, throwable) -> {
                     if (null != throwable) {
                         STARTUP_LOGGER.log(Level.SEVERE, throwable, () -> "gRPC server startup failed");
+                        startedFuture.completeExceptionally(throwable);
                     } else {
                         long t = TimeUnit.MILLISECONDS.convert(System.nanoTime() - beforeT, TimeUnit.NANOSECONDS);
 
@@ -89,6 +94,17 @@ public class GrpcServerCdiExtension
                         STARTUP_LOGGER.finest("gRPC server started up");
                         LOGGER.info(() -> "gRPC server started on localhost:" + port + " (and all other host addresses) "
                                 + "in " + t + " milliseconds.");
+
+                        grpcServer.whenShutdown()
+                                .whenComplete((server, error) -> {
+                                    if (error == null) {
+                                        shutdownFuture.complete(server);
+                                    } else {
+                                        shutdownFuture.completeExceptionally(error);
+                                    }
+                                });
+
+                        startedFuture.complete(grpcServer);
                     }
                 });
 
@@ -197,7 +213,9 @@ public class GrpcServerCdiExtension
     private void loadExtensions(BeanManager beanManager,
                                 Config config,
                                 GrpcRouting.Builder routingBuilder,
-                                GrpcServerConfiguration.Builder serverConfiguration) {
+                                GrpcServerConfiguration.Builder serverConfiguration,
+                                CompletionStage<GrpcServer> whenStarted,
+                                CompletionStage<GrpcServer> whenShutdown) {
 
         GrpcMpContext context = new GrpcMpContext() {
             @Override
@@ -218,6 +236,16 @@ public class GrpcServerCdiExtension
             @Override
             public BeanManager beanManager() {
                 return beanManager;
+            }
+
+            @Override
+            public CompletionStage<GrpcServer> whenStarted() {
+                return whenStarted;
+            }
+
+            @Override
+            public CompletionStage<GrpcServer> whenShutdown() {
+                return whenShutdown;
             }
         };
 

--- a/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/spi/GrpcMpContext.java
+++ b/microprofile/grpc/server/src/main/java/io/helidon/microprofile/grpc/server/spi/GrpcMpContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package io.helidon.microprofile.grpc.server.spi;
 
+import java.util.concurrent.CompletionStage;
+
 import javax.enterprise.inject.spi.BeanManager;
 
 import io.helidon.config.Config;
 import io.helidon.grpc.server.GrpcRouting;
+import io.helidon.grpc.server.GrpcServer;
 import io.helidon.grpc.server.GrpcServerConfiguration;
 
 /**
@@ -56,4 +59,18 @@ public interface GrpcMpContext {
      * @return the {@link javax.enterprise.inject.spi.BeanManager}
      */
     BeanManager beanManager();
+
+    /**
+     * Return a completion stage is completed when the gRPC server is started.
+     *
+     * @return a completion stage is completed when the gRPC server is started
+     */
+    CompletionStage<GrpcServer> whenStarted();
+
+    /**
+     * Return a completion stage is completed when the gRPC server is shut down.
+     *
+     * @return a completion stage is completed when the gRPC server is shut down
+     */
+    CompletionStage<GrpcServer> whenShutdown();
 }

--- a/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilderTest.java
+++ b/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,11 @@ public class GrpcServiceBuilderTest {
     @Test
     public void shouldCreateServiceFromClass() {
         assertServiceOne(GrpcServiceBuilder.create(ServiceOne.class, beanManager));
+    }
+
+    @Test
+    public void shouldCreateServiceFromClassWithoutBeanManager() {
+        assertServiceOne(GrpcServiceBuilder.create(ServiceOne.class, null));
     }
 
     public void assertServiceOne(GrpcServiceBuilder builder) {


### PR DESCRIPTION
Minor gRPC changes that have were applied to `helidon-1.x` branch in PR #1277 

- The `helidon-microprofile-grpc-metrics` module dependency on `helidon-microprofile-metrics` should have a scope of provided.
- Allow a gRPC service descriptors to be created without needing a BeanManager.
- Support creating gRPC Channels configured for a target URI in addition to a host and port.