### PR TITLE
build.sh: Remove integrations profile. Report mvn/java versions.

### DIFF
--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -45,9 +45,13 @@ fi
 
 inject_credentials
 
+echo "========="
+mvn --version
+echo "========="
+
 mvn -f ${WS_DIR}/pom.xml \
     clean install -e \
     -B \
-    -Pexamples,integrations,archetypes,spotbugs,javadoc,docs,sources,tck,tests,pipeline
+    -Pexamples,archetypes,spotbugs,javadoc,docs,sources,tck,tests,pipeline
 
 examples/quickstarts/archetypes/test-archetypes.sh

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018,2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018,2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The integrations profile was removed a while back, so we should not state it when we call `mvn`.

Also, report mvn and Java versions at start of build to confirm we are using what we expect.
