### PR TITLE
Support multiple jandex.idx files on the classpath

### DIFF
--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2019-2020 Oracle and/or its affiliates. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -58,6 +58,28 @@
                             <fileSets>
                                 <fileSet>
                                     <directory>${project.build.directory}/test-classes</directory>
+                                    <excludes>
+                                        <exclude>**/other/*.class</exclude>
+                                    </excludes>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make-second-test-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <classesDir>${project.build.directory}/test-classes</classesDir>
+                            <indexName>other.idx</indexName>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}/test-classes</directory>
+                                    <includes>
+                                        <include>**/other/*.class</include>
+                                    </includes>
                                 </fileSet>
                             </fileSets>
                         </configuration>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -116,7 +116,7 @@ public class IndexBuilder implements Extension {
         List<IndexView> indices = new ArrayList<>();
         for (URL indexURL : indexURLs) {
             try (InputStream indexIS = indexURL.openStream()) {
-                LOGGER.log(Level.FINE, "Adding Jandex index at {0}", INDEX_PATH);
+                LOGGER.log(Level.FINE, "Adding Jandex index at {0}", indexURL.toString());
                 indices.add(new IndexReader(indexIS).read());
             } catch (IOException ex) {
                 throw new IOException("Attempted to read from previously-located index file "

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/IndexBuilder.java
@@ -87,7 +87,7 @@ public class IndexBuilder implements Extension {
      * @param event {@code ProcessAnnotatedType} event
      */
     private <X> void processAnnotatedType(@Observes ProcessAnnotatedType<X> event) {
-        if (indexURLs == null) {
+        if (indexURLs.isEmpty()) {
             Class<?> c = event.getAnnotatedType()
                     .getJavaClass();
             annotatedTypes.add(c);
@@ -103,7 +103,7 @@ public class IndexBuilder implements Extension {
      * reading class bytecode from the classpath
      */
     public IndexView indexView() throws IOException {
-        return indexURLs != null ? existingIndexFileReader() : indexFromHarvestedClasses();
+        return !indexURLs.isEmpty() ? existingIndexFileReader() : indexFromHarvestedClasses();
     }
 
     /**

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestMultiJandex.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestMultiJandex.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.openapi;
+
+import io.helidon.microprofile.openapi.other.TestApp2;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class TestMultiJandex {
+
+    @Test
+    public void testMultipleIndexFiles() throws IOException {
+
+        /*
+         * The pom builds two differently-named test Jandex files, as an approximation
+         * to handling multiple same-named index files in the class path.
+         */
+        IndexBuilder builder = new IndexBuilder("META-INF/jandex.idx", "META-INF/other.idx");
+        IndexView indexView = builder.indexView();
+
+        DotName testAppName = DotName.createSimple(TestApp.class.getName());
+        DotName testApp2Name = DotName.createSimple(TestApp2.class.getName());
+
+        ClassInfo testAppInfo = indexView.getClassByName(testAppName);
+        assertNotNull(testAppInfo, "Expected index entry for TestApp not found");
+
+        ClassInfo testApp2Info = indexView.getClassByName(testApp2Name);
+        assertNotNull(testApp2Info, "Expected index entry for TestApp2 not found");
+    }
+}

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/other/TestApp2.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/other/TestApp2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.openapi.other;
+
+import io.helidon.common.CollectionsHelper;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+public class TestApp2 extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return CollectionsHelper.setOf(Test2Resources.class);
+    }
+
+    @Path("/testapp2")
+    public static class Test2Resources {
+
+        @Path("/go2")
+        @GET
+        @Operation(summary = "Test 2 for returning a fixed string",
+            description = "Provides a single, fixed string as the response")
+        @APIResponse(description = "Simple text string",
+            content = @Content(mediaType = "text/plain")
+        )
+        @Produces(MediaType.TEXT_PLAIN)
+        public Response go2() {
+            return Response.ok("Test").build();
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #1304 

These changes cause the OpenAPI annotation processing to handle all `jandex.idx` files that appear on the class path, not just the first one encountered. 

The PR also adds a test that approximates this use case.

