### PR TITLE
Update docs, examples, dockerfiles to Java 11. bom cleanup. Gradle fixes.

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -47,7 +47,7 @@
         <version.plugin.dependency>3.0.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
-        <version.plugin.helidon>1.1.0</version.plugin.helidon>
+        <version.plugin.helidon>1.1.1</version.plugin.helidon>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -503,74 +503,64 @@
                 <artifactId>helidon-common-metrics</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.helidon.common</groupId>
-                <artifactId>helidon-common-mapper</artifactId>
-                <version>${project.version}</version>
-            </dependency>
 
             <!-- db client -->
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-common</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-jdbc</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-mongodb</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.helidon.dbclient</groupId>
-                <artifactId>helidon-dbclient-mongodb</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-health</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-jsonp</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-metrics</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-metrics-jdbc</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-tracing</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.dbclient</groupId>
                 <artifactId>helidon-dbclient-webserver-jsonp</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
 
             <!-- db client examples -->
             <dependency>
                 <groupId>io.helidon.examples.dbclient</groupId>
                 <artifactId>helidon-examples-dbclient-common</artifactId>
-                <version>${project.version}</version>
+                <version>${helidon.version}</version>
             </dependency>
 
             <!-- tracing -->

--- a/docs/src/main/docs/about/03_prerequisites.adoc
+++ b/docs/src/main/docs/about/03_prerequisites.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/docs/about/03_prerequisites.adoc
+++ b/docs/src/main/docs/about/03_prerequisites.adoc
@@ -24,17 +24,16 @@ Everything you need to use Helidon is listed here.
 
 == Prerequisites
 
-Helidon requires Java 8 or Java 11 and Maven. You need Docker if you
+Helidon requires Java 11 (or newer) and Maven. You need Docker if you
 want to build and deploy Docker containers. If you want to
 deploy to Kubernetes, you need `kubectl` and a Kubernetes cluster (you can
 <<about/05_kubernetes.adoc,install one on your desktop>>).
 
 [role="flex, sm7"]
 |=======
-|https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}8] (http://jdk.java.net[Open{nbsp}JDK{nbsp}8])
- or https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}11] (http://jdk.java.net[Open{nbsp}JDK{nbsp}11])
-|https://maven.apache.org/download.cgi[Maven 3.5+]
-|https://docs.docker.com/install/[Docker 18.06+]
+|https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}11] (http://jdk.java.net[Open{nbsp}JDK{nbsp}11]) or newer
+|https://maven.apache.org/download.cgi[Maven 3.6.1+]
+|https://docs.docker.com/install/[Docker 18.09+]
 |https://kubernetes.io/docs/tasks/tools/install-kubectl/[Kubectl 1.11.9+]
 |=======
 
@@ -54,11 +53,11 @@ kubectl version --short
 .Setting JAVA_HOME
 ----
 # On Mac
-export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+export JAVA_HOME=`/usr/libexec/java_home -v 11`
 
 # On Linux
 # Use the appropriate path to your JDK
-export JAVA_HOME=/usr/lib/jvm/jdk-8
+export JAVA_HOME=/usr/lib/jvm/jdk-11
 ----
 
 == Try the Quickstart Examples

--- a/docs/src/main/docs/config/01_introduction.adoc
+++ b/docs/src/main/docs/config/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/docs/config/01_introduction.adoc
+++ b/docs/src/main/docs/config/01_introduction.adoc
@@ -84,7 +84,7 @@ An easy way to start with the link:{javadoc-base-url-api}/Config.html[Config] AP
 is to follow these four steps:
 
 1. <<maven-coords,add config-related dependencies to your `pom.xml`>>
-2. <<update-module-info, revise your `module-info.java` to refer to config (if you are using Java 9)>>
+2. <<update-module-info, revise your `module-info.java` to refer to config (if you are using Java 11)>>
 3. <<create-simple-config-props, create a simple config properties file>>
 4. <<Config-Basics-DefaultConfig, retrieve and use the default `Config` from your app>>
 
@@ -102,7 +102,7 @@ is to follow these four steps:
 ----
 
 ==== Update `module-info.java` [[update-module-info]]
-If you are using Java 9 then create or update the `module-info.java` file for your application:
+If you are using Java 11 then create or update the `module-info.java` file for your application:
 [source,java]
 .Config Dependency in `module-info.java`
 ----

--- a/docs/src/main/docs/config/05_mutability-support.adoc
+++ b/docs/src/main/docs/config/05_mutability-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/src/main/docs/config/05_mutability-support.adoc
+++ b/docs/src/main/docs/config/05_mutability-support.adoc
@@ -73,7 +73,7 @@ useful.
 ====
 This section describes the `Config.changes()` method. It is marked
 as deprecated because it returns an `io.helidon.reactive.Flow.Publisher` object.
-In a future Helidon release that requires Java 9 or later this method will be undeprecated 
+In a future Helidon release that requires Java 11 or later this method will be undeprecated
 and changed -- or a similar method will be added -- so that the return type is
 `java.util.concurrent.Flow.Publisher` instead. 
 

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.5.4-jdk-9 as build
+FROM maven:3.6.3-jdk-11 as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-quickstart-mp/README.md
@@ -4,7 +4,7 @@ This example implements a simple Hello World REST service using MicroProfile.
 
 ## Build and run
 
-With JDK8+
+With JDK11+
 ```bash
 mvn package
 java -jar target/helidon-quickstart-mp.jar

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-mp/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/build.gradle
@@ -22,14 +22,14 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-mp"""
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 ext {
-    helidonversion = '1.2.2-SNAPSHOT'
+    helidonversion = '2.0-SNAPSHOT'
 }
 
 repositories {
@@ -38,20 +38,24 @@ repositories {
 }
 
 dependencies {
-    compile "io.helidon:helidon-bom:${project.helidonversion}"
-    compile 'io.helidon.microprofile.bundles:helidon-microprofile-1.2'
-    compile 'org.glassfish.jersey.media:jersey-media-json-binding:2.29'
-    runtime 'org.jboss:jandex:2.0.4.Final'
-    runtime 'javax.activation:javax.activation-api:1.2.0'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    // import Helidon BOM
+    implementation platform("io.helidon:helidon-dependencies:${project.helidonversion}")
+
+    implementation 'io.helidon.microprofile.bundles:helidon-microprofile'
+    implementation 'org.glassfish.jersey.media:jersey-media-json-binding'
+
+    runtimeOnly 'org.jboss:jandex'
+    runtimeOnly 'javax.activation:javax.activation-api'
+
+    testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testCompileOnly 'org.junit.jupiter:junit-jupiter-api:5.1.0'
 }
 
 // define a custom task to copy all dependencies in the runtime classpath
 // into build/libs/libs
 // uses built-in Copy
 task copyLibs(type: Copy) {
-  from configurations.runtime
+  from configurations.runtimeClasspath
   into 'build/libs/libs'
 }
 
@@ -66,7 +70,7 @@ jar {
   archiveName = "${project.name}.jar"
   manifest {
     attributes ('Main-Class': 'io.helidon.examples.quickstart.mp.Main',
-                'Class-Path': configurations.runtime.files.collect { "libs/$it.name" }.join(' ')
+                'Class-Path': configurations.runtimeClasspath.files.collect { "libs/$it.name" }.join(' ')
                )
   }
 }

--- a/examples/quickstarts/helidon-quickstart-mp/settings.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-mp/settings.gradle
+++ b/examples/quickstarts/helidon-quickstart-mp/settings.gradle
@@ -15,4 +15,3 @@
  */
 
 rootProject.name = 'quickstart-mp'
-enableFeaturePreview("IMPROVED_POM_SUPPORT")

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.5.4-jdk-9 as build
+FROM maven:3.6.3-jdk-11 as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -4,7 +4,7 @@ This project implements a simple Hello World REST service using Helidon SE.
 
 ## Build and run
 
-With JDK8+
+With JDK11+
 ```bash
 mvn package
 java -jar target/helidon-quickstart-se.jar

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-se/build.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/build.gradle
@@ -22,14 +22,14 @@ version = '1.0-SNAPSHOT'
 
 description = """helidon-quickstart-se"""
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
 ext {
-    helidonversion = '1.2.2-SNAPSHOT'
+    helidonversion = '2.0-SNAPSHOT'
 }
 
 repositories {
@@ -38,21 +38,22 @@ repositories {
 }
 
 dependencies {
-    compile "io.helidon:helidon-bom:${project.helidonversion}"
-    compile 'io.helidon.bundles:helidon-bundles-webserver'
-    compile 'io.helidon.config:helidon-config-yaml'
-    compile 'io.helidon.health:helidon-health'
-    compile 'io.helidon.health:helidon-health-checks'
-    compile 'io.helidon.metrics:helidon-metrics'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    // import Helidon BOM
+    implementation platform("io.helidon:helidon-dependencies:${project.helidonversion}")
+    implementation 'io.helidon.bundles:helidon-bundles-webserver'
+    implementation 'io.helidon.config:helidon-config-yaml'
+    implementation 'io.helidon.health:helidon-health'
+    implementation 'io.helidon.health:helidon-health-checks'
+    implementation 'io.helidon.metrics:helidon-metrics'
+
+    testCompileOnly 'org.junit.jupiter:junit-jupiter-api'
 }
 
 // define a custom task to copy all dependencies in the runtime classpath
 // into build/libs/libs
 // uses built-in Copy
 task copyLibs(type: Copy) {
-  from configurations.runtime
+  from configurations.runtimeClasspath
   into 'build/libs/libs'
 }
 
@@ -67,7 +68,7 @@ jar {
   archiveName = "${project.name}.jar"
   manifest {
     attributes ('Main-Class': 'io.helidon.examples.quickstart.se.Main',
-                'Class-Path': configurations.runtime.files.collect { "libs/$it.name" }.join(' ')
+                'Class-Path': configurations.runtimeClasspath.files.collect { "libs/$it.name" }.join(' ')
                )
   }
 }

--- a/examples/quickstarts/helidon-quickstart-se/settings.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-se/settings.gradle
+++ b/examples/quickstarts/helidon-quickstart-se/settings.gradle
@@ -15,4 +15,3 @@
  */
 
 rootProject.name = 'helidon-quickstart-se'
-enableFeaturePreview("IMPROVED_POM_SUPPORT")

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.5.4-jdk-9 as build
+FROM maven:3.6.3-jdk-11 as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/README.md
@@ -5,7 +5,7 @@ This example implements a simple Hello World REST service using MicroProfile
 
 ## Build and run
 
-With JDK8+
+With JDK11+
 ```bash
 mvn package
 java -jar target/helidon-standalone-quickstart-mp.jar

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.5.4-jdk-9 as build
+FROM maven:3.6.3-jdk-11 as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:8-jre-slim
+FROM openjdk:11-jre-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-standalone-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/README.md
@@ -5,7 +5,7 @@ This project implements a simple Hello World REST service using Helidon SE with
 
 ## Build and run
 
-With JDK8+
+With JDK11+
 ```bash
 mvn package
 java -jar target/helidon-standalone-quickstart-se.jar

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
-        <version.plugin.helidon-build-tools>1.1.0</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>1.1.1</version.plugin.helidon-build-tools>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>1.0.6</version.plugin.jandex>
         <version.plugin.jar>3.0.2</version.plugin.jar>


### PR DESCRIPTION
Docs: update pre-reqs, change Java references to 11
Cleanup bom/pom.xml, remove project.version
Update quickstart Dockerfiles to maven:3.6.3-jdk-11 and openjdk:11-jre-slim
Update quickstart build.gradle to Java 11 and work with Gradle 6