### PR TITLE
add missing compile scope dependency

### DIFF
--- a/microprofile/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/pom.xml
@@ -73,6 +73,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>javax.interceptor</groupId>
+            <artifactId>javax.interceptor-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>internal-test-libs</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
 add missing compile scope dependency on javax.interceptor-api in microprofile/jwt-auth