### PR TITLE
Adds a default send(Throwable) method to ServerResponse.java as the first step in providing an easy facility for reporting exceptions during HTTP processing

### DIFF
--- a/media/common/src/main/java/io/helidon/media/common/ContentWriters.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentWriters.java
@@ -188,17 +188,4 @@ public final class ContentWriters {
         return byteChannelWriter(null);
     }
 
-    /**
-     * Returns a writer function for a {@link Throwable}'s stack trace.
-     *
-     * @param context a {@link MessageBodyWriterContext}
-     * @param setContentLength whether {@link MessageBodyWriterContext#contentLength(long)} should be called
-     * @return a {@link Throwable} writer
-     * @see #writeStackTrace(Throwable, MessageBodyWriterContext, boolean)
-     */
-    public static Function<Throwable, Publisher<DataChunk>> stackTraceWriter(MessageBodyWriterContext context,
-                                                                             boolean setContentLength) {
-        return throwable -> writeStackTrace(throwable, context, setContentLength);
-    }
-
 }

--- a/media/common/src/main/java/io/helidon/media/common/ContentWriters.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentWriters.java
@@ -88,13 +88,10 @@ public final class ContentWriters {
      * {@link Throwable} / {@link Charset} and return a {@link Single}.
      *
      * @param throwable the {@link Throwable}
-     * @param context a {@link MessageBodyWriterContext}
-     * @param setContentLength whether {@link MessageBodyWriterContext#contentLength(long)} should be called
+     * @param charset the charset to use to encode the stack trace
      * @return Single
      */
-    public static Single<DataChunk> writeStackTrace(Throwable throwable,
-                                                    MessageBodyWriterContext context,
-                                                    boolean setContentLength) {
+    public static Single<DataChunk> writeStackTrace(Throwable throwable, Charset charset) {
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter);
         String stackTraceString = null;
@@ -104,18 +101,10 @@ public final class ContentWriters {
         } finally {
             printWriter.close();
         }
-        assert stackTraceString != null;
         final Single<DataChunk> returnValue;
         if (stackTraceString.isEmpty()) {
-            if (setContentLength) {
-                context.contentLength(0);
-            }
             returnValue = Single.<DataChunk>empty();
         } else {
-            final Charset charset = context.charset();
-            if (setContentLength) {
-                context.contentLength(stackTraceString.getBytes(charset).length);
-            }
             returnValue = writeCharSequence(stackTraceString, charset);
         }
         return returnValue;

--- a/media/common/src/main/java/io/helidon/media/common/MediaSupport.java
+++ b/media/common/src/main/java/io/helidon/media/common/MediaSupport.java
@@ -116,7 +116,8 @@ public final class MediaSupport {
                     .registerWriter(CharSequenceBodyWriter.create())
                     .registerWriter(ByteChannelBodyWriter.create())
                     .registerWriter(PathBodyWriter.create())
-                    .registerWriter(FileBodyWriter.create());
+                    .registerWriter(FileBodyWriter.create())
+                    .registerWriter(ThrowableBodyWriter.create(false));
             return this;
         }
 

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -57,9 +57,19 @@ public final class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
     /**
      * Creates a new {@link ThrowableBodyWriter}.
      * @return a new {@link ThrowableBodyWriter}; never {@code null}
+     * @see #create(boolean)
      */
     public static ThrowableBodyWriter create() {
-        return new ThrowableBodyWriter();
+        return create(false);
+    }
+
+    /**
+     * Creates a new {@link ThrowableBodyWriter}.
+     * @param writeStackTrace whether stack traces are to be written
+     * @return a new {@link ThrowableBodyWriter}; never {@code null}
+     */
+    public static ThrowableBodyWriter create(boolean writeStackTrace) {
+        return new ThrowableBodyWriter(writeStackTrace);
     }
 
     private static final class ThrowableToChunks implements Mapper<Throwable, Publisher<DataChunk>> {

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -81,14 +81,7 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
         @Override
         public Publisher<DataChunk> map(Throwable throwable) {
             context.contentType(MediaType.TEXT_PLAIN);
-            final Publisher<DataChunk> returnValue;
-            if (throwable == null) {
-                context.contentLength(0);
-                returnValue = Single.<DataChunk>empty();
-            } else {
-                returnValue = ContentWriters.writeStackTrace(throwable, context.charset());
-            }
-            return returnValue;
+            return ContentWriters.writeStackTrace(throwable, context.charset());
         }
     }
 

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.media.common;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.Flow.Publisher;
 
 import io.helidon.common.GenericType;
@@ -35,7 +36,6 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
     }
 
     protected ThrowableBodyWriter(boolean writeStackTrace) {
-        super();
         this.writeStackTrace = writeStackTrace;
     }
 
@@ -48,7 +48,8 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
     public Publisher<DataChunk> write(Single<Throwable> content,
                                       GenericType<? extends Throwable> type,
                                       MessageBodyWriterContext context) {
-        return content.mapMany(new ThrowableToChunks(context));
+        context.contentType(MediaType.TEXT_PLAIN);
+        return content.mapMany(new ThrowableToChunks(context.charset()));
     }
 
     /**
@@ -71,17 +72,16 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
 
     private static final class ThrowableToChunks implements Mapper<Throwable, Publisher<DataChunk>> {
 
-        private final MessageBodyWriterContext context;
+        private final Charset charset;
 
-        private ThrowableToChunks(MessageBodyWriterContext context) {
+        private ThrowableToChunks(Charset charset) {
             super();
-            this.context = context;
+            this.charset = charset;
         }
 
         @Override
         public Publisher<DataChunk> map(Throwable throwable) {
-            context.contentType(MediaType.TEXT_PLAIN);
-            return ContentWriters.writeStackTrace(throwable, context.charset());
+          return ContentWriters.writeStackTrace(throwable, charset);
         }
     }
 

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -86,7 +86,7 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
                 context.contentLength(0);
                 returnValue = Single.<DataChunk>empty();
             } else {
-              returnValue = ContentWriters.writeStackTrace(throwable, context.charset());
+                returnValue = ContentWriters.writeStackTrace(throwable, context.charset());
             }
             return returnValue;
         }

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.media.common;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.util.concurrent.Flow.Publisher;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.MediaType;
+import io.helidon.common.mapper.Mapper;
+import io.helidon.common.reactive.Single;
+
+/**
+ * Message body writer for {@link Throwable}.
+ */
+public final class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
+
+    private final boolean writeStackTrace;
+
+    private ThrowableBodyWriter() {
+        this(false);
+    }
+
+    private ThrowableBodyWriter(boolean writeStackTrace) {
+        super();
+        this.writeStackTrace = writeStackTrace;
+    }
+
+    @Override
+    public boolean accept(GenericType<?> type, MessageBodyWriterContext context) {
+        return false;
+    }
+
+    @Override
+    public Publisher<DataChunk> write(Single<Throwable> content,
+                                      GenericType<? extends Throwable> type,
+                                      MessageBodyWriterContext context) {
+        return content.mapMany(new ThrowableToChunks(context));
+    }
+
+    /**
+     * Creates a new {@link ThrowableBodyWriter}.
+     * @return a new {@link ThrowableBodyWriter}; never {@code null}
+     */
+    public static ThrowableBodyWriter create() {
+        return new ThrowableBodyWriter();
+    }
+
+    private static final class ThrowableToChunks implements Mapper<Throwable, Publisher<DataChunk>> {
+
+        private final MessageBodyWriterContext context;
+
+        ThrowableToChunks(MessageBodyWriterContext context) {
+            super();
+            this.context = context;
+        }
+
+        @Override
+        public Publisher<DataChunk> map(Throwable throwable) {
+            context.contentType(MediaType.TEXT_PLAIN);
+            final Publisher<DataChunk> returnValue;
+            if (throwable == null) {
+                context.contentLength(0);
+                returnValue = Single.<DataChunk>empty();
+            } else {
+                final StringWriter stringWriter = new StringWriter();
+                final PrintWriter printWriter = new PrintWriter(stringWriter);
+                String stackTraceString = null;
+                try {
+                    throwable.printStackTrace(printWriter);
+                    stackTraceString = stringWriter.toString();
+                } finally {
+                    printWriter.close();
+                }
+                assert stackTraceString != null;
+                if (stackTraceString.isEmpty()) {
+                    context.contentLength(0);
+                    returnValue = Single.<DataChunk>empty();
+                } else {
+                    final Charset charset = context.charset();
+                    context.contentLength(stackTraceString.getBytes(charset).length);
+                    returnValue = ContentWriters.writeCharSequence(stackTraceString, charset);
+                }
+            }
+            return returnValue;
+        }
+    }
+
+}

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -75,7 +75,6 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
         private final Charset charset;
 
         private ThrowableToChunks(Charset charset) {
-            super();
             this.charset = charset;
         }
 

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -86,7 +86,7 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
                 context.contentLength(0);
                 returnValue = Single.<DataChunk>empty();
             } else {
-              returnValue = ContentWriters.writeStackTrace(throwable, context, true);
+              returnValue = ContentWriters.writeStackTrace(throwable, context.charset());
             }
             return returnValue;
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Response.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Response.java
@@ -158,6 +158,19 @@ abstract class Response implements ServerResponse {
     }
 
     @Override
+    public Void send(Throwable content) {
+        if (status() == null) {
+            if (content instanceof HttpException) {
+                status(((HttpException) content).status());
+            } else {
+                status(Http.Status.INTERNAL_SERVER_ERROR_500);
+            }
+        }
+        send((Object) content);
+        return null;
+    }
+
+    @Override
     public <T> CompletionStage<ServerResponse> send(T content) {
         try {
             sendLockSupport.execute(() -> {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -109,17 +109,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * @throws IllegalStateException if any {@code send(...)} method was already called
      * @see #send(Object)
      */
-    default Void send(Throwable content) {
-        if (status() == null) {
-            if (content instanceof HttpException) {
-                status(((HttpException) content).status());
-            } else {
-                status(Http.Status.INTERNAL_SERVER_ERROR_500);
-            }
-        }
-        send((Object) content);
-        return null;
-    }
+    Void send(Throwable content);
 
     /**
      * Send a message and close the response.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -100,6 +100,14 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      */
     MessageBodyWriterContext writerContext();
 
+    /**
+     * Send a {@link Throwable} and close the response.
+     *
+     * @param content the {@link Throwable} to send
+     * @throws IllegalArgumentException if there is no registered writer for a given type
+     * @throws IllegalStateException if any {@code send(...)} method was already called
+     * @see #send(Object)
+     */
     default void send(Throwable content) {
         Object status = status();
         if (status == null) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -100,6 +100,18 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      */
     MessageBodyWriterContext writerContext();
 
+    default void send(Throwable content) {
+        Object status = status();
+        if (status == null) {
+            if (content instanceof HttpException) {
+                status(((HttpException) content).status());
+            } else {
+                status(Http.Status.INTERNAL_SERVER_ERROR_500);
+            }
+        }
+        send((Object) content);
+    }
+
     /**
      * Send a message and close the response.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -104,13 +104,13 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * Send a {@link Throwable} and close the response.
      *
      * @param content the {@link Throwable} to send
+     * @return {@code null} when invoked
      * @throws IllegalArgumentException if there is no registered writer for a given type
      * @throws IllegalStateException if any {@code send(...)} method was already called
      * @see #send(Object)
      */
-    default void send(Throwable content) {
-        Object status = status();
-        if (status == null) {
+    default Void send(Throwable content) {
+        if (status() == null) {
             if (content instanceof HttpException) {
                 status(((HttpException) content).status());
             } else {
@@ -118,6 +118,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
             }
         }
         send((Object) content);
+        return null;
     }
 
     /**


### PR DESCRIPTION
This PR, when ready, will add the ability to conveniently send a `Throwable` during HTTP processing.

Signed-off-by: Laird Nelson <laird.nelson@oracle.com>