### PR TITLE
Added libstdc++-6-dev to the image

### DIFF
--- a/etc/dockerfiles/Dockerfile.jdk11-graalvm
+++ b/etc/dockerfiles/Dockerfile.jdk11-graalvm
@@ -50,7 +50,7 @@ FROM debian:stretch-slim as final
 
 RUN set -x \
     && apt-get -y update \
-    && apt-get -y install gcc zlib1g-dev \
+    && apt-get -y install gcc zlib1g-dev libstdc++-6-dev \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log


### PR DESCRIPTION
Fixes https://github.com/oracle/helidon/issues/1383

I've added libstdc++6-dev to the list of packages to install and now my specific native image build passes.