### PR TITLE
Always start test servers on ephemeral port (#1433)

### DIFF
--- a/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
+++ b/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
+++ b/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
@@ -52,7 +52,7 @@ class TestConfiguration {
     @BeforeEach
     void startServer() {
         this.stopServer();
-        final Server.Builder builder = Server.builder();
+        final Server.Builder builder = Server.builder().port(0);
         assertNotNull(builder);
         // The Helidon MicroProfile server implementation uses
         // ConfigProviderResolver#getConfig(ClassLoader) directly

--- a/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
+++ b/integrations/cdi/datasource-hikaricp/src/test/java/io/helidon/integrations/datasource/hikaricp/cdi/TestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
@@ -52,7 +52,7 @@ class TestDataSourceAcquisition {
     @BeforeEach
     void startServer() {
         this.stopServer();
-        final Server.Builder builder = Server.builder();
+        final Server.Builder builder = Server.builder().port(0);
         assertNotNull(builder);
         // The Helidon MicroProfile server implementation uses
         // ConfigProviderResolver#getConfig(ClassLoader) directly

--- a/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
+++ b/integrations/cdi/datasource-ucp/src/test/java/io/helidon/integrations/datasource/ucp/cdi/TestDataSourceAcquisition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/SchedulerConfigTest.java
@@ -38,7 +38,7 @@ class SchedulerConfigTest {
     void testNonDefaultConfig() {
         Server server = null;
         try {
-            server = Server.builder().port(-1).build();
+            server = Server.builder().port(0).build();
             server.start();
 
             CommandScheduler commandScheduler = CommandScheduler.create(8);

--- a/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
+++ b/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
+++ b/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
@@ -58,7 +58,7 @@ public class GrpcServerCdiExtensionIT {
 
     @BeforeAll
     public static void startServer() {
-        server = Server.create().start();
+        server = Server.builder().port(0).build().start();
         beanManager = server.cdiContainer().getBeanManager();
     }
 

--- a/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
+++ b/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServerCdiExtensionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -58,7 +58,7 @@ public class HealthMpServiceIT {
     public static void startServer() throws Exception {
         LogManager.getLogManager().readConfiguration(HealthMpServiceIT.class.getResourceAsStream("/logging.properties"));
 
-        server = Server.create().start();
+        server = Server.builder().port(0).build().start();
 
         client = ClientBuilder.newBuilder()
                 .register(new LoggingFeature(LOGGER, Level.WARNING, LoggingFeature.Verbosity.PAYLOAD_ANY, 500))

--- a/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
+++ b/microprofile/health/src/test/java/io/helidon/microprofile/health/HealthMpServiceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
+++ b/microprofile/jwt-auth/jwt-auth-cdi/src/test/java/io/helidon/microprofile/jwt/auth/cdi/JwtAuthTest.java
@@ -68,7 +68,10 @@ class JwtAuthTest {
 
     @BeforeAll
     static void startServer() {
-        server = Server.create(MyApp.class);
+        server = Server.builder()
+                .port(0)
+                .addApplication(MyApp.class)
+                .build();
         server.start();
 
         client = ClientBuilder.newClient();

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
@@ -54,7 +54,7 @@ class ParallelRunTest {
 
     @Test
     void testParallelRunDisabled() {
-        Server server2 = Server.builder().port(-1).build();
+        Server server2 = Server.builder().port(0).build();
         assertThrows(IllegalStateException.class, server2::start);
     }
 

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ParallelRunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/SequentialRunTest.java
@@ -24,7 +24,7 @@ public class SequentialRunTest {
     @Test
     void testSequentialRun() {
         // sequential must always work, as we do not compete for resources (even on same port)
-        Server server1 = Server.builder().port(-1).build();
+        Server server1 = Server.builder().port(0).build();
         server1.start();
         int port = server1.port();
         server1.stop();

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
@@ -88,6 +88,7 @@ class ServerImplTest {
     @Test
     void testTwoApps() {
         Server server = Server.builder()
+                .port(0)
                 .addApplication("/app1", new TestApplication1())
                 .addApplication("/app2/", new TestApplication2())       // trailing slash ignored
                 .build();

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
@@ -62,6 +62,7 @@ class ServerSseTest {
     @Test
     void testSse() throws Exception {
         Server server = Server.builder()
+                .port(0)
                 .addApplication("/", new TestApplication1())
                 .build();
         server.start();

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Changed all failing tests to explicitly force use of ephemeral ports.