### PR TITLE
Support for @Provider discovery in MP server (#1432)

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -320,7 +320,7 @@ public interface Server {
         private SeContainer createContainer(ClassLoader classLoader) {
             // not in CDI
             Weld initializer = new Weld();
-            initializer.addBeanDefiningAnnotations(Path.class, Provider.class);
+            initializer.addBeanDefiningAnnotations(Path.class);
             initializer.setClassLoader(classLoader);
             Map<String, Object> props = new HashMap<>(config.helidonConfig()
                                                               .get("cdi")

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessInjectionTarget;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
 
 /**
  * Extension to gather JAX-RS application or JAX-RS resource classes
@@ -33,6 +34,7 @@ import javax.ws.rs.core.Application;
  */
 public class ServerCdiExtension implements Extension {
     private final List<Class<?>> resourceClasses = new LinkedList<>();
+    private final List<Class<?>> providerClasses = new LinkedList<>();
     private final List<Class<? extends Application>> applications = new LinkedList<>();
 
     /**
@@ -53,9 +55,12 @@ public class ServerCdiExtension implements Extension {
         if (Application.class.isAssignableFrom(theClass)) {
             this.applications.add((Class<? extends Application>) theClass);
         } else {
-            // still may be a jax-rs resource (with no application attached)
+            // still may be a jax-rs resource or provider (with no application attached)
             if (at.isAnnotationPresent(Path.class)) {
                 this.resourceClasses.add(theClass);
+            }
+            if (at.isAnnotationPresent(Provider.class)) {
+                this.providerClasses.add(theClass);
             }
         }
 
@@ -67,5 +72,9 @@ public class ServerCdiExtension implements Extension {
 
     List<Class<?>> getResourceClasses() {
         return resourceClasses;
+    }
+
+    List<Class<?>> getProviderClasses() {
+        return providerClasses;
     }
 }

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
+++ b/microprofile/tests/arquillian/src/main/java/io/helidon/microprofile/arquillian/ServerRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
 
 import io.helidon.config.Config;
 import io.helidon.microprofile.config.MpConfig;
@@ -85,6 +86,7 @@ class ServerRunner {
         // first create classes end get all applications
         List<Class<?>> applicationClasses = new LinkedList<>();
         List<Class<?>> resourceClasses = new LinkedList<>();
+        List<Class<?>> providerClasses = new LinkedList<>();
 
         for (String className : classNames) {
             try {
@@ -96,6 +98,9 @@ class ServerRunner {
                 } else if (c.isAnnotationPresent(Path.class) && !c.isInterface()) {
                     LOGGER.finest(() -> "Adding resource class: " + c.getName());
                     resourceClasses.add(c);
+                } else if (c.isAnnotationPresent(Provider.class) && !c.isInterface()) {
+                    LOGGER.finest(() -> "Adding provider class: " + c.getName());
+                    providerClasses.add(c);
                 } else {
                     LOGGER.finest(() -> "Class " + c.getName() + " is neither annotated with Path nor an application.");
                 }
@@ -114,6 +119,9 @@ class ServerRunner {
             if (applicationClasses.isEmpty()) {
                 for (Class<?> resourceClass : resourceClasses) {
                     builder.addResourceClass(resourceClass);
+                }
+                for (Class<?> providerClass : providerClasses) {
+                    builder.addProviderClass(providerClass);
                 }
             }
         }

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HeaderAddingFilter.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HeaderAddingFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.ws.services;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Simple CDI-managed filter that should be discovered, configured
+ * and registered automatically.
+ */
+@ApplicationScoped
+@Provider
+public class HeaderAddingFilter implements ContainerResponseFilter {
+    @Inject
+    @ConfigProperty(name = "filter.header.name")
+    private String name;
+
+    @Inject
+    @ConfigProperty(name = "filter.header.value")
+    private String value;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        MultivaluedMap<String, Object> headers = responseContext.getHeaders();
+
+        headers.add(name, value);
+    }
+}

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloException.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,16 @@
  */
 package io.helidon.tests.integration.mp.ws.services;
 
-import io.helidon.microprofile.server.Server;
-
 /**
- * Main class for integration test.
+ * Simple exception class to use with custom exception mapper.
  */
-public class MpServicesMain {
-    public static void main(String[] args) {
-        startTheServer();
-    }
-
-    static Server startTheServer() {
-        return Server.builder()
-                // need to register this one explicitly in order to avoid
-                // generic type argument erasure by Weld proxy
-                .addProviderClass(HtmlWriter.class)
-                .build()
-                .start();
+public class HelloException extends RuntimeException {
+    /**
+     * Construct HelloException instance.
+     *
+     * @param message error message
+     */
+    public HelloException(String message) {
+        super(message);
     }
 }

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloExceptionMapper.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.ws.services;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_IMPLEMENTED;
+
+/**
+ * Simple CDI-managed exception mapper that should be discovered,
+ * configured and registered automatically.
+ */
+@ApplicationScoped
+@Provider
+public class HelloExceptionMapper implements ExceptionMapper<HelloException> {
+    @Inject
+    @ConfigProperty(name = "exception.upercase", defaultValue = "true")
+    private boolean fUppercase;
+
+    @Override
+    public Response toResponse(HelloException exception) {
+        String message = fUppercase
+                ? exception.getMessage().toUpperCase()
+                : exception.getMessage();
+
+        return Response.status(CREATED).entity(message).build();
+    }
+}

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloResource.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HelloResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,28 @@
  */
 package io.helidon.tests.integration.mp.ws.services;
 
-import io.helidon.microprofile.server.Server;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 
 /**
- * Main class for integration test.
+ * Simple resource that tests explicit resource registration.
  */
-public class MpServicesMain {
-    public static void main(String[] args) {
-        startTheServer();
+@ApplicationScoped
+@Path("/hello")
+public class HelloResource {
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public String sayHello() {
+        return "Hello";
     }
 
-    static Server startTheServer() {
-        return Server.builder()
-                // need to register this one explicitly in order to avoid
-                // generic type argument erasure by Weld proxy
-                .addProviderClass(HtmlWriter.class)
-                .build()
-                .start();
+    @GET
+    @Path("error")
+    public String error() {
+        throw new HelloException("hello error");
     }
 }

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HtmlWriter.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/HtmlWriter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.mp.ws.services;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static javax.interceptor.Interceptor.Priority.APPLICATION;
+
+/**
+ * Simple message body writer for HTML content.
+ */
+// can't make it ApplicationScoped yet as it needs to be registered explicitly
+// using Dependent scope in order to avoid generic type argument erasure by Weld proxy
+//@ApplicationScoped
+@Provider
+@Produces(MediaType.TEXT_HTML)
+public class HtmlWriter implements MessageBodyWriter<String> {
+
+    @Inject
+    @ConfigProperty(name = "html.tag")
+    private String tag;
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return String.class.equals(type) && MediaType.TEXT_HTML_TYPE.equals(mediaType);
+    }
+
+    @Override
+    public void writeTo(String s,
+                        Class<?> type,
+                        Type genericType,
+                        Annotation[] annotations,
+                        MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream out) throws IOException, WebApplicationException {
+        Writer writer = new OutputStreamWriter(out);
+        writer.write('<');
+        writer.write(tag);
+        writer.write('>');
+        writer.write(s);
+        writer.write("</");
+        writer.write(tag);
+        writer.write('>');
+        writer.flush();
+        writer.close();
+    }
+}

--- a/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/MpServicesMain.java
+++ b/tests/integration/mp-ws-services/src/main/java/io/helidon/tests/integration/mp/ws/services/MpServicesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/mp-ws-services/src/main/resources/application.yaml
+++ b/tests/integration/mp-ws-services/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/mp-ws-services/src/main/resources/application.yaml
+++ b/tests/integration/mp-ws-services/src/main/resources/application.yaml
@@ -35,3 +35,11 @@ io.helidon.tests.integration.mp.ws.services:
       path: "/jaxrs"
 
 app.message: "message"
+
+filter:
+  header:
+    name: "X-Foo"
+    value: "bar"
+
+html:
+  tag: "h1"

--- a/tests/integration/mp-ws-services/src/test/java/io/helidon/tests/integration/mp/ws/services/MpServicesTest.java
+++ b/tests/integration/mp-ws-services/src/test/java/io/helidon/tests/integration/mp/ws/services/MpServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds support for manual registration of providers (via Builder), as well as automatic discovery and registration of CDI beans with `@Provider` annotation