### PR TITLE
Grpc java upgrade for 1.x

### DIFF
--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
@@ -63,7 +63,7 @@ public class EtcdV3Client implements EtcdClient {
      */
     public EtcdV3Client(URI uri) {
         ManagedChannelBuilder mcb = ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort());
-        this.channel = mcb.usePlaintext(true).build();
+        this.channel = mcb.usePlaintext().build();
 
         kvStub = KVGrpc.newBlockingStub(channel);
         watchStub = WatchGrpc.newStub(channel);

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.5</version.lib.google-api-client>
         <version.lib.graalvm>19.2.0</version.lib.graalvm>
-        <version.lib.grpc>1.25.0</version.lib.grpc>
+        <version.lib.grpc>1.27.1</version.lib.grpc>
         <version.lib.guava>28.1-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/grpc/io.grpc/src/main/java9/module-info.java
+++ b/grpc/io.grpc/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/io.grpc/src/main/java9/module-info.java
+++ b/grpc/io.grpc/src/main/java9/module-info.java
@@ -27,7 +27,6 @@ module io.grpc {
     requires java.naming;
 
     requires static com.google.common;
-    requires static error.prone.annotations;
 
     uses io.grpc.ManagedChannelProvider;
     uses io.grpc.NameResolverProvider;


### PR DESCRIPTION
Follow up to upgrade netty also in transitive dependencies.