### PR TITLE
Reimplement ConcatPublisher + TCK tests

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/ConcatPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/ConcatPublisher.java
@@ -17,26 +17,20 @@
 
 package io.helidon.common.reactive;
 
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Concat streams to one.
  *
  * @param <T> item type
  */
-public class ConcatPublisher<T> implements Flow.Publisher<T>, Multi<T> {
-    private FirstSubscriber firstSubscriber;
-    private SecondSubscriber secondSubscriber;
-    private Flow.Subscriber<T> subscriber;
-    private Flow.Publisher<T> firstPublisher;
-    private Flow.Publisher<T> secondPublisher;
-    private RequestedCounter requested = new RequestedCounter(true);
-    private ReentrantLock firstPublisherCompleteLock = new ReentrantLock();
-    private CompletableFuture<Void> firstSubscriberCompleted = new CompletableFuture<>();
-    private CompletableFuture<Flow.Subscriber<T>> downstreamReady = new CompletableFuture<>();
+public final class ConcatPublisher<T> implements Flow.Publisher<T>, Multi<T> {
+    private final Flow.Publisher<T> firstPublisher;
+    private final Flow.Publisher<T> secondPublisher;
 
     private ConcatPublisher(Flow.Publisher<T> firstPublisher, Flow.Publisher<T> secondPublisher) {
         this.firstPublisher = firstPublisher;
@@ -44,130 +38,152 @@ public class ConcatPublisher<T> implements Flow.Publisher<T>, Multi<T> {
     }
 
     /**
-     * Create new {@link ConcatPublisher}.
+     * Create new {@code ConcatPublisher}.
      *
      * @param firstPublisher  first stream
      * @param secondPublisher second stream
      * @param <T>             item type
-     * @return {@link ConcatPublisher}
+     * @return {@code ConcatPublisher}
      */
     public static <T> ConcatPublisher<T> create(Flow.Publisher<T> firstPublisher, Flow.Publisher<T> secondPublisher) {
         return new ConcatPublisher<>(firstPublisher, secondPublisher);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void subscribe(Flow.Subscriber<? super T> subscriber) {
-        this.subscriber = (Flow.Subscriber<T>) subscriber;
+        ConcatCancelingSubscription<T> parent = new ConcatCancelingSubscription<>(subscriber, firstPublisher, secondPublisher);
+        subscriber.onSubscribe(parent);
+        parent.drain();
+    }
 
-        this.firstSubscriber = new FirstSubscriber();
-        this.secondSubscriber = new SecondSubscriber();
+    static final class ConcatCancelingSubscription<T>
+            extends AtomicInteger implements Flow.Subscription {
 
-        firstPublisher.subscribe(firstSubscriber);
+        private static final long serialVersionUID = -1593224722447706944L;
 
-        subscriber.onSubscribe(new Flow.Subscription() {
-            @Override
-            public void request(long n) {
-                if (!StreamValidationUtils.checkRequestParam(n, subscriber::onError)) {
-                    return;
-                }
-                requested.increment(n, subscriber::onError);
-                firstCompleteLock(() -> {
-                    if (!firstSubscriber.complete) {
-                        firstSubscriber.subscription.request(n);
-                    } else {
-                        secondSubscriber.subscription.request(n);
+        private final InnerSubscriber<T> inner1;
+
+        private final InnerSubscriber<T> inner2;
+
+        private final AtomicBoolean canceled;
+
+        private transient Flow.Publisher<T> source1;
+
+        private transient Flow.Publisher<T> source2;
+
+        private int index;
+
+        ConcatCancelingSubscription(Flow.Subscriber<? super T> subscriber,
+                                    Flow.Publisher<T> source1, Flow.Publisher<T> source2) {
+            this.inner1 = new InnerSubscriber<>(subscriber, this);
+            this.inner2 = new InnerSubscriber<>(subscriber, this);
+            this.canceled = new AtomicBoolean();
+            this.source1 = source1;
+            this.source2 = source2;
+        }
+
+        @Override
+        public void request(long n) {
+            SubscriptionHelper.deferredRequest(inner2, inner2.requested, n);
+            SubscriptionHelper.deferredRequest(inner1, inner1.requested, n);
+        }
+
+        @Override
+        public void cancel() {
+            if (canceled.compareAndSet(false, true)) {
+                SubscriptionHelper.cancel(inner1);
+                SubscriptionHelper.cancel(inner2);
+                drain();
+            }
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            for (;;) {
+
+                if (index == 0) {
+                    index = 1;
+                    Flow.Publisher<T> source = source1;
+                    source1 = null;
+                    source.subscribe(inner1);
+                } else if (index == 1) {
+                    index = 2;
+                    Flow.Publisher<T> source = source2;
+                    source2 = null;
+                    if (inner1.produced != 0L) {
+                        SubscriptionHelper.produced(inner2.requested, inner1.produced);
                     }
-                });
+                    source.subscribe(inner2);
+                } else if (index == 2) {
+                    index = 3;
+                    if (!canceled.get()) {
+                        inner1.downstream.onComplete();
+                    }
+                }
+
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+
+        static final class InnerSubscriber<T> extends AtomicReference<Flow.Subscription>
+                implements Flow.Subscriber<T> {
+
+            private static final long serialVersionUID = 3029954591185720794L;
+
+            private final Flow.Subscriber<? super T> downstream;
+
+            private final ConcatCancelingSubscription<T> parent;
+
+            private final AtomicLong requested;
+
+            private long produced;
+
+            InnerSubscriber(Flow.Subscriber<? super T> downstream, ConcatCancelingSubscription<T> parent) {
+                this.downstream = downstream;
+                this.parent = parent;
+                this.requested = new AtomicLong();
             }
 
             @Override
-            public void cancel() {
-                firstSubscriber.subscription.cancel();
-                secondSubscriber.subscription.cancel();
+            public void onSubscribe(Flow.Subscription s) {
+                SubscriptionHelper.deferredSetOnce(this, requested, s);
             }
-        });
-        downstreamReady.complete(this.subscriber);
-    }
 
-    private class FirstSubscriber implements Flow.Subscriber<T> {
-
-        private Flow.Subscription subscription;
-        private boolean complete = false;
-
-        @Override
-        public void onSubscribe(Flow.Subscription subscription) {
-            Objects.requireNonNull(subscription);
-            this.subscription = subscription;
-            secondPublisher.subscribe(secondSubscriber);
-        }
-
-        @Override
-        public void onNext(T o) {
-            requested.tryDecrement();
-            ConcatPublisher.this.subscriber.onNext(o);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            firstCompleteLock(() -> complete = true);
-            secondSubscriber.subscription.cancel();
-            subscription.cancel();
-            ConcatPublisher.this.subscriber.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            firstSubscriberCompleted.complete(null);
-            firstCompleteLock(() -> complete = true);
-            try {
-                requested.lock();
-                long n = requested.get();
-                if (n > 0) {
-                    secondSubscriber.subscription.request(n);
+            @Override
+            public void onNext(T t) {
+                if (get() != SubscriptionHelper.CANCELED) {
+                    produced++;
+                    downstream.onNext(t);
                 }
-            } finally {
-                requested.unlock();
             }
-        }
-    }
 
-    private class SecondSubscriber implements Flow.Subscriber<T> {
+            @Override
+            public void onError(Throwable t) {
+                if (get() != SubscriptionHelper.CANCELED) {
+                    lazySet(SubscriptionHelper.CANCELED);
+                    downstream.onError(t);
 
-        private Flow.Subscription subscription;
+                    parent.cancel();
+                } else {
+                    // FIXME
+                    //  HelidonReactivePlugins.onError(t);
+                }
+            }
 
-        @Override
-        public void onSubscribe(Flow.Subscription subscription) {
-            Objects.requireNonNull(subscription);
-            this.subscription = subscription;
-        }
-
-        @Override
-        public void onNext(T o) {
-            ConcatPublisher.this.subscriber.onNext(o);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            firstSubscriber.subscription.cancel();
-            subscription.cancel();
-            ConcatPublisher.this.subscriber.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            downstreamReady.whenComplete((downStreamSubscriber, th) -> {
-                firstSubscriberCompleted.whenComplete((aVoid, t) -> ConcatPublisher.this.subscriber.onComplete());
-            });
-        }
-    }
-
-    private void firstCompleteLock(Runnable runnable) {
-        try {
-            firstPublisherCompleteLock.lock();
-            runnable.run();
-        } finally {
-            firstPublisherCompleteLock.unlock();
+            @Override
+            public void onComplete() {
+                if (get() != SubscriptionHelper.CANCELED) {
+                    lazySet(SubscriptionHelper.CANCELED);
+                    parent.drain();
+                }
+            }
         }
     }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SubscriptionHelper.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SubscriptionHelper.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Helper enum with a singleton cancellation indicator and utility methods to perform
+ * atomic actions on {@link Flow.Subscription}s.
+ */
+enum SubscriptionHelper implements Flow.Subscription {
+    /**
+     * The singleton instance indicating a canceled subscription.
+     */
+    CANCELED;
+
+    @Override
+    public void request(long n) {
+        // deliberately no-op.
+    }
+
+    @Override
+    public void cancel() {
+        // deliberately no-op
+    }
+
+    /**
+     * Atomically add the given request amount to the field while capping it at
+     * {@link Long#MAX_VALUE}.
+     * @param field the target field to update
+     * @param n the request amount to add, must be positive (not verified)
+     * @return the new request amount after the operation
+     */
+    public static long addRequest(AtomicLong field, long n) {
+        for (;;) {
+            long current = field.get();
+            if (current == Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            long update = current + n;
+            if (update < 0L) {
+                update = Long.MAX_VALUE;
+            }
+            if (field.compareAndSet(current, update)) {
+                return update;
+            }
+        }
+    }
+
+    /**
+     * Atomically subtract the given number from the field if that field is not already
+     * at {@link Long#MAX_VALUE} and return the new value.
+     * @param field the target field to update
+     * @param n the number to subtract
+     * @return the new value after the subtraction
+     * @throws IllegalStateException if n is bigger than the field's value, which indicates an operator bug
+     */
+    public static long produced(AtomicLong field, long n) {
+        for (;;) {
+            long current = field.get();
+            if (current == Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            long update = current - n;
+            if (update < 0L) {
+                throw new IllegalStateException("More produced than requested: " + update);
+            }
+            if (field.compareAndSet(current, update)) {
+                return update;
+            }
+        }
+    }
+
+    /**
+     * Atomically sets the only upstream subscription in the field and then requests
+     * the amount accumulated in the requestedField.
+     * @param subscriptionField the field to store the only upstream subscription
+     * @param requestedField the request amounts accumulated so far
+     * @param upstream the only upstream to set and request from
+     * @return true if the operation succeeded, false if the field indicated the upstream
+     *         should be cancelled immediately
+     * @throws IllegalStateException if the subscriptionField already contains a non-canceled subscription instance
+     */
+    public static boolean deferredSetOnce(AtomicReference<Flow.Subscription> subscriptionField,
+                                          AtomicLong requestedField, Flow.Subscription upstream) {
+        Objects.requireNonNull(upstream);
+        for (;;) {
+            Flow.Subscription current = subscriptionField.get();
+            if (current == CANCELED) {
+                upstream.cancel();
+                return false;
+            }
+            if (current != null) {
+                upstream.cancel();
+                throw new IllegalStateException("Flow.Subscription already set.");
+            }
+
+            if (subscriptionField.compareAndSet(null, upstream)) {
+                long requested = requestedField.getAndSet(0L);
+                if (requested != 0L) {
+                    upstream.request(requested);
+                }
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Accumulates request amounts until the subscription field receives a Subscription instance,
+     * then requests this accumulated amount and forwards subsequent requests to it.
+     * @param subscriptionField the field possibly containing a Subscription instance.
+     * @param requestedField the field used for accumulating requests until the Subscription instance arrives
+     * @param n the request amount to accumulate or forward
+     */
+    public static void deferredRequest(AtomicReference<Flow.Subscription> subscriptionField,
+                                       AtomicLong requestedField, long n) {
+        Flow.Subscription subscription = subscriptionField.get();
+        if (subscription != null) {
+            subscription.request(n);
+        } else {
+            addRequest(requestedField, n);
+            subscription = subscriptionField.get();
+            if (subscription != null) {
+                long toRequest = requestedField.getAndSet(0L);
+                if (toRequest != 0L) {
+                    subscription.request(toRequest);
+                }
+            }
+        }
+    }
+
+    /**
+     * Atomically swap in the {@link #CANCELED} instance and call cancel() on
+     * any previous Subscription held.
+     * @param subscriptionField the target field to cancel atomically.
+     * @return true if the current thread succeeded with the cancellation (as only one thread is able to)
+     */
+    public static boolean cancel(AtomicReference<Flow.Subscription> subscriptionField) {
+        Flow.Subscription subscription = subscriptionField.get();
+        if (subscription != CANCELED) {
+            subscription = subscriptionField.getAndSet(CANCELED);
+            if (subscription != CANCELED) {
+                if (subscription != null) {
+                    subscription.cancel();
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if current is null and incoming is not null.
+     * @param current the current subscription, should be null
+     * @param incoming the incoming subscription, should be non-null
+     * @throws IllegalStateException if current is not-null indicating a bug in an operator calling onSubscribe
+     *                               more than once
+     */
+    public static void validate(Flow.Subscription current, Flow.Subscription incoming) {
+        Objects.requireNonNull(incoming);
+        if (current != null) {
+            incoming.cancel();
+            throw new IllegalStateException("Flow.Subscription already set.");
+        }
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/ConcatPublisher2TckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/ConcatPublisher2TckTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class ConcatPublisher2TckTest extends FlowPublisherVerification<Integer> {
+
+    public ConcatPublisher2TckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long n) {
+        int firstHalf = (int)Math.min(n, 1); // trigger the switch to the 2nd source early
+        return ConcatPublisher.create(
+                Multi.from(() -> IntStream.range(0, firstHalf).boxed().iterator()),
+                Multi.from(() -> IntStream.range(firstHalf, (int)n).boxed().iterator())
+        );
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/ConcatPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/ConcatPublisherTckTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.FlowAdapters;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class ConcatPublisherTckTest extends FlowPublisherVerification<Integer> {
+
+    public ConcatPublisherTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long n) {
+        int firstHalf = (int)(n / 2);
+        return ConcatPublisher.create(
+                Multi.from(() -> IntStream.range(0, firstHalf).boxed().iterator()),
+                Multi.from(() -> IntStream.range(firstHalf, (int)n).boxed().iterator())
+        );
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/GraphBuilder.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/GraphBuilder.java
@@ -17,6 +17,9 @@
 
 package io.helidon.microprofile.reactive;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -336,5 +339,15 @@ final class GraphBuilder extends HashMap<Class<? extends Stage>, Consumer<Stage>
     private <S extends Stage> GraphBuilder registerStage(Class<S> stageType, Consumer<S> consumer) {
         this.put(stageType, (Consumer<Stage>) consumer);
         return this;
+    }
+
+    private void writeObject(ObjectOutputStream stream)
+            throws IOException {
+        stream.defaultWriteObject();
+    }
+
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
     }
 }


### PR DESCRIPTION
Reimplement `io.helidon.common.reactive.ConcatPublisher` so it works as a properly reusable `Flow.Publisher`.

Fresh start due to master changes.