### PR TITLE
Reimplement Single.map + TCK test

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
@@ -56,9 +56,8 @@ final class MultiMapperPublisher<T, R> implements Multi<R> {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(this.upstream, subscription);
             this.upstream = subscription;
-            // FIXME onSubscribe(subscription) should work too, but there are bugs in other
-            //  pre-existing operators preventing the TCK from passing without this
             downstream.onSubscribe(this);
         }
 

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -44,6 +44,7 @@ public interface Single<T> extends Subscribable<T> {
      * @throws NullPointerException if mapper is {@code null}
      */
     default <U> Single<U> map(Mapper<T, U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
         return new SingleMapperPublisher<>(this, mapper);
     }
 

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -44,9 +44,7 @@ public interface Single<T> extends Subscribable<T> {
      * @throws NullPointerException if mapper is {@code null}
      */
     default <U> Single<U> map(Mapper<T, U> mapper) {
-        SingleMappingProcessor<T, U> processor = new SingleMappingProcessor<>(mapper);
-        this.subscribe(processor);
-        return processor;
+        return new SingleMapperPublisher<>(this, mapper);
     }
 
     /**

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.concurrent.Flow;
+
+import io.helidon.common.mapper.Mapper;
+
+/**
+ * Maps the upstream item via a {@link Mapper} function.
+ * @param <T> the upstream value type
+ * @param <R> the result value type
+ */
+final class SingleMapperPublisher<T, R> implements Single<R> {
+
+    private final Flow.Publisher<T> source;
+
+    private final Mapper<T, R> mapper;
+
+    SingleMapperPublisher(Flow.Publisher<T> source, Mapper<T, R> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super R> subscriber) {
+        source.subscribe(new MultiMapperPublisher.MapperSubscriber<>(subscriber, mapper));
+    }
+
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleMapperPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleMapperPublisherTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+public class SingleMapperPublisherTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleMapperPublisherTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long n) {
+        return Single.just(1)
+                .map(v -> v + 1);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -172,7 +172,7 @@ public class SingleTest {
         SingleTestSubscriber<String> subscriber = new SingleTestSubscriber<>();
         Single.just("bar").map((s) -> (String)null).subscribe(subscriber);
         assertThat(subscriber.isComplete(), is(equalTo(false)));
-        assertThat(subscriber.getLastError(), is(instanceOf(IllegalStateException.class)));
+        assertThat(subscriber.getLastError(), is(instanceOf(NullPointerException.class)));
         assertThat(subscriber.getItems(), is(empty()));
     }
 


### PR DESCRIPTION
It can simply delegate to the `MapperSubscriber` used for `Multi.map`.

Related: #1455