### PR TITLE
Rewrite collect, add juc.Collector overload + TCK tests

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/DeferredScalarSubscription.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/DeferredScalarSubscription.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Buffers a single item and emits it to the downstream when it requests.
+ * @param <T> the item type buffered
+ */
+class DeferredScalarSubscription<T> extends AtomicInteger implements Flow.Subscription {
+
+    private final Flow.Subscriber<? super T> downstream;
+
+    private T value;
+
+    static final int NO_VALUE_NO_REQUEST = 0;
+    static final int NO_VALUE_HAS_REQUEST = 1;
+    static final int HAS_VALUE_NO_REQUEST = 2;
+    static final int HAS_VALUE_HAS_REQUEST = 3;
+    static final int COMPLETE = 4;
+    static final int CANCELED = 5;
+
+    DeferredScalarSubscription(Flow.Subscriber<? super T> downstream) {
+        this.downstream = downstream;
+    }
+
+    @Override
+    public void cancel() {
+        if (getAndSet(CANCELED) != CANCELED) {
+            value = null;
+        }
+    }
+
+    @Override
+    public void request(long n) {
+        if (n <= 0L) {
+            if (getAndSet(CANCELED) != CANCELED) {
+                downstream.onError(
+                        new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden"));
+            }
+        } else {
+            for (;;) {
+                int state = get();
+                if (state == HAS_VALUE_NO_REQUEST) {
+                    T v = value;
+                    value = null;
+                    if (compareAndSet(HAS_VALUE_NO_REQUEST, HAS_VALUE_HAS_REQUEST)) {
+                        downstream.onNext(v);
+                        if (compareAndSet(HAS_VALUE_HAS_REQUEST, COMPLETE)) {
+                            downstream.onComplete();
+                        }
+                        break;
+                    }
+                } else if (state == NO_VALUE_NO_REQUEST) {
+                    if (compareAndSet(NO_VALUE_NO_REQUEST, NO_VALUE_HAS_REQUEST)) {
+                        break;
+                    }
+                } else {
+                    // state == COMPLETE
+                    // state == HAS_VALUE_HAS_REQUEST
+                    // state == NO_VALUE_HAS_REQUEST
+                    // state == CANCELED
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Signal the only item if possible or save it for later when there
+     * is a request for it.
+     * <p>
+     *     This method should be called at most once and from only one thread.
+     * </p>
+     * @param item the item to signal and then complete the downstream
+     */
+    public void complete(T item) {
+        for (;;) {
+            int state = get();
+            if (state == NO_VALUE_HAS_REQUEST) {
+                if (compareAndSet(NO_VALUE_HAS_REQUEST, HAS_VALUE_HAS_REQUEST)) {
+                    downstream.onNext(item);
+                    if (compareAndSet(HAS_VALUE_HAS_REQUEST, COMPLETE)) {
+                        downstream.onComplete();
+                    }
+                    break;
+                }
+            } else if (state == NO_VALUE_NO_REQUEST) {
+                value = item;
+                if (compareAndSet(NO_VALUE_NO_REQUEST, HAS_VALUE_NO_REQUEST)) {
+                    break;
+                }
+                value = null;
+            } else {
+                // state == COMPLETE
+                // state == HAS_VALUE_NO_REQUEST
+                // state == HAS_VALUE_HAS_REQUEST
+                // state == CANCELED
+                break;
+            }
+        }
+    }
+
+    protected final Flow.Subscriber<? super T> downstream() {
+        return downstream;
+    }
+
+    // Workaround for SpotBugs, Flow classes should never get serialized
+    private void writeObject(ObjectOutputStream stream)
+            throws IOException {
+        stream.defaultWriteObject();
+    }
+
+    // Workaround for SpotBugs, Flow classes should never get serialized
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+    }
+
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiCollectPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiCollectPublisher.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Collects up upstream items with the help of a collection supplier
+ * and a collection+item combiner.
+ * @param <T> the element type of the upstream
+ * @param <U> the collection type
+ */
+final class MultiCollectPublisher<T, U> implements Single<U> {
+
+    private final Multi<T> source;
+
+    private final Supplier<U> collectionSupplier;
+
+    private final BiConsumer<U, T> accumulator;
+
+    MultiCollectPublisher(Multi<T> source, Supplier<U> collectionSupplier, BiConsumer<U, T> combiner) {
+        this.source = source;
+        this.collectionSupplier = collectionSupplier;
+        this.accumulator = combiner;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super U> subscriber) {
+        U collection;
+        try {
+            collection = Objects.requireNonNull(collectionSupplier.get(),
+                    "The collectionSupplier returned a null value");
+        } catch (Throwable ex) {
+            subscriber.onSubscribe(EmptySubscription.INSTANCE);
+            subscriber.onError(ex);
+            return;
+        }
+
+        source.subscribe(new CollectSubscriber<>(subscriber, collection, accumulator));
+    }
+
+    static final class CollectSubscriber<T, U> extends DeferredScalarSubscription<U> implements Flow.Subscriber<T> {
+
+        private U collection;
+
+        private final BiConsumer<U, T> accumulator;
+
+        private Flow.Subscription upstream;
+
+        CollectSubscriber(Flow.Subscriber<? super U> downstream, U collection, BiConsumer<U, T> accumulator) {
+            super(downstream);
+            this.collection = collection;
+            this.accumulator = accumulator;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            this.upstream = subscription;
+            downstream().onSubscribe(this);
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            Flow.Subscription s = upstream;
+            U c = collection;
+            if (s != SubscriptionHelper.CANCELED && c != null) {
+                try {
+                    accumulator.accept(c, item);
+                } catch (Throwable ex) {
+                    super.cancel();
+                    s.cancel();
+                    onError(ex);
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                collection = null;
+                upstream = SubscriptionHelper.CANCELED;
+                downstream().onError(throwable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                U c = collection;
+                collection = null;
+                upstream = SubscriptionHelper.CANCELED;
+                if (c != null) {
+                    complete(c);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            collection = null;
+            super.cancel();
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELED;
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiCollectorPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiCollectorPublisher.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+/**
+ * Collects up upstream items with the help of a the callbacks of
+ * a {@link java.util.stream.Collector}.
+ * <p>
+ *     Unlike {@link MultiCollectPublisher}, the initial accumulator
+ *     value is retrieved when the upstream signals onSubscribe so
+ *     that the operator behaves as Microprofile Reactive Streams
+ *     expects it to.
+ * </p>
+ * @param <T> the element type of the upstream
+ * @param <A> the collection type
+ * @param <R> the result type
+ */
+final class MultiCollectorPublisher<T, A, R> implements Single<R> {
+
+    private final Multi<T> source;
+
+    private final Collector<T, A, R> collector;
+
+    MultiCollectorPublisher(Multi<T> source, Collector<T, A, R> collector) {
+        this.source = source;
+        this.collector = collector;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super R> subscriber) {
+        Supplier<A> collectionSupplier;
+        BiConsumer<A, T> accumulator;
+        Function<A, R> finisher;
+        try {
+            collectionSupplier = Objects.requireNonNull(collector.supplier(),
+                    "The collector.supplier returned a null value");
+            accumulator = Objects.requireNonNull(collector.accumulator(),
+                    "The collector.accumulator returned a null value");
+            finisher = Objects.requireNonNull(collector.finisher(),
+                    "The collector.finisher returned a null value");
+        } catch (Throwable ex) {
+            subscriber.onSubscribe(EmptySubscription.INSTANCE);
+            subscriber.onError(ex);
+            return;
+        }
+
+        source.subscribe(new CollectSubscriber<>(subscriber, collectionSupplier, accumulator, finisher));
+    }
+
+    static final class CollectSubscriber<T, A, R> extends DeferredScalarSubscription<R> implements Flow.Subscriber<T> {
+
+        private A collection;
+
+        private final Supplier<A> collectionSupplier;
+
+        private final BiConsumer<A, T> accumulator;
+
+        private final Function<A, R> finisher;
+
+        private Flow.Subscription upstream;
+
+        CollectSubscriber(Flow.Subscriber<? super R> downstream,
+                          Supplier<A> collectionSupplier, BiConsumer<A, T> accumulator,
+                          Function<A, R> finisher) {
+            super(downstream);
+            this.collectionSupplier = collectionSupplier;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            this.upstream = subscription;
+            try {
+                collection = collectionSupplier.get();
+            } catch (Throwable ex) {
+                subscription.cancel();
+                downstream().onSubscribe(EmptySubscription.INSTANCE);
+                downstream().onError(ex);
+                return;
+            }
+            downstream().onSubscribe(this);
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            Flow.Subscription s = upstream;
+            A c = collection;
+            if (s != SubscriptionHelper.CANCELED && c != null) {
+                try {
+                    accumulator.accept(c, item);
+                } catch (Throwable ex) {
+                    super.cancel();
+                    s.cancel();
+                    onError(ex);
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                collection = null;
+                upstream = SubscriptionHelper.CANCELED;
+                downstream().onError(throwable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                A c = collection;
+                collection = null;
+                upstream = SubscriptionHelper.CANCELED;
+                if (c != null) {
+                    R result;
+                    try {
+                        result = Objects.requireNonNull(finisher.apply(c),
+                                "The finisher returned a null value");
+                    } catch (Throwable ex) {
+                        downstream().onError(ex);
+                        return;
+                    }
+
+                    complete(result);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            collection = null;
+            super.cancel();
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELED;
+        }
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectTckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class MultiCollectTckTest extends FlowPublisherVerification<List<Integer>> {
+
+    public MultiCollectTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<List<Integer>> createFlowPublisher(long l) {
+        return Multi.from(() -> IntStream.range(0, (int)l).boxed().iterator()).collectList();
+    }
+
+    @Override
+    public Flow.Publisher<List<Integer>> createFailedFlowPublisher() {
+        return Multi.from(() -> { throw new RuntimeException(); });
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class MultiCollectTest {
+
+    @Test
+    public void collectionSupplierNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collect(() -> null, (a, b) -> { })
+        .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectionSupplierCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collect(() -> {throw new IllegalArgumentException(); }, (a, b) -> { })
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectorTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectorTckTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Test
+public class MultiCollectorTckTest extends FlowPublisherVerification<List<Integer>> {
+
+    public MultiCollectorTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<List<Integer>> createFlowPublisher(long l) {
+        return Multi.from(() -> IntStream.range(0, (int)l).boxed().iterator()).collectStream(Collectors.toList());
+    }
+
+    @Override
+    public Flow.Publisher<List<Integer>> createFailedFlowPublisher() {
+        return Multi.from(() -> { throw new RuntimeException(); });
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectorTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiCollectorTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public class MultiCollectorTest {
+
+    @Test
+    public void collectionSupplierCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(Collector.of(
+                        () -> { throw new IllegalArgumentException(); },
+                        (a, b) -> { },
+                        (a, b) -> a,
+                        a -> a
+                ))
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void accumulatorCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(Collector.of(
+                        () -> 0,
+                        (a, b) -> { throw new IllegalArgumentException(); },
+                        (a, b) -> a,
+                        a -> a
+                ))
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void finisherCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(Collector.of(
+                        () -> 0,
+                        (a, b) -> { },
+                        (a, b) -> a,
+                        a -> { throw new IllegalArgumentException(); }
+                ))
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void finisherNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(Collector.of(
+                        () -> 0,
+                        (a, b) -> { },
+                        (a, b) -> a,
+                        a -> null
+                ))
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void upstreamError() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.error(new IllegalArgumentException())
+                .collectStream(Collectors.toList())
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorCrashSupplier() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                throw new IllegalArgumentException();
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                return (a,b) -> { };
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                return a -> a;
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorNullSupplier() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                return null;
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                return (a,b) -> { };
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                return a -> a;
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorCrashAccumulator() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                return () -> 0;
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                throw new IllegalArgumentException();
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                return a -> a;
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorNullAccumulator() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                return () -> 0;
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                return null;
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                return a -> a;
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorCrashFinisher() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                return () -> 0;
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                return (a, b) -> { };
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                throw new IllegalArgumentException();
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void collectorNullFinisher() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(1)
+                .collectStream(
+                        new Collector<Integer, Object, Object>() {
+
+                            @Override
+                            public Supplier<Object> supplier() {
+                                return () -> 0;
+                            }
+
+                            @Override
+                            public BiConsumer<Object, Integer> accumulator() {
+                                return (a, b) -> { };
+                            }
+
+                            @Override
+                            public BinaryOperator<Object> combiner() {
+                                return (a, b) -> a;
+                            }
+
+                            @Override
+                            public Function<Object, Object> finisher() {
+                                return null;
+                            }
+
+                            @Override
+                            public Set<Characteristics> characteristics() {
+                                return Collections.emptySet();
+                            }
+                        }
+                )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -429,7 +429,8 @@ public class MultiTest {
         CompletableFuture<Throwable> beenError = new CompletableFuture<>();
         Multi.<Integer>error(new RuntimeException())
                 .onError(beenError::complete)
-                .collectList();
+                .collectList()
+                .subscribe(e -> { });
 
         beenError.get(1, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
Reimplement `Multi.collect` and delegate the old `collect(Collector)` and `collectList()` to it. In addition, implement `collectStream` with `java.util.stream.Collector` support.

Related #1455.