### PR TITLE
Reimplement Multi.just(T[]), add Multi.singleton(T) + TCK

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -243,7 +243,7 @@ public interface Multi<T> extends Subscribable<T> {
      * @param <T>   item type
      * @param items items to publish
      * @return Multi
-     * @throws NullPointerException if items is {@code null}
+     * @throws NullPointerException if {@code items} is {@code null}
      */
     static <T> Multi<T> just(Collection<T> items) {
         return Multi.from(items);
@@ -255,11 +255,29 @@ public interface Multi<T> extends Subscribable<T> {
      * @param <T>   item type
      * @param items items to publish
      * @return Multi
-     * @throws NullPointerException if items is {@code null}
+     * @throws NullPointerException if {@code items} is {@code null}
      */
     @SafeVarargs
     static <T> Multi<T> just(T... items) {
-        return Multi.from(List.of(items));
+        if (items.length == 0) {
+            return empty();
+        }
+        if (items.length == 1) {
+            return singleton(items[0]);
+        }
+        return new MultiFromArrayPublisher<>(items);
+    }
+
+    /**
+     * Create a {@link Multi} that emits a pre-existing item and then completes.
+     * @param item the item to emit.
+     * @param <T> the type of the item
+     * @return Multi
+     * @throws NullPointerException if {@code item} is {@code null}
+     */
+    static <T> Multi<T> singleton(T item) {
+        Objects.requireNonNull(item, "item is null");
+        return new MultiJustPublisher<>(item);
     }
 
     /**

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromArrayPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiFromArrayPublisher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Emits the elements of a non-empty array to the downstream on demand.
+ * @param <T> the element type of the array
+ */
+final class MultiFromArrayPublisher<T> implements Multi<T> {
+
+    private final T[] items;
+
+    MultiFromArrayPublisher(T[] items) {
+        this.items = items;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        subscriber.onSubscribe(new ArraySubscription<>(subscriber, items));
+    }
+
+    static final class ArraySubscription<T> extends AtomicLong implements Flow.Subscription {
+
+        private final Flow.Subscriber<? super T> downstream;
+
+        private final T[] array;
+
+        private int index;
+
+        private volatile int canceled;
+
+        static final int CANCEL = 1;
+        static final int BAD_REQUEST = 2;
+
+        ArraySubscription(Flow.Subscriber<? super T> downstream, T[] array) {
+            this.downstream = downstream;
+            this.array = array;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                canceled = BAD_REQUEST;
+                n = 1;
+            }
+            if (SubscriptionHelper.addRequest(this, n) != 0L) {
+                return;
+            }
+
+            long emitted = 0L;
+            int i = index;
+            T[] array = this.array;
+            int length = array.length;
+            outer:
+            for (;;) {
+                int c = canceled;
+                if (c != 0) {
+                    if (c == BAD_REQUEST) {
+                        downstream.onError(new IllegalArgumentException(
+                                "Rule §3.9 violated: non-positive requests are forbidden"));
+                    }
+                    return;
+                } else {
+
+                    for (; i != length && emitted != n; i++, emitted++) {
+                        T item = array[i];
+                        if (item == null) {
+                            c = CANCEL;
+                            downstream.onError(new NullPointerException(
+                                    "Array element at index " + i + " is null"));
+                            return;
+                        }
+                        downstream.onNext(item);
+                        if (canceled != 0) {
+                            continue outer;
+                        }
+                    }
+
+                    if (i == length) {
+                        downstream.onComplete();
+                        return;
+                    }
+
+                    n = get();
+                    if (n == emitted) {
+                        index = i;
+                        n = SubscriptionHelper.produced(this, n);
+                        if (n == 0L) {
+                            break;
+                        }
+                        emitted = 0L;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            canceled = CANCEL;
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiJustPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiJustPublisher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Signals a single item then completes.
+ * @param <T> the type of the single item
+ */
+final class MultiJustPublisher<T> implements Multi<T> {
+
+    private final T value;
+
+
+    MultiJustPublisher(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        subscriber.onSubscribe(new SingleSubscription<>(value, subscriber));
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SubscriptionHelper.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SubscriptionHelper.java
@@ -47,7 +47,7 @@ enum SubscriptionHelper implements Flow.Subscription {
      * {@link Long#MAX_VALUE}.
      * @param field the target field to update
      * @param n the request amount to add, must be positive (not verified)
-     * @return the new request amount after the operation
+     * @return the old request amount after the operation
      */
     public static long addRequest(AtomicLong field, long n) {
         for (;;) {
@@ -60,7 +60,7 @@ enum SubscriptionHelper implements Flow.Subscription {
                 update = Long.MAX_VALUE;
             }
             if (field.compareAndSet(current, update)) {
-                return update;
+                return current;
             }
         }
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapPublisherTest.java
@@ -238,7 +238,7 @@ public class MultiFlatMapPublisherTest {
     @Test
     public void justJust() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        Multi.just(1)
+        Multi.singleton(1)
                 .flatMap(Single::just)
                 .subscribe(ts);
 
@@ -258,7 +258,7 @@ public class MultiFlatMapPublisherTest {
                 subscription.request(Long.MAX_VALUE);
             }
         };
-        Multi.just(1)
+        Multi.singleton(1)
                 .flatMap(Single::just)
                 .subscribe(ts);
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromArrayTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromArrayTckTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class MultiFromArrayTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiFromArrayTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        Integer[] array = new Integer[(int)l];
+        Arrays.fill(array, 0);
+        return Multi.just(array);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return Multi.from(() -> { throw new RuntimeException(); });
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromArrayTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromArrayTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.testng.Assert.assertEquals;
+
+public class MultiFromArrayTest {
+    @Test
+    public void nullItem() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(new Integer[] { 1, null, 2 })
+        .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().size(), is(1));
+        assertThat(ts.isComplete(), is(false));
+        assertThat(ts.getLastError(), instanceOf(NullPointerException.class));
+    }
+
+    @Test
+    public void cancelAfterItem() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.just(new Integer[] { 1, 2, 3 })
+                .limit(2)
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().size(), is(2));
+        assertThat(ts.isComplete(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+    }
+
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiJustTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiJustTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Flow;
+
+@Test
+public class MultiJustTckTest extends FlowPublisherVerification<Long> {
+
+    public MultiJustTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Long> createFlowPublisher(long l) {
+        return Multi.singleton(l);
+    }
+
+    @Override
+    public Flow.Publisher<Long> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTakeWhilePublisherTest.java
@@ -63,7 +63,7 @@ public class MultiTakeWhilePublisherTest {
     public void predicateCrash() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Multi.<Integer>just(1)
+        Multi.<Integer>singleton(1)
                 .takeWhile(v -> { throw new IllegalArgumentException();})
                 .subscribe(ts);
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTappedPublisherTest.java
@@ -83,7 +83,7 @@ public class MultiTappedPublisherTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Multi.just(1)
+        Multi.singleton(1)
         .peek(v -> { throw new IllegalArgumentException(); })
         .subscribe(ts);
 
@@ -166,7 +166,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 null,
@@ -197,7 +197,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 null,
@@ -226,7 +226,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 e -> {
@@ -258,7 +258,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 e -> {
@@ -291,7 +291,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 null,
@@ -321,7 +321,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 e -> {
@@ -353,7 +353,7 @@ public class MultiTappedPublisherTest {
         AtomicInteger calls = new AtomicInteger();
 
         new MultiTappedPublisher<>(
-                Multi.just(1),
+                Multi.singleton(1),
                 null,
                 null,
                 e -> {
@@ -383,7 +383,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .peek(v -> calls.getAndIncrement())
                 .peek(v -> calls.getAndIncrement())
                 .subscribe(ts);
@@ -402,7 +402,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .onComplete(calls::getAndIncrement)
                 .onComplete(calls::getAndIncrement)
                 .subscribe(ts);
@@ -421,7 +421,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .onTerminate(calls::getAndIncrement)
                 .onTerminate(calls::getAndIncrement)
                 .subscribe(ts);
@@ -440,7 +440,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .onError(e -> calls.getAndIncrement())
                 .onError(e -> calls.getAndIncrement())
                 .subscribe(ts);
@@ -497,7 +497,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .peek(v -> calls.getAndIncrement())
                 .peek(v -> calls.getAndIncrement())
                 .peek(v -> calls.getAndIncrement())
@@ -523,7 +523,7 @@ public class MultiTappedPublisherTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         AtomicInteger calls = new AtomicInteger();
-        Multi.just(1)
+        Multi.singleton(1)
                 .peek(v -> calls.getAndIncrement())
                 .onComplete(calls::getAndIncrement)
                 .onError(v -> calls.getAndIncrement())

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -503,7 +503,7 @@ public class MultiTest {
     @Test
     void requestOneOfOneExpectComplete() {
         TestSubscriber<String> subscriber = new TestSubscriber<>();
-        Multi.just("foo").subscribe(subscriber);
+        Multi.singleton("foo").subscribe(subscriber);
         subscriber.request1();
         assertThat(subscriber.isComplete(), is(equalTo(true)));
         assertThat(subscriber.getLastError(), is(nullValue()));
@@ -542,7 +542,7 @@ public class MultiTest {
     public void testDoubleSubscribe() {
         TestSubscriber<Integer> subscriber1 = new TestSubscriber<>();
         TestSubscriber<Integer> subscriber2 = new TestSubscriber<>();
-        Multi<Integer> multi = Multi.just(1);
+        Multi<Integer> multi = Multi.singleton(1);
         multi.subscribe(subscriber1);
         multi.subscribe(subscriber2);
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SubscribableTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SubscribableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * {@link Subscribeable} test.
+ * {@link Subscribable} test.
  */
 public class SubscribableTest {
 

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SubscribableTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SubscribableTest.java
@@ -34,7 +34,7 @@ public class SubscribableTest {
     @Test
     public void testSubscriberFunctionalConsumer() {
         TestConsumer<String> consumer = new TestConsumer<>();
-        Multi.just("foo").subscribe(consumer);
+        Multi.singleton("foo").subscribe(consumer);
         assertThat(consumer.item, is(equalTo("foo")));
     }
 
@@ -54,7 +54,7 @@ public class SubscribableTest {
                 throw new IllegalStateException("foo!");
             }
         };
-        Multi.just("foo").subscribe(consumer, errorConsumer);
+        Multi.singleton("foo").subscribe(consumer, errorConsumer);
         assertThat(consumer.item, is(nullValue()));
         assertThat(errorConsumer.item, is(instanceOf(IllegalStateException.class)));
     }
@@ -107,7 +107,7 @@ public class SubscribableTest {
             }
         };
         TestConsumer<String> consumer = new TestConsumer<>();
-        Multi.just("foo").subscribe(consumer, null, null, subscriptionConsumer);
+        Multi.singleton("foo").subscribe(consumer, null, null, subscriptionConsumer);
         assertThat(consumer.item, is(equalTo("foo")));
     }
 
@@ -129,7 +129,7 @@ public class SubscribableTest {
                 throw new IllegalStateException("foo!");
             }
         };
-        Multi.<String>just("foo").subscribe(null, errorConsumer, null, subscriptionConsumer);
+        Multi.<String>singleton("foo").subscribe(null, errorConsumer, null, subscriptionConsumer);
         assertThat(errorConsumer.item, is(instanceOf(IllegalStateException.class)));
     }
 

--- a/media/common/src/test/java/io/helidon/media/common/ContentReadersTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/ContentReadersTest.java
@@ -38,7 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class ContentReadersTest {
     @Test
     void testStringReader() throws Exception {
-        Multi<DataChunk> chunks = Multi.just(DataChunk.create(new byte[] {(byte) 225, (byte) 226, (byte) 227}));
+        Multi<DataChunk> chunks = Multi.singleton(DataChunk.create(new byte[] {(byte) 225, (byte) 226, (byte) 227}));
 
         CompletableFuture<? extends String> future =
                 ContentReaders.stringReader(Charset.forName("cp1250"))
@@ -55,7 +55,7 @@ class ContentReadersTest {
         byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
 
         CompletableFuture<? extends byte[]> future = ContentReaders.byteArrayReader()
-                .apply(Multi.just(DataChunk.create(bytes)))
+                .apply(Multi.singleton(DataChunk.create(bytes)))
                 .toCompletableFuture();
 
         byte[] actualBytes = future.get(10, TimeUnit.SECONDS);
@@ -68,7 +68,7 @@ class ContentReadersTest {
         byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
 
         CompletableFuture<? extends InputStream> future = ContentReaders.inputStreamReader()
-                .apply(Multi.just(DataChunk.create(bytes)))
+                .apply(Multi.singleton(DataChunk.create(bytes)))
                 .toCompletableFuture();
 
         InputStream inputStream = future.get(10, TimeUnit.SECONDS);
@@ -80,7 +80,7 @@ class ContentReadersTest {
     void testURLDecodingReader() throws Exception {
         String original = "myParam=\"Now@is'the/time";
         String encoded = URLEncoder.encode(original, "UTF-8");
-        Multi<DataChunk> chunks = Multi.just(DataChunk.create(encoded.getBytes(StandardCharsets.UTF_8)));
+        Multi<DataChunk> chunks = Multi.singleton(DataChunk.create(encoded.getBytes(StandardCharsets.UTF_8)));
 
         CompletableFuture<? extends String> future =
                 ContentReaders.urlEncodedStringReader(StandardCharsets.UTF_8)

--- a/media/jsonp/server/src/test/java/io/helidon/media/jsonp/server/JsonContentReaderTest.java
+++ b/media/jsonp/server/src/test/java/io/helidon/media/jsonp/server/JsonContentReaderTest.java
@@ -48,7 +48,7 @@ public class JsonContentReaderTest {
 
     @Test
     public void simpleJsonObject() throws Exception {
-        Publisher<DataChunk> chunks = Multi.just("{ \"p\" : \"val\" }").map(s -> DataChunk.create(s.getBytes()));
+        Publisher<DataChunk> chunks = Multi.singleton("{ \"p\" : \"val\" }").map(s -> DataChunk.create(s.getBytes()));
 
         CompletionStage<? extends JsonObject> stage = JsonSupport.create()
                 .reader()
@@ -61,7 +61,7 @@ public class JsonContentReaderTest {
 
     @Test
     public void incompatibleTypes() throws Exception {
-        Publisher<DataChunk> chunks = Multi.just("{ \"p\" : \"val\" }").map(s -> DataChunk.create(s.getBytes()));
+        Publisher<DataChunk> chunks = Multi.singleton("{ \"p\" : \"val\" }").map(s -> DataChunk.create(s.getBytes()));
 
         CompletionStage<? extends JsonArray> stage = JsonSupport.create()
                 .reader()
@@ -81,7 +81,7 @@ public class JsonContentReaderTest {
 
     @Test
     public void simpleJsonArray() throws Exception {
-        Publisher<DataChunk> chunks = Multi.just("[ \"val\" ]").map(s -> DataChunk.create(s.getBytes()));
+        Publisher<DataChunk> chunks = Multi.singleton("[ \"val\" ]").map(s -> DataChunk.create(s.getBytes()));
 
         CompletionStage<? extends JsonArray> stage = JsonSupport.create()
                 .reader()
@@ -94,7 +94,7 @@ public class JsonContentReaderTest {
 
     @Test
     public void invalidJson() throws Exception {
-        Publisher<DataChunk> chunks = Multi.just("{ \"p\" : \"val\" ").map(s -> DataChunk.create(s.getBytes()));
+        Publisher<DataChunk> chunks = Multi.singleton("{ \"p\" : \"val\" ").map(s -> DataChunk.create(s.getBytes()));
 
         CompletionStage<? extends JsonObject> stage = JsonSupport.create()
                 .reader()

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/MediaPublisher.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/MediaPublisher.java
@@ -73,7 +73,7 @@ public interface MediaPublisher extends Flow.Publisher<DataChunk> {
                 .map(Charset::forName)
                 .orElse(StandardCharsets.UTF_8)
                 .encode(charSequence.toString());
-        Flow.Publisher<DataChunk> publisher = Multi.just(DataChunk.create(data));
+        Flow.Publisher<DataChunk> publisher = Multi.singleton(DataChunk.create(data));
         return new MediaPublisher() {
             @Override
             public MediaType mediaType() {

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/MediaPublisher.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/MediaPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/RequestContentTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/RequestContentTest.java
@@ -266,7 +266,7 @@ public class RequestContentTest {
 
     @Test
     public void failingSubscribe() throws Exception {
-        Request request = requestTestStub(Multi.just(DataChunk.create("data".getBytes())));
+        Request request = requestTestStub(Multi.singleton(DataChunk.create("data".getBytes())));
 
         request.content().registerFilter((Publisher<DataChunk> publisher) -> {
             throw new IllegalStateException("failed-publisher-transformation");
@@ -287,7 +287,7 @@ public class RequestContentTest {
 
     @Test
     public void readerTest() throws Exception {
-        Request request = requestTestStub(Multi.just(DataChunk.create("2010-01-02".getBytes())));
+        Request request = requestTestStub(Multi.singleton(DataChunk.create("2010-01-02".getBytes())));
 
         request.content().registerReader(LocalDate.class,
                 (publisher, clazz) -> ContentReaders
@@ -304,21 +304,21 @@ public class RequestContentTest {
 
     @Test
     public void implicitByteArrayContentReader() throws Exception {
-        Request request = requestTestStub(Multi.just(DataChunk.create("test-string".getBytes())));
+        Request request = requestTestStub(Multi.singleton(DataChunk.create("test-string".getBytes())));
         CompletionStage<String> complete = request.content().as(byte[].class).thenApply(String::new);
         assertThat(complete.toCompletableFuture().get(10, TimeUnit.SECONDS),  is("test-string"));
     }
 
     @Test
     public void implicitStringContentReader() throws Exception {
-        Request request = requestTestStub(Multi.just(DataChunk.create("test-string".getBytes())));
+        Request request = requestTestStub(Multi.singleton(DataChunk.create("test-string".getBytes())));
         CompletionStage<? extends String> complete = request.content().as(String.class);
         assertThat(complete.toCompletableFuture().get(10, TimeUnit.SECONDS), is("test-string"));
     }
 
     @Test
     public void overridingStringContentReader() throws Exception {
-        Request request = requestTestStub(Multi.just(DataChunk.create("test-string".getBytes())));
+        Request request = requestTestStub(Multi.singleton(DataChunk.create("test-string".getBytes())));
 
         request.content().registerReader(String.class, (publisher, clazz) -> {
             fail("Should not be called");


### PR DESCRIPTION
Reimplement `Multi.just` to be more efficient by not relying on the `Iterator` interface for mediation. 

In addition, the `Multi.singleton` has been implemented, which is essentially the same as `Single.just` but with return `Multi`. Unfortunately, there is a `just(Collection<T> items)` overload which would cause ambiguities with a `just(T)`.

In the future, I suggest removing `just(Collection<T>)` as `from(Iterable)` can already work with `Collection`s, then rename `singleton` to `just`.