### PR TITLE
Add JMH Benchmark baseline to reactive

### DIFF
--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -81,5 +81,17 @@
             <artifactId>reactive-streams-tck-flow</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/common/reactive/pom.xml
+++ b/common/reactive/pom.xml
@@ -84,13 +84,11 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.23</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineJMH.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineJMH.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive.jmh;
+
+import io.helidon.common.reactive.Multi;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@State(Scope.Benchmark)
+public class BaselineJMH {
+
+    public static void main(String[] args) throws Throwable {
+        Options opt = new OptionsBuilder()
+                .include(BaselineJMH.class.getSimpleName())
+                .include(BaselineSoloJMH.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(5)
+                .measurementTime(TimeValue.seconds(1))
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    Integer[] array;
+    Collection<Integer> collection;
+
+    @Param({/*"1", "10", "100", "1000", "10000", "100000",*/ "1000000"})
+    int count;
+
+    @Setup
+    public void setup() {
+        array = new Integer[count];
+        for (int i = 0; i < count; i++) {
+            array[i] = i + 1;
+        }
+        collection = Arrays.asList(array);
+    }
+
+    @Benchmark
+    public void justArray(Blackhole bh) {
+        Multi.just(array).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void from(Blackhole bh) {
+        Multi.from(collection).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void skipZero(Blackhole bh) {
+        Multi.just(array).skip(0).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void skipHalf(Blackhole bh) {
+        Multi.just(array).skip(count / 2).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void skipAll(Blackhole bh) {
+        Multi.just(array).skip(Long.MAX_VALUE).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void map(Blackhole bh) {
+        Multi.just(array).map(v -> v + 1).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void filterNone(Blackhole bh) {
+        Multi.just(array).filter(v -> v == 0).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void filterHalf(Blackhole bh) {
+        Multi.just(array).filter(v -> (v & 1) == 0).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void filterAll(Blackhole bh) {
+        Multi.just(array).filter(v -> v == Integer.MAX_VALUE).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void limitZero(Blackhole bh) {
+        Multi.just(array).limit(0).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void limitHalf(Blackhole bh) {
+        Multi.just(array).limit(count / 2).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void limitAll(Blackhole bh) {
+        Multi.just(array).limit(Long.MAX_VALUE).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineJMH.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineJMH.java
@@ -46,7 +46,7 @@ public class BaselineJMH {
     Integer[] array;
     Collection<Integer> collection;
 
-    @Param({/*"1", "10", "100", "1000", "10000", "100000",*/ "1000000"})
+    @Param({"1", "10", "100", "1000", "10000", "100000", "1000000"})
     int count;
 
     @Setup

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineSoloJMH.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/BaselineSoloJMH.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive.jmh;
+
+import io.helidon.common.reactive.Multi;
+import io.helidon.common.reactive.Single;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class BaselineSoloJMH {
+
+    @Benchmark
+    public void never(Blackhole bh) {
+        Multi.never().subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void empty(Blackhole bh) {
+        Multi.empty().subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void just(Blackhole bh) {
+        Multi.just(1).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void neverSingle(Blackhole bh) {
+        Single.never().subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void emptySingle(Blackhole bh) {
+        Single.empty().subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+
+    @Benchmark
+    public void justSingle(Blackhole bh) {
+        Single.just(1).subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/SyncBoundedJmhSubscriber.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/SyncBoundedJmhSubscriber.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive.jmh;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Subscriber for testing synchronous sources via an unbounded request amount.
+ */
+final class SyncBoundedJmhSubscriber implements Flow.Subscriber<Object> {
+
+    private final Blackhole bh;
+
+    SyncBoundedJmhSubscriber(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        subscription.request(Long.MAX_VALUE - 1);
+        bh.consume(subscription);
+    }
+
+    @Override
+    public void onNext(Object item) {
+        bh.consume(item);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        bh.consume(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        bh.consume(true);
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/SyncUnboundedJmhSubscriber.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/SyncUnboundedJmhSubscriber.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive.jmh;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.Flow;
+
+/**
+ * Subscriber for testing synchronous sources via an unbounded request amount.
+ */
+final class SyncUnboundedJmhSubscriber implements Flow.Subscriber<Object> {
+
+    private final Blackhole bh;
+
+    SyncUnboundedJmhSubscriber(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        subscription.request(Long.MAX_VALUE);
+        bh.consume(subscription);
+    }
+
+    @Override
+    public void onNext(Object item) {
+        bh.consume(item);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        bh.consume(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        bh.consume(true);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <version.lib.awaitility>3.1.6</version.lib.awaitility>
         <version.lib.weld-junit>2.0.0.Final</version.lib.weld-junit>
         <version.lib.weld>3.1.2.Final</version.lib.weld>
+        <version.lib.jmh>1.23</version.lib.jmh>
         <!--
         !Version statement! - end
         -->
@@ -918,6 +919,17 @@
                 <artifactId>awaitility</artifactId>
                 <version>${version.lib.awaitility}</version>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${version.lib.jmh}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${version.lib.jmh}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Baseline benchmark for sources and operators.

Results on i7 8700, Windows 10 x64, Java 11.0.3, 32 GB RAM, normalized to million ops/s

| Method | 1 | 10 | 100 | 1,000 | 10,000 | 100,000 | 1,000,000 |
|--|--:|--:|--:|--:|--:|--:|--:|
filterAll       |  38.420 | 136.987 | 166.146 | 167.023 | 162.727 | 162.662 |  72.114
filterHalf      |  38.761 | 119.692 | 117.361 | 123.794 | 141.007 | 132.630 |  68.971
filterNone      |  38.642 | 138.481 | 167.677 | 165.022 | 164.836 | 161.074 |  71.896
from            |  45.526 | 146.152 | 179.817 | 175.228 | 201.299 | 200.175 | 193.698
justArray       |  38.441 | 116.639 | 162.597 | 145.975 | 154.904 | 166.769 |  79.154
limitAll        |  36.958 | 106.949 | 133.697 | 137.351 | 136.280 | 130.993 |  76.357
limitHalf       |  35.006 | 139.230 | 207.367 | 221.141 | 229.690 | 212.053 |  97.577
limitZero       |  35.960 | 238.232 | 628.047 | 753.450 | 771.515 | 759.677 | 141.652
map             |  33.978 |  98.337 | 123.731 | 114.542 | 103.006 | 105.520 |  55.759
skipAll         |  36.861 | 152.659 | 235.858 | 242.059 | 227.272 | 225.956 |  91.846
skipHalf        |  35.201 | 125.754 | 153.587 | 151.007 | 158.035 | 159.836 |  83.221
skipZero        |  35.439 | 111.933 | 147.953 | 152.126 | 136.469 | 136.467 |  75.753
empty           | 313.651 |         |         |         |         |         |
emptySingle     | 312.483 |         |         |         |         |         |
just            |  43.606 |         |         |         |         |         |
justSingle      |  42.990 |         |         |         |         |         |
never           | 453.452 |         |         |         |         |         |
neverSingle     | 472.207 |         |         |         |         |         |

[Raw data](https://gist.github.com/akarnokd/4b8a87e22b679dbafa2e92afd531e8f9)