### PR TITLE
Expand TestSubscriber's API, fix a bug in MultiFirstProcessor

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiFirstProcessor.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiFirstProcessor.java
@@ -36,6 +36,7 @@ final class MultiFirstProcessor<T> extends BaseProcessor<T, T> implements Single
 
     @Override
     protected void next(T item) {
+        cancel();
         super.next(item);
         super.complete();
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BaseProcessorTest.java
@@ -152,12 +152,7 @@ public class BaseProcessorTest {
     @Test
     public void testDeferredOnSubscribe() {
         TestProcessor<String> processor = new TestProcessor<>();
-        TestSubscriber<String> subscriber = new TestSubscriber<String>() {
-            @Override
-            public void onSubscribe(Subscription subscription) {
-                subscription.request(1);
-            }
-        };
+        TestSubscriber<String> subscriber = new TestSubscriber<String>(1L);
         processor.subscribe(subscriber);
         processor.onSubscribe(new Subscription() {
             @Override
@@ -171,9 +166,7 @@ public class BaseProcessorTest {
             }
         });
 
-        assertThat(subscriber.isComplete(), is(equalTo(true)));
-        assertThat(subscriber.getLastError(), is(nullValue()));
-        assertThat(subscriber.getItems(), hasItems("foo"));
+        subscriber.assertResult("foo");
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -145,9 +145,7 @@ public class MultiTest {
     public void testFirst() {
         MultiTestSubscriber<String> subscriber = new MultiTestSubscriber<>();
         Multi.just("foo", "bar").first().subscribe(subscriber);
-        assertThat(subscriber.isComplete(), is(equalTo(true)));
-        assertThat(subscriber.getLastError(), is(nullValue()));
-        assertThat(subscriber.getItems().get(0), is(equalTo("foo")));
+        subscriber.assertResult("foo");
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -97,14 +97,13 @@ public class SingleTest {
         SingleTestSubscriber<String> subscriber = new SingleTestSubscriber<String>() {
             @Override
             public void onSubscribe(Subscription subscription) {
+                super.onSubscribe(subscription);
                 subscription.request(1);
                 subscription.request(1);
             }
         };
         Single.<String>just("foo").subscribe(subscriber);
-        assertThat(subscriber.isComplete(), is(equalTo(true)));
-        assertThat(subscriber.getLastError(), is(nullValue()));
-        assertThat(subscriber.getItems(), hasItems("foo"));
+        subscriber.assertResult("foo");
     }
 
     @Test
@@ -121,6 +120,7 @@ public class SingleTest {
         SingleTestSubscriber<Object> subscriber = new SingleTestSubscriber<Object>() {
             @Override
             public void onSubscribe(Subscription subscription) {
+                super.onSubscribe(subscription);
                 subscription.cancel();
             }
         };

--- a/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
@@ -16,110 +16,371 @@
 
 package io.helidon.common.reactive;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * A dummy subscriber for testing purpose.
+ * A dummy subscriber for testing purposes.
  */
 class TestSubscriber<T> implements Flow.Subscriber<T> {
 
-    private Flow.Subscription subcription = null;
-    private final List<T> items = new LinkedList<>();
-    private T lastItem = null;
-    private Throwable lastError = null;
-    private boolean complete = false;
+    private final long initialRequest;
+
+    private final AtomicReference<Flow.Subscription> upstream;
+
+    private final List<T> items;
+
+    private final List<Throwable> errors;
+
+    private volatile int completions;
+
+    /**
+     * Construct a {@code TestSubscriber} with no initial request.
+     */
+    TestSubscriber() {
+        this(0L);
+    }
+
+    /**
+     * Construct a {@code TestSubscriber} with the given non-negative initial request.
+     * @param initialRequest the initial request amount, non-negative
+     */
+    TestSubscriber(long initialRequest) {
+        if (initialRequest < 0L) {
+            throw new IllegalArgumentException("initialRequest >= 0L required");
+        }
+        this.initialRequest = initialRequest;
+        this.upstream = new AtomicReference<>();
+        this.items = Collections.synchronizedList(new ArrayList<>());
+        this.errors = Collections.synchronizedList(new ArrayList<>());
+    }
 
     @Override
     public void onSubscribe(Flow.Subscription subscription) {
-        this.subcription = subscription;
-    }
-
-    /**
-     * Request one item.
-     */
-    public void request1() {
-        this.subcription.request(1);
-    }
-
-    /**
-     * Request n items.
-     *
-     * @param n number of items being requested
-     */
-    public void request(long n) {
-        this.subcription.request(n);
-    }
-
-    /**
-     * Request the maximum number of items.
-     */
-    public void requestMax() {
-        this.subcription.request(Long.MAX_VALUE);
+        Objects.requireNonNull(subscription, "subscription is null");
+        if (upstream.compareAndSet(null, subscription)) {
+            if (initialRequest != 0L) {
+                subscription.request(initialRequest);
+            }
+        } else {
+            subscription.cancel();
+            if (upstream.get() != SubscriptionHelper.CANCELED) {
+                errors.add(new IllegalStateException("Subscription already set!"));
+            }
+        }
     }
 
     @Override
     public void onNext(T item) {
+        Objects.requireNonNull(item, "item is null");
+        if (upstream.get() == null) {
+            errors.add(new IllegalStateException("onSubscribe not called before onNext!"));
+        }
         items.add(item);
-        lastItem = item;
     }
 
     @Override
     public void onError(Throwable throwable) {
-        this.lastError = throwable;
-    }
-
-    /**
-     * Indicates completeness.
-     *
-     * @return {@code true} if complete, {@code false} otherwise
-     */
-    public boolean isComplete() {
-        return complete;
+        Objects.requireNonNull(throwable, "throwable is null");
+        if (upstream.get() == null) {
+            errors.add(new IllegalStateException("onSubscribe not called before onError!"));
+        }
+        errors.add(throwable);
     }
 
     @Override
     public void onComplete() {
-        this.complete = true;
+        if (upstream.get() == null) {
+            errors.add(new IllegalStateException("onSubscribe not called before onComplete!"));
+        }
+        if (!errors.isEmpty()) {
+            errors.add(new IllegalStateException("onComplete called when error(s) are present"));
+        }
+        int c = completions;
+        if (c > 1) {
+            errors.add(new IllegalStateException("onComplete called again"));
+        }
+        completions = c + 1;
     }
 
     /**
-     * Get the items accumulated by this subscriber.
-     *
-     * @return list of items
+     * Returns a mutable, thread-safe list of items received so far.
+     * @return a mutable, thread-safe list of items received so far
      */
-    public List<T> getItems() {
+    public final List<T> getItems() {
         return items;
     }
 
     /**
-     * Get the last item accumulated by this subscriber.
-     *
-     * @return last item, or {@code null} or this subscriber has not
-     * received any items yet
+     * Returns a mutable, thread-safe list of error(s) encountered so far.
+     * @return a mutable, thread-safe list of error(s) encountered so far
      */
-    public T getLastItem() {
-        return lastItem;
+    public final List<Throwable> getErrors() {
+        return errors;
     }
 
     /**
-     * Get the last error received by this subscriber.
-     *
-     * @return a {@code Throwable} or {@code null} or this subscriber has not
-     * received any
+     * Returns the last error received by this {@code TestSubscriber} or {@code null}
+     * if no error happened.
+     * @return the last error received by this {@code TestSubscriber} or {@code null}
      */
-    public Throwable getLastError() {
-        return lastError;
+    public final Throwable getLastError() {
+        int n = errors.size();
+        if (n != 0) {
+            return errors.get(n - 1);
+        }
+        return null;
     }
 
     /**
-     * Get the subscription set on this subscriber.
-     *
-     * @return a {@code Flow.Subscription} or {@code null} if onSubcribe has not
-     * been called
+     * Returns true if this {@code TestSubscriber} received any {@link #onComplete()} calls.
+     * @return true if this {@code TestSubscriber} has been completed
      */
-    public Flow.Subscription getSubcription() {
-        return subcription;
+    public final boolean isComplete() {
+        return completions != 0;
+    }
+
+    /**
+     * Returns the current upstream {@link Flow.Subscription} instance.
+     * @return the current upstream {@link Flow.Subscription} instance.
+     */
+    public final Flow.Subscription getSubcription() {
+        return upstream.get();
+    }
+
+    /**
+     * Assembles an {@link AssertionError} with the current internal state and
+     * captured errors.
+     * @param message the extra message to add
+     * @return the AssertionError instance
+     */
+    protected final AssertionError fail(String message) {
+        StringBuilder sb = new StringBuilder();
+        sb
+        .append(message)
+        .append(" (")
+        .append("items: ")
+        .append(items.size())
+        .append(", errors: ")
+        .append(errors.size())
+        .append(", completions: ")
+        .append(completions)
+                ;
+
+        if (upstream.get() == null) {
+            sb.append(", no onSubscribe!");
+        } else
+        if (upstream.get() == SubscriptionHelper.CANCELED) {
+            sb.append(", canceled!");
+        }
+
+        sb.append(")");
+
+        AssertionError ae = new AssertionError(sb.toString());
+
+        for (Throwable error : errors) {
+            ae.addSuppressed(error);
+        }
+
+        return ae;
+    }
+
+    /**
+     * Request more from the upstream.
+     * @param n the request amount, positive
+     * @return this
+     * @throws IllegalArgumentException if {@code n} is non-positive
+     * @throws IllegalStateException if {@link #onSubscribe} was not called on this {@code TestSubscriber} yet.
+     */
+    public final TestSubscriber<T> request(long n) {
+        if (n <= 0L) {
+            throw new IllegalArgumentException("n > 0L required");
+        }
+        Flow.Subscription s = upstream.get();
+        if (s == null) {
+            throw new IllegalStateException("onSubscribe not called yet!");
+        }
+        s.request(n);
+        return this;
+    }
+
+    /**
+     * Request one more item from the upstream.
+     * @return this
+     * @throws IllegalStateException if {@link #onSubscribe} was not called on this {@code TestSubscriber} yet.
+     */
+    public final TestSubscriber<T> request1() {
+        Flow.Subscription s = upstream.get();
+        if (s == null) {
+            throw new IllegalStateException("onSubscribe not called yet!");
+        }
+        s.request(1);
+        return this;
+    }
+
+    /**
+     * Request {@link Long#MAX_VALUE} items from the upstream.
+     * @return this
+     * @throws IllegalStateException if {@link #onSubscribe} was not called on this {@code TestSubscriber} yet.
+     */
+    public final TestSubscriber<T> requestMax() {
+        Flow.Subscription s = upstream.get();
+        if (s == null) {
+            throw new IllegalStateException("onSubscribe not called yet!");
+        }
+        s.request(Long.MAX_VALUE);
+        return this;
+    }
+
+    /**
+     * Cancel the upstream.
+     * @return this
+     */
+    public final TestSubscriber<T> cancel() {
+        SubscriptionHelper.cancel(upstream);
+        return this;
+    }
+
+    /**
+     * Turn a value into a value + class name string.
+     * @param o the object turn into a string
+     * @return the string representation
+     */
+    private String valueAndClass(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o + " (" + o.getClass().getName() + ")";
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} received the exactly the expected items
+     * in the expected order.
+     * @param expectedItems the vararg array of the expected items
+     * @return this
+     * @throws AssertionError if the number of items or the items themselves are not equal to the expected items
+     */
+    @SafeVarargs
+    public final TestSubscriber<T> assertValues(T... expectedItems) {
+        int n = items.size();
+        if (n != expectedItems.length) {
+            throw fail("Number of items differ. Expected: " + expectedItems.length + ", Actual: " + n + ".");
+        }
+        for (int i = 0; i < n; i++) {
+            T actualItem = items.get(i);
+            T expectedItem = expectedItems[i];
+            if (!Objects.equals(expectedItem, actualItem)) {
+                throw fail("Item @ index " + i + " differ. Expected: " + valueAndClass(expectedItem) + ", Actual: " + valueAndClass(actualItem) + ".");
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} has received exactly one {@link #onComplete()} call.
+     * @return this
+     * @throws AssertionError if there was none, more than one {@code onComplete} call or there are also errors
+     */
+    public final TestSubscriber<T> assertComplete() {
+        int c = completions;
+        if (c == 0) {
+            throw fail("onComplete not called.");
+        }
+        if (c > 1) {
+            throw fail("onComplete called too many times.");
+        }
+        if (!errors.isEmpty()) {
+            throw fail("onComplete called but there are errors.");
+        }
+        return this;
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} has received exactly one {@link Throwable} (subclass) of the
+     * given {@code clazz}.
+     * @param clazz the expected (parent) class of the Throwable received
+     * @return this
+     * @throws AssertionError if no errors were received, different error(s) were received, the same error
+     * received multiple times or there were also {@code onComplete} calls as well.
+     */
+    public final TestSubscriber<T> assertError(Class<? extends Throwable> clazz) {
+        if (errors.isEmpty()) {
+            throw fail("onError not called");
+        }
+
+        int found = 0;
+        for (Throwable ex : errors) {
+            if (clazz.isInstance(ex)) {
+                found++;
+            }
+        }
+
+        if (found == 0) {
+            throw fail("Error not found: " + clazz);
+        }
+        if (found > 1) {
+            throw fail("Multiple onError calls with " + clazz);
+        }
+        if (completions != 0) {
+            throw fail("Error found but there were onComplete calls as well");
+        }
+
+        return this;
+    }
+
+    /**
+     * Assert that the upstream called {@link #onSubscribe}.
+     * @return this
+     * @throws AssertionError if {@code onSubscribe} was not yet called
+     */
+    public final TestSubscriber<T> assertOnSubscribe() {
+        if (upstream.get() == null) {
+            throw fail("onSubscribe not called");
+        }
+        return this;
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} received the given expected items in the expected order and
+     * then completed normally.
+     * @param expectedItems the varargs of items expected
+     * @return this
+     */
+    @SafeVarargs
+    public final TestSubscriber<T> assertResult(T... expectedItems) {
+        assertOnSubscribe();
+        assertValues(expectedItems);
+        assertComplete();
+        return this;
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} received the given expected items in the expected order
+     * and the received an {@link #onError} that is an instance of the given class.
+     * @param clazz the expected (parent) class of the Throwable received
+     * @param expectedItems the vararg array of the expected items
+     * @return this
+     */
+    @SafeVarargs
+    public final TestSubscriber<T> assertFailure(Class<? extends Throwable> clazz, T... expectedItems) {
+        assertOnSubscribe();
+        assertValues(expectedItems);
+        assertError(clazz);
+        return this;
+    }
+
+    /**
+     * Assert that this {@code TestSubscriber} received the given number of items.
+     * @param count the expected item count
+     * @return this
+     * @throws AssertionError if the number of items received differs from the given {@code count}
+     */
+    public final TestSubscriber<T> assertItemCount(int count) {
+        int n = items.size();
+        if (n != count) {
+            throw fail("Number of items differ. Expected: " + count + ", Actual: " + n + ".");
+        }
+        return this;
     }
 }


### PR DESCRIPTION
Have the typical state assertions available on the `TestSubscriber` as well as add protocol validation checks.

The upgrade found a bug in `Multi.first`: the upstream was not canceled and the downstream received multiple items and multiple completions too.