### PR TITLE
Reimplement Multi.flatMapIterable + TCK test

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -158,10 +158,23 @@ public interface Multi<T> extends Subscribable<T> {
      * @param <U>            output item type
      * @return Multi
      */
-    default <U> Multi<U> flatMapIterable(Function<T, Iterable<U>> iterableMapper) {
-        MultiFlatMapProcessor<T, U> processor = MultiFlatMapProcessor.fromIterableMapper(iterableMapper);
-        this.subscribe(processor);
-        return processor;
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper) {
+        return flatMapIterable(iterableMapper, 32);
+    }
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
+     *
+     * @param iterableMapper {@link Function} receiving item as parameter and returning {@link Iterable}
+     * @param prefetch the number of upstream items to request upfront, then 75% of this value after
+     *                 75% received and mapped
+     * @param <U>            output item type
+     * @return Multi
+     */
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper,
+                                         int prefetch) {
+        Objects.requireNonNull(iterableMapper, "iterableMapper is null");
+        return new MultiFlatMapIterable<>(this, iterableMapper, prefetch);
     }
 
     /**

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiFlatMapIterable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiFlatMapIterable.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+/**
+ * Map each upstream item into an Iterable and stream their values.
+ * @param <T> the upstream item type
+ * @param <R> the output item type
+ */
+final class MultiFlatMapIterable<T, R> implements Multi<R> {
+
+    private final Multi<T> source;
+
+    private final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+    private final int prefetch;
+
+    MultiFlatMapIterable(Multi<T> source,
+                         Function<? super T, ? extends Iterable<? extends R>> mapper,
+                         int prefetch) {
+        this.source = source;
+        this.mapper = mapper;
+        this.prefetch = prefetch;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super R> subscriber) {
+        source.subscribe(new FlatMapIterableSubscriber<>(subscriber, mapper, prefetch));
+    }
+
+    static final class FlatMapIterableSubscriber<T, R>
+    extends AtomicInteger
+    implements Flow.Subscriber<T>, Flow.Subscription {
+
+        private final Flow.Subscriber<? super R> downstream;
+
+        private final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+        private final int prefetch;
+
+        private final AtomicLong requested;
+
+        private final ConcurrentLinkedQueue<T> queue;
+
+        private Flow.Subscription upstream;
+
+        private long emitted;
+
+        private volatile boolean upstreamDone;
+        private Throwable error;
+
+        private volatile boolean canceled;
+
+        private Iterator<? extends R> currentIterator;
+
+        private int upstreamConsumed;
+
+        FlatMapIterableSubscriber(Flow.Subscriber<? super R> downstream,
+                                  Function<? super T, ? extends Iterable<? extends R>> mapper,
+                                  int prefetch) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.prefetch = prefetch;
+            this.requested = new AtomicLong();
+            this.queue = new ConcurrentLinkedQueue<>();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            downstream.onSubscribe(this);
+            subscription.request(prefetch);
+        }
+
+        @Override
+        public void onNext(T item) {
+            queue.offer(item);
+            drain();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error = throwable;
+            upstreamDone = true;
+            drain();
+        }
+
+        @Override
+        public void onComplete() {
+            upstreamDone = true;
+            drain();
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                onError(new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden!"));
+            } else {
+                SubscriptionHelper.addRequest(requested, n);
+                drain();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            canceled = true;
+            upstream.cancel();
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            Iterator<? extends R> iterator = currentIterator;
+            Flow.Subscriber<? super R> downstream = this.downstream;
+            long e = emitted;
+            int limit = prefetch - (prefetch >> 2);
+
+            int missed = 1;
+            outer:
+            for (;;) {
+
+                if (canceled) {
+                    iterator = null;
+                    currentIterator = null;
+                    queue.clear();
+                } else {
+                    if (upstreamDone) {
+                        Throwable ex = error;
+                        if (ex != null) {
+                            canceled = true;
+                            downstream.onError(ex);
+                            continue;
+                        }
+                    }
+                    if (iterator == null) {
+                        boolean d = upstreamDone;
+                        T item = queue.poll();
+                        boolean empty = item == null;
+
+                        if (d && empty) {
+                            canceled = true;
+                            downstream.onComplete();
+                            continue;
+                        }
+
+                        if (!empty) {
+
+                            int c = upstreamConsumed + 1;
+                            if (c == limit) {
+                                upstreamConsumed = 0;
+                                upstream.request(limit);
+                            } else {
+                                upstreamConsumed = c;
+                            }
+
+                            boolean hasNext;
+                            try {
+                                iterator = Objects.requireNonNull(
+                                        mapper.apply(item).iterator(),
+                                        "The Iterable returned a null iterator"
+                                );
+
+                                if (canceled) {
+                                    continue;
+                                }
+
+                                hasNext = iterator.hasNext();
+                            } catch (Throwable ex) {
+                                canceled = true;
+                                downstream.onError(ex);
+                                continue;
+                            }
+
+                            if (!hasNext) {
+                                iterator = null;
+                                continue;
+                            }
+                            currentIterator = iterator;
+                        }
+                    }
+
+                    if (iterator != null) {
+                        long r = requested.get();
+
+                        while (e != r) {
+
+                            if (canceled) {
+                                continue outer;
+                            }
+
+                            R result;
+
+                            try {
+                                result = Objects.requireNonNull(iterator.next(),
+                                        "The iterator returned a null item");
+                            } catch (Throwable ex) {
+                                canceled = true;
+                                downstream.onError(ex);
+                                continue outer;
+                            }
+
+                            if (canceled) {
+                                continue outer;
+                            }
+
+                            downstream.onNext(result);
+                            e++;
+
+                            if (canceled) {
+                                continue outer;
+                            }
+
+                            boolean hasNext;
+                            try {
+                                hasNext = iterator.hasNext();
+                            } catch (Throwable ex) {
+                                canceled = true;
+                                downstream.onError(ex);
+                                continue outer;
+                            }
+
+                            if (canceled) {
+                                continue outer;
+                            }
+
+                            if (!hasNext) {
+                                iterator = null;
+                                currentIterator = null;
+                                continue outer;
+                            }
+                        }
+                    }
+                }
+
+                emitted = e;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableManyToManyTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableManyToManyTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.Collections;
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+public class MultiFlatMapIterableManyToManyTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiFlatMapIterableManyToManyTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.just(l >> 1, l - (l >> 1))
+                .flatMapIterable(v -> () -> IntStream.range(0, v.intValue()).boxed().iterator());
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableManyToOneTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableManyToOneTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.Collections;
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+public class MultiFlatMapIterableManyToOneTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiFlatMapIterableManyToOneTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.from(() -> IntStream.range(0, (int)l).boxed().iterator())
+                .flatMapIterable(Collections::singleton);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableOneToManyTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableOneToManyTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+public class MultiFlatMapIterableOneToManyTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiFlatMapIterableOneToManyTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.just(1)
+                .flatMapIterable(v -> () -> IntStream.range(0, (int)l).boxed().iterator());
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFlatMapIterableTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.testng.Assert.assertEquals;
+
+public class MultiFlatMapIterableTest {
+
+    Iterable<Integer> range(int count) {
+        return () -> IntStream.range(0, count).boxed().iterator();
+    }
+
+    void crossMap(int count) {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+        int rest = 1_000_000 / count;
+
+        Multi.from(range(count))
+                .flatMapIterable(v -> range(rest))
+                .subscribe(ts);
+
+        ts.assertItemCount(1_000_000)
+                .assertComplete();
+    }
+
+    @Test
+    public void crossMap1() {
+        crossMap(1);
+    }
+
+    @Test
+    public void crossMap10() {
+        crossMap(10);
+    }
+
+    @Test
+    public void crossMap100() {
+        crossMap(100);
+    }
+
+    @Test
+    public void crossMap1000() {
+        crossMap(1000);
+    }
+
+    @Test
+    public void crossMap10000() {
+        crossMap(10_000);
+    }
+
+    @Test
+    public void crossMap100000() {
+        crossMap(100_000);
+    }
+
+    @Test
+    public void crossMap1000000() {
+        crossMap(1_000_000);
+    }
+
+    @Test
+    public void cancelAfterIterator() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    ts.cancel();
+                    return IntStream.range(0, 2).boxed().iterator();
+                })
+                .subscribe(ts);
+
+        ts.assertEmpty();
+    }
+
+
+    @Test
+    public void crashInIterator() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    throw new IllegalArgumentException();
+                })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void cancelAfterFirstHasNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    return new Iterator<Integer>() {
+
+                        @Override
+                        public boolean hasNext() {
+                            ts.cancel();
+                            return true;
+                        }
+
+                        @Override
+                        public Integer next() {
+                            return 1;
+                        }
+                    };
+                })
+                .subscribe(ts);
+
+        ts.assertEmpty();
+
+    }
+
+    @Test
+    public void cancelAfterFirstNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    return new Iterator<Integer>() {
+
+                        @Override
+                        public boolean hasNext() {
+                            return true;
+                        }
+
+                        @Override
+                        public Integer next() {
+                            ts.cancel();
+                            return 1;
+                        }
+                    };
+                })
+                .subscribe(ts);
+
+        ts.assertEmpty();
+    }
+
+    @Test
+    public void crashAfterFirstNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    return new Iterator<Integer>() {
+
+                        @Override
+                        public boolean hasNext() {
+                            return true;
+                        }
+
+                        @Override
+                        public Integer next() {
+                            throw new IllegalArgumentException();
+                        }
+                    };
+                })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void limit() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+            .flatMapIterable(v -> range(5))
+                .limit(3)
+                .subscribe(ts);
+
+        ts.assertResult(0, 1, 2);
+    }
+
+    @Test
+    public void crashAfterSecondHasNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .<Integer>flatMapIterable(v -> () -> {
+                    return new Iterator<Integer>() {
+                        int count;
+                        @Override
+                        public boolean hasNext() {
+                            if (++count == 2) {
+                                throw new IllegalArgumentException();
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public Integer next() {
+                            return 1;
+                        }
+                    };
+                })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class, 1);
+    }
+
+    @Test
+    public void cancelAfterSecondHasNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.just(1)
+                .flatMapIterable(v -> () -> {
+                    return new Iterator<Integer>() {
+                        int count;
+                        @Override
+                        public boolean hasNext() {
+                            if (++count == 2) {
+                                ts.cancel();
+                            }
+                            return true;
+                        }
+
+                        @Override
+                        public Integer next() {
+                            return 1;
+                        }
+                    };
+                })
+                .subscribe(ts);
+
+        ts.assertValuesOnly(1);
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
@@ -383,4 +383,47 @@ class TestSubscriber<T> implements Flow.Subscriber<T> {
         }
         return this;
     }
+
+    /**
+     * Assert that there were no items or terminal events received by
+     * this {@code TestSubscriber}.
+     * @return this
+     * @throws AssertionError if items or terminal events were received
+     */
+    public final TestSubscriber<T> assertEmpty() {
+        assertOnSubscribe();
+        assertItemCount(0);
+        assertNotTerminated();
+        return this;
+    }
+
+    /**
+     * Assert that there were no items or terminal events received by
+     * this {@code TestSubscriber}.
+     * @return this
+     * @throws AssertionError if items or terminal events were received
+     */
+    @SafeVarargs
+    public final TestSubscriber<T> assertValuesOnly(T... expectedItems) {
+        assertOnSubscribe();
+        assertValues(expectedItems);
+        assertNotTerminated();
+        return this;
+    }
+
+    /**
+     * Assert that there were no terminal events received by this
+     * {@code TestSubscriber}.
+     * @return this
+     * @throws AssertionError if terminal events were received
+     */
+    public final TestSubscriber<T> assertNotTerminated() {
+        if (!errors.isEmpty()) {
+            throw fail("Unexpected errror(s) present.");
+        }
+        if (completions != 0) {
+            throw fail("Unexpected completion(s).");
+        }
+        return this;
+    }
 }


### PR DESCRIPTION
In addition, expand `TestSubscriber` a bit further.

Related #1455.