### PR TITLE
Move onXXX from Subscribable to Single + TCK

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.helidon.common.mapper.Mapper;
@@ -215,5 +216,64 @@ public interface Single<T> extends Subscribable<T> {
      */
     static <T> Single<T> never() {
         return SingleNever.<T>instance();
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
+     *
+     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @return Single
+     */
+    default Single<T> onTerminate(Runnable onTerminate) {
+        return new SingleTappedPublisher<>(this,
+                null,
+                null,
+                e -> onTerminate.run(),
+                onTerminate,
+                null,
+                onTerminate);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onComplete signal is received.
+     *
+     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @return Single
+     */
+    default Single<T> onComplete(Runnable onTerminate) {
+        return new SingleTappedPublisher<>(this,
+                null,
+                null,
+                null,
+                onTerminate,
+                null,
+                null);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onError signal is received.
+     *
+     * @param onErrorConsumer {@link java.lang.Runnable} to be executed.
+     * @return Single
+     */
+    default Single<T> onError(Consumer<Throwable> onErrorConsumer) {
+        return new SingleTappedPublisher<>(this,
+                null,
+                null,
+                onErrorConsumer,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Invoke provided consumer for the item in stream.
+     *
+     * @param consumer consumer to be invoked
+     * @return Single
+     */
+    default Single<T> peek(Consumer<T> consumer) {
+        return new SingleTappedPublisher<>(this, null, consumer,
+                null, null, null, null);
     }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleTappedPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleTappedPublisher.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+
+import io.helidon.common.reactive.MultiTappedPublisher.ConsumerChain;
+import io.helidon.common.reactive.MultiTappedPublisher.MultiTappedSubscriber;
+import io.helidon.common.reactive.MultiTappedPublisher.RunnableChain;
+
+/**
+ * Intercept the calls to the various Flow interface methods and calls the appropriate
+ * user callbacks.
+ * @param <T> the element type of the sequence
+ */
+final class SingleTappedPublisher<T> implements Single<T> {
+
+    private final Single<T> source;
+
+    // FIXME contravariance in the API signatures
+    private final Consumer<Flow.Subscription> onSubscribeCallback;
+
+    private final Consumer<T> onNextCallback;
+
+    private final Consumer<Throwable> onErrorCallback;
+
+    private final Runnable onCompleteCallback;
+
+    private final LongConsumer onRequestCallback;
+
+    private final Runnable onCancelCallback;
+
+    SingleTappedPublisher(Single<T> source,
+                          Consumer<Flow.Subscription> onSubscribeCallback,
+                          Consumer<T> onNextCallback,
+                          Consumer<Throwable> onErrorCallback,
+                          Runnable onCompleteCallback,
+                          LongConsumer onRequestCallback,
+                          Runnable onCancelCallback) {
+        this.source = source;
+        this.onSubscribeCallback = onSubscribeCallback;
+        this.onNextCallback = onNextCallback;
+        this.onErrorCallback = onErrorCallback;
+        this.onCompleteCallback = onCompleteCallback;
+        this.onRequestCallback = onRequestCallback;
+        this.onCancelCallback = onCancelCallback;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber is null");
+        source.subscribe(new MultiTappedSubscriber<>(subscriber,
+                onSubscribeCallback, onNextCallback,
+                onErrorCallback, onCompleteCallback,
+                onRequestCallback, onCancelCallback));
+    }
+
+    @Override
+    public Single<T> onComplete(Runnable onTerminate) {
+        return new SingleTappedPublisher<>(
+                source,
+                onSubscribeCallback,
+                onNextCallback,
+                onErrorCallback,
+                RunnableChain.combine(onCompleteCallback, onTerminate),
+                onRequestCallback,
+                onCancelCallback
+        );
+    }
+
+    @Override
+    public Single<T> onError(Consumer<Throwable> onErrorConsumer) {
+        return new SingleTappedPublisher<>(
+                source,
+                onSubscribeCallback,
+                onNextCallback,
+                ConsumerChain.combine(onErrorCallback, onErrorConsumer),
+                onCompleteCallback,
+                onRequestCallback,
+                onCancelCallback
+        );
+    }
+
+    @Override
+    public Single<T> onTerminate(Runnable onTerminate) {
+        return new SingleTappedPublisher<>(
+                source,
+                onSubscribeCallback,
+                onNextCallback,
+                ConsumerChain.combine(onErrorCallback, e -> onTerminate.run()),
+                RunnableChain.combine(onCompleteCallback, onTerminate),
+                onRequestCallback,
+                RunnableChain.combine(onCancelCallback, onTerminate)
+        );
+    }
+
+    @Override
+    public Single<T> peek(Consumer<T> consumer) {
+        return new SingleTappedPublisher<>(
+                source,
+                onSubscribeCallback,
+                ConsumerChain.combine(onNextCallback, consumer),
+                onErrorCallback,
+                onCompleteCallback,
+                onRequestCallback,
+                onCancelCallback
+        );
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
@@ -71,47 +71,6 @@ public interface Subscribable<T> extends Publisher<T> {
     }
 
     /**
-     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
-     *
-     * @param onTerminate {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onTerminate(Runnable onTerminate) {
-        MultiTappedProcessor<T> processor = MultiTappedProcessor.<T>create()
-                .onComplete(onTerminate)
-                .onCancel((s) -> onTerminate.run())
-                .onError((t) -> onTerminate.run());
-        this.subscribe(processor);
-        return processor;
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when onComplete signal is received.
-     *
-     * @param onTerminate {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onComplete(Runnable onTerminate) {
-        MultiTappedProcessor<T> processor = MultiTappedProcessor.<T>create()
-                .onComplete(onTerminate);
-        this.subscribe(processor);
-        return processor;
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when onError signal is received.
-     *
-     * @param onErrorConsumer {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onError(Consumer<Throwable> onErrorConsumer) {
-        MultiTappedProcessor<T> processor = MultiTappedProcessor.<T>create()
-                .onError(onErrorConsumer);
-        this.subscribe(processor);
-        return processor;
-    }
-
-    /**
      * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
      *
      * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SinglePeekTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SinglePeekTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+public class SinglePeekTckTest extends FlowPublisherVerification<Integer> {
+
+    public SinglePeekTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.just(1)
+                .peek(v -> { });
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SinglePeekTwiceTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SinglePeekTwiceTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+
+public class SinglePeekTwiceTckTest extends FlowPublisherVerification<Integer> {
+
+    public SinglePeekTwiceTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.just(1)
+                .peek(v -> { })
+                .peek(v -> { });
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTappedPublisherTest.java
@@ -1,0 +1,546 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.testng.Assert.assertEquals;
+
+public class SingleTappedPublisherTest {
+
+    @Test
+    public void onSubscribeCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        new SingleTappedPublisher<>(
+                Single.<Integer>empty(),
+                s -> { throw new IllegalArgumentException(); },
+                null,
+                null,
+                null,
+                null,
+                null
+        )
+        .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+
+    @Test
+    public void onSubscribeNormal() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.<Integer>empty(),
+                s -> { calls.getAndIncrement(); },
+                null,
+                null,
+                null,
+                null,
+                null
+        )
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(1));
+    }
+
+    @Test
+    public void onNextCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1)
+        .peek(v -> { throw new IllegalArgumentException(); })
+        .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void onErrorCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onError(v -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IOException.class));
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void onCompleteCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>empty()
+                .onComplete(() -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void onTerminateCrashWhenCompleted() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>empty()
+                .onTerminate(() -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void onTerminateCrashWhenError() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onTerminate(() -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IOException.class));
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IllegalArgumentException.class));
+        assertThat(ts.isComplete(), is(false));
+    }
+
+    @Test
+    public void onRequestCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                null,
+                null,
+                r -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                },
+                null
+        )
+        .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(1));
+    }
+
+
+    @Test
+    public void onRequestPass() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                null,
+                null,
+                r -> {
+                    calls.getAndIncrement();
+                },
+                null
+        )
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(1));
+    }
+
+    @Test
+    public void onRequestCrashAndThenOnErrorPass() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                e -> {
+                    calls.getAndIncrement();
+                },
+                null,
+                r -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                },
+                null
+        )
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onRequestCrashAndThenOnErrorCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                e -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                },
+                null,
+                r -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                },
+                null
+        )
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onCancelCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                null,
+                null,
+                null,
+                () -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                }
+        )
+        .subscribe(ts);
+
+        ts.getSubcription().cancel();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(false));
+
+        assertThat(calls.get(), is(1));
+    }
+
+    @Test
+    public void onCancelCrashThenOnErrorPass() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                e -> {
+                    calls.getAndIncrement();
+                },
+                null,
+                null,
+                () -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                }
+        )
+                .subscribe(ts);
+
+        ts.getSubcription().cancel();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(false));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onCancelCrashThenOnErrorCrash() {
+
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+
+        new SingleTappedPublisher<>(
+                Single.just(1),
+                null,
+                null,
+                e -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                },
+                null,
+                null,
+                () -> {
+                    calls.getAndIncrement();
+                    throw new IllegalArgumentException();
+                }
+        )
+                .subscribe(ts);
+
+        ts.getSubcription().cancel();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(false));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void peakTwice() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .peek(v -> calls.getAndIncrement())
+                .peek(v -> calls.getAndIncrement())
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onCompleteTwice() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .onComplete(calls::getAndIncrement)
+                .onComplete(calls::getAndIncrement)
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onTerminateTwice() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .onTerminate(calls::getAndIncrement)
+                .onTerminate(calls::getAndIncrement)
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onErrorTwice() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .onError(e -> calls.getAndIncrement())
+                .onError(e -> calls.getAndIncrement())
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(0));
+    }
+
+    @Test
+    public void onErrorTwiceFailure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.<Integer>error(new IOException())
+                .onError(e -> calls.getAndIncrement())
+                .onError(e -> calls.getAndIncrement())
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IOException.class));
+        assertThat(ts.isComplete(), is(false));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void onTerminateTwiceFailure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.<Integer>error(new IOException())
+                .onTerminate(calls::getAndIncrement)
+                .onTerminate(calls::getAndIncrement)
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.getLastError(), instanceOf(IOException.class));
+        assertThat(ts.isComplete(), is(false));
+
+        assertThat(calls.get(), is(2));
+    }
+
+    @Test
+    public void allAppliedMultipleTimes() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .peek(v -> calls.getAndIncrement())
+                .peek(v -> calls.getAndIncrement())
+                .peek(v -> calls.getAndIncrement())
+                .onComplete(calls::getAndIncrement)
+                .onComplete(calls::getAndIncrement)
+                .onComplete(calls::getAndIncrement)
+                .onError(v -> calls.getAndIncrement())
+                .onError(v -> calls.getAndIncrement())
+                .onError(v -> calls.getAndIncrement())
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(6));
+    }
+
+    @Test
+    public void allAppliedMultipleTimes2() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        AtomicInteger calls = new AtomicInteger();
+        Single.just(1)
+                .peek(v -> calls.getAndIncrement())
+                .onComplete(calls::getAndIncrement)
+                .onError(v -> calls.getAndIncrement())
+                .peek(v -> calls.getAndIncrement())
+                .onComplete(calls::getAndIncrement)
+                .onError(v -> calls.getAndIncrement())
+                .peek(v -> calls.getAndIncrement())
+                .onComplete(calls::getAndIncrement)
+                .onError(v -> calls.getAndIncrement())
+                .subscribe(ts);
+
+        ts.requestMax();
+
+        assertEquals(ts.getItems(), Collections.singletonList(1));
+        assertThat(ts.getLastError(), is(nullValue()));
+        assertThat(ts.isComplete(), is(true));
+
+        assertThat(calls.get(), is(6));
+    }
+}


### PR DESCRIPTION
Move `onTerminate`, `onError` and `onComplete` from `Subscribable` into `Single` to have the proper return type.

Add `peek` to `Single` as well.

Related: #1455.