### PR TITLE
Reimplement onErrorResume[With] + TCK tests

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -454,4 +454,24 @@ public interface Multi<T> extends Subscribable<T> {
         }
         return new MultiRangeLongPublisher(start, start + count);
     }
+
+    /**
+     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
+     *
+     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
+     * @return Multi
+     */
+    default Multi<T> onErrorResume(Function<? super Throwable, ? extends T> onError) {
+        return onErrorResumeWith(e -> Multi.singleton(onError.apply(e)));
+    }
+
+    /**
+     * Resume stream from supplied publisher if onError signal is intercepted.
+     *
+     * @param onError supplier of new stream publisher
+     * @return Multi
+     */
+    default Multi<T> onErrorResumeWith(Function<? super Throwable, ? extends Flow.Publisher<? extends T>> onError) {
+        return new MultiOnErrorResumeWith<>(this, onError);
+    }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiError.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiError.java
@@ -16,7 +16,6 @@
 package io.helidon.common.reactive;
 
 import java.util.Objects;
-import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.Flow.Subscriber;
 
@@ -40,17 +39,7 @@ final class MultiError<T> implements Multi<T> {
 
     @Override
     public void subscribe(Subscriber<? super T> subscriber) {
-        subscriber.onSubscribe(new Flow.Subscription() {
-            @Override
-            public void request(long n) {
-                subscriber.onError(error);
-            }
-
-            @Override
-            public void cancel() {
-
-            }
-        });
+        subscriber.onSubscribe(EmptySubscription.INSTANCE);
         subscriber.onError(error);
     }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiOnErrorResumeWith.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiOnErrorResumeWith.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * If the upstream fails, switch to a generated Flow.Publisher and relay its signals then on.
+ * @param <T> the element type of the flows
+ */
+final class MultiOnErrorResumeWith<T> implements Multi<T> {
+
+    private final Multi<T> source;
+
+    private final Function<? super Throwable, ? extends Flow.Publisher<? extends T>> fallbackFunction;
+
+    MultiOnErrorResumeWith(Multi<T> source,
+           Function<? super Throwable, ? extends Flow.Publisher<? extends T>> fallbackFunction) {
+        this.source = source;
+        this.fallbackFunction = fallbackFunction;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        source.subscribe(new OnErrorResumeWithSubscriber<>(subscriber, fallbackFunction));
+    }
+
+    static final class OnErrorResumeWithSubscriber<T> implements Flow.Subscriber<T>, Flow.Subscription {
+
+        private final Flow.Subscriber<? super T> downstream;
+
+        private final Function<? super Throwable, ? extends Flow.Publisher<? extends T>> fallbackFunction;
+
+        private Flow.Subscription upstream;
+
+        private long received;
+
+        private final AtomicLong requested;
+
+        private final FallbackSubscriber<T> fallbackSubscriber;
+
+        OnErrorResumeWithSubscriber(Flow.Subscriber<? super T> downstream,
+                Function<? super Throwable, ? extends Flow.Publisher<? extends T>> fallbackFunction) {
+            this.downstream = downstream;
+            this.fallbackFunction = fallbackFunction;
+            this.requested = new AtomicLong();
+            fallbackSubscriber = new FallbackSubscriber<>(downstream, requested);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(T item) {
+            received++;
+            downstream.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            upstream = SubscriptionHelper.CANCELED;
+            long p = received;
+            if (p != 0L) {
+                SubscriptionHelper.produced(requested, p);
+            }
+
+            Flow.Publisher<? extends T> publisher;
+
+            try {
+                publisher = Objects.requireNonNull(fallbackFunction.apply(throwable),
+                        "The fallback function returned a null Flow.Publisher");
+            } catch (Throwable ex) {
+                ex.addSuppressed(throwable);
+                downstream.onError(ex);
+                return;
+            }
+
+            publisher.subscribe(fallbackSubscriber);
+        }
+
+        @Override
+        public void onComplete() {
+            upstream = SubscriptionHelper.CANCELED;
+            downstream.onComplete();
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                downstream.onError(new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden"));
+            } else {
+                SubscriptionHelper.deferredRequest(fallbackSubscriber, requested, n);
+                upstream.request(n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            upstream.cancel();
+            SubscriptionHelper.cancel(fallbackSubscriber);
+        }
+
+        static final class FallbackSubscriber<T> extends AtomicReference<Flow.Subscription>
+        implements Flow.Subscriber<T> {
+
+            private final Flow.Subscriber<? super T> downstream;
+
+            private final AtomicLong requested;
+
+            FallbackSubscriber(Flow.Subscriber<? super T> downstream, AtomicLong requested) {
+                this.downstream = downstream;
+                this.requested = requested;
+            }
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                SubscriptionHelper.deferredSetOnce(this, requested, subscription);
+            }
+
+            @Override
+            public void onNext(T item) {
+                downstream.onNext(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                downstream.onError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -273,4 +273,25 @@ public interface Single<T> extends Subscribable<T> {
         return new SingleTappedPublisher<>(this, null, consumer,
                 null, null, null, null);
     }
+
+    /**
+     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
+     *
+     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
+     * @return Single
+     */
+    default Single<T> onErrorResume(Function<? super Throwable, ? extends T> onError) {
+        return new SingleOnErrorResume<>(this, onError);
+    }
+
+
+    /**
+     * Resume stream from supplied publisher if onError signal is intercepted.
+     *
+     * @param onError supplier of new stream publisher
+     * @return Single
+     */
+    default Single<T> onErrorResumeWith(Function<? super Throwable, ? extends Single<? extends T>> onError) {
+        return new SingleOnErrorResumeWith<>(this, onError);
+    }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleOnErrorResume.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleOnErrorResume.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.Function;
+
+/**
+ * If the upstream fails, generate a fallback success item via a function.
+ * @param <T> the element type of the sequence
+ */
+final class SingleOnErrorResume<T> implements Single<T> {
+
+    private final Single<T> source;
+
+    private final Function<? super Throwable, ? extends T> fallbackFunction;
+
+    SingleOnErrorResume(Single<T> source,
+                        Function<? super Throwable, ? extends T> fallbackFunction) {
+        this.source = source;
+        this.fallbackFunction = fallbackFunction;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber is null");
+        source.subscribe(new OnErrorResumeSubscriber<>(subscriber, fallbackFunction));
+    }
+
+    static final class OnErrorResumeSubscriber<T> extends DeferredScalarSubscription<T>
+            implements Flow.Subscriber<T> {
+
+        private final Function<? super Throwable, ? extends T> fallbackFunction;
+
+        private Flow.Subscription upstream;
+
+        OnErrorResumeSubscriber(Flow.Subscriber<? super T> downstream,
+                                Function<? super Throwable, ? extends T> fallbackFunction) {
+            super(downstream);
+            this.fallbackFunction = fallbackFunction;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(this.upstream, subscription);
+            this.upstream = subscription;
+            subscribeSelf();
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            upstream = SubscriptionHelper.CANCELED;
+            complete(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            upstream = SubscriptionHelper.CANCELED;
+            T fallback;
+            try {
+                fallback = Objects.requireNonNull(fallbackFunction.apply(throwable),
+                        "The fallback function returned a null item");
+            } catch (Throwable ex) {
+                ex.addSuppressed(throwable);
+                error(ex);
+                return;
+            }
+            complete(fallback);
+        }
+
+        @Override
+        public void onComplete() {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                complete();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            upstream.cancel();
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleOnErrorResumeWith.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleOnErrorResumeWith.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * If the upstream fails, generate a fallback Single and emit its signals.
+ * @param <T> the element type of the source and fallback
+ */
+final class SingleOnErrorResumeWith<T> implements Single<T> {
+
+    private final Single<T> source;
+
+    private final Function<? super Throwable, ? extends Single<? extends T>> fallbackFunction;
+
+    SingleOnErrorResumeWith(Single<T> source,
+                            Function<? super Throwable, ? extends Single<? extends T>> fallbackFunction) {
+        this.source = source;
+        this.fallbackFunction = fallbackFunction;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        Objects.requireNonNull(subscriber, "subscriber is null");
+        source.subscribe(new OnErrorResumeWithSubscriber<>(subscriber, fallbackFunction));
+    }
+
+    static final class OnErrorResumeWithSubscriber<T> extends DeferredScalarSubscription<T>
+    implements Flow.Subscriber<T> {
+
+        private final Function<? super Throwable, ? extends Single<? extends T>> fallbackFunction;
+
+        private final FallbackSubscriber<T> fallbackSubscriber;
+
+        private Flow.Subscription upstream;
+
+        OnErrorResumeWithSubscriber(Flow.Subscriber<? super T> downstream,
+                                    Function<? super Throwable, ? extends Single<? extends T>> fallbackFunction) {
+            super(downstream);
+            this.fallbackFunction = fallbackFunction;
+            this.fallbackSubscriber = new FallbackSubscriber<>(this);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            subscribeSelf();
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            upstream = SubscriptionHelper.CANCELED;
+            complete(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            upstream = SubscriptionHelper.CANCELED;
+            Single<? extends T> fallback;
+
+            try {
+                fallback = Objects.requireNonNull(fallbackFunction.apply(throwable),
+                        "The fallback function returned a null Single");
+            } catch (Throwable ex) {
+                ex.addSuppressed(throwable);
+                error(ex);
+                return;
+            }
+
+            fallback.subscribe(fallbackSubscriber);
+        }
+
+        @Override
+        public void onComplete() {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                complete();
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            upstream.cancel();
+            SubscriptionHelper.cancel(fallbackSubscriber);
+        }
+
+        static final class FallbackSubscriber<T> extends AtomicReference<Flow.Subscription>
+        implements Flow.Subscriber<T> {
+
+            private final OnErrorResumeWithSubscriber<T> parent;
+
+            FallbackSubscriber(OnErrorResumeWithSubscriber<T> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                SubscriptionHelper.setOnce(this, subscription);
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(T item) {
+                parent.complete(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                parent.error(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                parent.complete();
+            }
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
@@ -18,7 +18,6 @@ package io.helidon.common.reactive;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Publisher;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Decorated publisher that allows subscribing to individual events with java functions.
@@ -68,29 +67,5 @@ public interface Subscribable<T> extends Publisher<T> {
             Consumer<? super Flow.Subscription> subscriptionConsumer) {
 
         this.subscribe(new FunctionalSubscriber<>(consumer, errorConsumer, completeConsumer, subscriptionConsumer));
-    }
-
-    /**
-     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
-     *
-     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
-     * @return Multi
-     */
-    default Multi<T> onErrorResume(Function<Throwable, T> onError) {
-        MultiOnErrorResumeProcessor<T> processor = MultiOnErrorResumeProcessor.resume(onError);
-        this.subscribe(processor);
-        return processor;
-    }
-
-    /**
-     * Resume stream from supplied publisher if onError signal is intercepted.
-     *
-     * @param onError supplier of new stream publisher
-     * @return Multi
-     */
-    default Multi<T> onErrorResumeWith(Function<Throwable, Publisher<T>> onError) {
-        MultiOnErrorResumeProcessor<T> processor = MultiOnErrorResumeProcessor.resumeWith(onError);
-        this.subscribe(processor);
-        return processor;
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeFailureTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeFailureTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.io.IOException;
+import java.util.concurrent.Flow;
+
+public class MultiOnErrorResumeFailureTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiOnErrorResumeFailureTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Multi.singleton((int)l));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeSuccessTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeSuccessTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.io.IOException;
+import java.util.concurrent.Flow;
+
+public class MultiOnErrorResumeSuccessTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiOnErrorResumeSuccessTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.range(0, (int)l)
+                .onErrorResumeWith(e -> Multi.singleton((int)l));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class MultiOnErrorResumeTest {
+
+    @Test
+    public void fallbackFunctionCrash() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException())
+                .onErrorResume(e -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
+    }
+
+    @Test
+    public void emptySource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>empty()
+                .onErrorResume(Object::hashCode)
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void failAfterItems() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>error(new IOException()))
+                .onErrorResume(v -> 4)
+                .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4);
+    }
+
+    @Test
+    public void failAfterItemsBackpressure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>error(new IOException()))
+                .onErrorResume(v -> 4)
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(3)
+                .assertValuesOnly(1, 2, 3)
+                .request(1)
+                .assertResult(1, 2, 3, 4);
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithFailureTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithFailureTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.io.IOException;
+import java.util.concurrent.Flow;
+
+public class MultiOnErrorResumeWithFailureTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiOnErrorResumeWithFailureTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Multi.range(0, (int)l));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithSuccessTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithSuccessTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+
+public class MultiOnErrorResumeWithSuccessTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiOnErrorResumeWithSuccessTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.range(0, (int)l)
+                .onErrorResumeWith(e -> Multi.range(1, 100));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnErrorResumeWithTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class MultiOnErrorResumeWithTest {
+
+    @Test
+    public void fallbackFunctionCrash() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
+    }
+
+    @Test
+    public void fallbackToError() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Multi.error(new IllegalArgumentException()))
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void emptySource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>empty()
+                .onErrorResumeWith(e -> Multi.just(e.hashCode()))
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void emptyFallback() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Multi.empty())
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void failAfterItems() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>error(new IOException()))
+                .onErrorResumeWith(v -> Multi.range(4, 2))
+                .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void failAfterItemsBackpressure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>error(new IOException()))
+                .onErrorResumeWith(v -> Multi.range(4, 2))
+                .subscribe(ts);
+
+        ts.assertEmpty()
+        .request(3)
+        .assertValuesOnly(1, 2, 3)
+        .request(2)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeFailureTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeFailureTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.io.IOException;
+import java.util.concurrent.Flow;
+
+public class SingleOnErrorResumeFailureTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleOnErrorResumeFailureTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.<Integer>error(new IOException())
+                .onErrorResume(Object::hashCode);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeSuccessTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeSuccessTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+
+public class SingleOnErrorResumeSuccessTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleOnErrorResumeSuccessTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.just(1)
+                .onErrorResume(Object::hashCode);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.testng.Assert.assertEquals;
+
+public class SingleOnErrorResumeTest {
+
+    @Test
+    public void fallbackFunctionCrash() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onErrorResume(e -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
+    }
+
+    @Test
+    public void emptySource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>empty()
+                .onErrorResume(Object::hashCode)
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithFailureTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithFailureTckTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.io.IOException;
+import java.util.concurrent.Flow;
+
+public class SingleOnErrorResumeWithFailureTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleOnErrorResumeWithFailureTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Single.just(e.hashCode()));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithSuccessTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithSuccessTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.util.concurrent.Flow;
+
+public class SingleOnErrorResumeWithSuccessTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleOnErrorResumeWithSuccessTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.just(1)
+                .onErrorResumeWith(e -> Single.just(e.hashCode()));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleOnErrorResumeWithTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class SingleOnErrorResumeWithTest {
+
+    @Test
+    public void fallbackFunctionCrash() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+
+        assertThat(ts.getLastError().getSuppressed()[0], instanceOf(IOException.class));
+    }
+
+    @Test
+    public void fallbackToError() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Single.error(new IllegalArgumentException()))
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void emptySource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>empty()
+                .onErrorResumeWith(e -> Single.just(e.hashCode()))
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void emptyFallback() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .onErrorResumeWith(e -> Single.empty())
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+}


### PR DESCRIPTION
Reimplement `onErrorResume` and `onErrorResumeWith` for `Multi` and `Single`.

Also:
- Fix `Multi.error`.
- Make some cleanups in `SubscriptionHelper`.
- Expand `DeferredScalarSubscription` API.

Related: #1455.