### PR TITLE
[Reactive] Implement reduce() + TCK tests

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiReduce.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiReduce.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.BiFunction;
+
+/**
+ * Combine subsequent items via a callback function and emit
+ * the result as a Single.
+ * @param <T> the element type of the source and result
+ */
+final class MultiReduce<T> implements Single<T> {
+
+    private final Multi<T> source;
+
+    private final BiFunction<T, T, T> reducer;
+
+    MultiReduce(Multi<T> source, BiFunction<T, T, T> reducer) {
+        this.source = source;
+        this.reducer = reducer;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        source.subscribe(new ReducerSubscriber<>(subscriber, reducer));
+    }
+
+    static final class ReducerSubscriber<T> extends DeferredScalarSubscription<T>
+    implements Flow.Subscriber<T> {
+
+        private final BiFunction<T, T, T> reducer;
+
+        private Flow.Subscription upstream;
+
+        private T current;
+
+        ReducerSubscriber(Flow.Subscriber<? super T> downstream, BiFunction<T, T, T> reducer) {
+            super(downstream);
+            this.reducer = reducer;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            // FIXME subscribeSelf()
+            downstream().onSubscribe(this);
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                T current = this.current;
+                if (current == null) {
+                    this.current = item;
+                } else {
+                    try {
+                        this.current = Objects.requireNonNull(reducer.apply(current, item),
+                        "The reducer returned a null item");
+                    } catch (Throwable ex) {
+                        s.cancel();
+                        onError(ex);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                current = null;
+                // FIXME error()
+                downstream().onError(throwable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                T current = this.current;
+                this.current = null;
+                if (current == null) {
+                    // FIXME complete()
+                    downstream().onComplete();
+                } else {
+                    complete(current);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELED;
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiReduceFull.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiReduceFull.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * Combine items via an accumulator and function into a single value.
+ * @param <T> the source value type
+ * @param <R> the accumulator and result type
+ */
+final class MultiReduceFull<T, R> implements Single<R> {
+
+    private final Multi<T> source;
+
+    private final Supplier<? extends R> supplier;
+
+    private final BiFunction<R, T, R> reducer;
+
+    MultiReduceFull(Multi<T> source, Supplier<? extends R> supplier, BiFunction<R, T, R> reducer) {
+        this.source = source;
+        this.supplier = supplier;
+        this.reducer = reducer;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super R> subscriber) {
+        R initial;
+        try {
+            initial = Objects.requireNonNull(supplier.get(),
+                    "The supplier returned a null item");
+        } catch (Throwable ex) {
+            subscriber.onSubscribe(EmptySubscription.INSTANCE);
+            subscriber.onError(ex);
+            return;
+        }
+        source.subscribe(new ReduceFullSubscriber<>(subscriber, initial, reducer));
+    }
+
+    static final class ReduceFullSubscriber<T, R> extends DeferredScalarSubscription<R>
+    implements Flow.Subscriber<T> {
+
+        private final BiFunction<R, T, R> reducer;
+
+        private R accumulator;
+
+        private Flow.Subscription upstream;
+
+        ReduceFullSubscriber(Flow.Subscriber<? super R> downstream, R initial, BiFunction<R, T, R> reducer) {
+            super(downstream);
+            this.reducer = reducer;
+            this.accumulator = initial;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            // FIXME subscribeSelf()
+            downstream().onSubscribe(this);
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                try {
+                    accumulator = Objects.requireNonNull(reducer.apply(accumulator, item),
+                            "The reducer returned a null item");
+                } catch (Throwable ex) {
+                    s.cancel();
+                    onError(ex);
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                accumulator = null;
+                // FIXME error()
+                downstream().onError(throwable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            if (upstream != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                R accumulator = this.accumulator;
+                this.accumulator = null;
+                complete(accumulator);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            super.cancel();
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELED;
+        }
+   }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceFullTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceFullTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Flow;
+
+@Test
+public class MultiReduceFullTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiReduceFullTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.range(1, 10).reduce(() -> 0, Integer::sum);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceFullTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceFullTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class MultiReduceFullTest {
+
+    @Test
+    public void empty() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.<Integer>empty().reduce(() -> 100, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult(100);
+    }
+
+    @Test
+    public void single() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.singleton(1).reduce(() -> 100, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult(101);
+    }
+
+    @Test
+    public void range() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.range(1, 10).reduce(() -> 100, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult(155);
+    }
+
+    @Test
+    public void error() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException()).reduce(() -> 100, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertFailure(IOException.class);
+    }
+
+    @Test
+    public void supplierNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce(() -> null, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void supplierCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce(() -> { throw new IllegalArgumentException(); }, Integer::sum)
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void reducerNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce(() -> 100, (a, b) -> null)
+                .subscribe(ts);
+
+        ts.assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void reducerCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce(() -> 100, (a, b) -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void cancel() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.<Integer>never()
+                .reduce(() -> 100, Integer::sum)
+                .subscribe(ts);
+
+        ts.cancel();
+
+        ts.assertEmpty();
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceTckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class MultiReduceTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiReduceTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.range(1, 10).reduce(Integer::sum);
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 1;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiReduceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class MultiReduceTest {
+
+    @Test
+    public void empty() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.<Integer>empty().reduce(Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void single() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.singleton(1).reduce(Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult(1);
+    }
+
+    @Test
+    public void range() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.range(1, 10).reduce(Integer::sum)
+                .subscribe(ts);
+
+        ts.assertResult(55);
+    }
+
+    @Test
+    public void error() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException()).reduce(Integer::sum)
+                .subscribe(ts);
+
+        ts.assertFailure(IOException.class);
+    }
+
+    @Test
+    public void reducerNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce((a, b) -> null)
+                .subscribe(ts);
+
+        ts.assertFailure(NullPointerException.class);
+    }
+
+
+    @Test
+    public void reducerCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.range(1, 5)
+                .reduce((a, b) -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void cancel() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Multi.<Integer>never()
+        .reduce(Integer::sum)
+        .subscribe(ts);
+
+        ts.cancel();
+
+        ts.assertEmpty();
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
@@ -162,8 +162,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
         Function<String, Single<Integer>> bonusForDoubleLetter =
             word -> toBeMaxed.apply(word)
                         .map(scoreOfALetter)
-                    .collectStream(Collectors.summarizingInt(value -> value))
-                    .map(v -> (int)v.getMax())
+                    .reduce(Integer::max)
                     ;
 
         // score of the word put on the board

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
@@ -125,8 +125,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
                             Multi.from(histoOfLetters.apply(word))
                             .flatMapIterable(HashMap::entrySet)
                             .map(blank)
-                            .collectStream(Collectors.summarizingLong(value -> value))
-                            .map(LongSummaryStatistics::getSum)
+                            .reduce(Long::sum)
                     ;
 
 
@@ -143,8 +142,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
                                     HashMap::entrySet
                             )
                             .map(letterScore)
-                            .collectStream(Collectors.summarizingInt(value -> value))
-                            .map(v -> (int)v.getSum())
+                            .reduce(Integer::sum)
                             ;
 
         // Placing the word on the board
@@ -175,11 +173,8 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
                     Multi.from(score2.apply(word)),
                     Multi.from(bonusForDoubleLetter.apply(word))
                 )
-                .collectStream(Collectors.summarizingInt(value -> value))
-                .map(w -> {
-                    int v = (int) w.getSum();
-                    return v * 2 + (word.length() == 7 ? 50 : 0);
-                })
+                .reduce(Integer::sum)
+                .map(v -> v * 2 + (word.length() == 7 ? 50 : 0))
                 ;
 
         Function<Function<String, Single<Integer>>, Single<TreeMap<Integer, List<String>>>> buildHistoOnScore =


### PR DESCRIPTION
Related #1500 

Benchmark updated (i7 8700, Windows 10 x64, Java 11.0.6):

```
ShakespearePlaysScrabbleWithHelidonReactiveOpt.before   sample  165  30,909 ± 0,136  ms/op
ShakespearePlaysScrabbleWithHelidonReactiveOpt.after    sample  184  27,701 ± 0,207  ms/op
```
