### PR TITLE
[Reactive] Implement Single.flatMapIterable + TCK tests

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -104,6 +104,20 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
+     * Maps the single upstream value into an {@link Iterable} and relays its
+     * items to the downstream.
+     * @param mapper the function that receives the single upstream value and
+     *               should return an Iterable instance
+     * @param <U> the result type
+     * @return Multi
+     * @throws NullPointerException if {@code mapper} is {@code null}
+     */
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return new SingleFlatMapIterable<>(this, mapper);
+    }
+
+    /**
      * Exposes this {@link Single} instance as a {@link CompletionStage}.
      * Note that if this {@link Single} completes without a value, the resulting {@link CompletionStage} will be completed
      * exceptionally with an {@link IllegalStateException}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleFlatMapIterable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleFlatMapIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleFlatMapIterable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleFlatMapIterable.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+/**
+ * Maps the success value of a {@link Single} into an {@link Iterable} and
+ * emits its items to the downstream.
+ * @param <T> the source value type
+ * @param <R> the result value type
+ */
+final class SingleFlatMapIterable<T, R> implements Multi<R> {
+
+    private final Single<T> source;
+
+    private final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+    SingleFlatMapIterable(Single<T> source, Function<? super T, ? extends Iterable<? extends R>> mapper) {
+        this.source = source;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super R> subscriber) {
+        source.subscribe(new FlatMapIterableSubscriber<>(subscriber, mapper));
+    }
+
+    static final class FlatMapIterableSubscriber<T, R>
+            extends AtomicInteger
+            implements Flow.Subscriber<T>, Flow.Subscription {
+
+        private final Flow.Subscriber<? super R> downstream;
+
+        private final Function<? super T, ? extends Iterable<? extends R>> mapper;
+
+        private final AtomicLong requested;
+
+        private Flow.Subscription upstream;
+
+        private long emitted;
+
+        private volatile int canceled;
+
+        private volatile Iterator<? extends R> iterator;
+
+        private static final int CANCELED = 1;
+
+        private static final int BAD_REQUEST = 2;
+
+        FlatMapIterableSubscriber(Flow.Subscriber<? super R> downstream,
+                                  Function<? super T, ? extends Iterable<? extends R>> mapper) {
+            this.downstream = downstream;
+            this.mapper = mapper;
+            this.requested = new AtomicLong();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            downstream.onSubscribe(this);
+            subscription.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(T item) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+
+                Iterator<? extends R> iterator;
+                try {
+                    Iterable<? extends R> iterable = Objects.requireNonNull(mapper.apply(item),
+                            "The mapper returned a null Iterable");
+
+                    iterator = iterable.iterator();
+
+                    if (!iterator.hasNext()) {
+                        iterator = null;
+                    }
+                } catch (Throwable ex) {
+                    downstream.onError(ex);
+                    return;
+                }
+
+                if (iterator != null) {
+                    this.iterator = iterator;
+                    drain();
+                } else {
+                    downstream.onComplete();
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                downstream.onError(throwable);
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            Flow.Subscription s = upstream;
+            if (s != SubscriptionHelper.CANCELED) {
+                upstream = SubscriptionHelper.CANCELED;
+                downstream.onComplete();
+            }
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                canceled = BAD_REQUEST;
+                n = 1;
+            }
+            SubscriptionHelper.addRequest(requested, n);
+            drain();
+        }
+
+        @Override
+        public void cancel() {
+            canceled = CANCELED;
+            upstream.cancel();
+            upstream = SubscriptionHelper.CANCELED;
+            drain();
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            int missed = 1;
+            Iterator<? extends R> it = iterator;
+            Flow.Subscriber<? super R> downstream = this.downstream;
+            long e = emitted;
+
+            outer:
+            for (;;) {
+
+                int c = canceled;
+                if (c != 0) {
+                    it = null;
+                    iterator = null;
+                    if (c == BAD_REQUEST) {
+                        downstream.onError(new IllegalArgumentException(
+                                "Rule §3.9 violated: non-positive requests are forbidden"));
+                    }
+                } else {
+                    if (it != null) {
+
+                        long r = requested.get();
+
+                        while (r != e) {
+                            R item;
+                            try {
+                                item = Objects.requireNonNull(it.next(),
+                                        "The iterator returned a null item");
+                            } catch (Throwable ex) {
+                                canceled = CANCELED;
+                                downstream.onError(ex);
+                                continue outer;
+                            }
+
+                            if (canceled != 0) {
+                                continue outer;
+                            }
+
+                            downstream.onNext(item);
+                            e++;
+
+                            if (canceled != 0) {
+                                continue outer;
+                            }
+
+                            boolean hasNext;
+                            try {
+                                hasNext = it.hasNext();
+                            } catch (Throwable ex) {
+                                canceled = CANCELED;
+                                downstream.onError(ex);
+                                continue outer;
+                            }
+
+                            if (!hasNext) {
+                                canceled = CANCELED;
+                                downstream.onComplete();
+                                continue outer;
+                            }
+
+                            if (canceled != 0) {
+                                continue outer;
+                            }
+                        }
+                    }
+                }
+
+                emitted = e;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
+                }
+                if (it == null) {
+                    it = iterator;
+                }
+            }
+        }
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Flow;
+import java.util.stream.IntStream;
+
+@Test
+public class SingleFlatMapIterableTckTest extends FlowPublisherVerification<Integer> {
+
+    public SingleFlatMapIterableTckTest() {
+        super(new TestEnvironment(50));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Single.just(1)
+                .flatMapIterable(v -> () -> IntStream.range(0, (int)l).boxed().iterator());
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleFlatMapIterableTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.common.reactive;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.testng.Assert.assertEquals;
+
+public class SingleFlatMapIterableTest {
+
+    @Test
+    public void sourceEmpty() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>empty()
+                .flatMapIterable(v -> Arrays.asList(v, v + 1))
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void sourceError() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>error(new IOException())
+                .flatMapIterable(v -> Arrays.asList(v, v + 1))
+                .subscribe(ts);
+
+        ts.assertFailure(IOException.class);
+    }
+
+    @Test
+    public void normal() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> Arrays.asList(v, v + 1))
+                .subscribe(ts);
+
+        ts.assertResult(1, 2);
+    }
+
+    @Test
+    public void mappedToEmpty() {
+        TestSubscriber<Object> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> Collections.emptyList())
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void normalBackpressured() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> Arrays.asList(v, v + 1))
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(1)
+                .assertValuesOnly(1)
+                .request(2)
+                .assertResult(1, 2);
+    }
+
+    @Test
+    public void normalOneBackpressured() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>just(1)
+                .flatMapIterable(Collections::singletonList)
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(1)
+                .assertResult(1);
+    }
+
+    @Test
+    public void mapperNull() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> null)
+                .subscribe(ts);
+
+        ts.assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void mapperCrash() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> { throw new IllegalArgumentException(); })
+                .subscribe(ts);
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void nullIteratorValue() {
+        TestSubscriber<Object> ts = new TestSubscriber<>();
+
+        Single.<Integer>just(1)
+                .flatMapIterable(v -> Collections.singletonList(null))
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(1)
+                .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void iteratorNextCrash() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1).flatMapIterable(v -> () -> new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                throw new IllegalArgumentException();
+            }
+        })
+                .subscribe(ts);
+
+        ts.request1();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.isComplete(), is(false));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void iteratorNextCancel() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1).flatMapIterable(v -> () -> new Iterator<Integer>() {
+
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                ts.getSubcription().cancel();
+                return 1;
+            }
+        })
+                .subscribe(ts);
+
+        ts.request1();
+
+        assertThat(ts.getItems().isEmpty(), is(true));
+        assertThat(ts.isComplete(), is(false));
+        assertThat(ts.getLastError(), is(nullValue()));
+    }
+
+    @Test
+    public void iteratorHasNextCrash2ndCall() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1).flatMapIterable(v -> () -> new Iterator<Integer>() {
+            int calls;
+            @Override
+            public boolean hasNext() {
+                if (++calls == 2) {
+                    throw new IllegalArgumentException();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        })
+                .subscribe(ts);
+
+        ts.request1();
+
+        assertEquals(ts.getItems(), Collections.singleton(1));
+        assertThat(ts.isComplete(), is(false));
+        assertThat(ts.getLastError(), instanceOf(IllegalArgumentException.class));
+    }
+
+
+    @Test
+    public void iteratorHasNextCancel2ndCall() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Single.just(1).flatMapIterable(v -> () -> new Iterator<Integer>() {
+            int calls;
+            @Override
+            public boolean hasNext() {
+                if (++calls == 2) {
+                    ts.getSubcription().cancel();
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return 1;
+            }
+        })
+                .subscribe(ts);
+
+        ts.request1();
+
+        assertEquals(ts.getItems(), Collections.singleton(1));
+        assertThat(ts.isComplete(), is(false));
+        assertThat(ts.getLastError(), is(nullValue()));
+    }
+
+    @Test
+    public void cancelInOnNext() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>() {
+            @Override
+            public void onNext(Integer item) {
+                super.onNext(item);
+                getSubcription().cancel();
+                super.onComplete();
+            }
+        };
+
+        Single.just(1).flatMapIterable(v -> Collections.singleton(1))
+                .subscribe(ts);
+
+        ts.requestMax();
+        assertEquals(ts.getItems(), Collections.singleton(1));
+        assertThat(ts.isComplete(), is(true));
+        assertThat(ts.getLastError(), is(nullValue()));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
@@ -122,7 +122,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
         // number of blanks for a given word
         Function<String, Single<Long>> nBlanks =
                 word ->
-                            Multi.from(histoOfLetters.apply(word))
+                            histoOfLetters.apply(word)
                             .flatMapIterable(HashMap::entrySet)
                             .map(blank)
                             .reduce(Long::sum)
@@ -137,7 +137,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
         // score taking blanks into account letterScore1
         Function<String, Single<Integer>> score2 =
                 word ->
-                        Multi.from(histoOfLetters.apply(word))
+                        histoOfLetters.apply(word)
                             .flatMapIterable(
                                     HashMap::entrySet
                             )
@@ -195,7 +195,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
 
         // best key / value pairs
         List<Entry<Integer, List<String>>> finalList2 =
-                    Multi.from(buildHistoOnScore.apply(score3))
+                    buildHistoOnScore.apply(score3)
                     .flatMapIterable(
                             TreeMap::entrySet
                     )


### PR DESCRIPTION
Related: #1500

Benchmark (i7 8700, Windows 10 x64, JDK 15b13)
```
ShakespearePlaysScrabbleWithHelidonReactiveOpt.before   sample  175  29,014 ± 0,155  ms/op
ShakespearePlaysScrabbleWithHelidonReactiveOpt.after    sample  185  27,343 ± 0,183  ms/op
```