### PR TITLE
Openapi custom context root 2.x

### DIFF
--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -105,7 +105,7 @@ public final class Main {
 
         return Routing.builder()
                 .register(JsonSupport.create())
-                .register(OpenAPISupport.create(config))
+                .register(OpenAPISupport.create(config.get(OpenAPISupport.Builder.CONFIG_KEY)))
                 .register(health)                   // Health at "/health"
                 .register(metrics)                  // Metrics at "/metrics"
                 .register("/greet", greetService)

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
@@ -99,13 +99,15 @@ public class OpenApiCdiExtension implements Extension {
 
     void registerOpenApi(@Observes @Initialized(ApplicationScoped.class) Object adv, BeanManager bm) {
         try {
+            Config openapiNode = config.get(OpenAPISupport.Builder.CONFIG_KEY);
             OpenAPISupport openApiSupport = new MPOpenAPIBuilder()
                     .openAPIConfig(new OpenApiConfigImpl(mpConfig))
                     .indexView(indexView())
-                    .helidonConfig(config)
+                    .config(openapiNode)
                     .build();
 
-            openApiSupport.configureEndpoint(RoutingBuilders.create(config.get("openapi")).routingBuilder());
+            openApiSupport.configureEndpoint(
+                    RoutingBuilders.create(openapiNode).routingBuilder());
         } catch (IOException e) {
             throw new DeploymentException("Failed to obtain index view", e);
         }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
@@ -102,6 +102,7 @@ public class OpenApiCdiExtension implements Extension {
             OpenAPISupport openApiSupport = new MPOpenAPIBuilder()
                     .openAPIConfig(new OpenApiConfigImpl(mpConfig))
                     .indexView(indexView())
+                    .helidonConfig(config)
                     .build();
 
             openApiSupport.configureEndpoint(RoutingBuilders.create(config.get("openapi")).routingBuilder());

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.util.Map;
 
 import io.helidon.common.http.MediaType;
+import io.helidon.config.Config;
 import io.helidon.microprofile.server.Server;
 
 import org.junit.jupiter.api.AfterAll;
@@ -53,7 +54,7 @@ public class BasicServerTest {
      */
     @BeforeAll
     public static void startServer() throws Exception {
-        server = TestUtil.startServer(TestApp.class);
+        server = TestUtil.startServer(TestApp.class, Config.create());
         cnx = TestUtil.getURLConnection(
                 server.port(),
                 "GET",

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestServerWithConfig.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestServerWithConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,22 @@
  */
 package io.helidon.microprofile.openapi;
 
-import java.net.HttpURLConnection;
-import java.util.Map;
-
 import io.helidon.common.http.MediaType;
+import io.helidon.config.ClasspathConfigSource;
+import io.helidon.config.Config;
 import io.helidon.microprofile.server.Server;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.net.HttpURLConnection;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Test that MP OpenAPI support works when retrieving the OpenAPI document
- * from the server's /openapi endpoint.
- */
-public class BasicServerTest {
+public class TestServerWithConfig {
 
-    private static final String OPENAPI_PATH = "/openapi";
+    private static final String ALTERNATE_OPENAPI_PATH = "/otheropenapi";
 
     private static Server server;
 
@@ -42,44 +39,28 @@ public class BasicServerTest {
 
     private static Map<String, Object> yaml;
 
-    public BasicServerTest() {
+    public TestServerWithConfig() {
     }
 
-    /**
-     * Start the server to run the test app and read the response from the
-     * /openapi endpoint into a map that all tests can use.
-     *
-     * @throws Exception in case of error reading the response as yaml
-     */
     @BeforeAll
     public static void startServer() throws Exception {
-        server = TestUtil.startServer(TestApp.class);
+        Config helidonConfig = Config.builder().addSource(ClasspathConfigSource.create("/serverConfig.yml")).build();
+        server = TestUtil.startServer(TestApp.class, helidonConfig);
         cnx = TestUtil.getURLConnection(
                 server.port(),
                 "GET",
-                OPENAPI_PATH,
+                ALTERNATE_OPENAPI_PATH,
                 MediaType.APPLICATION_OPENAPI_YAML);
-
         yaml = TestUtil.yamlFromResponse(cnx);
     }
 
-    /**
-     * Stop the server.
-     */
     @AfterAll
     public static void stopServer() {
         TestUtil.cleanup(server, cnx);
     }
 
-    /**
-     * Make sure that the annotations in the test app were found and properly
-     * incorporated into the OpenAPI document.
-     *
-     * @throws Exception in case of errors reading the HTTP response
-     */
-    @SuppressWarnings("unchecked")
     @Test
-    public void simpleTest() throws Exception {
+    public void testAlternatePath() throws Exception {
         String goSummary = TestUtil.fromYaml(yaml, "paths./testapp/go.get.summary", String.class);
         assertEquals(TestApp.GO_SUMMARY, goSummary);
     }

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
@@ -17,6 +17,7 @@
 package io.helidon.microprofile.openapi;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -27,6 +28,7 @@ import java.util.Map;
 import javax.ws.rs.core.Application;
 
 import io.helidon.common.http.MediaType;
+import io.helidon.config.Config;
 import io.helidon.microprofile.server.Server;
 
 import org.yaml.snakeyaml.Yaml;
@@ -54,13 +56,28 @@ public class TestUtil {
                 .start();
     }
 
+    public static Server startServer(Class<? extends Application> appClass, Config helidonConfig) {
+        return Server.builder()
+                .config(helidonConfig)
+                .port(0)
+                .addApplication(appClass)
+                .build()
+                .start();
+    }
+
     /**
-     * Stops the previously-started MP server.
+     * Cleans up, stopping the server and disconnecting the connection.
      *
      * @param server the {@code Server} to stop
+     * @param cnx the connection to disconnect
      */
-    public static void stopServer(Server server) {
-        server.stop();
+    public static void cleanup(Server server, HttpURLConnection cnx) {
+        if (cnx != null) {
+            cnx.disconnect();
+        }
+        if (server != null) {
+            server.stop();
+        }
     }
 
     /**
@@ -163,7 +180,9 @@ public class TestUtil {
         if (returnedMediaType.charset().isPresent()) {
             cs = Charset.forName(returnedMediaType.charset().get());
         }
-        return (Map<String, Object>) yaml.load(new InputStreamReader(cnx.getInputStream(), cs));
+        try (InputStream is = cnx.getInputStream(); InputStreamReader isr =  new InputStreamReader(is, cs)) {
+            return (Map<String, Object>) yaml.load(isr);
+        }
     }
 
     /**

--- a/microprofile/openapi/src/test/resources/serverConfig.yml
+++ b/microprofile/openapi/src/test/resources/serverConfig.yml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+openapi:
+    web-context: /otheropenapi
+    port: 0

--- a/microprofile/openapi/src/test/resources/serverConfig.yml
+++ b/microprofile/openapi/src/test/resources/serverConfig.yml
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-#
+
 openapi:
     web-context: /otheropenapi
     port: 0

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -590,7 +590,7 @@ public class OpenAPISupport implements Service {
      * helidonConfig settings
      */
     public static OpenAPISupport create(Config config) {
-        return builderSE().helidonConfig(config).build();
+        return builderSE().config(config).build();
     }
 
     /**
@@ -612,7 +612,10 @@ public class OpenAPISupport implements Service {
      */
     public abstract static class Builder implements io.helidon.common.Builder<OpenAPISupport> {
 
-        static final String CONFIG_PREFIX = "openapi";
+        /**
+         * Config key to select the openapi node from Helidon config.
+         */
+        public static final String CONFIG_KEY = "openapi";
 
         private Optional<String> webContext = Optional.empty();
         private Optional<String> staticFilePath = Optional.empty();
@@ -626,19 +629,18 @@ public class OpenAPISupport implements Service {
         /**
          * Set various builder attributes from the specified {@code Config} object.
          * <p>
-         * The {@code Config} object can specify {@value #CONFIG_PREFIX}.web-context
-         * and {@value #CONFIG_PREFIX}.static-file in addition to settings
+         * The {@code Config} object can specify web-context and static-file in addition to settings
          * supported by {@link OpenAPIConfigImpl.Builder}.
          *
-         * @param config the {@code Config} object possibly containing settings
+         * @param config the openapi {@code Config} object possibly containing settings
          * @exception NullPointerException if the provided {@code Config} is null
          * @return updated builder instance
          */
-        public Builder helidonConfig(Config config) {
-            config.get(CONFIG_PREFIX + ".web-context")
+        public Builder config(Config config) {
+            config.get("web-context")
                     .asString()
                     .ifPresent(this::webContext);
-            config.get(CONFIG_PREFIX + ".static-file")
+            config.get("static-file")
                     .asString()
                     .ifPresent(this::staticFile);
             return this;

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -54,6 +54,7 @@ import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.server.JsonSupport;
+import io.helidon.openapi.internal.OpenAPIConfigImpl;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
@@ -611,6 +612,8 @@ public class OpenAPISupport implements Service {
      */
     public abstract static class Builder implements io.helidon.common.Builder<OpenAPISupport> {
 
+        static final String CONFIG_PREFIX = "openapi";
+
         private Optional<String> webContext = Optional.empty();
         private Optional<String> staticFilePath = Optional.empty();
 
@@ -618,6 +621,27 @@ public class OpenAPISupport implements Service {
         public OpenAPISupport build() {
             validate();
             return new OpenAPISupport(this);
+        }
+
+        /**
+         * Set various builder attributes from the specified {@code Config} object.
+         * <p>
+         * The {@code Config} object can specify {@value #CONFIG_PREFIX}.web-context
+         * and {@value #CONFIG_PREFIX}.static-file in addition to settings
+         * supported by {@link OpenAPIConfigImpl.Builder}.
+         *
+         * @param config the {@code Config} object possibly containing settings
+         * @exception NullPointerException if the provided {@code Config} is null
+         * @return updated builder instance
+         */
+        public Builder helidonConfig(Config config) {
+            config.get(CONFIG_PREFIX + ".web-context")
+                    .asString()
+                    .ifPresent(this::webContext);
+            config.get(CONFIG_PREFIX + ".static-file")
+                    .asString()
+                    .ifPresent(this::staticFile);
+            return this;
         }
 
         /**
@@ -683,6 +707,9 @@ public class OpenAPISupport implements Service {
          * @return updated builder instance
          */
         public Builder webContext(String path) {
+            if (!path.startsWith("/")) {
+                path = "/" + path;
+            }
             this.webContext = Optional.of(path);
             return this;
         }

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
@@ -37,18 +37,17 @@ public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder {
     private final OpenAPIConfigImpl.Builder apiConfigBuilder = OpenAPIConfigImpl.builder();
 
     /**
-     * Set various builder attributes from the specified {@code Config} object.
+     * Set various builder attributes from the specified openapi {@code Config} object.
      * <p>
-     * The {@code Config} object can specify {@value #CONFIG_PREFIX}.web-context
-     * and {@value #CONFIG_PREFIX}.static-file in addition to settings
+     * The {@code Config} object can specify web-context and static-file in addition to settings
      * supported by {@link OpenAPIConfigImpl.Builder}.
      *
-     * @param config the {@code Config} object possibly containing settings
+     * @param config the OpenAPI {@code Config} object possibly containing settings
      * @exception NullPointerException if the provided {@code Config} is null
      * @return updated builder instance
      */
-    public SEOpenAPISupportBuilder helidonConfig(Config config) {
-        super.helidonConfig(config);
+    public SEOpenAPISupportBuilder config(Config config) {
+        super.config(config);
         apiConfigBuilder.config(config);
         return this;
     }

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.jboss.jandex.IndexView;
  */
 public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder {
 
-    private static final String CONFIG_PREFIX = "openapi";
     private final OpenAPIConfigImpl.Builder apiConfigBuilder = OpenAPIConfigImpl.builder();
 
     /**
@@ -49,8 +48,7 @@ public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder {
      * @return updated builder instance
      */
     public SEOpenAPISupportBuilder helidonConfig(Config config) {
-        config.get(CONFIG_PREFIX + ".web-context").asString().ifPresent(this::webContext);
-        config.get(CONFIG_PREFIX + ".static-file").asString().ifPresent(this::staticFile);
+        super.helidonConfig(config);
         apiConfigBuilder.config(config);
         return this;
     }

--- a/openapi/src/main/java/io/helidon/openapi/internal/OpenAPIConfigImpl.java
+++ b/openapi/src/main/java/io/helidon/openapi/internal/OpenAPIConfigImpl.java
@@ -180,17 +180,15 @@ public class OpenAPIConfigImpl implements OpenApiConfig {
      */
     public static final class Builder implements io.helidon.common.Builder<OpenApiConfig> {
 
-        private static final String CONFIG_PREFIX = "openapi.";
-
         // Key names are inspired by the MP OpenAPI config key names
-        static final String MODEL_READER = CONFIG_PREFIX + "model.reader";
-        static final String FILTER = CONFIG_PREFIX + "filter";
-        static final String SERVERS = CONFIG_PREFIX + "servers";
-        static final String SERVERS_PATH = CONFIG_PREFIX + "servers.path";
-        static final String SERVERS_OPERATION = CONFIG_PREFIX + "servers.operation";
-        static final String SCHEMA_REFERENCES_ENABLE = CONFIG_PREFIX + "schema-references.enable";
-        static final String CUSTOM_SCHEMA_REGISTRY_CLASS = CONFIG_PREFIX + "custom-schema-registry.class";
-        static final String APPLICATION_PATH_DISABLE = CONFIG_PREFIX + "application-path.disable";
+        static final String MODEL_READER = "model.reader";
+        static final String FILTER = "filter";
+        static final String SERVERS = "servers";
+        static final String SERVERS_PATH = "servers.path";
+        static final String SERVERS_OPERATION = "servers.operation";
+        static final String SCHEMA_REFERENCES_ENABLE = "schema-references.enable";
+        static final String CUSTOM_SCHEMA_REGISTRY_CLASS = "custom-schema-registry.class";
+        static final String APPLICATION_PATH_DISABLE = "application-path.disable";
 
         static final List<String> CONFIG_KEYS = Arrays.asList(new String[] {MODEL_READER, FILTER, SERVERS});
 
@@ -214,9 +212,9 @@ public class OpenAPIConfigImpl implements OpenApiConfig {
 
         /**
          * Sets the builder's attributes according to the corresponding entries
-         * (if present) in the specified {@link Config} object.
+         * (if present) in the specified openapi {@link Config} object.
          *
-         * @param config {@code} Config object to process
+         * @param config {@code} openapi Config object to process
          * @return updated builder
          */
         public Builder config(Config config) {

--- a/openapi/src/test/java/io/helidon/openapi/OpenAPIConfigTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/OpenAPIConfigTest.java
@@ -1,7 +1,5 @@
-package io.helidon.openapi;
-
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +14,7 @@ package io.helidon.openapi;
  * limitations under the License.
  *
  */
+package io.helidon.openapi;
 
 import java.nio.file.Paths;
 
@@ -48,7 +47,7 @@ public class OpenAPIConfigTest {
                 .sources(ConfigSources.file(Paths.get(TEST_CONFIG_DIR, "simple.properties").toString()))
                 .build();
         OpenApiConfig openAPIConfig = OpenAPIConfigImpl.builder()
-                .config(config)
+                .config(config.get(OpenAPISupport.Builder.CONFIG_KEY))
                 .build();
 
         assertThat("reader mismatch", openAPIConfig.modelReader(), is("io.helidon.openapi.test.MyModelReader"));
@@ -66,7 +65,7 @@ public class OpenAPIConfigTest {
                 .sources(ConfigSources.file(Paths.get(TEST_CONFIG_DIR, "simple.properties").toString()))
                 .build();
         OpenApiConfig openAPIConfig = OpenAPIConfigImpl.builder()
-                .config(config)
+                .config(config.get(OpenAPISupport.Builder.CONFIG_KEY))
                 .build();
 
         assertThat("scan disable mismatch", openAPIConfig.scanDisable(), is(true));

--- a/openapi/src/test/java/io/helidon/openapi/ServerModelReaderTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerModelReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class ServerModelReaderTest {
 
     private static final OpenAPISupport.Builder OPENAPI_SUPPORT_BUILDER =
         OpenAPISupport.builderSE()
-                .helidonConfig(Config.create(ConfigSources.classpath("simple.properties")));
+                .config(Config.create(ConfigSources.classpath("simple.properties")).get(OpenAPISupport.Builder.CONFIG_KEY));
 
     private static WebServer webServer;
 


### PR DESCRIPTION
Addresses #1350 for Helidon 2.x

The changes include a little refactoring to reuse logic from both SE and MP so both can use Helidon config to set an alternate, non-default context root.