### PR TITLE
javadoc tweaks to avoid deployment problems 

### DIFF
--- a/config/test-infrastructure/pom.xml
+++ b/config/test-infrastructure/pom.xml
@@ -33,10 +33,6 @@
         Configuration test infrastructure module
     </description>
 
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/microprofile/weld/weld-core-impl/pom.xml
+++ b/microprofile/weld/weld-core-impl/pom.xml
@@ -77,4 +77,31 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/microprofile/weld/weld-se-core/pom.xml
+++ b/microprofile/weld/weld-se-core/pom.xml
@@ -164,4 +164,43 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-sources-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>sources</classifier>
+                                    <classesDirectory>${project.build.directory}/sources</classesDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -968,7 +968,7 @@
                         <configuration>
                             <skip>false</skip>
                             <skippedModules>
-helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,helidon-mp-graal-native-image-extension,helidon-graal-native-image-extension,weld-se-core
+helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,helidon-mp-graal-native-image-extension,helidon-graal-native-image-extension,helidon-config-test-infrastructure,helidon-webserver-test-support
                             </skippedModules>
                             <excludePackageNames>io.grpc</excludePackageNames>
                             <sourceFileExcludes>

--- a/webserver/test-support/pom.xml
+++ b/webserver/test-support/pom.xml
@@ -29,10 +29,6 @@
     <artifactId>helidon-webserver-test-support</artifactId>
     <name>Helidon WebServer Test Support</name>
 
-    <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.webserver</groupId>


### PR DESCRIPTION
Noticed a few modules that were not generating javadoc jars which could lead to deployment problems. 

For the stuff under `microprofile/weld` this change creates an empty javadoc.jar (and empty source jar if needed).

For `config/test-infrastructure` and `webserver/test-support` we go ahead and generate the module javadoc, but exclude it from the aggregated javadoc.
