### PR TITLE
[Reactive] Reduce the overhead of flatMapIterable + minor fixes

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/FlatMapIterableJMH.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/FlatMapIterableJMH.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.reactive.jmh;
+
+import io.helidon.common.reactive.Multi;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+@State(Scope.Thread)
+public class FlatMapIterableJMH {
+
+    public static void main(String[] args) throws Throwable {
+        Options opt = new OptionsBuilder()
+                .include(FlatMapIterableJMH.class.getSimpleName())
+                .forks(1)
+                .warmupIterations(5)
+                .warmupTime(TimeValue.seconds(1))
+                .measurementIterations(5)
+                .measurementTime(TimeValue.seconds(1))
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Param({"1", "10", "100", "1000", "10000", "100000", "1000000"})
+    int count;
+
+    Multi<Integer> multi;
+
+    @Setup
+    public void setup() {
+        Integer[] outer = new Integer[count];
+        Arrays.fill(outer, 777);
+        List<Integer> outerList = Arrays.asList(outer);
+
+        Integer[] inner = new Integer[1_000_000 / count];
+        Arrays.fill(inner, 888);
+        List<Integer> innerList = Arrays.asList(inner);
+
+        multi = Multi.from(outerList).flatMapIterable(v -> innerList);
+    }
+
+    @Benchmark
+    public void measure(Blackhole bh) {
+        multi.subscribe(new SyncUnboundedJmhSubscriber(bh));
+    }
+}


### PR DESCRIPTION
The `flatMapIterable` was underperforming with some short inner collections in benchmarks. The following changes have been applied:

- Use an inlined SPSC queue instead of the ConcurrentLinkedQueue.
- Remove the cancel check between the mapping to the iterator and the first hasNext test
- Disconnect the upstream upon termination so that `request` on a prefetch boundary becomes no-op (See [this discussion](https://github.com/oracle/helidon/commit/1673ddf93f107d3f24160bfb3589a22383aa7c2b#r37950078).)
- Add a dedicated cross-mapping benchmark measuring `flatMapIterable`.

### Benchmark 
(i7 4770K, Windows 7 x64, JDK 13b29)

![image](https://user-images.githubusercontent.com/1269832/77318163-de9ba980-6d0c-11ea-82f9-887e82da8ea2.png)

```
ShakespearePlaysScrabbleWithHelidonReactiveOpt before  147  34,605 ± 0,210  ms/op
ShakespearePlaysScrabbleWithHelidonReactiveOpt after   153  33,225 ± 0,183  ms/op
```