### PR TITLE
[skip ci] WIP: Fix dependency convergence issues

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -60,12 +60,14 @@
         <version.lib.interceptor-api>1.2.2</version.lib.interceptor-api>
         <version.lib.jackson>2.10.0</version.lib.jackson>
         <version.lib.jaegertracing>1.1.0</version.lib.jaegertracing>
+        <version.lib.jakarta-json>1.1.5</version.lib.jakarta-json>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>
         <version.lib.jaxb-api>2.3.0</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>
         <version.lib.jaxb-impl>2.3.2</version.lib.jaxb-impl>
         <version.lib.jaxrs-api>2.1</version.lib.jaxrs-api>
+        <version.lib.jboss.logging>3.2.1.Final</version.lib.jboss.logging>
         <version.lib.jboss-transaction-spi>7.6.0.Final</version.lib.jboss-transaction-spi>
         <version.lib.jedis>3.1.0</version.lib.jedis>
         <version.lib.jersey>2.30.1</version.lib.jersey>
@@ -665,6 +667,26 @@
                 <groupId>com.oracle.substratevm</groupId>
                 <artifactId>svm</artifactId>
                 <version>${version.lib.graalvm}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.lib.jboss.logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${version.lib.jakarta-json}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${version.lib.jakarta-json}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${version.lib.jakarta-json}</version>
             </dependency>
 
             <!-- Testing libraries -->

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -267,6 +267,12 @@
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.lib.yasson}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish</groupId>
+                        <artifactId>jakarta.json</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Config related -->

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -683,11 +683,6 @@
                 <artifactId>jakarta.json-api</artifactId>
                 <version>${version.lib.jakarta-json}</version>
             </dependency>
-            <dependency>
-                <groupId>jakarta.json</groupId>
-                <artifactId>jakarta.json</artifactId>
-                <version>${version.lib.jakarta-json}</version>
-            </dependency>
 
             <!-- Testing libraries -->
             <dependency>

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -89,6 +89,16 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -89,12 +89,6 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>jakarta.json</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -134,6 +134,16 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
@@ -156,10 +166,6 @@
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -125,11 +125,6 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-yaml</artifactId>
                 </exclusion>
-                <!-- Start of exclusions to resolve dependency convergence issues -->
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -134,12 +134,6 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>jakarta.json</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -125,6 +125,11 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-yaml</artifactId>
                 </exclusion>
+                <!-- Start of exclusions to resolve dependency convergence issues -->
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -156,6 +161,10 @@
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <version.lib.jboss-annotations-api_1.3_spec>1.0.0.Final</version.lib.jboss-annotations-api_1.3_spec>
         <version.lib.jboss-el-api_3.0_spec>1.0.0.Final</version.lib.jboss-el-api_3.0_spec>
         <version.lib.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.lib.jboss-interceptors-api_1.2_spec>
-        <version.lib.jboss.logging>3.2.1.Final</version.lib.jboss.logging>
         <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
         <version.lib.netty.tcnative>2.0.26.Final</version.lib.netty.tcnative>
@@ -794,11 +793,6 @@
                 <groupId>org.jboss.spec.javax.interceptor</groupId>
                 <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
                 <version>${version.lib.jboss-interceptors-api_1.2_spec}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.lib.jboss.logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.weld</groupId>


### PR DESCRIPTION
Addresses #1559 

Helidon has transitive (or explicit and transitive) dependencies on both JBoss logging and Jakarta JSON along different dependency paths and the transitive dependencies are pulling in conflicting versions.

In OpenAPI, our dependency on SmallRye's OpenAPI pulls in JBoss logging. And an artifact outside of Helidon -- `org.glassfish.jersey.media:jersey-media-json-binding`-- itself depends on jarkata.json and also depends on yasson which in turn depends on a newer version of jakarta.json. 
