### PR TITLE
[Reactive] Workaround for an RS 1.0.3 TCK bug

### DIFF
--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
@@ -527,21 +527,21 @@ public final class HelidonReactiveStreamsEngine implements ReactiveStreamsEngine
     }
 
     static void complete(CompletableFuture<Object> cf) {
-        COUPLED_EXECUTOR.submit(() -> {
+        coupledExecutor.submit(() -> {
             cf.complete(null);
             return null;
         });
     }
 
     static void fail(CompletableFuture<Object> cf, Throwable ex) {
-        COUPLED_EXECUTOR.submit(() -> {
+        coupledExecutor.submit(() -> {
             cf.completeExceptionally(ex);
             return null;
         });
     }
 
     // Workaround for a TCK bug when calling cancel() from any method named onComplete().
-    private static volatile ExecutorService COUPLED_EXECUTOR = ForkJoinPool.commonPool();
+    private static volatile ExecutorService coupledExecutor = ForkJoinPool.commonPool();
 
     /**
      * Override the ExecutorService used by the cross-termination and cross-cancellation
@@ -550,9 +550,9 @@ public final class HelidonReactiveStreamsEngine implements ReactiveStreamsEngine
      */
     public static void setCoupledExecutor(ExecutorService executor) {
         if (executor == null) {
-            COUPLED_EXECUTOR = ForkJoinPool.commonPool();
+            coupledExecutor = ForkJoinPool.commonPool();
         } else {
-            COUPLED_EXECUTOR = executor;
+            coupledExecutor = executor;
         }
     }
 }

--- a/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
+++ b/microprofile/reactive-streams/src/main/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngine.java
@@ -527,16 +527,14 @@ public final class HelidonReactiveStreamsEngine implements ReactiveStreamsEngine
     }
 
     static void complete(CompletableFuture<Object> cf) {
-        coupledExecutor.submit(() -> {
+        coupledExecutor.execute(() -> {
             cf.complete(null);
-            return null;
         });
     }
 
     static void fail(CompletableFuture<Object> cf, Throwable ex) {
-        coupledExecutor.submit(() -> {
+        coupledExecutor.execute(() -> {
             cf.completeExceptionally(ex);
-            return null;
         });
     }
 

--- a/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
+++ b/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
@@ -21,6 +21,12 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreamsFactor
 import org.eclipse.microprofile.reactive.streams.operators.tck.ReactiveStreamsTck;
 import org.reactivestreams.tck.TestEnvironment;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+
 public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<HelidonReactiveStreamsEngine> {
 
     public HelidonReactiveStreamsEngineTckTest() {
@@ -41,4 +47,19 @@ public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<Heli
     protected boolean isEnabled(Object test) {
         return true;
     }
+
+    private ExecutorService executor;
+
+    @BeforeSuite(alwaysRun = true)
+    public void before() {
+        executor = Executors.newSingleThreadExecutor();
+        HelidonReactiveStreamsEngine.setCoupledExecutor(executor);
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public void after() {
+        HelidonReactiveStreamsEngine.setCoupledExecutor(null);
+        executor.shutdown();
+    }
+
 }

--- a/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
+++ b/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
@@ -19,6 +19,7 @@ package io.helidon.microprofile.reactive;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;

--- a/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
+++ b/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.reactive.streams.operators.tck.spi.CustomCoupled
 import org.eclipse.microprofile.reactive.streams.operators.tck.spi.ReactiveStreamsSpiVerification;
 import org.reactivestreams.tck.TestEnvironment;
 import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Factory;
 
 public class HelidonReactiveStreamsTckTest extends ReactiveStreamsTck<HelidonReactiveStreamsEngine> {
@@ -43,6 +44,20 @@ public class HelidonReactiveStreamsTckTest extends ReactiveStreamsTck<HelidonRea
     @Override
     protected HelidonReactiveStreamsEngine createEngine() {
         return new HelidonReactiveStreamsEngine();
+    }
+
+    private ExecutorService executor;
+
+    @BeforeSuite(alwaysRun = true)
+    public void before() {
+        executor = Executors.newSingleThreadExecutor();
+        HelidonReactiveStreamsEngine.setCoupledExecutor(executor);
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public void after() {
+        HelidonReactiveStreamsEngine.setCoupledExecutor(null);
+        executor.shutdown();
     }
 
 }


### PR DESCRIPTION
Cross cancellation from an `onError`/`onComplete` method is not correctly verified by the Reactive Streams TCK. There is a [patch waiting](https://github.com/reactive-streams/reactive-streams-jvm/pull/483) to be included but it could take an arbitrary amount of time to get it in a released form.

In addition, the original workaround of using the ForkJoinPool sometimes doesn't work because the FJP executes the task on the caller thread, thus triggering the TCK bug again.

This PR adds a workaround in the form of a configurable ExecutorService which is set to a single-threaded one for the duration of the TCK.