### PR TITLE
[Reactive MP] Try a different TestNG annotation for the TCK test

### DIFF
--- a/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
+++ b/microprofile/reactive-streams/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsEngineTckTest.java
@@ -24,9 +24,11 @@ import org.reactivestreams.tck.TestEnvironment;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
+@Test
 public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<HelidonReactiveStreamsEngine> {
 
     public HelidonReactiveStreamsEngineTckTest() {
@@ -50,16 +52,20 @@ public class HelidonReactiveStreamsEngineTckTest extends ReactiveStreamsTck<Heli
 
     private ExecutorService executor;
 
-    @BeforeSuite(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     public void before() {
         executor = Executors.newSingleThreadExecutor();
         HelidonReactiveStreamsEngine.setCoupledExecutor(executor);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void after() {
         HelidonReactiveStreamsEngine.setCoupledExecutor(null);
         executor.shutdown();
     }
 
+    @Test
+    public void hasExecutor() {
+        org.testng.Assert.assertNotNull(executor);
+    }
 }

--- a/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
+++ b/microprofile/tests/tck/tck-reactive-operators/src/test/java/io/helidon/microprofile/reactive/HelidonReactiveStreamsTckTest.java
@@ -32,10 +32,11 @@ import org.eclipse.microprofile.reactive.streams.operators.tck.spi.CoupledStageV
 import org.eclipse.microprofile.reactive.streams.operators.tck.spi.CustomCoupledStageVerification;
 import org.eclipse.microprofile.reactive.streams.operators.tck.spi.ReactiveStreamsSpiVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-import org.testng.annotations.Factory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
+@Test
 public class HelidonReactiveStreamsTckTest extends ReactiveStreamsTck<HelidonReactiveStreamsEngine> {
 
     public HelidonReactiveStreamsTckTest() {
@@ -49,16 +50,20 @@ public class HelidonReactiveStreamsTckTest extends ReactiveStreamsTck<HelidonRea
 
     private ExecutorService executor;
 
-    @BeforeSuite(alwaysRun = true)
+    @BeforeClass(alwaysRun = true)
     public void before() {
         executor = Executors.newSingleThreadExecutor();
         HelidonReactiveStreamsEngine.setCoupledExecutor(executor);
     }
 
-    @AfterSuite(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void after() {
         HelidonReactiveStreamsEngine.setCoupledExecutor(null);
         executor.shutdown();
     }
 
+    @Test
+    public void hasExecutor() {
+        org.testng.Assert.assertNotNull(executor);
+    }
 }


### PR DESCRIPTION
Looks like TestNG didn't execute the preparations for the `HelidonReactiveStreamsTckTest`. Now using a different annotation.