### PR TITLE
Support for TracerResolver.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -619,6 +619,12 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
+                <!-- to add TracerResolver support -->
+                <groupId>io.helidon.tracing</groupId>
+                <artifactId>helidon-tracing-tracer-resolver</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
                 <!-- Client support -->
                 <groupId>io.helidon.tracing</groupId>
                 <artifactId>helidon-tracing-jersey-client</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -93,6 +93,7 @@
         <version.lib.ojdbc8>19.3.0.0</version.lib.ojdbc8>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
+        <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.persistence-api>2.2</version.lib.persistence-api>
         <version.lib.prometheus>0.6.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
@@ -159,6 +160,11 @@
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-noop</artifactId>
                 <version>${version.lib.opentracing}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-tracerresolver</artifactId>
+                <version>${version.lib.opentracing.tracerresolver}</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml.bind</groupId>

--- a/microprofile/tracing/pom.xml
+++ b/microprofile/tracing/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>microprofile-opentracing-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing-tracer-resolver</artifactId>
+        </dependency>
+        <dependency>
             <!-- Jersey on java 9 -->
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,11 @@ module io.helidon.microprofile.tracing {
     requires io.helidon.jersey.common;
     requires transitive io.helidon.tracing;
     requires transitive io.helidon.tracing.jersey;
+    requires io.helidon.tracing.tracerresolver;
 
     requires transitive microprofile.opentracing.api;
     requires microprofile.rest.client.api;
+
 
     exports io.helidon.microprofile.tracing;
 

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -37,5 +37,6 @@
         <module>tests</module>
         <module>jaeger</module>
         <module>config</module>
+        <module>tracer-resolver</module>
     </modules>
 </project>

--- a/tracing/tracer-resolver/pom.xml
+++ b/tracing/tracer-resolver/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 Oracle and/or its affiliates.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tracing</groupId>
+        <artifactId>helidon-tracing-project</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tracing-tracer-resolver</artifactId>
+    <name>Helidon Tracing Tracer Resolver</name>
+
+    <description>
+        Support for OpenTracing Tracer Resolver
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+        </dependency>
+        <!--
+         - Test dependencies
+         -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/TracerResolverBuilder.java
+++ b/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/TracerResolverBuilder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.tracerresolver;
+
+import java.util.logging.Logger;
+
+import io.helidon.config.Config;
+import io.helidon.tracing.TracerBuilder;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.noop.NoopTracerFactory;
+import io.opentracing.util.GlobalTracer;
+
+class TracerResolverBuilder implements TracerBuilder<TracerResolverBuilder> {
+    private static final Logger LOGGER = Logger.getLogger(TracerResolverBuilder.class.getName());
+
+    private String helidonServiceName;
+    private boolean enabled = true;
+    private boolean registerGlobal;
+
+    @Override
+    public TracerResolverBuilder serviceName(String name) {
+        this.helidonServiceName = name;
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder collectorProtocol(String protocol) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder collectorPort(int port) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder collectorHost(String host) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder collectorPath(String path) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder addTracerTag(String key, String value) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder addTracerTag(String key, Number value) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder addTracerTag(String key, boolean value) {
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder config(Config config) {
+        config.get("enabled").asBoolean().ifPresent(this::enabled);
+        config.get("service").asString().ifPresent(this::serviceName);
+        config.get("global").asBoolean().ifPresent(this::registerGlobal);
+
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder enabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @Override
+    public TracerResolverBuilder registerGlobal(boolean global) {
+        this.registerGlobal = global;
+        return this;
+    }
+
+    @Override
+    public Tracer build() {
+        Tracer tracer;
+        if (enabled) {
+            tracer = TracerResolver.resolveTracer();
+            if (null == tracer) {
+                tracer = NoopTracerFactory.create();
+                LOGGER.info("TracerResolver not configured, tracing is disabled");
+            } else {
+                LOGGER.info("Using resolved tracer (all Helidon specific configuration options ignored): " + tracer);
+            }
+        } else {
+            LOGGER.info("TracerResolver tracer is explicitly disabled for " + helidonServiceName + ".");
+            tracer = NoopTracerFactory.create();
+        }
+
+        if (registerGlobal) {
+            GlobalTracer.registerIfAbsent(tracer);
+        }
+
+        return tracer;
+    }
+}

--- a/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/TracerResolverProvider.java
+++ b/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/TracerResolverProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.tracerresolver;
+
+import javax.annotation.Priority;
+
+import io.helidon.common.Prioritized;
+import io.helidon.tracing.TracerBuilder;
+import io.helidon.tracing.spi.TracerProvider;
+
+/**
+ * Service to use {@link io.opentracing.contrib.tracerresolver.TracerResolver} to find tracer to use with Helidon.
+ */
+// lower priority, so this get overridden by specific tracers if present
+@Priority(Prioritized.DEFAULT_PRIORITY + 1000)
+public class TracerResolverProvider implements TracerProvider {
+    @Override
+    public TracerBuilder<?> createBuilder() {
+        return new TracerResolverBuilder();
+    }
+}

--- a/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/package-info.java
+++ b/tracing/tracer-resolver/src/main/java/io/helidon/tracing/tracerresolver/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon tracing support for {@link io.opentracing.contrib.tracerresolver.TracerResolver}.
+ */
+package io.helidon.tracing.tracerresolver;

--- a/tracing/tracer-resolver/src/main/java/module-info.java
+++ b/tracing/tracer-resolver/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * {@link io.opentracing.contrib.tracerresolver.TracerResolver} tracing support.
+ */
+module io.helidon.tracing.tracerresolver {
+    requires io.helidon.common;
+    requires io.helidon.config;
+    requires io.helidon.tracing;
+
+    requires java.logging;
+    requires io.opentracing.util;
+    requires io.opentracing.noop;
+    requires io.opentracing.contrib.tracerresolver;
+
+    exports io.helidon.tracing.tracerresolver;
+
+    provides io.helidon.tracing.spi.TracerProvider with io.helidon.tracing.tracerresolver.TracerResolverProvider;
+}

--- a/tracing/tracer-resolver/src/main/resources/META-INF/services/io.helidon.tracing.spi.TracerProvider
+++ b/tracing/tracer-resolver/src/main/resources/META-INF/services/io.helidon.tracing.spi.TracerProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.tracing.tracerresolver.TracerResolverProvider


### PR DESCRIPTION
Fixes #1384 
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

OpenTracing contrib includes a way to add tracer using a service loader. We have explicit support for Jaeger and Zipkin, this would add a generic support for any tracer, although without support for configuration using Helidon config - the configuration is ignored except for:
```
# Whether the tracer is enabled (defaults to true)
enabled: true
# Service name - used only to log a statement, IGNORED for the actual tracing
service: "name"
# Whether to register this tracer as a global tracer (defaults to false)
global: true
```