### PR TITLE
Do not use cached URLs for locating the Jandex indexes

### DIFF
--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -72,7 +72,7 @@
                         </goals>
                         <phase>process-test-classes</phase>
                         <configuration>
-                            <classesDir>${project.build.directory}/test-classes}</classesDir>
+                            <classesDir>${project.build.directory}/test-classes</classesDir>
                             <indexName>other.idx</indexName>
                             <fileSets>
                                 <fileSet>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
@@ -69,8 +69,8 @@ public class OpenApiCdiExtension implements Extension {
         HelidonFeatures.register("OpenAPI");
     }
 
-    private final List<URL> indexURLs; // used only in early processing
     private final String[] indexPaths;
+    private final int indexURLCount;
 
     private final Set<Class<?>> annotatedTypes = new HashSet<>();
 
@@ -88,7 +88,8 @@ public class OpenApiCdiExtension implements Extension {
 
     OpenApiCdiExtension(String... indexPaths) throws IOException {
         this.indexPaths = indexPaths;
-        indexURLs = findIndexFiles(indexPaths);
+        List<URL> indexURLs = findIndexFiles(indexPaths);
+        indexURLCount = indexURLs.size();
         if (indexURLs.isEmpty()) {
             LOGGER.log(Level.INFO, () -> String.format(
                     "OpenAPI support could not locate the Jandex index file %s "
@@ -130,7 +131,7 @@ public class OpenApiCdiExtension implements Extension {
      * @param event {@code ProcessAnnotatedType} event
      */
     private <X> void processAnnotatedType(@Observes ProcessAnnotatedType<X> event) {
-        if (indexURLs.isEmpty()) {
+        if (indexURLCount == 0) {
             Class<?> c = event.getAnnotatedType()
                     .getJavaClass();
             annotatedTypes.add(c);
@@ -146,7 +147,7 @@ public class OpenApiCdiExtension implements Extension {
      * reading class bytecode from the classpath
      */
     public IndexView indexView() throws IOException {
-        return !indexURLs.isEmpty() ? existingIndexFileReader() : indexFromHarvestedClasses();
+        return indexURLCount > 0 ? existingIndexFileReader() : indexFromHarvestedClasses();
     }
 
     /**


### PR DESCRIPTION
Resolves #1578.

The Jandex indexes have always been located using the classpath but that happened early at what turns out to be native image build time. The resulting index URLs were cached and then used later to actually read the indexes -- at native image runtime, by which time the cached`file:` URLs were useless.

In this PR the code still keeps the _count_ of the index URLs because that is used from several places in the code to make decisions based on whether any indexes were present, but the native image runtime code now invokes the method that uses  `getResources` rather than using the cached URLs as it used to.

There was also a typo in the pom that crept in somehow which prevented the second test Jandex index from being built. I fixed that also in this PR.