### PR TITLE
Order the apps to run by class name to provide more predictable ordering

### DIFF
--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -18,10 +18,8 @@ package io.helidon.microprofile.openapi;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -17,8 +17,11 @@
 package io.helidon.microprofile.openapi;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -92,8 +95,12 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
          * which case we'll try to instantiate them ourselves (unless they are synthetic apps or lack no-args constructors).
          *
          * Each set in the list holds the classes related to one app.
+         *
+         * Sort the stream by the Application class name to help keep the list of endpoints in the OpenAPI document in a stable
+         * order.
          */
         List<Set<Class<?>>> appClassesToScan = appInstancesToRun().stream()
+                .sorted(Comparator.comparing(app -> app.getClass().getName()))
                 .map(this::classesToScanForApp)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Resolves #1545 

The SnakeYAML code itself seems to preserve insertion ordering when it creates output documents.

To provide more predictable ordering in the OpenAPI document, this PR sorts the `Application` objects retrieved from the server's CDI extension by class name before submitting them to SmallRye's annotation processing. SnakeYAML should preserve the ordering of endpoints within each app.