### PR TITLE
Dependency convergence + jakarta libraries.

### DIFF
--- a/applications/mp/pom.xml
+++ b/applications/mp/pom.xml
@@ -59,13 +59,13 @@
                     <version>${version.plugin.eclipselink}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>javax.annotation</groupId>
-                            <artifactId>javax.annotation-api</artifactId>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
                             <version>${version.lib.annotation-api}</version>
                         </dependency>
                         <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
                             <version>${version.lib.jaxb-api}</version>
                         </dependency>
                     </dependencies>

--- a/archetypes/mp/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/mp/src/main/resources/archetype-resources/pom.xml
@@ -32,11 +32,6 @@
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
 #if( $unitTest.matches("y|yes|true") )
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -415,6 +415,13 @@
                 <groupId>io.helidon.microprofile.weld</groupId>
                 <artifactId>weld-se-core</artifactId>
                 <version>${helidon.version}</version>
+                <exclusions>
+                    <!-- need to exclude javax APIs - we have moved to Jakarta -->
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.helidon.microprofile.cdi</groupId>

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -56,8 +56,8 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/common/service-loader/pom.xml
+++ b/common/service-loader/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -39,8 +39,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/config/hocon/pom.xml
+++ b/config/hocon/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/config/tests/module-mappers-1-base/pom.xml
+++ b/config/tests/module-mappers-1-base/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/config/tests/module-mappers-2-override/pom.xml
+++ b/config/tests/module-mappers-2-override/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/config/tests/module-parsers-1-override/pom.xml
+++ b/config/tests/module-parsers-1-override/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/config/tests/test-bundle/pom.xml
+++ b/config/tests/test-bundle/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>helidon-bundles-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/config/tests/test-default_config-2-hocon-json/pom.xml
+++ b/config/tests/test-default_config-2-hocon-json/pom.xml
@@ -58,8 +58,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/tests/test-default_config-3-hocon/pom.xml
+++ b/config/tests/test-default_config-3-hocon/pom.xml
@@ -53,8 +53,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/config/tests/test-default_config-4-yaml/pom.xml
+++ b/config/tests/test-default_config-4-yaml/pom.xml
@@ -68,8 +68,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/tests/test-default_config-5-env_vars/pom.xml
+++ b/config/tests/test-default_config-5-env_vars/pom.xml
@@ -63,8 +63,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/tests/test-default_config-7-meta-hocon-json/pom.xml
+++ b/config/tests/test-default_config-7-meta-hocon-json/pom.xml
@@ -64,8 +64,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/tests/test-default_config-8-meta-hocon/pom.xml
+++ b/config/tests/test-default_config-8-meta-hocon/pom.xml
@@ -59,8 +59,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/tests/test-default_config-9-meta-yaml/pom.xml
+++ b/config/tests/test-default_config-9-meta-yaml/pom.xml
@@ -68,8 +68,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/config/yaml/pom.xml
+++ b/config/yaml/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/dbclient/common/src/test/java/io/helidon/dbclient/common/mapper/MapperTest.java
+++ b/dbclient/common/src/test/java/io/helidon/dbclient/common/mapper/MapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ public class MapperTest {
      * @return current time with date set to 1. 1. 1970 (epoch)
      */
     private static OffsetDateTime currentTime() {
+        // this returns time in current timezone, but moved to 1970 January, so daylight savings will cause mayhem
         return OffsetDateTime.now()
                 .with(ChronoField.YEAR, 1970)
                 .with(ChronoField.MONTH_OF_YEAR, 1)

--- a/dbclient/jsonp/pom.xml
+++ b/dbclient/jsonp/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/dbclient/mongodb/pom.xml
+++ b/dbclient/mongodb/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/dbclient/webserver-jsonp/pom.xml
+++ b/dbclient/webserver-jsonp/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
     </dependencies>
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -324,8 +324,14 @@
                 <version>${version.lib.grpc}</version>
                 <exclusions>
                     <exclusion>
+                        <!-- Used for compilation of "their" sources -->
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- Used for compilation of "their" sources -->
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -333,12 +339,28 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-api</artifactId>
                 <version>${version.lib.grpc}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence - used from io.grpc and from guava -->
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-annotations</artifactId>
-                <version>${version.lib.animal-sniffer}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- Used for compilation of "their" sources -->
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- Used for compilation of "their" sources -->
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- Used for compilation of "their" sources -->
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- Used for compilation of "their" sources -->
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.grpc</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -42,6 +42,7 @@
         <version.lib.apache-httpclient>4.5.10</version.lib.apache-httpclient>
         <version.lib.brave-opentracing>0.35.0</version.lib.brave-opentracing>
         <version.lib.cdi-api>2.0.2</version.lib.cdi-api>
+        <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>2.7.4</version.lib.eclipselink>
         <version.lib.el-api>3.0.3</version.lib.el-api>
@@ -67,8 +68,10 @@
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>
         <version.lib.jaxb-impl>2.3.2</version.lib.jaxb-impl>
         <version.lib.jaxrs-api>2.1.6</version.lib.jaxrs-api>
-        <version.lib.jboss-transaction-spi>7.6.0.Final</version.lib.jboss-transaction-spi>
-        <version.lib.jboss-transaction-api>1.0.0.Final</version.lib.jboss-transaction-api>
+        <version.lib.jboss.classfilewriter>1.2.4.Final</version.lib.jboss.classfilewriter>
+        <version.lib.jboss.logging>3.2.1.Final</version.lib.jboss.logging>
+        <version.lib.jboss.transaction-spi>7.6.0.Final</version.lib.jboss.transaction-spi>
+        <version.lib.jboss.transaction-api>1.0.0.Final</version.lib.jboss.transaction-api>
         <version.lib.jedis>3.1.0</version.lib.jedis>
         <version.lib.jersey>2.30.1</version.lib.jersey>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
@@ -784,7 +787,7 @@
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-transaction-spi</artifactId>
-                <version>${version.lib.jboss-transaction-spi}</version>
+                <version>${version.lib.jboss.transaction-spi}</version>
                 <exclusions>
                   <exclusion>
                       <groupId>org.jboss.spec.javax.resource</groupId>
@@ -795,7 +798,42 @@
             <dependency>
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                <version>${version.lib.jboss-transaction-api}</version>
+                <version>${version.lib.jboss.transaction-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.environment</groupId>
+                <artifactId>weld-environment-common</artifactId>
+                <version>${version.lib.weld}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.probe</groupId>
+                <artifactId>weld-probe-core</artifactId>
+                <version>${version.lib.weld}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.classfilewriter</groupId>
+                <artifactId>jboss-classfilewriter</artifactId>
+                <version>${version.lib.jboss.classfilewriter}</version>
+            </dependency>
+            <dependency>
+                <!-- if needed (as excluded from weld) -->
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${version.lib.groovy-all}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence, transitive dependency of both
+                commons-configuration (through hystrix-core)
+                org.apache.httpcomponents:httpclient (through health-tck)
+                -->
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${version.lib.commons-logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.lib.jboss.logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -36,18 +36,20 @@
         <!--
         Changing these versions requires approval for a new third party dependency!
         -->
-        <version.lib.activation-api>1.2.0</version.lib.activation-api>
-        <version.lib.annotation-api>1.3.1</version.lib.annotation-api>
+        <version.lib.activation-api>1.2.2</version.lib.activation-api>
+        <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
+        <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.apache-httpclient>4.5.10</version.lib.apache-httpclient>
         <version.lib.brave-opentracing>0.35.0</version.lib.brave-opentracing>
-        <version.lib.cdi-api>2.0</version.lib.cdi-api>
+        <version.lib.cdi-api>2.0.2</version.lib.cdi-api>
         <version.lib.dropwizard.metrics>4.1.2</version.lib.dropwizard.metrics>
         <version.lib.eclipselink>2.7.4</version.lib.eclipselink>
-        <version.lib.el-api>3.0.0</version.lib.el-api>
-        <version.lib.el-impl>3.0.0</version.lib.el-impl>
+        <version.lib.el-api>3.0.3</version.lib.el-api>
+        <version.lib.el-impl>3.0.2</version.lib.el-impl>
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
         <version.lib.google-api-client>1.30.5</version.lib.google-api-client>
+        <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.graalvm>19.2.0</version.lib.graalvm>
         <version.lib.grpc>1.27.1</version.lib.grpc>
         <version.lib.guava>28.1-jre</version.lib.guava>
@@ -56,23 +58,24 @@
         <version.lib.hibernate>5.4.4.Final</version.lib.hibernate>
         <version.lib.hikaricp>3.4.1</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
-        <version.lib.inject>1</version.lib.inject>
-        <version.lib.interceptor-api>1.2.2</version.lib.interceptor-api>
+        <version.lib.inject>1.0</version.lib.inject>
+        <version.lib.interceptor-api>1.2.5</version.lib.interceptor-api>
         <version.lib.jackson>2.10.0</version.lib.jackson>
         <version.lib.jaegertracing>1.1.0</version.lib.jaegertracing>
-        <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>
-        <version.lib.jaxb-api>2.3.0</version.lib.jaxb-api>
+        <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>
         <version.lib.jaxb-impl>2.3.2</version.lib.jaxb-impl>
-        <version.lib.jaxrs-api>2.1</version.lib.jaxrs-api>
+        <version.lib.jaxrs-api>2.1.6</version.lib.jaxrs-api>
         <version.lib.jboss-transaction-spi>7.6.0.Final</version.lib.jboss-transaction-spi>
+        <version.lib.jboss-transaction-api>1.0.0.Final</version.lib.jboss-transaction-api>
         <version.lib.jedis>3.1.0</version.lib.jedis>
         <version.lib.jersey>2.30.1</version.lib.jersey>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
-        <version.lib.jsonp-api>1.1.2</version.lib.jsonp-api>
-        <version.lib.jsonp-impl>1.1.2</version.lib.jsonp-impl>
+        <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
+        <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>
         <version.lib.junit>5.1.0</version.lib.junit>
+        <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.microprofile-config>1.3</version.lib.microprofile-config>
         <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
@@ -94,21 +97,23 @@
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
-        <version.lib.persistence-api>2.2</version.lib.persistence-api>
+        <version.lib.persistence-api>2.2.3</version.lib.persistence-api>
         <version.lib.prometheus>0.6.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
         <version.lib.slf4j>1.7.26</version.lib.slf4j>
         <version.lib.smallrye-openapi>1.2.0</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.24</version.lib.snakeyaml>
-        <version.lib.transaction-api>1.3</version.lib.transaction-api>
+        <version.lib.transaction-api>1.3.3</version.lib.transaction-api>
         <version.lib.typesafe-config>1.4.0</version.lib.typesafe-config>
         <version.lib.tyrus>1.15</version.lib.tyrus>
         <version.lib.ucp>19.3.0.0</version.lib.ucp>
-        <version.lib.validation-api>2.0.1.Final</version.lib.validation-api>
+        <version.lib.validation-api>2.0.2</version.lib.validation-api>
         <version.lib.websockets-api>1.1.2</version.lib.websockets-api>
-        <version.lib.weld>3.1.1.Final</version.lib.weld>
+        <version.lib.weld>3.1.3.Final</version.lib.weld>
+        <version.lib.weld-api>3.1.SP2</version.lib.weld-api>
         <version.lib.yasson>1.0.6</version.lib.yasson>
-        <version.lib.zipkin>2.12.0</version.lib.zipkin>
+        <version.lib.zipkin>2.12.5</version.lib.zipkin>
+        <version.lib.zipkin.sender-urlconnection>2.12.0</version.lib.zipkin.sender-urlconnection>
     </properties>
 
     <dependencyManagement>
@@ -145,11 +150,23 @@
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
                 <version>${version.lib.jaegertracing}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-util</artifactId>
                 <version>${version.lib.opentracing}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>javax.annotation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.opentracing</groupId>
@@ -167,8 +184,8 @@
                 <version>${version.lib.opentracing.tracerresolver}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${version.lib.jaxb-api}</version>
             </dependency>
             <dependency>
@@ -182,38 +199,38 @@
                 <version>${version.lib.jaxb-impl}</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${version.lib.jaxrs-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${version.lib.cdi-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
                 <version>${version.lib.el-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
                 <version>${version.lib.annotation-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.interceptor</groupId>
-                <artifactId>javax.interceptor-api</artifactId>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
                 <version>${version.lib.interceptor-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
                 <version>${version.lib.inject}</version>
             </dependency>
             <dependency>
-                <groupId>javax.json</groupId>
-                <artifactId>javax.json-api</artifactId>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
                 <version>${version.lib.jsonp-api}</version>
             </dependency>
             <dependency>
@@ -222,14 +239,19 @@
                 <version>${version.lib.jsonb-api}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${version.lib.activation-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
+                <artifactId>jakarta.json</artifactId>
                 <version>${version.lib.jsonp-impl}</version>
             </dependency>
             <dependency>
                 <!-- contains the API as well -->
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
+                <artifactId>jakarta.el</artifactId>
                 <version>${version.lib.el-impl}</version>
             </dependency>
             <dependency>
@@ -271,6 +293,13 @@
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.lib.yasson}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- we must only have implementation on classpath, not API - module conflict -->
+                        <groupId>jakarta.json</groupId>
+                        <artifactId>jakarta.json-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Config related -->
@@ -306,6 +335,12 @@
                 <version>${version.lib.grpc}</version>
             </dependency>
             <dependency>
+                <!-- required for dependency convergence - used from io.grpc and from guava -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-annotations</artifactId>
+                <version>${version.lib.animal-sniffer}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-context</artifactId>
                 <version>${version.lib.grpc}</version>
@@ -331,17 +366,18 @@
                 <version>${version.lib.grpc}</version>
             </dependency>
             <dependency>
+                <!-- required for dependency convergence, used from guava and perfmark-api -->
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${version.lib.google-error-prone}</version>
+            </dependency>
+            <dependency>
               <groupId>io.opentracing.contrib</groupId>
               <artifactId>opentracing-grpc</artifactId>
               <version>${version.lib.opentracing.grpc}</version>
             </dependency>
 
             <!-- Webserver related -->
-            <dependency>
-                <groupId>io.zipkin.reporter2</groupId>
-                <artifactId>zipkin-sender-urlconnection</artifactId>
-                <version>${version.lib.zipkin}</version>
-            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
@@ -353,9 +389,34 @@
                 <version>${version.lib.prometheus}</version>
             </dependency>
             <dependency>
+                <groupId>io.zipkin.zipkin2</groupId>
+                <artifactId>zipkin</artifactId>
+                <version>${version.lib.zipkin}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.zipkin.reporter2</groupId>
+                <artifactId>zipkin-sender-urlconnection</artifactId>
+                <version>${version.lib.zipkin.sender-urlconnection}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.opentracing.brave</groupId>
                 <artifactId>brave-opentracing</artifactId>
                 <version>${version.lib.brave-opentracing}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- failure in dependency convergence -->
+                        <groupId>io.zipkin.reporter2</groupId>
+                        <artifactId>zipkin-reporter</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.zipkin.brave</groupId>
+                        <artifactId>brave-tests</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.zipkin.zipkin2</groupId>
+                        <artifactId>zipkin</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -447,6 +508,10 @@
                         <groupId>org.osgi</groupId>
                         <artifactId>org.osgi.annotation.versioning</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -490,6 +555,10 @@
                     <exclusion>
                         <groupId>org.osgi</groupId>
                         <artifactId>org.osgi.annotation.versioning</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -561,21 +630,16 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>${version.lib.jakarta-persistence-api}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
                 <version>${version.lib.persistence-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.transaction</groupId>
-                <artifactId>javax.transaction-api</artifactId>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
                 <version>${version.lib.transaction-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
                 <version>${version.lib.validation-api}</version>
             </dependency>
             <dependency>
@@ -606,7 +670,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
-                        <artifactId>javax.inject</artifactId>
+                        <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -635,6 +699,20 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${version.lib.hibernate}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.persistence</groupId>
+                        <artifactId>javax.persistence-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.narayana.jta</groupId>
@@ -652,6 +730,36 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-api</artifactId>
+                <version>${version.lib.weld-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core-impl</artifactId>
+                <version>${version.lib.weld}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-spi</artifactId>
+                <version>${version.lib.weld-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.module</groupId>
+                <artifactId>weld-jta</artifactId>
+                <version>${version.lib.weld}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.injects</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.weld</groupId>
+                        <artifactId>weld-core-impl</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-transaction-spi</artifactId>
                 <version>${version.lib.jboss-transaction-spi}</version>
@@ -661,6 +769,11 @@
                       <artifactId>jboss-connector-api_1.7_spec</artifactId>
                   </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                <version>${version.lib.jboss-transaction-api}</version>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.sdk</groupId>
@@ -705,9 +818,71 @@
                 <version>${version.lib.hamcrest}</version>
             </dependency>
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>javax.activation-api</artifactId>
-                <version>${version.lib.activation-api}</version>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-binding</artifactId>
+                <version>${version.lib.jersey}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.json</groupId>
+                        <artifactId>jakarta.json-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+                <artifactId>jersey-mp-rest-client</artifactId>
+                <version>${version.lib.jersey}</version>
+                <exclusions>
+                    <!-- most of these libraries are either bad (javax*), or we need additional exclusions on them -->
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.core</groupId>
+                        <artifactId>jersey-server</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.core</groupId>
+                        <artifactId>jersey-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.inject</groupId>
+                        <artifactId>jersey-hk2</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.media</groupId>
+                        <artifactId>jersey-media-json-binding</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.jersey.ext.cdi</groupId>
+                        <artifactId>jersey-cdi1x</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish</groupId>
+                        <artifactId>jsonp-jaxrs</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.microprofile.config</groupId>
+                        <artifactId>microprofile-config-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>javax.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.interceptor</groupId>
+                        <artifactId>javax.interceptor-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.json</groupId>
+                        <artifactId>jakarta.json-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- imported boms -->
             <dependency>

--- a/etc/javadoc/README.md
+++ b/etc/javadoc/README.md
@@ -52,7 +52,7 @@ OK, so if you need to add a new link to external javadocs this is what you do
    download a `package-list` (`element-list`) file it will complain. You'll then need 
    to figure out why the URL is no good. But better now, rather than during a javadoc build.
    
-4. If all goes well goes well you should have a `package-list` (`element-list`) file in
+4. If all goes well you should have a `package-list` (`element-list`) file in
    this directory under the component's name. You can now run a javadoc build and verify
    all is good.
    

--- a/etc/scripts/build.sh
+++ b/etc/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018,2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,6 +56,15 @@ mvn -f ${WS_DIR}/pom.xml \
     -Pexamples,archetypes,spotbugs,javadoc,sources,tck,tests,pipeline
 
 examples/quickstarts/archetypes/test-archetypes.sh
+
+#
+# test running from jar file, and then from module path
+#
+# The first integration test tests all MP features except for JPA/JTA
+# with multiple JAX-RS applications including security
+tests/integration/native-image/mp-1/test-runtime.sh
+# The third integration test tests Helidon Quickstart MP
+tests/integration/native-image/mp-3/test-runtime.sh
 
 # Build site and agregated javadocs
 mvn  -f ${WS_DIR}/pom.xml site

--- a/examples/grpc/security-abac/pom.xml
+++ b/examples/grpc/security-abac/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.grpc</groupId>

--- a/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-h2/pom.xml
@@ -34,13 +34,13 @@
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -77,8 +77,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp-mysql/pom.xml
@@ -34,13 +34,13 @@
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -71,16 +71,6 @@
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_3.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -88,8 +78,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/examples/integrations/cdi/datasource-hikaricp/pom.xml
@@ -34,13 +34,13 @@
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -75,16 +75,6 @@
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_3.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -92,8 +82,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/jedis/pom.xml
+++ b/examples/integrations/cdi/jedis/pom.xml
@@ -33,13 +33,13 @@
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -69,16 +69,6 @@
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_3.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -86,8 +76,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -80,16 +80,6 @@
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_3.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -109,30 +99,30 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/oci-objectstorage/pom.xml
+++ b/examples/integrations/cdi/oci-objectstorage/pom.xml
@@ -33,8 +33,8 @@
     <dependencies>
         <!-- Compile-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -65,16 +65,6 @@
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_3.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.spec.javax.interceptor</groupId>
-                    <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
@@ -82,8 +72,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/examples/microprofile/hello-world-implicit/pom.xml
+++ b/examples/microprofile/hello-world-implicit/pom.xml
@@ -52,8 +52,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/microprofile/mp1_1-static-content/pom.xml
+++ b/examples/microprofile/mp1_1-static-content/pom.xml
@@ -56,8 +56,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/microprofile/openapi-basic/pom.xml
+++ b/examples/microprofile/openapi-basic/pom.xml
@@ -56,8 +56,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/examples/microprofile/websocket/pom.xml
+++ b/examples/microprofile/websocket/pom.xml
@@ -56,8 +56,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/quickstarts/helidon-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-mp/pom.xml
@@ -43,8 +43,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -72,18 +72,14 @@
             <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-binding</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/examples/security/attribute-based-access-control/pom.xml
+++ b/examples/security/attribute-based-access-control/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/examples/security/attribute-based-access-control/src/main/java/module-info.java
+++ b/examples/security/attribute-based-access-control/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@
  */
 module io.helidon.security.examples.abac {
     // CDI API
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
     // implementation of expression language to use (used by the abac provider: policy expression language
-    requires javax.el;
+    requires jakarta.el.api;
     requires io.helidon.microprofile.bundle;
     // needed for security components and restrictions of this module
     requires io.helidon.security;

--- a/examples/security/google-login/pom.xml
+++ b/examples/security/google-login/pom.xml
@@ -81,8 +81,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/security/jersey/pom.xml
+++ b/examples/security/jersey/pom.xml
@@ -80,8 +80,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/security/webserver-digest-auth/pom.xml
+++ b/examples/security/webserver-digest-auth/pom.xml
@@ -86,8 +86,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/security/webserver-signatures/pom.xml
+++ b/examples/security/webserver-signatures/pom.xml
@@ -84,8 +84,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/translator-app/frontend/pom.xml
+++ b/examples/translator-app/frontend/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,6 +60,10 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/webserver/basics/pom.xml
+++ b/examples/webserver/basics/pom.xml
@@ -72,8 +72,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/webserver/websocket/pom.xml
+++ b/examples/webserver/websocket/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -47,6 +47,11 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-tyrus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.jersey</groupId>

--- a/grpc/client/pom.xml
+++ b/grpc/client/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import io.grpc.NameResolver;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import services.TreeMapService;
 
@@ -45,7 +44,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Disabled("Certificate expired on 27th March 2020")
 public class GrpcChannelsProviderIT {
 
     private static final String CLIENT_CERT = "ssl/clientCert.pem";

--- a/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/GrpcChannelsProviderIT.java
@@ -37,6 +37,7 @@ import io.grpc.NameResolver;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import services.TreeMapService;
 
@@ -44,6 +45,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@Disabled("Certificate expired on 27th March 2020")
 public class GrpcChannelsProviderIT {
 
     private static final String CLIENT_CERT = "ssl/clientCert.pem";

--- a/grpc/core/pom.xml
+++ b/grpc/core/pom.xml
@@ -109,12 +109,12 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>
@@ -128,8 +128,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/grpc/core/src/main/java/module-info.java
+++ b/grpc/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,5 +40,5 @@ module io.helidon.grpc.core {
     requires java.logging;
     requires java.naming;
 
-    requires javax.inject;
+    requires jakarta.inject.api;
 }

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,8 +80,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/grpc/metrics/src/main/java/module-info.java
+++ b/grpc/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/server/pom.xml
+++ b/grpc/server/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/grpc/server/src/main/java/module-info.java
+++ b/grpc/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,5 +36,5 @@ module io.helidon.grpc.server {
     requires java.annotation;
     requires java.logging;
 
-    requires javax.inject;
+    requires jakarta.inject.api;
 }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,22 +33,19 @@ import io.helidon.grpc.server.test.EchoServiceGrpc;
 
 import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.network.AvailablePortIterator;
-
 import io.grpc.Channel;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
-
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
 import services.EchoService;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -57,6 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests for gRPC server with SSL connections
  */
+@Disabled("Certificate expired on 27th March 2020")
 public class SslIT {
 
     // ----- data members ---------------------------------------------------

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -44,7 +44,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import services.EchoService;
 
@@ -54,7 +53,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests for gRPC server with SSL connections
  */
-@Disabled("Certificate expired on 27th March 2020")
 public class SslIT {
 
     // ----- data members ---------------------------------------------------

--- a/health/common/pom.xml
+++ b/health/common/pom.xml
@@ -31,8 +31,8 @@
     <dependencies>
         <dependency>
             <!-- only needed for compilation, not required in runtime -->
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/health/common/src/main/java/module-info.java
+++ b/health/common/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
  */
 module io.helidon.health.common {
 
-    requires static cdi.api;
-    requires static javax.inject;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
 
     exports io.helidon.health.common;
 }

--- a/health/health-checks/pom.xml
+++ b/health/health-checks/pom.xml
@@ -43,8 +43,8 @@
         </dependency>
         <dependency>
             <!-- only needed for compilation, not required in runtime -->
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/health/health-checks/src/main/java/module-info.java
+++ b/health/health-checks/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ module io.helidon.health.checks {
     requires java.logging;
     requires java.management;
 
-    requires static cdi.api;
-    requires static javax.inject;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
 
     requires io.helidon.common;
     requires io.helidon.health;
@@ -31,4 +31,7 @@ module io.helidon.health.checks {
     requires microprofile.health.api;
 
     exports io.helidon.health.checks;
+
+    // required for CDI
+    opens io.helidon.health.checks to weld.core.impl;
 }

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -46,8 +46,8 @@
                     <artifactId>org.osgi.annotation.versioning</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.inject</groupId>
-                    <artifactId>javax.inject</artifactId>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/integrations/cdi/common-cdi/delegates/pom.xml
+++ b/integrations/cdi/common-cdi/delegates/pom.xml
@@ -32,8 +32,8 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/common-cdi/delegates/src/main/java/module-info.java
+++ b/integrations/cdi/common-cdi/delegates/src/main/java/module-info.java
@@ -18,7 +18,7 @@
  * Provides classes and interfaces that wrap existing CDI constructs.
  */
 module io.helidon.integrations.cdi.delegates {
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
 
     exports io.helidon.integrations.cdi.delegates;
 }

--- a/integrations/cdi/common-cdi/reference-counted-context/pom.xml
+++ b/integrations/cdi/common-cdi/reference-counted-context/pom.xml
@@ -62,8 +62,8 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/common-cdi/reference-counted-context/src/main/java/module-info.java
+++ b/integrations/cdi/common-cdi/reference-counted-context/src/main/java/module-info.java
@@ -22,7 +22,7 @@
  */
 module io.helidon.integrations.cdi.referencecountedcontext {
     requires io.helidon.integrations.cdi.delegates;
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
 
     exports io.helidon.integrations.cdi.referencecountedcontext;
 }

--- a/integrations/cdi/datasource-hikaricp/pom.xml
+++ b/integrations/cdi/datasource-hikaricp/pom.xml
@@ -64,18 +64,18 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/datasource-hikaricp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-hikaricp/src/main/java/module-info.java
@@ -23,8 +23,8 @@
  * io.helidon.integrations.datasource.hikaricp.cdi.HikariCPBackedDataSourceExtension
  */
 module io.helidon.integrations.datasource.hikaricp.cdi {
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.sql;
     requires java.annotation;
     requires microprofile.config.api;

--- a/integrations/cdi/datasource-ucp/pom.xml
+++ b/integrations/cdi/datasource-ucp/pom.xml
@@ -63,18 +63,18 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/datasource-ucp/src/main/java/module-info.java
+++ b/integrations/cdi/datasource-ucp/src/main/java/module-info.java
@@ -26,8 +26,8 @@
 module io.helidon.integrations.datasource.ucp.cdi {
     requires java.sql;
     requires java.desktop; // For java.beans
-    requires javax.inject;
-    requires cdi.api;
+    requires jakarta.inject.api;
+    requires jakarta.enterprise.cdi.api;
     requires microprofile.config.api;
     requires ucp;
     requires io.helidon.service.configuration.microprofile.config;

--- a/integrations/cdi/datasource/pom.xml
+++ b/integrations/cdi/datasource/pom.xml
@@ -43,13 +43,13 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/datasource/src/main/java/module-info.java
+++ b/integrations/cdi/datasource/src/main/java/module-info.java
@@ -22,8 +22,8 @@
  * io.helidon.integrations.datasource.cdi.AbstractDataSourceExtension
  */
 module io.helidon.integrations.datasource.cdi {
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.sql;
     requires microprofile.config.api;
 

--- a/integrations/cdi/eclipselink-cdi/pom.xml
+++ b/integrations/cdi/eclipselink-cdi/pom.xml
@@ -71,13 +71,13 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/eclipselink-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/eclipselink-cdi/src/main/java/module-info.java
@@ -25,8 +25,8 @@ module io.helidon.integrations.cdi.eclipselink {
     requires java.management;
 
     requires java.transaction;
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.sql;
     requires org.eclipse.persistence.jpa;
     requires org.eclipse.persistence.core;

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -51,13 +51,13 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/hibernate-cdi/pom.xml
+++ b/integrations/cdi/hibernate-cdi/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>hibernate-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <!-- As we exclude javax from hibernate, we need to add jakarta -->
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -26,8 +26,8 @@
 module io.helidon.integrations.cdi.hibernate {
     requires java.transaction;
     requires java.sql;
-    requires javax.inject;
-    requires cdi.api;
+    requires jakarta.inject.api;
+    requires jakarta.enterprise.cdi.api;
     requires org.hibernate.orm.core;
 
     exports io.helidon.integrations.cdi.hibernate;

--- a/integrations/cdi/jedis-cdi/pom.xml
+++ b/integrations/cdi/jedis-cdi/pom.xml
@@ -49,8 +49,8 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/jedis-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jedis-cdi/src/main/java/module-info.java
@@ -21,8 +21,8 @@
  */
 module io.helidon.integrations.jedis.cdi {
     requires java.desktop; // For java.beans
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.sql;
     requires microprofile.config.api;
     requires jedis;

--- a/integrations/cdi/jpa-cdi/pom.xml
+++ b/integrations/cdi/jpa-cdi/pom.xml
@@ -96,19 +96,23 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
 
         <!-- Compile-scoped dependencies. -->
@@ -122,12 +126,6 @@
             <artifactId>helidon-integrations-cdi-reference-counted-context</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.cdi</groupId>
-            <artifactId>helidon-microprofile-cdi</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -382,13 +380,13 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.activation</groupId>
-                    <artifactId>javax.activation-api</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/integrations/cdi/jpa-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-cdi/src/main/java/module-info.java
@@ -28,15 +28,14 @@ module io.helidon.integrations.cdi.jpa {
     requires java.xml.bind;
     requires java.transaction;
     requires java.annotation;
+    requires jakarta.activation;
     requires java.sql;
     requires java.persistence;
-    requires javax.interceptor.api;
-    requires javax.inject;
-    requires cdi.api;
+    requires jakarta.interceptor.api;
+    requires jakarta.inject.api;
+    requires jakarta.enterprise.cdi.api;
     requires io.helidon.integrations.cdi.referencecountedcontext;
     requires io.helidon.integrations.cdi.delegates;
-    requires io.helidon.microprofile.cdi;
-    requires io.helidon.common;
 
     exports io.helidon.integrations.cdi.jpa;
 }

--- a/integrations/cdi/jpa-weld/pom.xml
+++ b/integrations/cdi/jpa-weld/pom.xml
@@ -102,13 +102,13 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -117,13 +117,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/jpa-weld/src/main/java/module-info.java
+++ b/integrations/cdi/jpa-weld/src/main/java/module-info.java
@@ -28,9 +28,9 @@ module io.helidon.integrations.cdi.jpa.weld {
     requires java.annotation;
     requires java.sql;
     requires java.persistence;
-    requires javax.interceptor.api;
-    requires javax.inject;
-    requires cdi.api;
+    requires jakarta.interceptor.api;
+    requires jakarta.inject.api;
+    requires jakarta.enterprise.cdi.api;
     requires weld.spi;
 
     exports io.helidon.integrations.cdi.jpa.weld;

--- a/integrations/cdi/jta-cdi/pom.xml
+++ b/integrations/cdi/jta-cdi/pom.xml
@@ -66,18 +66,18 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/jta-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/jta-cdi/src/main/java/module-info.java
@@ -27,9 +27,9 @@ module io.helidon.integrations.jta.cdi {
     requires java.annotation;
     requires java.sql;
     requires java.rmi;
-    requires javax.interceptor.api;
-    requires javax.inject;
-    requires cdi.api;
+    requires jakarta.interceptor.api;
+    requires jakarta.inject.api;
+    requires jakarta.enterprise.cdi.api;
     requires cdi;    // org.jboss.narayana.jta
     requires jta;    //org.jboss.narayana.jta.jta
     requires common; // org.jboss.narayana.common

--- a/integrations/cdi/jta-weld/pom.xml
+++ b/integrations/cdi/jta-weld/pom.xml
@@ -73,23 +73,17 @@
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-jta</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.weld</groupId>
-                    <artifactId>weld-core-impl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/jta-weld/src/main/java/module-info.java
+++ b/integrations/cdi/jta-weld/src/main/java/module-info.java
@@ -27,7 +27,7 @@ module io.helidon.integrations.jta.weld {
     requires java.transaction;
     requires java.logging;
     requires java.rmi;
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
     requires cdi;    // org.jboss.narayana.jta
     requires jta;    //org.jboss.narayana.jta.jta
     requires common; // org.jboss.narayana.common

--- a/integrations/cdi/oci-objectstorage-cdi/pom.xml
+++ b/integrations/cdi/oci-objectstorage-cdi/pom.xml
@@ -67,8 +67,8 @@
 
         <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/integrations/cdi/oci-objectstorage-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/oci-objectstorage-cdi/src/main/java/module-info.java
@@ -20,11 +20,11 @@
  */
 module io.helidon.integrations.cdi.oci.objectstorage {
 
-    requires javax.inject;
+    requires jakarta.inject.api;
     requires oci.java.sdk.common;
     requires oci.java.sdk.objectstorage.generated;
     requires oci.java.sdk.objectstorage.extensions;
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
     requires microprofile.config.api;
 
     exports io.helidon.integrations.cdi.oci.objectstorage;

--- a/integrations/graal/mp-native-image-extension/pom.xml
+++ b/integrations/graal/mp-native-image-extension/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/jersey/client/pom.xml
+++ b/jersey/client/pom.xml
@@ -39,14 +39,6 @@
             <version>${version.lib.jersey}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
                     <artifactId>jakarta.inject</artifactId>
                 </exclusion>
@@ -55,33 +47,16 @@
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.glassfish.hk2.external</groupId>
-                    <artifactId>javax.inject</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-        </dependency>
-        <dependency>
-            <!-- needed for correct module name -->
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
         </dependency>
     </dependencies>
 

--- a/jersey/client/src/main/java/module-info.java
+++ b/jersey/client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,6 @@ module io.helidon.jersey.client {
     requires transitive java.ws.rs;
     requires transitive jersey.common;
     requires transitive jersey.client;
-
-    requires transitive java.annotation;
-    requires transitive javax.inject;
 
     requires java.xml.bind;
 }

--- a/jersey/jsonp/pom.xml
+++ b/jersey/jsonp/pom.xml
@@ -37,21 +37,6 @@
             <!-- Jersey support for JSON-P -->
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-processing</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>jakarta.json</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!-- this is provided anyway -->
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/jersey/server/pom.xml
+++ b/jersey/server/pom.xml
@@ -46,58 +46,20 @@
                     <groupId>org.glassfish.hk2.external</groupId>
                     <artifactId>jakarta.inject</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.hk2.external</groupId>
-                    <artifactId>javax.inject</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.activation</groupId>
-                    <artifactId>jakarta.activation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-        </dependency>
-        <dependency>
-            <!-- needed for correct module name -->
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <!-- needed for proper module name in module-info.java -->
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/jersey/server/src/main/java/module-info.java
+++ b/jersey/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ module io.helidon.jersey.server {
     requires transitive jersey.common;
     requires transitive jersey.server;
 
-    requires transitive javax.inject;
-    requires transitive java.activation;
+    requires transitive jakarta.inject.api;
+    requires transitive jakarta.activation;
     requires transitive java.annotation;
 
-    requires java.xml.bind;
+    requires transitive java.xml.bind;
 }

--- a/media/jsonb/common/pom.xml
+++ b/media/jsonb/common/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/media/jsonp/common/pom.xml
+++ b/media/jsonp/common/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/microprofile/access-log/pom.xml
+++ b/microprofile/access-log/pom.xml
@@ -40,8 +40,8 @@
             <artifactId>helidon-webserver-access-log</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/microprofile/access-log/src/main/java/module-info.java
+++ b/microprofile/access-log/src/main/java/module-info.java
@@ -24,9 +24,12 @@ module io.helidon.microprofile.accesslog {
 
     requires io.helidon.microprofile.server;
     requires io.helidon.webserver.accesslog;
-    requires javax.interceptor.api;
+    requires jakarta.interceptor.api;
 
     exports io.helidon.microprofile.accesslog;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.accesslog to weld.core.impl;
 
     provides Extension with io.helidon.microprofile.accesslog.AccessLogCdiExtension;
 }

--- a/microprofile/bundles/helidon-microprofile-core/pom.xml
+++ b/microprofile/bundles/helidon-microprofile-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,16 +33,6 @@
         <dependency>
             <groupId>io.helidon.microprofile.server</groupId>
             <artifactId>helidon-microprofile-server</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.interceptor</groupId>
-                    <artifactId>javax.interceptor-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.hk2.external</groupId>
-                    <artifactId>javax.inject</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>

--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -80,6 +80,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
             <scope>runtime</scope>

--- a/microprofile/bundles/helidon-microprofile/src/main/java/module-info.java
+++ b/microprofile/bundles/helidon-microprofile/src/main/java/module-info.java
@@ -27,6 +27,6 @@ module io.helidon.microprofile.bundle {
     requires transitive io.helidon.microprofile.tracing;
     requires transitive io.helidon.microprofile.restclient;
     requires transitive io.helidon.microprofile.openapi;
-
+    requires transitive java.json.bind;
     requires io.helidon.health.checks;
 }

--- a/microprofile/cdi/src/main/java/module-info.java
+++ b/microprofile/cdi/src/main/java/module-info.java
@@ -22,9 +22,10 @@ import io.helidon.microprofile.cdi.HelidonContainerInitializer;
  * CDI implementation enhancements for Helidon MP.
  */
 module io.helidon.microprofile.cdi {
-    uses javax.enterprise.inject.spi.Extension;
+    // needed for Unsafe used from Weld
+    requires jdk.unsupported;
     requires java.logging;
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
 
     requires io.helidon.common;
     requires io.helidon.config;
@@ -34,9 +35,11 @@ module io.helidon.microprofile.cdi {
     requires weld.environment.common;
     requires weld.se.core;
     requires io.helidon.common.context;
-    requires javax.inject;
+    requires jakarta.inject.api;
 
     exports io.helidon.microprofile.cdi;
+
+    uses javax.enterprise.inject.spi.Extension;
 
     provides SeContainerInitializer with HelidonContainerInitializer;
 }

--- a/microprofile/config/pom.xml
+++ b/microprofile/config/pom.xml
@@ -46,15 +46,22 @@
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-object-mapping</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.cdi</groupId>
             <artifactId>helidon-microprofile-cdi</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <!-- provided by CDI implementation -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/config/src/main/java/module-info.java
+++ b/microprofile/config/src/main/java/module-info.java
@@ -19,15 +19,16 @@
  */
 module io.helidon.microprofile.config {
     requires java.logging;
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires io.helidon.common;
     requires io.helidon.config;
-    requires io.helidon.config.objectmapping;
-    requires io.helidon.microprofile.cdi;
     requires microprofile.config.api;
 
     exports io.helidon.microprofile.config;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.config to weld.core.impl;
 
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.config.ConfigCdiExtension;
 }

--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -83,13 +83,13 @@
             <artifactId>failsafe</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -106,8 +106,8 @@
         </dependency>
         <!-- To keep HK2 from complaining when run with Java9+ -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandRetrier.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandRetrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,7 +301,7 @@ public class CommandRetrier {
 
         Object result;
         try {
-            LOGGER.info(() -> "About to execute command with key "
+            LOGGER.fine(() -> "About to execute command with key "
                     + command.getCommandKey()
                     + " on thread " + Thread.currentThread().getName());
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,7 +442,7 @@ public class FaultToleranceCommand extends HystrixCommand<Object> {
     private void logCircuitBreakerState(String preamble) {
         if (introspector.hasCircuitBreaker()) {
             String hystrixState = isCircuitBreakerOpen() ? "OPEN" : "CLOSED";
-            LOGGER.info(() -> preamble + ": breaker for " + getCommandKey() + " in state "
+            LOGGER.fine(() -> preamble + ": breaker for " + getCommandKey() + " in state "
                     + breakerHelper.getState() + " (Hystrix: " + hystrixState
                     + " Thread:" + Thread.currentThread().getName() + ")");
         }
@@ -464,7 +464,7 @@ public class FaultToleranceCommand extends HystrixCommand<Object> {
             try {
                 int waitTime = 250;
                 while (runThread.getState() == Thread.State.RUNNABLE && waitTime <= threadWaitingPeriod) {
-                    LOGGER.info(() -> "Waiting for completion of thread " + runThread);
+                    LOGGER.fine(() -> "Waiting for completion of thread " + runThread);
                     Thread.sleep(waitTime);
                     waitTime += 250;
                 }

--- a/microprofile/fault-tolerance/src/main/java/module-info.java
+++ b/microprofile/fault-tolerance/src/main/java/module-info.java
@@ -20,8 +20,8 @@
 module io.helidon.microprofile.faulttolerance {
     requires java.logging;
     requires java.annotation;
-    requires javax.inject;
-    requires javax.interceptor.api;
+    requires jakarta.inject.api;
+    requires jakarta.interceptor.api;
 
     requires io.helidon.common.context;
     requires io.helidon.common.configurable;
@@ -30,7 +30,7 @@ module io.helidon.microprofile.faulttolerance {
     requires io.helidon.microprofile.server;
     requires io.helidon.microprofile.metrics;
 
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
     requires hystrix.core;
     requires archaius.core;
     requires commons.configuration;
@@ -41,6 +41,9 @@ module io.helidon.microprofile.faulttolerance {
     requires microprofile.fault.tolerance.api;
 
     exports io.helidon.microprofile.faulttolerance;
+
+    // needed when running with modules - to make private methods accessible
+    opens io.helidon.microprofile.faulttolerance to weld.core.impl;
 
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.faulttolerance.FaultToleranceExtension;
 }

--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>helidon-grpc-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/grpc/client/pom.xml
+++ b/microprofile/grpc/client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2019, 2020 Oracle and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -39,26 +39,18 @@
             <artifactId>helidon-grpc-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.microprofile.config</groupId>
-            <artifactId>helidon-microprofile-config</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.microprofile.cdi</groupId>
             <artifactId>helidon-microprofile-cdi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <!-- redirecting Weld logging to JUL logging -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/microprofile/grpc/client/src/main/java/module-info.java
+++ b/microprofile/grpc/client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,17 @@
  */
 
 /**
- * @author jk  2019.08.15
+ * gRPC client implementation for Helidon MP.
  */
 module io.helidon.microprofile.grpc.client {
-    exports io.helidon.microprofile.grpc.client;
+    requires java.logging;
+
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
 
     requires transitive io.helidon.microprofile.grpc.core;
 
-    requires java.logging;
+    exports io.helidon.microprofile.grpc.client;
 
     provides javax.enterprise.inject.spi.Extension
             with io.helidon.microprofile.grpc.client.GrpcClientCdiExtension;

--- a/microprofile/grpc/core/pom.xml
+++ b/microprofile/grpc/core/pom.xml
@@ -39,8 +39,8 @@
             <artifactId>helidon-grpc-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/GrpcInterceptorBinding.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/GrpcInterceptorBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * used to specify the binding of a gRPC client or server interceptor to target gRPC service and methods.
  * <p>
  * The annotation type that is marked as a binding must be applied to a client of server gRPC interceptor
- * implementation class (marked with the {@link javax.interceptor.Interceptor @Interceptor} annotation to associate that annotation with an interceptor.  The annotation
- * may then be applied instead of, or in addition to, the {@link javax.interceptor.Interceptors @Interceptors} annotation to specify
+ * implementation class (marked with the {@code javax.interceptor.Interceptor @Interceptor} annotation to associate that annotation with an interceptor.  The annotation
+ * may then be applied instead of, or in addition to, the {@code javax.interceptor.Interceptors @Interceptors} annotation to specify
  * what interceptors are attached to the class or method.
  * <p>
  * The associated annotation type must be associated only with {@link java.lang.annotation.ElementType#TYPE TYPE}s and/or

--- a/microprofile/grpc/core/src/main/java/module-info.java
+++ b/microprofile/grpc/core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ module io.helidon.microprofile.grpc.core {
     requires transitive io.helidon.microprofile.config;
     requires io.helidon.common.serviceloader;
 
-    requires transitive cdi.api;
+    requires transitive jakarta.enterprise.cdi.api;
 
     requires java.logging;
-    requires javax.inject;
+    requires jakarta.inject.api;
 
     uses io.helidon.microprofile.grpc.core.MethodHandlerSupplier;
 

--- a/microprofile/grpc/metrics/pom.xml
+++ b/microprofile/grpc/metrics/pom.xml
@@ -48,8 +48,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/grpc/metrics/src/main/java/module-info.java
+++ b/microprofile/grpc/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ module io.helidon.microprofile.grpc.metrics {
     requires transitive io.helidon.microprofile.server;
 
     requires java.logging;
-    requires javax.interceptor.api;
+    requires jakarta.interceptor.api;
 
     provides io.helidon.microprofile.grpc.server.AnnotatedServiceConfigurer
             with io.helidon.microprofile.grpc.metrics.MetricsConfigurer;

--- a/microprofile/grpc/server/pom.xml
+++ b/microprofile/grpc/server/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -51,8 +51,8 @@
             from hk2). If you run application on Java 9, you need to add this dependency
             in compile scope to prevent the error messages.
             -->
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/microprofile/health/src/main/java/module-info.java
+++ b/microprofile/health/src/main/java/module-info.java
@@ -27,14 +27,17 @@ module io.helidon.microprofile.health {
     requires io.helidon.health.common;
     requires io.helidon.microprofile.server;
 
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.ws.rs;
-    requires org.glassfish.java.json;
+    requires java.json;
     requires microprofile.config.api;
     requires microprofile.health.api;
 
     exports io.helidon.microprofile.health;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.health to weld.core.impl;
 
     uses io.helidon.microprofile.health.HealthCheckProvider;
 

--- a/microprofile/jwt-auth/pom.xml
+++ b/microprofile/jwt-auth/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -73,9 +73,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
-            <scope>compile</scope>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -611,6 +611,13 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
 
             URL url = Thread.currentThread().getContextClassLoader().getResource(uri);
             if (url == null) {
+                // if uri starts with "/", remove it
+                if (uri.startsWith("/")) {
+                    url = Thread.currentThread().getContextClassLoader().getResource(uri.substring(1));
+                }
+            }
+
+            if (url == null) {
                 is = JwtAuthProvider.class.getResourceAsStream(uri);
 
                 if (null == is) {

--- a/microprofile/jwt-auth/src/main/java/module-info.java
+++ b/microprofile/jwt-auth/src/main/java/module-info.java
@@ -20,8 +20,8 @@
 module io.helidon.microprofile.jwt.auth {
     requires java.logging;
 
-    requires cdi.api;
-    requires javax.inject;
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.inject.api;
     requires java.ws.rs;
     requires microprofile.config.api;
     requires transitive microprofile.jwt.auth.api;
@@ -40,5 +40,10 @@ module io.helidon.microprofile.jwt.auth {
 
     exports io.helidon.microprofile.jwt.auth;
 
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.jwt.auth to weld.core.impl;
+
+    provides io.helidon.security.providers.common.spi.AnnotationAnalyzer with io.helidon.microprofile.jwt.auth.JwtAuthAnnotationAnalyzer;
+    provides io.helidon.security.spi.SecurityProviderService with io.helidon.microprofile.jwt.auth.JwtAuthProviderService;
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.jwt.auth.JwtAuthCdiExtension;
 }

--- a/microprofile/messaging/pom.xml
+++ b/microprofile/messaging/pom.xml
@@ -60,8 +60,8 @@
             <artifactId>helidon-microprofile-reactive-streams</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/messaging/src/main/java/module-info.java
+++ b/microprofile/messaging/src/main/java/module-info.java
@@ -20,10 +20,10 @@
 module io.helidon.microprofile.messaging {
     requires java.logging;
 
-    requires static cdi.api;
-    requires static javax.inject;
-    requires static java.activation;
-    requires javax.interceptor.api;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.activation;
+    requires jakarta.interceptor.api;
     requires io.helidon.config;
     requires io.helidon.microprofile.config;
     requires io.helidon.microprofile.server;

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -36,13 +36,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/metrics/src/main/java/module-info.java
+++ b/microprofile/metrics/src/main/java/module-info.java
@@ -20,11 +20,11 @@
 module io.helidon.microprofile.metrics {
     requires java.logging;
 
-    requires static cdi.api;
-    requires static javax.inject;
-    requires static javax.interceptor.api;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.interceptor.api;
     requires static java.annotation;
-    requires static java.activation;
+    requires static jakarta.activation;
 
     requires io.helidon.microprofile.server;
     requires io.helidon.microprofile.config;
@@ -36,6 +36,9 @@ module io.helidon.microprofile.metrics {
 
 
     exports io.helidon.microprofile.metrics;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.metrics to weld.core.impl;
 
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.metrics.MetricsCdiExtension;
 }

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -103,8 +103,8 @@
             <artifactId>helidon-openapi</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/openapi/src/main/java/module-info.java
+++ b/microprofile/openapi/src/main/java/module-info.java
@@ -32,5 +32,8 @@ module io.helidon.microprofile.openapi {
 
     exports io.helidon.microprofile.openapi;
 
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.openapi to weld.core.impl;
+
     provides Extension with OpenApiCdiExtension;
 }

--- a/microprofile/rest-client/pom.xml
+++ b/microprofile/rest-client/pom.xml
@@ -37,8 +37,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -52,48 +52,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.ext.microprofile</groupId>
             <artifactId>jersey-mp-rest-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.inject</groupId>
-                    <artifactId>jersey-hk2</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-json-binding</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.ext.cdi</groupId>
-                    <artifactId>jersey-cdi1x</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.json</groupId>
-                    <artifactId>jakarta.json-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish</groupId>
-                    <artifactId>jsonp-jaxrs</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.ws.rs</groupId>
-                    <artifactId>jakarta.ws.rs-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.microprofile.config</groupId>
-                    <artifactId>microprofile-config-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/microprofile/security/pom.xml
+++ b/microprofile/security/pom.xml
@@ -43,8 +43,8 @@
             <artifactId>helidon-microprofile-cdi</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/security/src/main/java/module-info.java
+++ b/microprofile/security/src/main/java/module-info.java
@@ -26,9 +26,12 @@ module io.helidon.microprofile.security {
     requires transitive io.helidon.security.integration.webserver;
     requires io.helidon.microprofile.server;
     requires io.helidon.microprofile.cdi;
-    requires javax.interceptor.api;
+    requires jakarta.interceptor.api;
 
     exports io.helidon.microprofile.security;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.security to weld.core.impl;
 
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.security.SecurityCdiExtension;
 }

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -53,29 +53,27 @@
             <artifactId>helidon-common-service-loader</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.interceptor</groupId>
-            <artifactId>javax.interceptor-api</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -88,13 +88,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <!-- redirecting Weld logging to JUL logging -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <!-- Jersey integration with Weld -->
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-weld2-se</artifactId>

--- a/microprofile/server/src/main/java/module-info.java
+++ b/microprofile/server/src/main/java/module-info.java
@@ -26,9 +26,9 @@ module io.helidon.microprofile.server {
 
     requires transitive io.helidon.microprofile.cdi;
 
-    requires transitive cdi.api;
+    requires transitive jakarta.enterprise.cdi.api;
     requires transitive java.ws.rs;
-    requires javax.interceptor.api;
+    requires jakarta.interceptor.api;
 
     requires java.logging;
     requires io.helidon.common.serviceloader;

--- a/microprofile/tests/tck/pom.xml
+++ b/microprofile/tests/tck/pom.xml
@@ -42,6 +42,15 @@
         <module>tck-reactive-operators</module>
     </modules>
 
+    <properties>
+        <!--
+        We do not want to fix problems in TCK tests themselves, let's ignore enforcer here
+         -->
+        <enforcer.skip>true</enforcer.skip>
+    </properties>
+
+
+
     <dependencies>
          <dependency>
             <groupId>org.testng</groupId>

--- a/microprofile/tests/tck/tck-config/src/test/resources/logging.properties
+++ b/microprofile/tests/tck/tck-config/src/test/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-config/src/test/tck-suite-win.xml
+++ b/microprofile/tests/tck/tck-config/src/test/tck-suite-win.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-config/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-config/src/test/tck-suite.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-fault-tolerance/pom.xml
+++ b/microprofile/tests/tck/tck-fault-tolerance/pom.xml
@@ -35,12 +35,6 @@
             <artifactId>helidon-arquillian</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.helidon.microprofile.bundles</groupId>
-                    <artifactId>helidon-microprofile</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
@@ -48,8 +42,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/microprofile/tests/tck/tck-health/pom.xml
+++ b/microprofile/tests/tck/tck-health/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,8 +57,8 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-jwt-auth/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/microprofile/tests/tck/tck-jwt-auth/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-metrics/pom.xml
+++ b/microprofile/tests/tck/tck-metrics/pom.xml
@@ -37,8 +37,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,8 +81,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -59,12 +59,12 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -54,8 +54,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingExtension.java
+++ b/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingJavaMockTracerBuilder.java
+++ b/microprofile/tests/tck/tck-opentracing/src/test/java/io/helidon/microprofile/opentracing/tck/OpentracingJavaMockTracerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-opentracing/src/test/resources/META-INF/beans.xml
+++ b/microprofile/tests/tck/tck-opentracing/src/test/resources/META-INF/beans.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License v. 2.0, which is available at
-    http://www.eclipse.org/legal/epl-2.0.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    This Source Code may also be made available under the following Secondary
-    Licenses when the conditions for such availability set forth in the
-    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-    version 2 with the GNU Classpath Exception, which is available at
-    https://www.gnu.org/software/classpath/license.html.
+        http://www.apache.org/licenses/LICENSE-2.0
 
-    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
 -->
 

--- a/microprofile/tests/tck/tck-opentracing/src/test/resources/tck-application.yaml
+++ b/microprofile/tests/tck/tck-opentracing/src/test/resources/tck-application.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 tracing:
   service: "TCK"
   components:

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -48,8 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microprofile/tests/tck/tck-rest-client/src/test/resources/arquillian.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/resources/arquillian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
-  Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/microprofile/tracing/pom.xml
+++ b/microprofile/tracing/pom.xml
@@ -36,8 +36,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,8 +66,8 @@
         </dependency>
         <dependency>
             <!-- Jersey on java 9 -->
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/tracing/src/main/java/module-info.java
+++ b/microprofile/tracing/src/main/java/module-info.java
@@ -27,9 +27,9 @@ module io.helidon.microprofile.tracing {
     requires jersey.common;
     requires io.opentracing.api;
 
-    requires static cdi.api;
-    requires static javax.inject;
-    requires static javax.interceptor.api;
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.interceptor.api;
 
     requires io.helidon.microprofile.server;
     requires transitive io.helidon.microprofile.config;
@@ -45,6 +45,9 @@ module io.helidon.microprofile.tracing {
 
 
     exports io.helidon.microprofile.tracing;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.tracing to weld.core.impl,hk2.utils;
 
     provides Extension with io.helidon.microprofile.tracing.TracingCdiExtension;
     provides org.glassfish.jersey.internal.spi.AutoDiscoverable with io.helidon.microprofile.tracing.MpTracingAutoDiscoverable;

--- a/microprofile/websocket/pom.xml
+++ b/microprofile/websocket/pom.xml
@@ -53,8 +53,8 @@
             <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/microprofile/websocket/src/main/java/module-info.java
+++ b/microprofile/websocket/src/main/java/module-info.java
@@ -19,10 +19,10 @@
  */
 module io.helidon.microprofile.tyrus {
     requires java.logging;
-    requires javax.inject;
-    requires javax.interceptor.api;
+    requires jakarta.inject.api;
+    requires jakarta.interceptor.api;
 
-    requires cdi.api;
+    requires jakarta.enterprise.cdi.api;
     requires transitive jakarta.websocket.api;
 
     requires io.helidon.common;
@@ -34,5 +34,9 @@ module io.helidon.microprofile.tyrus {
     requires tyrus.spi;
 
     exports io.helidon.microprofile.tyrus;
+
+    // this is needed for CDI extensions that use non-public observer methods
+    opens io.helidon.microprofile.tyrus to weld.core.impl;
+
     provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.tyrus.WebSocketCdiExtension;
 }

--- a/microprofile/weld/weld-se-core/pom.xml
+++ b/microprofile/weld/weld-se-core/pom.xml
@@ -80,45 +80,33 @@
             <artifactId>weld-spi</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!--
+        Using Jakarta API instead of the Weld specific spec libraries
+        The library naming of weld is not compatible with java module system
+        -->
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-            <scope>compile</scope>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_3.0_spec</artifactId>
-            <scope>compile</scope>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.interceptor</groupId>
-            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-            <scope>compile</scope>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>javax.el-api</artifactId>
-                    <groupId>javax.el</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>javax.interceptor-api</artifactId>
-                    <groupId>javax.interceptor</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <scope>compile</scope>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.classfilewriter</groupId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -132,12 +132,18 @@
             <artifactId>helidon-media-jsonp-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,7 @@
         <version.lib.asciidoctor.diagram>1.5.4.1</version.lib.asciidoctor.diagram>
         <version.lib.asm>6.0</version.lib.asm>
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
-        <version.lib.classfilewriter>1.2.4.Final</version.lib.classfilewriter>
-        <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
-        <version.lib.jboss-annotations-api_1.3_spec>1.0.0.Final</version.lib.jboss-annotations-api_1.3_spec>
-        <version.lib.jboss-el-api_3.0_spec>1.0.0.Final</version.lib.jboss-el-api_3.0_spec>
-        <version.lib.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.lib.jboss-interceptors-api_1.2_spec>
-        <version.lib.jboss.logging>3.2.1.Final</version.lib.jboss.logging>
         <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
         <version.lib.netty.tcnative>2.0.26.Final</version.lib.netty.tcnative>
@@ -143,7 +137,7 @@
         <javadoc.link.javax-jaxb>https://static.javadoc.io/javax.xml.bind/jaxb-api/${version.lib.jaxb-api}</javadoc.link.javax-jaxb>
         <javadoc.link.javax-persistence>https://static.javadoc.io/javax.persistence/javax.persistence-api/${version.lib.persistence-api}</javadoc.link.javax-persistence>
         <javadoc.link.javax-transaction>https://static.javadoc.io/javax.transaction/javax.transaction-api/${version.lib.transaction-api}</javadoc.link.javax-transaction>
-        <javadoc.link.microprofile-config>https://static.javadoc.io/org.eclipse.microprofile.config/microprofile-config-api/${version.lib.microprofile-config-api}</javadoc.link.microprofile-config>
+        <javadoc.link.microprofile-config>https://static.javadoc.io/org.eclipse.microprofile.config/microprofile-config-api/${version.lib.microprofile-config}</javadoc.link.microprofile-config>
         <javadoc.link.microprofile-health>https://static.javadoc.io/org.eclipse.microprofile.health/microprofile-health-api/${version.lib.microprofile-health}</javadoc.link.microprofile-health>
         <javadoc.link.microprofile-metrics>https://static.javadoc.io/org.eclipse.microprofile.metrics/microprofile-metrics-api/${version.lib.microprofile-metrics-api}</javadoc.link.microprofile-metrics>
         <javadoc.link.weld>https://docs.jboss.org/weld/javadoc/3.0/weld-spi/</javadoc.link.weld>
@@ -794,59 +788,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.jboss.weld.environment</groupId>
-                <artifactId>weld-environment-common</artifactId>
-                <version>${version.lib.weld}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.weld.probe</groupId>
-                <artifactId>weld-probe-core</artifactId>
-                <version>${version.lib.weld}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.classfilewriter</groupId>
-                <artifactId>jboss-classfilewriter</artifactId>
-                <version>${version.lib.classfilewriter}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence, transitive dependency of both
-                commons-configuration (through hystrix-core)
-                org.apache.httpcomponents:httpclient (through health-tck)
-                -->
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${version.lib.commons-logging}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.annotation</groupId>
-                <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-                <version>${version.lib.jboss-annotations-api_1.3_spec}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.el</groupId>
-                <artifactId>jboss-el-api_3.0_spec</artifactId>
-                <version>${version.lib.jboss-el-api_3.0_spec}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.interceptor</groupId>
-                <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                <version>${version.lib.jboss-interceptors-api_1.2_spec}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.lib.jboss.logging}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-junit5</artifactId>
                 <version>${version.lib.weld-junit}</version>
-            </dependency>
-            <dependency>
-                <!-- if needed (as excluded from weld) -->
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>${version.lib.groovy-all}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <version.lib.asm>6.0</version.lib.asm>
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.classfilewriter>1.2.4.Final</version.lib.classfilewriter>
+        <version.lib.commons-logging>1.2</version.lib.commons-logging>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <version.lib.jboss-annotations-api_1.3_spec>1.0.0.Final</version.lib.jboss-annotations-api_1.3_spec>
         <version.lib.jboss-el-api_3.0_spec>1.0.0.Final</version.lib.jboss-el-api_3.0_spec>
@@ -77,9 +78,9 @@
         <version.lib.zipkin.junit>2.12.5</version.lib.zipkin.junit>
         <version.lib.bedrock>5.0.11</version.lib.bedrock>
         <version.lib.okhttp3>3.14.1</version.lib.okhttp3>
+        <version.lib.okio>1.17.2</version.lib.okio>
         <version.lib.awaitility>3.1.6</version.lib.awaitility>
         <version.lib.weld-junit>2.0.0.Final</version.lib.weld-junit>
-        <version.lib.weld>3.1.2.Final</version.lib.weld>
         <version.lib.jmh>1.23</version.lib.jmh>
         <!--
         !Version statement! - end
@@ -94,7 +95,6 @@
         <version.plugin.dependency>3.0.0</version.plugin.dependency>
         <version.plugin.directory>0.1</version.plugin.directory>
         <version.plugin.eclipselink>2.7.1.1</version.plugin.eclipselink>
-        <version.plugin.enforcer>1.4.1</version.plugin.enforcer>
         <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
@@ -137,7 +137,7 @@
         <javadoc.link.prometheus>https://static.javadoc.io/io.prometheus/simpleclient/${version.lib.prometheus}</javadoc.link.prometheus>
         <javadoc.link.zipkin>https://static.javadoc.io/io.zipkin.reporter2/zipkin-reporter/${version.lib.zipkin}</javadoc.link.zipkin>
         <javadoc.link.jakarta-jsonb>https://static.javadoc.io/jakarta.json.bind/jakarta.json.bind-api/${version.lib.jsonb-api}</javadoc.link.jakarta-jsonb>
-        <javadoc.link.jakarta-persistence>https://static.javadoc.io/jakarta.persistence/jakarta.persistence-api/${version.lib.jakarta-persistence-api}</javadoc.link.jakarta-persistence>
+        <javadoc.link.jakarta-persistence>https://static.javadoc.io/jakarta.persistence/jakarta.persistence-api/${version.lib.persistence-api}</javadoc.link.jakarta-persistence>
         <javadoc.link.jakarta-jsonp>https://static.javadoc.io/jakarta.json/jakarta.json-api/1.1.6</javadoc.link.jakarta-jsonp>
         <javadoc.link.javax-jsonb>https://static.javadoc.io/javax.json.bind/javax.json.bind-api/1.0</javadoc.link.javax-jsonb>
         <javadoc.link.javax-jaxb>https://static.javadoc.io/javax.xml.bind/jaxb-api/${version.lib.jaxb-api}</javadoc.link.javax-jaxb>
@@ -608,6 +608,25 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence>
+                                    <uniqueVersions>true</uniqueVersions>
+                                </dependencyConvergence>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
                 <executions>
@@ -748,6 +767,22 @@
                 <version>${version.lib.reactivestreams}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-provider-api</artifactId>
+                <version>${version.lib.maven-wagon}</version>
+            </dependency>
+            <dependency>
+                <!--
+                Required for dependency convergence
+                Used by both
+                io.rest-assured:rest-assured (from metrics rest TCK)
+                hamcrest-integration (from metrics API TCK)
+                -->
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${version.lib.hamcrest}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-core</artifactId>
                 <version>${version.lib.weld}</version>
@@ -769,16 +804,18 @@
                 <version>${version.lib.weld}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-core-bom</artifactId>
-                <version>${version.lib.weld}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.classfilewriter</groupId>
                 <artifactId>jboss-classfilewriter</artifactId>
                 <version>${version.lib.classfilewriter}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence, transitive dependency of both
+                commons-configuration (through hystrix-core)
+                org.apache.httpcomponents:httpclient (through health-tck)
+                -->
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${version.lib.commons-logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -820,6 +857,12 @@
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-tck</artifactId>
                 <version>${version.lib.microprofile-jwt}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.enterprise</groupId>
+                        <artifactId>cdi-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
@@ -893,6 +936,11 @@
                 <version>${version.lib.arquillian}</version>
             </dependency>
             <dependency>
+                <groupId>org.jboss.arquillian.test</groupId>
+                <artifactId>arquillian-test-spi</artifactId>
+                <version>${version.lib.arquillian}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.arquillian.container</groupId>
                 <artifactId>arquillian-container-spi</artifactId>
                 <version>${version.lib.arquillian}</version>
@@ -932,6 +980,18 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>${version.lib.okhttp3}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence
+                used from both
+                com.squareup.okhttp3:mockwebserver:3.13.1
+                com.squareup.moshi:moshi:1.8.0
+                both referenced by
+                io.zipkin.zipkin2:zipkin-junit:2.12.5
+                -->
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${version.lib.okio}</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/security/abac/policy-el/pom.xml
+++ b/security/abac/policy-el/pom.xml
@@ -39,13 +39,13 @@
             <artifactId>helidon-security-abac-policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/security/abac/policy-el/src/main/java/module-info.java
+++ b/security/abac/policy-el/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ module io.helidon.security.abac.policy.el {
     requires io.helidon.security.abac.policy;
     requires java.logging;
     // expected to be provided by the actual EL implementation
-    requires static javax.el.api;
+    requires static jakarta.el.api;
     requires java.desktop;
     requires io.helidon.security.util;
 

--- a/security/abac/role/src/main/java/module-info.java
+++ b/security/abac/role/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ module io.helidon.security.abac.role {
 
     exports io.helidon.security.abac.role;
 
+    provides io.helidon.security.providers.common.spi.AnnotationAnalyzer with io.helidon.security.abac.role.RoleAnnotationAnalyzer;
     provides io.helidon.security.providers.abac.spi.AbacValidatorService with io.helidon.security.abac.role.RoleValidatorService;
 
     uses io.helidon.security.providers.common.spi.AnnotationAnalyzer;

--- a/security/integration/grpc/pom.xml
+++ b/security/integration/grpc/pom.xml
@@ -117,8 +117,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security/integration/jersey-client/pom.xml
+++ b/security/integration/jersey-client/pom.xml
@@ -49,8 +49,8 @@
             <artifactId>helidon-jersey-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -71,6 +71,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/security/integration/jersey-client/src/main/java/module-info.java
+++ b/security/integration/jersey-client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ module io.helidon.security.integration.jersey.client {
     requires io.helidon.webclient.jaxrs;
     requires jersey.common;
     requires jersey.client;
-    requires javax.inject;
 
     exports io.helidon.security.integration.jersey.client;
 

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -63,8 +63,8 @@
             <artifactId>helidon-common-service-loader</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -86,8 +86,8 @@
             <artifactId>opentracing-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -112,9 +112,9 @@
         </dependency>
         <dependency>
             <!-- needed to mock jersey container request -->
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <scope>test</scope>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
@@ -132,8 +132,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security/integration/jersey/src/main/java/module-info.java
+++ b/security/integration/jersey/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,17 +30,16 @@ module io.helidon.security.integration.jersey {
 
     requires io.helidon.common.context;
     requires io.helidon.jersey.common;
+    requires io.helidon.jersey.server;
+    requires io.helidon.jersey.client;
     requires io.helidon.security.integration.common;
     requires io.helidon.webclient.jaxrs;
-    requires jersey.common;
-    requires jersey.server;
-    requires jersey.client;
-    requires javax.inject;
+    requires jakarta.inject.api;
 
     exports io.helidon.security.integration.jersey;
 
     // needed for jersey injection
-    opens io.helidon.security.integration.jersey to hk2.locator,hk2.utils;
+    opens io.helidon.security.integration.jersey to hk2.locator,hk2.utils,weld.core.impl;
 
     uses io.helidon.security.providers.common.spi.AnnotationAnalyzer;
 }

--- a/security/integration/webserver/pom.xml
+++ b/security/integration/webserver/pom.xml
@@ -100,13 +100,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/security/jwt/pom.xml
+++ b/security/jwt/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/security/jwt/src/main/java/module-info.java
+++ b/security/jwt/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.security.jwt {
     requires transitive io.helidon.config;
     requires transitive io.helidon.common;
     requires transitive io.helidon.common.configurable;
-    requires transitive org.glassfish.java.json;
+    requires transitive java.json;
     requires io.helidon.security.util;
     requires java.logging;
 

--- a/security/providers/http-auth/pom.xml
+++ b/security/providers/http-auth/pom.xml
@@ -84,8 +84,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -96,5 +96,10 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/security/security/src/main/java/module-info.java
+++ b/security/security/src/main/java/module-info.java
@@ -42,5 +42,8 @@ module io.helidon.security {
 
     exports io.helidon.security.internal to io.helidon.security.integration.jersey, io.helidon.security.integration.webserver, io.helidon.security.integration.grpc;
 
+    // needed for CDI integration
+    opens io.helidon.security to weld.core.impl;
+
     uses io.helidon.security.spi.SecurityProviderService;
 }

--- a/tests/apps/bookstore/bookstore-mp/pom.xml
+++ b/tests/apps/bookstore/bookstore-mp/pom.xml
@@ -66,11 +66,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 
 import static io.helidon.tests.apps.bookstore.se.TestServer.APPLICATION_JSON;
 
@@ -52,7 +50,6 @@ public class Http2SslTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
     public void testHelloWorldHtt2Ssl() throws Exception {
         Request.Builder builder = TestServer.newRequestBuilder(webServer, "/books", true);
 
@@ -91,7 +88,6 @@ public class Http2SslTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_8)
     public void testHelloWorldHtt2SslPostFirst() throws Exception {
         Request.Builder builder = TestServer.newRequestBuilder(webServer, "/books", true);
         Request postBook = builder.post(

--- a/tests/apps/bookstore/common/pom.xml
+++ b/tests/apps/bookstore/common/pom.xml
@@ -32,8 +32,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/functional/bookstore/pom.xml
+++ b/tests/functional/bookstore/pom.xml
@@ -77,8 +77,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -54,7 +54,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/tests/integration/native-image/mp-1/README.md
+++ b/tests/integration/native-image/mp-1/README.md
@@ -13,3 +13,9 @@ mvn clean package -Dnative.image=$path_to_native_image
 There are a tests run from within the application.
 Tests:
 1. Injection of Config
+
+
+To run using module-path:
+```shell script
+java --module-path target/libs:target/helidon-tests-native-image-mp-1.jar -m helidon.tests.nimage.mp/io.helidon.tests.integration.nativeimage.mp1.Mp1Main
+```

--- a/tests/integration/native-image/mp-1/pom.xml
+++ b/tests/integration/native-image/mp-1/pom.xml
@@ -46,13 +46,6 @@
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
             <artifactId>helidon-microprofile</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- this library uses method handles and that is not (maybe yet) supported by native-image -->
-                    <groupId>io.helidon.config</groupId>
-                    <artifactId>helidon-config-object-mapping</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.security.providers</groupId>
@@ -99,6 +92,11 @@
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
@@ -70,6 +70,14 @@ public final class Mp1Main {
      * @param args command line arguments.
      */
     public static void main(final String[] args) {
+
+        String property = System.getProperty("java.class.path");
+        if (null == property || property.trim().isEmpty()) {
+            System.out.println("** Running on module path");
+        } else {
+            System.out.println("** Running on class path");
+        }
+
         // cleanup before tests
         cleanup();
 

--- a/tests/integration/native-image/mp-1/src/main/java/module-info.java
+++ b/tests/integration/native-image/mp-1/src/main/java/module-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 module helidon.tests.nimage.mp {
     requires jakarta.enterprise.cdi.api;
     requires java.ws.rs;
@@ -19,5 +34,10 @@ module helidon.tests.nimage.mp {
 
     exports io.helidon.tests.integration.nativeimage.mp1;
 
-    opens io.helidon.tests.integration.nativeimage.mp1 to weld.core.impl,hk2.utils;
+    opens io.helidon.tests.integration.nativeimage.mp1 to weld.core.impl,hk2.utils,io.helidon.webserver;
+
+    // we need to open the static resource on classpath directory to everybody, as otherwise
+    // static content will not see it
+    // if you want to add subdirectories, you will need to open them as well
+    opens web;
 }

--- a/tests/integration/native-image/mp-1/src/main/java/module-info.java
+++ b/tests/integration/native-image/mp-1/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+module helidon.tests.nimage.mp {
+    requires jakarta.enterprise.cdi.api;
+    requires java.ws.rs;
+    requires io.helidon.security.annotations;
+    requires io.helidon.security.abac.scope;
+    requires java.annotation;
+    requires microprofile.openapi.api;
+    requires java.json;
+    requires jakarta.inject.api;
+    requires java.logging;
+    requires microprofile.jwt.auth.api;
+    requires microprofile.health.api;
+    requires io.helidon.security.jwt;
+    requires io.helidon.microprofile.server;
+    requires microprofile.fault.tolerance.api;
+    requires microprofile.rest.client.api;
+    requires microprofile.metrics.api;
+    requires java.json.bind;
+
+    exports io.helidon.tests.integration.nativeimage.mp1;
+
+    opens io.helidon.tests.integration.nativeimage.mp1 to weld.core.impl,hk2.utils;
+}

--- a/tests/integration/native-image/mp-1/test-runtime.sh
+++ b/tests/integration/native-image/mp-1/test-runtime.sh
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+trap 'echo "ERROR: Error occurred at ${BASH_SOURCE}:${LINENO} command: ${BASH_COMMAND}"' ERR
+set -eo pipefail
+
+# Path to this script
+if [ -h "${0}" ] ; then
+  readonly SCRIPT_PATH="$(readlink "$0")"
+else
+  readonly SCRIPT_PATH="${0}"
+fi
+
+# Directory this script resides in
+readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
+
+# cd the my dir, so we can start the application with correct current directory
+cd "${MY_DIR}"
+
+# Attempt to run this example as a java -jar
+# This is a self-testing application
+
+java -jar target/helidon-tests-native-image-mp-1.jar
+
+# Attempt to run this example as a java with module path
+java --module-path target/helidon-tests-native-image-mp-1.jar:target/libs \
+     -m helidon.tests.nimage.mp/io.helidon.tests.integration.nativeimage.mp1.Mp1Main

--- a/tests/integration/native-image/mp-1/test-runtime.sh
+++ b/tests/integration/native-image/mp-1/test-runtime.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# This file is called from /etc/scripts/build.sh
+
 trap 'echo "ERROR: Error occurred at ${BASH_SOURCE}:${LINENO} command: ${BASH_COMMAND}"' ERR
 set -eo pipefail
 
@@ -31,11 +33,15 @@ readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
 # cd the my dir, so we can start the application with correct current directory
 cd "${MY_DIR}"
 
+# build the binary
+mvn clean package -DskipTests
+
 # Attempt to run this example as a java -jar
 # This is a self-testing application
 
 java -jar target/helidon-tests-native-image-mp-1.jar
 
 # Attempt to run this example as a java with module path
+
 java --module-path target/helidon-tests-native-image-mp-1.jar:target/libs \
      -m helidon.tests.nimage.mp/io.helidon.tests.integration.nativeimage.mp1.Mp1Main

--- a/tests/integration/native-image/mp-2/pom.xml
+++ b/tests/integration/native-image/mp-2/pom.xml
@@ -48,11 +48,6 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
             <artifactId>helidon-microprofile-config</artifactId>
         </dependency>
@@ -66,12 +61,10 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.integrations.cdi</groupId>

--- a/tests/integration/native-image/mp-2/pom.xml
+++ b/tests/integration/native-image/mp-2/pom.xml
@@ -48,20 +48,13 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.config</groupId>
             <artifactId>helidon-microprofile-config</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- this library uses method handles and that is not (maybe yet) supported by native-image -->
-                    <groupId>io.helidon.config</groupId>
-                    <artifactId>helidon-config-object-mapping</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
@@ -76,8 +69,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/native-image/mp-3/README.md
+++ b/tests/integration/native-image/mp-3/README.md
@@ -15,4 +15,7 @@ Requires at least GraalVM 20.0.0
 
 This test validates that Quickstart can run on native image with minimal number of changes - eventually with no changes.
 
-
+To run this test using module path:
+```shell script
+java --module-path target/libs:target/helidon-tests-native-image-mp-3.jar --add-modules helidon.tests.nimage.quickstartmp -m io.helidon.microprofile.cdi/io.helidon.microprofile.cdi.Main
+```

--- a/tests/integration/native-image/mp-3/pom.xml
+++ b/tests/integration/native-image/mp-3/pom.xml
@@ -45,11 +45,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/tests/integration/native-image/mp-3/src/main/java/module-info.java
+++ b/tests/integration/native-image/mp-3/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module helidon.tests.nimage.quickstartmp {
+    requires java.logging;
+    requires io.helidon.microprofile.bundle;
+
+    exports io.helidon.tests.integration.nativeimage.mp3;
+
+    opens io.helidon.tests.integration.nativeimage.mp3 to weld.core.impl,hk2.utils;
+}

--- a/tests/integration/native-image/mp-3/test-runtime.sh
+++ b/tests/integration/native-image/mp-3/test-runtime.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+trap 'echo "ERROR: Error occurred at ${BASH_SOURCE}:${LINENO} command: ${BASH_COMMAND}"' ERR
+set -eo pipefail
+
+# Path to this script
+if [ -h "${0}" ] ; then
+  readonly SCRIPT_PATH="$(readlink "$0")"
+else
+  readonly SCRIPT_PATH="${0}"
+fi
+
+# Directory this script resides in
+readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
+
+# cd the my dir, so we can start the application with correct current directory
+cd "${MY_DIR}"
+
+# Attempt to run this example as a java -jar
+# This is a self-testing application
+
+java -jar -Dexit.on.started=! target/helidon-tests-native-image-mp-3.jar
+
+# Attempt to run this example as a java with module path
+java -Dexit.on.started=! \
+     --module-path target/helidon-tests-native-image-mp-3.jar:target/libs \
+     --add-modules helidon.tests.nimage.quickstartmp \
+     -m io.helidon.microprofile.cdi/io.helidon.microprofile.cdi.Main

--- a/tests/integration/native-image/mp-3/test-runtime.sh
+++ b/tests/integration/native-image/mp-3/test-runtime.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# This file is called from /etc/scripts/build.sh
+
 trap 'echo "ERROR: Error occurred at ${BASH_SOURCE}:${LINENO} command: ${BASH_COMMAND}"' ERR
 set -eo pipefail
 
@@ -31,12 +33,16 @@ readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
 # cd the my dir, so we can start the application with correct current directory
 cd "${MY_DIR}"
 
+# build the binary
+mvn clean package -DskipTests
+
 # Attempt to run this example as a java -jar
 # This is a self-testing application
 
 java -jar -Dexit.on.started=! target/helidon-tests-native-image-mp-3.jar
 
 # Attempt to run this example as a java with module path
+
 java -Dexit.on.started=! \
      --module-path target/helidon-tests-native-image-mp-3.jar:target/libs \
      --add-modules helidon.tests.nimage.quickstartmp \

--- a/tests/integration/security/gh1487/pom.xml
+++ b/tests/integration/security/gh1487/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/tests/integration/zipkin-mp-2.2/pom.xml
+++ b/tests/integration/zipkin-mp-2.2/pom.xml
@@ -45,8 +45,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
         <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <spotbugs.skip>true</spotbugs.skip>
+        <checkstyle.skip>true</checkstyle.skip>
     </properties>
 
     <modules>

--- a/tracing/jaeger/src/main/java/module-info.java
+++ b/tracing/jaeger/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ module io.helidon.tracing.jaeger {
     requires jaeger.client;
     requires jaeger.core;
     requires io.opentracing.noop;
+    // need to explicitly require transitive dependency, as jaeger is not a module
+    requires com.google.gson;
+
 
     exports io.helidon.tracing.jaeger;
 

--- a/tracing/jersey-client/src/main/java/module-info.java
+++ b/tracing/jersey-client/src/main/java/module-info.java
@@ -24,7 +24,6 @@ module io.helidon.tracing.jersey.client {
     requires java.annotation;
 
     requires java.ws.rs;
-    requires javax.inject;
     requires jersey.client;
     requires jersey.common;
 

--- a/tracing/tests/it-tracing-client-zipkin/pom.xml
+++ b/tracing/tests/it-tracing-client-zipkin/pom.xml
@@ -73,8 +73,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tracing/zipkin/pom.xml
+++ b/tracing/zipkin/pom.xml
@@ -56,12 +56,6 @@
         <dependency>
             <groupId>io.opentracing.brave</groupId>
             <artifactId>brave-opentracing</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.zipkin.brave</groupId>
-                    <artifactId>brave-tests</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/webclient/jaxrs/pom.xml
+++ b/webclient/jaxrs/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>helidon-jersey-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>

--- a/webclient/jaxrs/src/main/java/module-info.java
+++ b/webclient/jaxrs/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ module io.helidon.webclient.jaxrs {
     requires java.annotation;
 
     requires java.ws.rs;
-    requires jersey.client;
-    requires jersey.common;
+    requires io.helidon.jersey.client;
+    requires io.helidon.jersey.common;
 
     requires io.helidon.common;
     requires io.helidon.common.configurable;

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -118,7 +118,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -142,8 +142,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -152,8 +152,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Switched to `jakarta` group id for Jakarta EE standards (keeping `javax` package).
Fixed all related issues with imports, exclusions etc.
Added dependency convergence plugin to Helidon project.
Added sanity checks for MP - both classpath and module path to `build.sh`

Also resolved problems with MP JPMS - quickstart should now work with JPMS without issues.

Marking as API change, as the libraries we depend on have changed.