### PR TITLE
Improve metrics interceptor performance; avoid MetricID creations - 2.x

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -473,7 +473,7 @@ public final class MetricsSupport implements Service {
                 .ifPresentOrElse(entry -> {
                     if (req.headers().isAccepted(MediaType.APPLICATION_JSON)) {
                         JsonObjectBuilder builder = JSON.createObjectBuilder();
-                        entry.getKey().jsonMeta(builder, entry.getValue());
+                        HelidonMetric.class.cast(entry.getKey()).jsonMeta(builder, entry.getValue());
                         res.send(builder.build());
                     } else {
                         res.status(Http.Status.NOT_ACCEPTABLE_406);

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -523,7 +523,7 @@ public class Registry extends MetricRegistry implements io.helidon.common.metric
      * @param metricName The metric name.
      * @return Optional map entry..
      */
-    synchronized Optional<Map.Entry<HelidonMetric, List<MetricID>>> getOptionalMetricWithIDsEntry(String metricName) {
+    public synchronized Optional<Map.Entry<? extends Metric, List<MetricID>>> getOptionalMetricWithIDsEntry(String metricName) {
         final List<MetricID> metricIDs = allMetricIDsByName.get(metricName);
         if (metricIDs == null || metricIDs.isEmpty()) {
             return Optional.empty();

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -64,4 +64,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>pipeline</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <helidon.microprofile.metrics.perfTest.enabled>false</helidon.microprofile.metrics.perfTest.enabled>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorConcurrentGauge.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorConcurrentGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ final class InterceptorConcurrentGauge
                 ConcurrentGauge::name,
                 ConcurrentGauge::tags,
                 ConcurrentGauge::absolute,
-                MetricRegistry::getConcurrentGauges,
-                CONCURRENT_GAUGE.toString());
+                CONCURRENT_GAUGE.toString(),
+                org.eclipse.microprofile.metrics.ConcurrentGauge.class);
     }
 
     @Override

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorCounted.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorCounted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ final class InterceptorCounted extends InterceptorBase<Counter, Counted> {
               Counted::name,
               Counted::tags,
               Counted::absolute,
-              MetricRegistry::getCounters,
-              "counter");
+              "counter",
+              Counter.class);
     }
 
     @Override

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorMetered.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorMetered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ final class InterceptorMetered extends InterceptorBase<Meter, Metered> {
               Metered::name,
               Metered::tags,
               Metered::absolute,
-              MetricRegistry::getMeters,
-              "meter");
+              "meter",
+              org.eclipse.microprofile.metrics.Meter.class);
     }
 
     @Override

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorTimed.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorTimed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ final class InterceptorTimed extends InterceptorBase<Timer, Timed> {
               Timed::name,
               Timed::tags,
               Timed::absolute,
-              MetricRegistry::getTimers,
-              "timer");
+              "timer",
+              Timer.class);
     }
 
     @Override

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsTest.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.Timer;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -43,9 +43,10 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
  */
 public class MetricsTest extends MetricsBaseTest {
 
-    private static final int PERF_TEST_COUNT = Integer.getInteger("helidon.test.metrics.perf-test-count", 10000);
+    private static final String PERF_TEST_PROP_PREFIX = "helidon.microprofile.metrics.perfTest.";
+    private static final int PERF_TEST_COUNT = Integer.getInteger(PERF_TEST_PROP_PREFIX + "count", 10000);
     private static final long PERF_TEST_FAILURE_THRESHOLD_NS = Integer.getInteger(
-            "helidon.test.metrics.perf-test-failure-threshold-ns", 150 * 1000 * 1000); // roughly double informal expc
+            PERF_TEST_PROP_PREFIX + ".failureThresholdNS", 150 * 1000 * 1000); // roughly double informal expc
 
     @Test
     public void testCounted1() {
@@ -64,10 +65,10 @@ public class MetricsTest extends MetricsBaseTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "WERCKER", matches = "true") // do not run in pipeline in case of slowness issues
+    @DisabledIfSystemProperty(named = PERF_TEST_PROP_PREFIX + "enabled", matches = "false")
     public void testCounted2Perf() {
         /*
-         * Informal experience shows that, without the performance fix in InterceptorBase, this test measures more than
+         * Informal experience shows that, without the performance fix in InterceptorBase, this test measures more than 1 s
          *  to perform 10000 intercepted calls to the bean. With the fix, the time is around .06-.08 seconds.
          */
         CountedBean bean = newBean(CountedBean.class);


### PR DESCRIPTION
Resolves #1595 

The existing metrics annotation interceptor creates a new `MetricID` each time an intercepted method is invoked, in order to help locate the relevant metric to update. This is expensive because the `MetricID` constructor consults config to look for global tags and an app identifier tag. 

This PR avoids the expense of creating all those `MetricID` objects by:
1. Allocating a single "dummy" `MetricID` to gather the global and app tags.
2. Building and consulting maps -- one map for each metric type (counter, timer, etc.) -- that associates each annotation`Element` with the metric instance to be updated when that element is intercepted. On the first intercepted call for an element, the revised code:
    1. Retrieves from the `Registry` all metric IDs that share the same metric name.
    1. Finds the metric ID from those that matches the metric ID inferred from the intercepted element. 
    1. Retrieves the corresponding metric from the registry.
    1. Adds that metric to the map.

Assumptions/possible issues:
1. The `Element` is the correct unique identifier to use in the map to relevant metric. This seems right; remember that each metric type has its own map.
2. Collecting the global and app tags from a single `MetricID` created when the `Interceptor` is instantiated is OK. Because config is not dynamic, this should be fine and the global and app tags obtained via config would not change as the app runs. The harvested tags should match the global and app tags in any `MetricID` created at any time during the app's lifetime.
3. This PR makes `public` one existing package-private method on our `Registry` implementation class in the SE `metrics` project. This does increase the exposed surface area of our `Registry` but users should be using `MetricRegistry` and not `Registry` directly anyway. Also, using the newly-exposed method helps to streamline the code that locates and caches the metric associated with an interception point on the first usage.

Our tests and the TCK pass.

In informal experience with a new unit test, the time to execute 10,000 calls to an intercepted site dropped from 1.25 s to about .06 - .08 s.