### PR TITLE
[Reactive] Reorganize methods, remove Single.mapMany

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -36,8 +36,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import io.helidon.common.mapper.Mapper;
-
 /**
  * Represents a {@link Flow.Publisher} emitting zero or more items, optionally followed by
  * an error or completion.
@@ -518,14 +516,14 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
-     * Map this {@link Multi} instance to a new {@link Multi} of another type using the given {@link Mapper}.
+     * Map this {@link Multi} instance to a new {@link Multi} of another type using the given {@link Function}.
      *
      * @param <U>    mapped item type
      * @param mapper mapper
      * @return Multi
      * @throws NullPointerException if mapper is {@code null}
      */
-    default <U> Multi<U> map(Mapper<? super T, ? extends U> mapper) {
+    default <U> Multi<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return new MultiMapperPublisher<>(this, mapper);
     }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -39,11 +39,29 @@ import java.util.stream.Stream;
 import io.helidon.common.mapper.Mapper;
 
 /**
- * Multiple items publisher facility.
+ * Represents a {@link Flow.Publisher} emitting zero or more items, optionally followed by
+ * an error or completion.
  *
  * @param <T> item type
+ * @see Single
  */
 public interface Multi<T> extends Subscribable<T> {
+
+    // --------------------------------------------------------------------------------------------------------
+    // Factory (source-like) methods
+    // --------------------------------------------------------------------------------------------------------
+
+    /**
+     * Concat streams to one.
+     *
+     * @param firstMulti  first stream
+     * @param secondMulti second stream
+     * @param <T>         item type
+     * @return Multi
+     */
+    static <T> Multi<T> concat(Flow.Publisher<T> firstMulti, Flow.Publisher<T> secondMulti) {
+        return ConcatPublisher.create(firstMulti, secondMulti);
+    }
 
     /**
      * Call the given supplier function for each individual downstream Subscriber
@@ -59,302 +77,26 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
-     * Map this {@link Multi} instance to a new {@link Multi} of another type using the given {@link Mapper}.
+     * Get a {@link Multi} instance that completes immediately.
      *
-     * @param <U>    mapped item type
-     * @param mapper mapper
-     * @return Multi
-     * @throws NullPointerException if mapper is {@code null}
-     */
-    default <U> Multi<U> map(Mapper<? super T, ? extends U> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return new MultiMapperPublisher<>(this, mapper);
-    }
-
-    /**
-     * Signals the default item if the upstream is empty.
-     * @param defaultItem the item to signal if the upstream is empty
-     * @return Multi
-     * @throws NullPointerException if {@code defaultItem} is {@code null}
-     */
-    default Multi<T> defaultIfEmpty(T defaultItem) {
-        Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return new MultiDefaultIfEmpty<>(this, defaultItem);
-    }
-
-    /**
-     * Switch to the other publisher if the upstream is empty.
-     * @param other the publisher to switch to if the upstream is empty.
-     * @return Multi
-     * @throws NullPointerException if {@code other} is {@code null}
-     */
-    default Multi<T> switchIfEmpty(Flow.Publisher<T> other) {
-        Objects.requireNonNull(other, "other is null");
-        return new MultiSwitchIfEmpty<>(this, other);
-    }
-
-    /**
-     * Invoke provided consumer for every item in stream.
-     *
-     * @param consumer consumer to be invoked
+     * @param <T> item type
      * @return Multi
      */
-    default Multi<T> peek(Consumer<? super T> consumer) {
-        return new MultiTappedPublisher<>(this, null, consumer,
-                null, null, null, null);
+    static <T> Multi<T> empty() {
+        return MultiEmpty.instance();
     }
 
     /**
-     * Filter out all duplicates.
+     * Create a {@link Multi} instance that reports the given exception to its subscriber(s). The exception is reported by
+     * invoking {@link Subscriber#onError(java.lang.Throwable)} when {@link Publisher#subscribe(Subscriber)} is called.
      *
+     * @param <T>   item type
+     * @param error exception to hold
      * @return Multi
+     * @throws NullPointerException if error is {@code null}
      */
-    default Multi<T> distinct() {
-        return new MultiDistinctPublisher<>(this, v -> v);
-    }
-
-    /**
-     * Filter stream items with provided predicate.
-     *
-     * @param predicate predicate to filter stream with
-     * @return Multi
-     */
-    default Multi<T> filter(Predicate<? super T> predicate) {
-        return new MultiFilterPublisher<>(this, predicate);
-    }
-
-    /**
-     * Take the longest prefix of elements from this stream that satisfy the given predicate.
-     * As long as predicate returns true, items from upstream are sent to downstream,
-     * when predicate returns false stream is completed.
-     *
-     * @param predicate predicate to filter stream with
-     * @return Multi
-     */
-    default Multi<T> takeWhile(Predicate<? super T> predicate) {
-        return new MultiTakeWhilePublisher<>(this, predicate);
-    }
-
-    /**
-     * Drop the longest prefix of elements from this stream that satisfy the given predicate.
-     * As long as predicate returns true, items from upstream are NOT sent to downstream but being dropped,
-     * predicate is never called again after it returns false for the first time.
-     *
-     * @param predicate predicate to filter stream with
-     * @return Multi
-     */
-    default Multi<T> dropWhile(Predicate<? super T> predicate) {
-        Objects.requireNonNull(predicate, "predicate is null");
-        return new MultiDropWhilePublisher<>(this, predicate);
-    }
-
-    /**
-     * Limit stream to allow only specified number of items to pass.
-     *
-     * @param limit with expected number of items to be produced
-     * @return Multi
-     */
-    default Multi<T> limit(long limit) {
-        return new MultiLimitPublisher<>(this, limit);
-    }
-
-    /**
-     * Skip first n items, all the others are emitted.
-     *
-     * @param skip number of items to be skipped
-     * @return Multi
-     */
-    default Multi<T> skip(long skip) {
-        return new MultiSkipPublisher<>(this, skip);
-    }
-
-    /**
-     * Transform item with supplied function and flatten resulting {@link Flow.Publisher} to downstream.
-     *
-     * @param publisherMapper {@link Function} receiving item as parameter and returning {@link Flow.Publisher}
-     * @param <U>             output item type
-     * @return Multi
-     */
-    default <U> Multi<U> flatMap(Function<? super T, ? extends Flow.Publisher<? extends U>> publisherMapper) {
-        return new MultiFlatMapPublisher<>(this, publisherMapper, 32, 32, false);
-    }
-    /**
-     * Transform item with supplied function and flatten resulting {@link Flow.Publisher} to downstream
-     * while limiting the maximum number of concurrent inner {@link Flow.Publisher}s and their in-flight
-     * item count, optionally aggregating and delaying all errors until all sources terminate.
-     *
-     * @param mapper {@link Function} receiving item as parameter and returning {@link Flow.Publisher}
-     * @param <U>             output item type
-     * @param maxConcurrency the maximum number of inner sources to run
-     * @param delayErrors if true, any error from the main and inner sources are aggregated and delayed until
-     *                    all of them terminate
-     * @param prefetch the number of items to request upfront from the inner sources, then request 75% more after 75%
-     *                 has been delivered
-     * @return Multi
-     */
-    default <U> Multi<U> flatMap(Function<? super T, ? extends Flow.Publisher<? extends U>> mapper,
-                                 long maxConcurrency, boolean delayErrors, long prefetch) {
-        return new MultiFlatMapPublisher<>(this, mapper, maxConcurrency, prefetch, delayErrors);
-    }
-
-    /**
-     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
-     *
-     * @param iterableMapper {@link Function} receiving item as parameter and returning {@link Iterable}
-     * @param <U>            output item type
-     * @return Multi
-     */
-    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper) {
-        return flatMapIterable(iterableMapper, 32);
-    }
-
-    /**
-     * Re-emit the upstream's signals to the downstream on the given executor's thread
-     * using a default buffer size of 32 and errors skipping ahead of items.
-     * @param executor the executor to signal the downstream from.
-     * @return Multi
-     * @throws NullPointerException if {@code executor} is {@code null}
-     * @see #observeOn(Executor, int, boolean)
-     */
-    default Multi<T> observeOn(Executor executor) {
-        return observeOn(executor, 32, false);
-    }
-
-    /**
-     * Re-emit the upstream's signals to the downstream on the given executor's thread.
-     * @param executor the executor to signal the downstream from.
-     * @param bufferSize the number of items to prefetch and buffer at a time
-     * @param delayError if {@code true}, errors are emitted after items,
-     *                   if {@code false}, errors may cut ahead of items during emission
-     * @return Multi
-     * @throws NullPointerException if {@code executor} is {@code null}
-     */
-    default Multi<T> observeOn(Executor executor, int bufferSize, boolean delayError) {
-        Objects.requireNonNull(executor, "executor is null");
-        if (bufferSize <= 0) {
-            throw new IllegalArgumentException("bufferSize > 0 required");
-        }
-        return new MultiObserveOn<>(this, executor, bufferSize, delayError);
-    }
-
-    /**
-     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
-     *
-     * @param iterableMapper {@link Function} receiving item as parameter and returning {@link Iterable}
-     * @param prefetch the number of upstream items to request upfront, then 75% of this value after
-     *                 75% received and mapped
-     * @param <U>            output item type
-     * @return Multi
-     */
-    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper,
-                                         int prefetch) {
-        Objects.requireNonNull(iterableMapper, "iterableMapper is null");
-        return new MultiFlatMapIterable<>(this, iterableMapper, prefetch);
-    }
-
-    /**
-     * Terminal stage, invokes provided consumer for every item in the stream.
-     *
-     * @param consumer consumer to be invoked for each item
-     */
-    default void forEach(Consumer<? super T> consumer) {
-        FunctionalSubscriber<T> subscriber = new FunctionalSubscriber<>(consumer, null, null, null);
-        this.subscribe(subscriber);
-    }
-
-    /**
-     * Collect the items of this {@link Multi} instance into a {@link Single} of {@link List}.
-     *
-     * @return Single
-     */
-    default Single<List<T>> collectList() {
-        return collect(ArrayList::new, List::add);
-    }
-
-    /**
-     * Collect the items of this {@link Multi} instance into a {@link Single}.
-     *
-     * @param <U>       collector container type
-     * @param collector collector to use
-     * @return Single
-     * @throws NullPointerException if collector is {@code null}
-     */
-    default <U> Single<U> collect(Collector<T, U> collector) {
-        return collect(() -> collector, Collector::collect).map(Collector::value);
-    }
-
-    /**
-     * Collect the items of this {@link Multi} into a collection provided via a {@link Supplier}
-     * and mutated by a {@code BiConsumer} callback.
-     * @param collectionSupplier the {@link Supplier} that is called for each incoming {@link Subscriber}
-     *                           to create a fresh collection to collect items into
-     * @param accumulator the {@link BiConsumer} that receives the collection and the current item to put in
-     * @param <U> the type of the collection and result
-     * @return Single
-     * @throws NullPointerException if {@code collectionSupplier} or {@code combiner} is {@code null}
-     */
-    default <U> Single<U> collect(Supplier<? extends U> collectionSupplier, BiConsumer<U, T> accumulator) {
-        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
-        Objects.requireNonNull(accumulator, "combiner is null");
-        return new MultiCollectPublisher<>(this, collectionSupplier, accumulator);
-    }
-
-    /**
-     * Collects up upstream items with the help of a the callbacks of
-     * a {@link java.util.stream.Collector}.
-     * @param collector the collector whose {@code supplier()}, {@code accumulator()} and {@code finisher()} callbacks
-     *                  are used for collecting upstream items into a final form.
-     * @param <A> the accumulator type
-     * @param <R> the result type
-     * @return Single
-     * @throws NullPointerException if {@code collector} is {@code null}
-     */
-    default <A, R> Single<R> collectStream(java.util.stream.Collector<T, A, R> collector) {
-        Objects.requireNonNull(collector, "collector is null");
-        return new MultiCollectorPublisher<>(this, collector);
-    }
-
-    /**
-     * Combine subsequent items via a callback function and emit
-     * the final value result as a Single.
-     * <p>
-     *     If the upstream is empty, the resulting Single is also empty.
-     *     If the upstream contains only one item, the reducer function
-     *     is not invoked and the resulting Single will have only that
-     *     single item.
-     * </p>
-     * @param reducer the function called with the first value or the previous result,
-     *                the current upstream value and should return a new value
-     * @return Single
-     */
-    default Single<T> reduce(BiFunction<T, T, T> reducer) {
-        Objects.requireNonNull(reducer, "reducer is null");
-        return new MultiReduce<>(this, reducer);
-    }
-
-    /**
-     * Combine every upstream item with an accumulator value to produce a new accumulator
-     * value and emit the final accumulator value as a Single.
-     * @param supplier the function to return the initial accumulator value for each incoming
-     *                 Subscriber
-     * @param reducer the function that receives the current accumulator value, the current
-     *                upstream value and should return a new accumulator value
-     * @param <R> the accumulator and result type
-     * @return Single
-     */
-    default <R> Single<R> reduce(Supplier<? extends R> supplier, BiFunction<R, T, R> reducer) {
-        Objects.requireNonNull(supplier, "supplier is null");
-        Objects.requireNonNull(reducer, "reducer is null");
-        return new MultiReduceFull<>(this, supplier, reducer);
-    }
-
-    /**
-     * Get the first item of this {@link Multi} instance as a {@link Single}.
-     *
-     * @return Single
-     */
-    default Single<T> first() {
-        return new MultiFirstPublisher<>(this);
+    static <T> Multi<T> error(Throwable error) {
+        return MultiError.create(error);
     }
 
     /**
@@ -386,6 +128,18 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
+     * Create a {@link Multi} instance that publishes the given iterable.
+     *
+     * @param <T>      item type
+     * @param iterable iterable to publish
+     * @return Multi
+     * @throws NullPointerException if iterable is {@code null}
+     */
+    static <T> Multi<T> from(Iterable<T> iterable) {
+        return new MultiFromIterable<>(iterable);
+    }
+
+    /**
      * Create a {@link Multi} instance wrapped around the given publisher.
      *
      * @param <T>    item type
@@ -398,18 +152,6 @@ public interface Multi<T> extends Subscribable<T> {
             return (Multi<T>) source;
         }
         return new MultiFromPublisher<>(source);
-    }
-
-    /**
-     * Create a {@link Multi} instance that publishes the given iterable.
-     *
-     * @param <T>      item type
-     * @param iterable iterable to publish
-     * @return Multi
-     * @throws NullPointerException if iterable is {@code null}
-     */
-    static <T> Multi<T> from(Iterable<T> iterable) {
-        return new MultiFromIterable<>(iterable);
     }
 
     /**
@@ -436,6 +178,43 @@ public interface Multi<T> extends Subscribable<T> {
     static <T> Multi<T> from(Stream<T> stream) {
         Objects.requireNonNull(stream, "stream is null");
         return new MultiFromStream<>(stream);
+    }
+
+    /**
+     * Signal 0L, 1L and so on periodically to the downstream.
+     * <p>
+     *     Note that if the downstream applies backpressure,
+     *     subsequent values may be delivered instantly upon
+     *     further requests from the downstream.
+     * </p>
+     * @param period the initial and in-between time
+     * @param unit the time unit
+     * @param executor the scheduled executor to use for the periodic emission
+     * @return Multi
+     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     */
+    static Multi<Long> interval(long period, TimeUnit unit, ScheduledExecutorService executor) {
+        return interval(period, period, unit, executor);
+    }
+
+    /**
+     * Signal 0L after an initial delay, then 1L, 2L and so on periodically to the downstream.
+     * <p>
+     *     Note that if the downstream applies backpressure,
+     *     subsequent values may be delivered instantly upon
+     *     further requests from the downstream.
+     * </p>
+     * @param initialDelay the time before signaling 0L
+     * @param period the in-between wait time for values 1L, 2L and so on
+     * @param unit the time unit
+     * @param executor the scheduled executor to use for the periodic emission
+     * @return Multi
+     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     */
+    static Multi<Long> interval(long initialDelay, long period, TimeUnit unit, ScheduledExecutorService executor) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(executor, "executor is null");
+        return new MultiInterval(initialDelay, period, unit, executor);
     }
 
     /**
@@ -470,41 +249,6 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
-     * Create a {@link Multi} that emits a pre-existing item and then completes.
-     * @param item the item to emit.
-     * @param <T> the type of the item
-     * @return Multi
-     * @throws NullPointerException if {@code item} is {@code null}
-     */
-    static <T> Multi<T> singleton(T item) {
-        Objects.requireNonNull(item, "item is null");
-        return new MultiJustPublisher<>(item);
-    }
-
-    /**
-     * Create a {@link Multi} instance that reports the given exception to its subscriber(s). The exception is reported by
-     * invoking {@link Subscriber#onError(java.lang.Throwable)} when {@link Publisher#subscribe(Subscriber)} is called.
-     *
-     * @param <T>   item type
-     * @param error exception to hold
-     * @return Multi
-     * @throws NullPointerException if error is {@code null}
-     */
-    static <T> Multi<T> error(Throwable error) {
-        return MultiError.create(error);
-    }
-
-    /**
-     * Get a {@link Multi} instance that completes immediately.
-     *
-     * @param <T> item type
-     * @return Multi
-     */
-    static <T> Multi<T> empty() {
-        return MultiEmpty.instance();
-    }
-
-    /**
      * Get a {@link Multi} instance that never completes.
      *
      * @param <T> item type
@@ -512,94 +256,6 @@ public interface Multi<T> extends Subscribable<T> {
      */
     static <T> Multi<T> never() {
         return MultiNever.instance();
-    }
-
-    /**
-     * Concat streams to one.
-     *
-     * @param firstMulti  first stream
-     * @param secondMulti second stream
-     * @param <T>         item type
-     * @return Multi
-     */
-    static <T> Multi<T> concat(Flow.Publisher<T> firstMulti, Flow.Publisher<T> secondMulti) {
-        return ConcatPublisher.create(firstMulti, secondMulti);
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
-     *
-     * @param onTerminate {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onTerminate(Runnable onTerminate) {
-        return new MultiTappedPublisher<>(this,
-                null,
-                null,
-                e -> onTerminate.run(),
-                onTerminate,
-                null,
-                onTerminate);
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when onComplete signal is received.
-     *
-     * @param onComplete {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onComplete(Runnable onComplete) {
-        return new MultiTappedPublisher<>(this,
-                null,
-                null,
-                null,
-                onComplete,
-                null,
-                null);
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when onError signal is received.
-     *
-     * @param onErrorConsumer {@link java.util.function.Consumer} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onError(Consumer<? super Throwable> onErrorConsumer) {
-        return new MultiTappedPublisher<>(this,
-                null,
-                null,
-                onErrorConsumer,
-                null,
-                null,
-                null);
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when a cancel signal is received.
-     *
-     * @param onCancel {@link java.lang.Runnable} to be executed.
-     * @return Multi
-     */
-    default Multi<T> onCancel(Runnable onCancel) {
-        return new MultiTappedPublisher<>(this,
-                null,
-                null,
-                null,
-                null,
-                null,
-                onCancel);
-    }
-
-    /**
-     * Relay upstream items until the other source signals an item or completes.
-     * @param other the other sequence to signal the end of the main sequence
-     * @param <U> the element type of the other sequence
-     * @return Multi
-     * @throws NullPointerException if {@code other} is {@code null}
-     */
-    default <U> Multi<T> takeUntil(Flow.Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return new MultiTakeUntilPublisher<>(this, other);
     }
 
     /**
@@ -643,6 +299,18 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
+     * Create a {@link Multi} that emits a pre-existing item and then completes.
+     * @param item the item to emit.
+     * @param <T> the type of the item
+     * @return Multi
+     * @throws NullPointerException if {@code item} is {@code null}
+     */
+    static <T> Multi<T> singleton(T item) {
+        Objects.requireNonNull(item, "item is null");
+        return new MultiJustPublisher<>(item);
+    }
+
+    /**
      * Signal 0L and complete the sequence after the given time elapsed.
      * @param time the time to wait before signaling 0L and completion
      * @param unit the unit of time
@@ -656,75 +324,287 @@ public interface Multi<T> extends Subscribable<T> {
         return new MultiTimer(time, unit, executor);
     }
 
+    // --------------------------------------------------------------------------------------------------------
+    // Instance Operators
+    // --------------------------------------------------------------------------------------------------------
+
     /**
-     * Signal 0L, 1L and so on periodically to the downstream.
+     * Collect the items of this {@link Multi} instance into a {@link Single}.
+     *
+     * @param <U>       collector container type
+     * @param collector collector to use
+     * @return Single
+     * @throws NullPointerException if collector is {@code null}
+     */
+    default <U> Single<U> collect(Collector<T, U> collector) {
+        return collect(() -> collector, Collector::collect).map(Collector::value);
+    }
+
+    /**
+     * Collect the items of this {@link Multi} into a collection provided via a {@link Supplier}
+     * and mutated by a {@code BiConsumer} callback.
+     * @param collectionSupplier the {@link Supplier} that is called for each incoming {@link Subscriber}
+     *                           to create a fresh collection to collect items into
+     * @param accumulator the {@link BiConsumer} that receives the collection and the current item to put in
+     * @param <U> the type of the collection and result
+     * @return Single
+     * @throws NullPointerException if {@code collectionSupplier} or {@code combiner} is {@code null}
+     */
+    default <U> Single<U> collect(Supplier<? extends U> collectionSupplier, BiConsumer<U, T> accumulator) {
+        Objects.requireNonNull(collectionSupplier, "collectionSupplier is null");
+        Objects.requireNonNull(accumulator, "combiner is null");
+        return new MultiCollectPublisher<>(this, collectionSupplier, accumulator);
+    }
+
+    /**
+     * Collect the items of this {@link Multi} instance into a {@link Single} of {@link List}.
+     *
+     * @return Single
+     */
+    default Single<List<T>> collectList() {
+        return collect(ArrayList::new, List::add);
+    }
+
+    /**
+     * Collects up upstream items with the help of a the callbacks of
+     * a {@link java.util.stream.Collector}.
+     * @param collector the collector whose {@code supplier()}, {@code accumulator()} and {@code finisher()} callbacks
+     *                  are used for collecting upstream items into a final form.
+     * @param <A> the accumulator type
+     * @param <R> the result type
+     * @return Single
+     * @throws NullPointerException if {@code collector} is {@code null}
+     */
+    default <A, R> Single<R> collectStream(java.util.stream.Collector<T, A, R> collector) {
+        Objects.requireNonNull(collector, "collector is null");
+        return new MultiCollectorPublisher<>(this, collector);
+    }
+
+    /**
+     * Apply the given {@code composer} function to the current {@code Multi} instance and
+     * return a{@code Multi} wrapping the returned {@link Flow.Publisher} of this function.
      * <p>
-     *     Note that if the downstream applies backpressure,
-     *     subsequent values may be delivered instantly upon
-     *     further requests from the downstream.
+     *     Note that the {@code composer} function is executed upon calling this method
+     *     immediately and not when the resulting sequence gets subscribed to.
      * </p>
-     * @param period the initial and in-between time
-     * @param unit the time unit
-     * @param executor the scheduled executor to use for the periodic emission
+     * @param composer the function that receives the current {@code Multi} instance and
+     *                 should return a {@code Flow.Publisher} to be wrapped into a
+     *                 {@code Multie} to be returned by the method
+     * @param <U> the output element type
      * @return Multi
-     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     * @throws NullPointerException if {@code composer} is {@code null}
      */
-    static Multi<Long> interval(long period, TimeUnit unit, ScheduledExecutorService executor) {
-        return interval(period, period, unit, executor);
+    @SuppressWarnings("unchecked")
+    default <U> Multi<U> compose(Function<? super Multi<T>, ? extends Flow.Publisher<? extends U>> composer) {
+        return from((Flow.Publisher<U>) to(composer));
     }
 
     /**
-     * Signal 0L after an initial delay, then 1L, 2L and so on periodically to the downstream.
-     * <p>
-     *     Note that if the downstream applies backpressure,
-     *     subsequent values may be delivered instantly upon
-     *     further requests from the downstream.
-     * </p>
-     * @param initialDelay the time before signaling 0L
-     * @param period the in-between wait time for values 1L, 2L and so on
-     * @param unit the time unit
-     * @param executor the scheduled executor to use for the periodic emission
+     * Signals the default item if the upstream is empty.
+     * @param defaultItem the item to signal if the upstream is empty
      * @return Multi
-     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     * @throws NullPointerException if {@code defaultItem} is {@code null}
      */
-    static Multi<Long> interval(long initialDelay, long period, TimeUnit unit, ScheduledExecutorService executor) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(executor, "executor is null");
-        return new MultiInterval(initialDelay, period, unit, executor);
-    }
-
-
-    /**
-     * Signals a {@link TimeoutException} if the upstream doesn't signal the next item, error
-     * or completion within the specified time.
-     * @param timeout the time to wait for the upstream to signal
-     * @param unit the time unit
-     * @param executor the executor to use for waiting for the upstream signal
-     * @return Multi
-     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
-     */
-    default Multi<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(executor, "executor is null");
-        return new MultiTimeout<>(this, timeout, unit, executor, null);
+    default Multi<T> defaultIfEmpty(T defaultItem) {
+        Objects.requireNonNull(defaultItem, "defaultItem is null");
+        return new MultiDefaultIfEmpty<>(this, defaultItem);
     }
 
     /**
-     * Switches to a fallback single if the upstream doesn't signal the next item, error
-     * or completion within the specified time.
-     * @param timeout the time to wait for the upstream to signal
-     * @param unit the time unit
-     * @param executor the executor to use for waiting for the upstream signal
-     * @param fallback the Single to switch to if the upstream doesn't signal in time
+     * Filter out all duplicates.
+     *
      * @return Multi
-     * @throws NullPointerException if {@code unit}, {@code executor}
-     *                              or {@code fallback} is {@code null}
      */
-    default Multi<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor, Flow.Publisher<T> fallback) {
-        Objects.requireNonNull(unit, "unit is null");
+    default Multi<T> distinct() {
+        return new MultiDistinctPublisher<>(this, v -> v);
+    }
+
+    /**
+     * Drop the longest prefix of elements from this stream that satisfy the given predicate.
+     * As long as predicate returns true, items from upstream are NOT sent to downstream but being dropped,
+     * predicate is never called again after it returns false for the first time.
+     *
+     * @param predicate predicate to filter stream with
+     * @return Multi
+     */
+    default Multi<T> dropWhile(Predicate<? super T> predicate) {
+        Objects.requireNonNull(predicate, "predicate is null");
+        return new MultiDropWhilePublisher<>(this, predicate);
+    }
+
+    /**
+     * Filter stream items with provided predicate.
+     *
+     * @param predicate predicate to filter stream with
+     * @return Multi
+     */
+    default Multi<T> filter(Predicate<? super T> predicate) {
+        return new MultiFilterPublisher<>(this, predicate);
+    }
+
+    /**
+     * Get the first item of this {@link Multi} instance as a {@link Single}.
+     *
+     * @return Single
+     */
+    default Single<T> first() {
+        return new MultiFirstPublisher<>(this);
+    }
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Flow.Publisher} to downstream.
+     *
+     * @param publisherMapper {@link Function} receiving item as parameter and returning {@link Flow.Publisher}
+     * @param <U>             output item type
+     * @return Multi
+     */
+    default <U> Multi<U> flatMap(Function<? super T, ? extends Flow.Publisher<? extends U>> publisherMapper) {
+        return new MultiFlatMapPublisher<>(this, publisherMapper, 32, 32, false);
+    }
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Flow.Publisher} to downstream
+     * while limiting the maximum number of concurrent inner {@link Flow.Publisher}s and their in-flight
+     * item count, optionally aggregating and delaying all errors until all sources terminate.
+     *
+     * @param mapper {@link Function} receiving item as parameter and returning {@link Flow.Publisher}
+     * @param <U>             output item type
+     * @param maxConcurrency the maximum number of inner sources to run
+     * @param delayErrors if true, any error from the main and inner sources are aggregated and delayed until
+     *                    all of them terminate
+     * @param prefetch the number of items to request upfront from the inner sources, then request 75% more after 75%
+     *                 has been delivered
+     * @return Multi
+     */
+    default <U> Multi<U> flatMap(Function<? super T, ? extends Flow.Publisher<? extends U>> mapper,
+                                 long maxConcurrency, boolean delayErrors, long prefetch) {
+        return new MultiFlatMapPublisher<>(this, mapper, maxConcurrency, prefetch, delayErrors);
+    }
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
+     *
+     * @param iterableMapper {@link Function} receiving item as parameter and returning {@link Iterable}
+     * @param <U>            output item type
+     * @return Multi
+     */
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper) {
+        return flatMapIterable(iterableMapper, 32);
+    }
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
+     *
+     * @param iterableMapper {@link Function} receiving item as parameter and returning {@link Iterable}
+     * @param prefetch the number of upstream items to request upfront, then 75% of this value after
+     *                 75% received and mapped
+     * @param <U>            output item type
+     * @return Multi
+     */
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> iterableMapper,
+                                         int prefetch) {
+        Objects.requireNonNull(iterableMapper, "iterableMapper is null");
+        return new MultiFlatMapIterable<>(this, iterableMapper, prefetch);
+    }
+
+    /**
+     * Limit stream to allow only specified number of items to pass.
+     *
+     * @param limit with expected number of items to be produced
+     * @return Multi
+     */
+    default Multi<T> limit(long limit) {
+        return new MultiLimitPublisher<>(this, limit);
+    }
+
+    /**
+     * Map this {@link Multi} instance to a new {@link Multi} of another type using the given {@link Mapper}.
+     *
+     * @param <U>    mapped item type
+     * @param mapper mapper
+     * @return Multi
+     * @throws NullPointerException if mapper is {@code null}
+     */
+    default <U> Multi<U> map(Mapper<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return new MultiMapperPublisher<>(this, mapper);
+    }
+
+    /**
+     * Re-emit the upstream's signals to the downstream on the given executor's thread
+     * using a default buffer size of 32 and errors skipping ahead of items.
+     * @param executor the executor to signal the downstream from.
+     * @return Multi
+     * @throws NullPointerException if {@code executor} is {@code null}
+     * @see #observeOn(Executor, int, boolean)
+     */
+    default Multi<T> observeOn(Executor executor) {
+        return observeOn(executor, 32, false);
+    }
+
+    /**
+     * Re-emit the upstream's signals to the downstream on the given executor's thread.
+     * @param executor the executor to signal the downstream from.
+     * @param bufferSize the number of items to prefetch and buffer at a time
+     * @param delayError if {@code true}, errors are emitted after items,
+     *                   if {@code false}, errors may cut ahead of items during emission
+     * @return Multi
+     * @throws NullPointerException if {@code executor} is {@code null}
+     */
+    default Multi<T> observeOn(Executor executor, int bufferSize, boolean delayError) {
         Objects.requireNonNull(executor, "executor is null");
-        Objects.requireNonNull(fallback, "fallback is null");
-        return new MultiTimeout<>(this, timeout, unit, executor, fallback);
+        if (bufferSize <= 0) {
+            throw new IllegalArgumentException("bufferSize > 0 required");
+        }
+        return new MultiObserveOn<>(this, executor, bufferSize, delayError);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when a cancel signal is received.
+     *
+     * @param onCancel {@link java.lang.Runnable} to be executed.
+     * @return Multi
+     */
+    default Multi<T> onCancel(Runnable onCancel) {
+        return new MultiTappedPublisher<>(this,
+                null,
+                null,
+                null,
+                null,
+                null,
+                onCancel);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onComplete signal is received.
+     *
+     * @param onComplete {@link java.lang.Runnable} to be executed.
+     * @return Multi
+     */
+    default Multi<T> onComplete(Runnable onComplete) {
+        return new MultiTappedPublisher<>(this,
+                null,
+                null,
+                null,
+                onComplete,
+                null,
+                null);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onError signal is received.
+     *
+     * @param onErrorConsumer {@link java.util.function.Consumer} to be executed.
+     * @return Multi
+     */
+    default Multi<T> onError(Consumer<? super Throwable> onErrorConsumer) {
+        return new MultiTappedPublisher<>(this,
+                null,
+                null,
+                onErrorConsumer,
+                null,
+                null,
+                null);
     }
 
     /**
@@ -745,6 +625,67 @@ public interface Multi<T> extends Subscribable<T> {
      */
     default Multi<T> onErrorResumeWith(Function<? super Throwable, ? extends Flow.Publisher<? extends T>> onError) {
         return new MultiOnErrorResumeWith<>(this, onError);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
+     *
+     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @return Multi
+     */
+    default Multi<T> onTerminate(Runnable onTerminate) {
+        return new MultiTappedPublisher<>(this,
+                null,
+                null,
+                e -> onTerminate.run(),
+                onTerminate,
+                null,
+                onTerminate);
+    }
+
+    /**
+     * Invoke provided consumer for every item in stream.
+     *
+     * @param consumer consumer to be invoked
+     * @return Multi
+     */
+    default Multi<T> peek(Consumer<? super T> consumer) {
+        return new MultiTappedPublisher<>(this, null, consumer,
+                null, null, null, null);
+    }
+
+    /**
+     * Combine subsequent items via a callback function and emit
+     * the final value result as a Single.
+     * <p>
+     *     If the upstream is empty, the resulting Single is also empty.
+     *     If the upstream contains only one item, the reducer function
+     *     is not invoked and the resulting Single will have only that
+     *     single item.
+     * </p>
+     * @param reducer the function called with the first value or the previous result,
+     *                the current upstream value and should return a new value
+     * @return Single
+     */
+    default Single<T> reduce(BiFunction<T, T, T> reducer) {
+        Objects.requireNonNull(reducer, "reducer is null");
+        return new MultiReduce<>(this, reducer);
+    }
+
+    /**
+     * Combine every upstream item with an accumulator value to produce a new accumulator
+     * value and emit the final accumulator value as a Single.
+     * @param supplier the function to return the initial accumulator value for each incoming
+     *                 Subscriber
+     * @param reducer the function that receives the current accumulator value, the current
+     *                upstream value and should return a new accumulator value
+     * @param <R> the accumulator and result type
+     * @return Single
+     */
+    default <R> Single<R> reduce(Supplier<? extends R> supplier, BiFunction<R, T, R> reducer) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        Objects.requireNonNull(reducer, "reducer is null");
+        return new MultiReduceFull<>(this, supplier, reducer);
     }
 
     /**
@@ -801,22 +742,81 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
-     * Apply the given {@code composer} function to the current {@code Multi} instance and
-     * return a{@code Multi} wrapping the returned {@link Flow.Publisher} of this function.
-     * <p>
-     *     Note that the {@code composer} function is executed upon calling this method
-     *     immediately and not when the resulting sequence gets subscribed to.
-     * </p>
-     * @param composer the function that receives the current {@code Multi} instance and
-     *                 should return a {@code Flow.Publisher} to be wrapped into a
-     *                 {@code Multie} to be returned by the method
-     * @param <U> the output element type
+     * Skip first n items, all the others are emitted.
+     *
+     * @param skip number of items to be skipped
      * @return Multi
-     * @throws NullPointerException if {@code composer} is {@code null}
      */
-    @SuppressWarnings("unchecked")
-    default <U> Multi<U> compose(Function<? super Multi<T>, ? extends Flow.Publisher<? extends U>> composer) {
-        return from((Flow.Publisher<U>) to(composer));
+    default Multi<T> skip(long skip) {
+        return new MultiSkipPublisher<>(this, skip);
+    }
+
+    /**
+     * Switch to the other publisher if the upstream is empty.
+     * @param other the publisher to switch to if the upstream is empty.
+     * @return Multi
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    default Multi<T> switchIfEmpty(Flow.Publisher<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return new MultiSwitchIfEmpty<>(this, other);
+    }
+
+    /**
+     * Relay upstream items until the other source signals an item or completes.
+     * @param other the other sequence to signal the end of the main sequence
+     * @param <U> the element type of the other sequence
+     * @return Multi
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    default <U> Multi<T> takeUntil(Flow.Publisher<U> other) {
+        Objects.requireNonNull(other, "other is null");
+        return new MultiTakeUntilPublisher<>(this, other);
+    }
+
+    /**
+     * Take the longest prefix of elements from this stream that satisfy the given predicate.
+     * As long as predicate returns true, items from upstream are sent to downstream,
+     * when predicate returns false stream is completed.
+     *
+     * @param predicate predicate to filter stream with
+     * @return Multi
+     */
+    default Multi<T> takeWhile(Predicate<? super T> predicate) {
+        return new MultiTakeWhilePublisher<>(this, predicate);
+    }
+
+    /**
+     * Signals a {@link TimeoutException} if the upstream doesn't signal the next item, error
+     * or completion within the specified time.
+     * @param timeout the time to wait for the upstream to signal
+     * @param unit the time unit
+     * @param executor the executor to use for waiting for the upstream signal
+     * @return Multi
+     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     */
+    default Multi<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(executor, "executor is null");
+        return new MultiTimeout<>(this, timeout, unit, executor, null);
+    }
+
+    /**
+     * Switches to a fallback single if the upstream doesn't signal the next item, error
+     * or completion within the specified time.
+     * @param timeout the time to wait for the upstream to signal
+     * @param unit the time unit
+     * @param executor the executor to use for waiting for the upstream signal
+     * @param fallback the Single to switch to if the upstream doesn't signal in time
+     * @return Multi
+     * @throws NullPointerException if {@code unit}, {@code executor}
+     *                              or {@code fallback} is {@code null}
+     */
+    default Multi<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor, Flow.Publisher<T> fallback) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(executor, "executor is null");
+        Objects.requireNonNull(fallback, "fallback is null");
+        return new MultiTimeout<>(this, timeout, unit, executor, fallback);
     }
 
     /**
@@ -835,4 +835,19 @@ public interface Multi<T> extends Subscribable<T> {
     default <U> U to(Function<? super Multi<T>, ? extends U> converter) {
         return converter.apply(this);
     }
+
+    // --------------------------------------------------------------------------------------------------------
+    // Terminal operators
+    // --------------------------------------------------------------------------------------------------------
+
+    /**
+     * Terminal stage, invokes provided consumer for every item in the stream.
+     *
+     * @param consumer consumer to be invoked for each item
+     */
+    default void forEach(Consumer<? super T> consumer) {
+        FunctionalSubscriber<T> subscriber = new FunctionalSubscriber<>(consumer, null, null, null);
+        this.subscribe(subscriber);
+    }
+
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiMapperPublisher.java
@@ -17,6 +17,7 @@ package io.helidon.common.reactive;
 
 import java.util.Objects;
 import java.util.concurrent.Flow;
+import java.util.function.Function;
 
 import io.helidon.common.mapper.Mapper;
 
@@ -29,9 +30,9 @@ final class MultiMapperPublisher<T, R> implements Multi<R> {
 
     private final Flow.Publisher<T> source;
 
-    private final Mapper<? super T, ? extends R> mapper;
+    private final Function<? super T, ? extends R> mapper;
 
-    MultiMapperPublisher(Flow.Publisher<T> source, Mapper<? super T, ? extends R> mapper) {
+    MultiMapperPublisher(Flow.Publisher<T> source, Function<? super T, ? extends R> mapper) {
         this.source = source;
         this.mapper = mapper;
     }
@@ -45,11 +46,11 @@ final class MultiMapperPublisher<T, R> implements Multi<R> {
 
         private final Flow.Subscriber<? super R> downstream;
 
-        private final Mapper<? super T, ? extends R> mapper;
+        private final Function<? super T, ? extends R> mapper;
 
         private Flow.Subscription upstream;
 
-        MapperSubscriber(Flow.Subscriber<? super R> downstream, Mapper<? super T, ? extends R> mapper) {
+        MapperSubscriber(Flow.Subscriber<? super R> downstream, Function<? super T, ? extends R> mapper) {
             this.downstream = downstream;
             this.mapper = mapper;
         }
@@ -69,7 +70,7 @@ final class MultiMapperPublisher<T, R> implements Multi<R> {
                 R result;
 
                 try {
-                    result = Objects.requireNonNull(mapper.map(item), "The mapper returned a null value.");
+                    result = Objects.requireNonNull(mapper.apply(item), "The mapper returned a null value.");
                 } catch (Throwable ex) {
                     s.cancel();
                     onError(ex);

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -256,14 +256,14 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Map this {@link Single} instance to a new {@link Single} of another type using the given {@link Mapper}.
+     * Map this {@link Single} instance to a new {@link Single} of another type using the given {@link Function}.
      *
      * @param <U>    mapped item type
      * @param mapper mapper
      * @return Single
      * @throws NullPointerException if mapper is {@code null}
      */
-    default <U> Single<U> map(Mapper<? super T, ? extends U> mapper) {
+    default <U> Single<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper, "mapper is null");
         return new SingleMapperPublisher<>(this, mapper);
     }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -36,11 +36,17 @@ import java.util.function.Supplier;
 import io.helidon.common.mapper.Mapper;
 
 /**
- * Single item publisher utility.
+ * Represents a {@link Flow.Publisher} that may: signal one item then completes, complete without
+ * an item or signal an error.
  *
  * @param <T> item type
+ * @see Multi
  */
 public interface Single<T> extends Subscribable<T> {
+
+    // --------------------------------------------------------------------------------------------------------
+    // Factory (source-like) methods
+    // --------------------------------------------------------------------------------------------------------
 
     /**
      * Call the given supplier function for each individual downstream Subscriber
@@ -56,166 +62,54 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Map this {@link Single} instance to a new {@link Single} of another type using the given {@link Mapper}.
+     * Get a {@link Single} instance that completes immediately.
      *
-     * @param <U>    mapped item type
-     * @param mapper mapper
+     * @param <T> item type
      * @return Single
-     * @throws NullPointerException if mapper is {@code null}
      */
-    default <U> Single<U> map(Mapper<? super T, ? extends U> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return new SingleMapperPublisher<>(this, mapper);
+    static <T> Single<T> empty() {
+        return SingleEmpty.instance();
     }
 
     /**
-     * Signals the default item if the upstream is empty.
-     * @param defaultItem the item to signal if the upstream is empty
+     * Create a {@link Single} instance that reports the given given exception to its subscriber(s). The exception is reported by
+     * invoking {@link Subscriber#onError(java.lang.Throwable)} when {@link Publisher#subscribe(Subscriber)} is called.
+     *
+     * @param <T>   item type
+     * @param error exception to hold
      * @return Single
-     * @throws NullPointerException if {@code defaultItem} is {@code null}
+     * @throws NullPointerException if error is {@code null}
      */
-    default Single<T> defaultIfEmpty(T defaultItem) {
-        Objects.requireNonNull(defaultItem, "defaultItem is null");
-        return new SingleDefaultIfEmpty<>(this, defaultItem);
+    static <T> Single<T> error(Throwable error) {
+        return new SingleError<>(error);
     }
 
     /**
-     * Switch to the other Single if the upstream is empty.
-     * @param other the Single to switch to if the upstream is empty.
+     * Wrap a CompletionStage into a Multi and signal its outcome non-blockingly.
+     * <p>
+     *     A null result from the CompletionStage will yield a
+     *     {@link NullPointerException} signal.
+     * </p>
+     * @param completionStage the CompletionStage to
+     * @param <T> the element type of the stage and result
      * @return Single
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @see #from(CompletionStage, boolean)
      */
-    default Single<T> switchIfEmpty(Single<T> other) {
-        Objects.requireNonNull(other, "other is null");
-        return new SingleSwitchIfEmpty<>(this, other);
+    static <T> Single<T> from(CompletionStage<T> completionStage) {
+        return from(completionStage, false);
     }
 
     /**
-     * Map this {@link Single} instance to a publisher using the given {@link Mapper}.
-     *
-     * @param <U>    mapped items type
-     * @param mapper mapper
-     * @return Publisher
-     * @throws NullPointerException if mapper is {@code null}
-     * @deprecated Use {@link Single#flatMap}
-     */
-    @Deprecated
-    default <U> Multi<U> mapMany(Mapper<? super T, ? extends Publisher<? extends U>> mapper) {
-        return flatMap(mapper::map);
-    }
-
-    /**
-     * Map this {@link Single} instance to a publisher using the given {@link Mapper}.
-     *
-     * @param <U>    mapped items type
-     * @param mapper mapper
-     * @return Publisher
-     * @throws NullPointerException if mapper is {@code null}
-     */
-    default <U> Multi<U> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return new SingleFlatMapMulti<>(this, mapper);
-    }
-
-    /**
-     * Map this {@link Single} instance to a {@link Single} using the given {@link Mapper}.
-     *
-     * @param <U>    mapped items type
-     * @param mapper mapper
+     * Wrap a CompletionStage into a Multi and signal its outcome non-blockingly.
+     * @param completionStage the CompletionStage to
+     * @param nullMeansEmpty if true, a null result is interpreted to be an empty sequence
+     *                       if false, the resulting sequence fails with {@link NullPointerException}
+     * @param <T> the element type of the stage and result
      * @return Single
-     * @throws NullPointerException if mapper is {@code null}
      */
-    default <U> Single<U> flatMapSingle(Function<? super T, ? extends Single<? extends U>> mapper) {
-        return new SingleFlatMapSingle<>(this, mapper);
-    }
-
-    /**
-     * Maps the single upstream value into an {@link Iterable} and relays its
-     * items to the downstream.
-     * @param mapper the function that receives the single upstream value and
-     *               should return an Iterable instance
-     * @param <U> the result type
-     * @return Multi
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     */
-    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        return new SingleFlatMapIterable<>(this, mapper);
-    }
-
-    /**
-     * Re-emit the upstream's signals to the downstream on the given executor's thread.
-     * @param executor the executor to signal the downstream from.
-     * @return Single
-     * @throws NullPointerException if {@code executor} is {@code null}
-     */
-    default Single<T> observeOn(Executor executor) {
-        Objects.requireNonNull(executor, "executor is null");
-        return new SingleObserveOn<>(this, executor);
-    }
-
-    /**
-     * Exposes this {@link Single} instance as a {@link CompletionStage}.
-     * Note that if this {@link Single} completes without a value, the resulting {@link CompletionStage} will be completed
-     * exceptionally with an {@link IllegalStateException}
-     *
-     * @return CompletionStage
-     */
-    default CompletionStage<T> toStage() {
-        try {
-            SingleToFuture<T> subscriber = new SingleToFuture<>();
-            this.subscribe(subscriber);
-            return subscriber;
-        } catch (Throwable ex) {
-            CompletableFuture<T> future = new CompletableFuture<>();
-            future.completeExceptionally(ex);
-            return future;
-        }
-    }
-
-    /**
-     * Exposes this {@link Single} instance as a {@link CompletionStage} with {@code Optional<T>} return type
-     * of the asynchronous operation.
-     * Note that if this {@link Single} completes without a value, the resulting {@link CompletionStage} will be completed
-     * exceptionally with an {@link IllegalStateException}
-     *
-     * @return CompletionStage
-     */
-    default CompletionStage<Optional<T>> toOptionalStage() {
-        try {
-            SingleToOptionalFuture<T> subscriber = new SingleToOptionalFuture<>();
-            this.subscribe(subscriber);
-            return subscriber;
-        } catch (Throwable ex) {
-            CompletableFuture<Optional<T>> future = new CompletableFuture<>();
-            future.completeExceptionally(ex);
-            return future;
-        }
-    }
-
-    /**
-     * Short-hand for {@code  toFuture().toCompletableFuture().get()}.
-     *
-     * @return T
-     * @throws InterruptedException if the current thread was interrupted while waiting
-     * @throws ExecutionException   if the future completed exceptionally
-     */
-    default T get() throws InterruptedException, ExecutionException {
-        return toStage().toCompletableFuture().get();
-    }
-
-    /**
-     * Short-hand for {@code toFuture().toCompletableFuture().get()}.
-     *
-     * @param timeout the maximum time to wait
-     * @param unit    the time unit of the timeout argument
-     * @return T
-     * @throws InterruptedException if the current thread was interrupted while waiting
-     * @throws ExecutionException   if the future completed exceptionally
-     * @throws TimeoutException     if the wait timed out
-     */
-    default T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        return toStage().toCompletableFuture().get(timeout, unit);
+    static <T> Single<T> from(CompletionStage<T> completionStage, boolean nullMeansEmpty) {
+        Objects.requireNonNull(completionStage, "completionStage is null");
+        return new SingleFromCompletionStage<>(completionStage, nullMeansEmpty);
     }
 
     /**
@@ -249,36 +143,13 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Create a {@link Single} instance that reports the given given exception to its subscriber(s). The exception is reported by
-     * invoking {@link Subscriber#onError(java.lang.Throwable)} when {@link Publisher#subscribe(Subscriber)} is called.
-     *
-     * @param <T>   item type
-     * @param error exception to hold
-     * @return Single
-     * @throws NullPointerException if error is {@code null}
-     */
-    static <T> Single<T> error(Throwable error) {
-        return new SingleError<>(error);
-    }
-
-    /**
-     * Get a {@link Single} instance that completes immediately.
-     *
-     * @param <T> item type
-     * @return Single
-     */
-    static <T> Single<T> empty() {
-        return SingleEmpty.<T>instance();
-    }
-
-    /**
      * Get a {@link Single} instance that never completes.
      *
      * @param <T> item type
      * @return Single
      */
     static <T> Single<T> never() {
-        return SingleNever.<T>instance();
+        return SingleNever.instance();
     }
 
     /**
@@ -296,92 +167,132 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Wrap a CompletionStage into a Multi and signal its outcome non-blockingly.
+     * Apply the given {@code converter} function to the current {@code Single} instance
+     * and return the value returned by this function.
      * <p>
-     *     A null result from the CompletionStage will yield a
-     *     {@link NullPointerException} signal.
+     *     Note that the {@code converter} function is executed upon calling this method
+     *     immediately and not when the resulting sequence gets subscribed to.
      * </p>
-     * @param completionStage the CompletionStage to
-     * @param <T> the element type of the stage and result
-     * @return Single
-     * @see #from(CompletionStage, boolean)
+     * @param converter the function that receives the current {@code Single} instance and
+     *                  should return a value to be returned by the method
+     * @param <U> the output type
+     * @return the value returned by the function
+     * @throws NullPointerException if {@code converter} is {@code null}
      */
-    static <T> Single<T> from(CompletionStage<T> completionStage) {
-        return from(completionStage, false);
+    default <U> U to(Function<? super Single<T>, ? extends U> converter) {
+        return converter.apply(this);
+    }
+
+    // --------------------------------------------------------------------------------------------------------
+    // Instance Operators
+    // --------------------------------------------------------------------------------------------------------
+
+    /**
+     * Apply the given {@code composer} function to the current {@code Single} instance and
+     * return the {@code Single} returned by this function.
+     * <p>
+     *     Note that the {@code composer} function is executed upon calling this method
+     *     immediately and not when the resulting sequence gets subscribed to.
+     * </p>
+     * @param composer the function that receives the current {@code Single} instance and
+     *                 should return a {@code Single} to be returned by the method
+     * @param <U> the output element type
+     * @return Single
+     * @throws NullPointerException if {@code composer} is {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    default <U> Single<U> compose(Function<? super Single<T>, ? extends Single<? extends U>> composer) {
+        return (Single<U>) to(composer);
     }
 
     /**
-     * Wrap a CompletionStage into a Multi and signal its outcome non-blockingly.
-     * @param completionStage the CompletionStage to
-     * @param nullMeansEmpty if true, a null result is interpreted to be an empty sequence
-     *                       if false, the resulting sequence fails with {@link NullPointerException}
-     * @param <T> the element type of the stage and result
+     * Signals the default item if the upstream is empty.
+     * @param defaultItem the item to signal if the upstream is empty
      * @return Single
+     * @throws NullPointerException if {@code defaultItem} is {@code null}
      */
-    static <T> Single<T> from(CompletionStage<T> completionStage, boolean nullMeansEmpty) {
-        Objects.requireNonNull(completionStage, "completionStage is null");
-        return new SingleFromCompletionStage<>(completionStage, nullMeansEmpty);
+    default Single<T> defaultIfEmpty(T defaultItem) {
+        Objects.requireNonNull(defaultItem, "defaultItem is null");
+        return new SingleDefaultIfEmpty<>(this, defaultItem);
     }
 
     /**
-     * Signals a {@link TimeoutException} if the upstream doesn't signal an item, error
-     * or completion within the specified time.
-     * @param timeout the time to wait for the upstream to signal
-     * @param unit the time unit
-     * @param executor the executor to use for waiting for the upstream signal
-     * @return Single
-     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
-     */
-    default Single<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(executor, "executor is null");
-        return new SingleTimeout<>(this, timeout, unit, executor, null);
-    }
-
-    /**
-     * Switches to a fallback single if the upstream doesn't signal an item, error
-     * or completion within the specified time.
-     * @param timeout the time to wait for the upstream to signal
-     * @param unit the time unit
-     * @param executor the executor to use for waiting for the upstream signal
-     * @param fallback the Single to switch to if the upstream doesn't signal in time
-     * @return Single
-     * @throws NullPointerException if {@code unit}, {@code executor}
-     *                              or {@code fallback} is {@code null}
-     */
-    default Single<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor, Single<T> fallback) {
-        Objects.requireNonNull(unit, "unit is null");
-        Objects.requireNonNull(executor, "executor is null");
-        Objects.requireNonNull(fallback, "fallback is null");
-        return new SingleTimeout<>(this, timeout, unit, executor, fallback);
-    }
-
-    /**
-     * Relay upstream items until the other source signals an item or completes.
-     * @param other the other sequence to signal the end of the main sequence
-     * @param <U> the element type of the other sequence
-     * @return Single
-     * @throws NullPointerException if {@code other} is {@code null}
-     */
-    default <U> Single<T> takeUntil(Flow.Publisher<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return new SingleTakeUntilPublisher<>(this, other);
-    }
-
-    /**
-     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
+     * Map this {@link Single} instance to a publisher using the given {@link Mapper}.
      *
-     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @param <U>    mapped items type
+     * @param mapper mapper
+     * @return Publisher
+     * @throws NullPointerException if mapper is {@code null}
+     */
+    default <U> Multi<U> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return new SingleFlatMapMulti<>(this, mapper);
+    }
+
+    /**
+     * Maps the single upstream value into an {@link Iterable} and relays its
+     * items to the downstream.
+     * @param mapper the function that receives the single upstream value and
+     *               should return an Iterable instance
+     * @param <U> the result type
+     * @return Multi
+     * @throws NullPointerException if {@code mapper} is {@code null}
+     */
+    default <U> Multi<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return new SingleFlatMapIterable<>(this, mapper);
+    }
+
+    /**
+     * Map this {@link Single} instance to a {@link Single} using the given {@link Mapper}.
+     *
+     * @param <U>    mapped items type
+     * @param mapper mapper
+     * @return Single
+     * @throws NullPointerException if mapper is {@code null}
+     */
+    default <U> Single<U> flatMapSingle(Function<? super T, ? extends Single<? extends U>> mapper) {
+        return new SingleFlatMapSingle<>(this, mapper);
+    }
+
+    /**
+     * Map this {@link Single} instance to a new {@link Single} of another type using the given {@link Mapper}.
+     *
+     * @param <U>    mapped item type
+     * @param mapper mapper
+     * @return Single
+     * @throws NullPointerException if mapper is {@code null}
+     */
+    default <U> Single<U> map(Mapper<? super T, ? extends U> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return new SingleMapperPublisher<>(this, mapper);
+    }
+
+    /**
+     * Re-emit the upstream's signals to the downstream on the given executor's thread.
+     * @param executor the executor to signal the downstream from.
+     * @return Single
+     * @throws NullPointerException if {@code executor} is {@code null}
+     */
+    default Single<T> observeOn(Executor executor) {
+        Objects.requireNonNull(executor, "executor is null");
+        return new SingleObserveOn<>(this, executor);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when a cancel signal is received.
+     *
+     * @param onCancel {@link java.lang.Runnable} to be executed.
      * @return Single
      */
-    default Single<T> onTerminate(Runnable onTerminate) {
+    default Single<T> onCancel(Runnable onCancel) {
         return new SingleTappedPublisher<>(this,
                 null,
                 null,
-                e -> onTerminate.run(),
-                onTerminate,
                 null,
-                onTerminate);
+                null,
+                null,
+                onCancel);
     }
 
     /**
@@ -417,19 +328,39 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Executes given {@link java.lang.Runnable} when a cancel signal is received.
+     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
      *
-     * @param onCancel {@link java.lang.Runnable} to be executed.
+     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
      * @return Single
      */
-    default Single<T> onCancel(Runnable onCancel) {
+    default Single<T> onErrorResume(Function<? super Throwable, ? extends T> onError) {
+        return new SingleOnErrorResume<>(this, onError);
+    }
+
+    /**
+     * Resume stream from supplied publisher if onError signal is intercepted.
+     *
+     * @param onError supplier of new stream publisher
+     * @return Single
+     */
+    default Single<T> onErrorResumeWith(Function<? super Throwable, ? extends Single<? extends T>> onError) {
+        return new SingleOnErrorResumeWith<>(this, onError);
+    }
+
+    /**
+     * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
+     *
+     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @return Single
+     */
+    default Single<T> onTerminate(Runnable onTerminate) {
         return new SingleTappedPublisher<>(this,
                 null,
                 null,
+                e -> onTerminate.run(),
+                onTerminate,
                 null,
-                null,
-                null,
-                onCancel);
+                onTerminate);
     }
 
     /**
@@ -441,27 +372,6 @@ public interface Single<T> extends Subscribable<T> {
     default Single<T> peek(Consumer<? super T> consumer) {
         return new SingleTappedPublisher<>(this, null, consumer,
                 null, null, null, null);
-    }
-
-    /**
-     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
-     *
-     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
-     * @return Single
-     */
-    default Single<T> onErrorResume(Function<? super Throwable, ? extends T> onError) {
-        return new SingleOnErrorResume<>(this, onError);
-    }
-
-
-    /**
-     * Resume stream from supplied publisher if onError signal is intercepted.
-     *
-     * @param onError supplier of new stream publisher
-     * @return Single
-     */
-    default Single<T> onErrorResumeWith(Function<? super Throwable, ? extends Single<? extends T>> onError) {
-        return new SingleOnErrorResumeWith<>(this, onError);
     }
 
     /**
@@ -518,37 +428,126 @@ public interface Single<T> extends Subscribable<T> {
     }
 
     /**
-     * Apply the given {@code composer} function to the current {@code Single} instance and
-     * return the {@code Single} returned by this function.
-     * <p>
-     *     Note that the {@code composer} function is executed upon calling this method
-     *     immediately and not when the resulting sequence gets subscribed to.
-     * </p>
-     * @param composer the function that receives the current {@code Single} instance and
-     *                 should return a {@code Single} to be returned by the method
-     * @param <U> the output element type
+     * Switch to the other Single if the upstream is empty.
+     * @param other the Single to switch to if the upstream is empty.
      * @return Single
-     * @throws NullPointerException if {@code composer} is {@code null}
+     * @throws NullPointerException if {@code other} is {@code null}
      */
-    @SuppressWarnings("unchecked")
-    default <U> Single<U> compose(Function<? super Single<T>, ? extends Single<? extends U>> composer) {
-        return (Single<U>) to(composer);
+    default Single<T> switchIfEmpty(Single<T> other) {
+        Objects.requireNonNull(other, "other is null");
+        return new SingleSwitchIfEmpty<>(this, other);
     }
 
     /**
-     * Apply the given {@code converter} function to the current {@code Single} instance
-     * and return the value returned by this function.
-     * <p>
-     *     Note that the {@code converter} function is executed upon calling this method
-     *     immediately and not when the resulting sequence gets subscribed to.
-     * </p>
-     * @param converter the function that receives the current {@code Single} instance and
-     *                  should return a value to be returned by the method
-     * @param <U> the output type
-     * @return the value returned by the function
-     * @throws NullPointerException if {@code converter} is {@code null}
+     * Relay upstream items until the other source signals an item or completes.
+     * @param other the other sequence to signal the end of the main sequence
+     * @param <U> the element type of the other sequence
+     * @return Single
+     * @throws NullPointerException if {@code other} is {@code null}
      */
-    default <U> U to(Function<? super Single<T>, ? extends U> converter) {
-        return converter.apply(this);
+    default <U> Single<T> takeUntil(Flow.Publisher<U> other) {
+        Objects.requireNonNull(other, "other is null");
+        return new SingleTakeUntilPublisher<>(this, other);
+    }
+
+    /**
+     * Signals a {@link TimeoutException} if the upstream doesn't signal an item, error
+     * or completion within the specified time.
+     * @param timeout the time to wait for the upstream to signal
+     * @param unit the time unit
+     * @param executor the executor to use for waiting for the upstream signal
+     * @return Single
+     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     */
+    default Single<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(executor, "executor is null");
+        return new SingleTimeout<>(this, timeout, unit, executor, null);
+    }
+
+    /**
+     * Switches to a fallback single if the upstream doesn't signal an item, error
+     * or completion within the specified time.
+     * @param timeout the time to wait for the upstream to signal
+     * @param unit the time unit
+     * @param executor the executor to use for waiting for the upstream signal
+     * @param fallback the Single to switch to if the upstream doesn't signal in time
+     * @return Single
+     * @throws NullPointerException if {@code unit}, {@code executor}
+     *                              or {@code fallback} is {@code null}
+     */
+    default Single<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor, Single<T> fallback) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(executor, "executor is null");
+        Objects.requireNonNull(fallback, "fallback is null");
+        return new SingleTimeout<>(this, timeout, unit, executor, fallback);
+    }
+
+    // --------------------------------------------------------------------------------------------------------
+    // Terminal operators
+    // --------------------------------------------------------------------------------------------------------
+
+    /**
+     * Short-hand for {@code  toFuture().toCompletableFuture().get()}.
+     *
+     * @return T
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException   if the future completed exceptionally
+     */
+    default T get() throws InterruptedException, ExecutionException {
+        return toStage().toCompletableFuture().get();
+    }
+
+    /**
+     * Short-hand for {@code toFuture().toCompletableFuture().get()}.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit of the timeout argument
+     * @return T
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException   if the future completed exceptionally
+     * @throws TimeoutException     if the wait timed out
+     */
+    default T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return toStage().toCompletableFuture().get(timeout, unit);
+    }
+
+    /**
+     * Exposes this {@link Single} instance as a {@link CompletionStage} with {@code Optional<T>} return type
+     * of the asynchronous operation.
+     * Note that if this {@link Single} completes without a value, the resulting {@link CompletionStage} will be completed
+     * exceptionally with an {@link IllegalStateException}
+     *
+     * @return CompletionStage
+     */
+    default CompletionStage<Optional<T>> toOptionalStage() {
+        try {
+            SingleToOptionalFuture<T> subscriber = new SingleToOptionalFuture<>();
+            this.subscribe(subscriber);
+            return subscriber;
+        } catch (Throwable ex) {
+            CompletableFuture<Optional<T>> future = new CompletableFuture<>();
+            future.completeExceptionally(ex);
+            return future;
+        }
+    }
+
+    /**
+     * Exposes this {@link Single} instance as a {@link CompletionStage}.
+     * Note that if this {@link Single} completes without a value, the resulting {@link CompletionStage} will be completed
+     * exceptionally with an {@link IllegalStateException}
+     *
+     * @return CompletionStage
+     */
+    default CompletionStage<T> toStage() {
+        try {
+            SingleToFuture<T> subscriber = new SingleToFuture<>();
+            this.subscribe(subscriber);
+            return subscriber;
+        } catch (Throwable ex) {
+            CompletableFuture<T> future = new CompletableFuture<>();
+            future.completeExceptionally(ex);
+            return future;
+        }
     }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleMapperPublisher.java
@@ -16,6 +16,7 @@
 package io.helidon.common.reactive;
 
 import java.util.concurrent.Flow;
+import java.util.function.Function;
 
 import io.helidon.common.mapper.Mapper;
 
@@ -28,9 +29,9 @@ final class SingleMapperPublisher<T, R> implements Single<R> {
 
     private final Flow.Publisher<T> source;
 
-    private final Mapper<? super T, ? extends R> mapper;
+    private final Function<? super T, ? extends R> mapper;
 
-    SingleMapperPublisher(Flow.Publisher<T> source, Mapper<? super T, ? extends R> mapper) {
+    SingleMapperPublisher(Flow.Publisher<T> source, Function<? super T, ? extends R> mapper) {
         this.source = source;
         this.mapper = mapper;
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -240,11 +241,8 @@ public class MultiTest {
     @Test
     public void testMapBadMapper() {
         MultiTestSubscriber<String> subscriber = new MultiTestSubscriber<>();
-        Multi.<String>just("foo", "bar").map(new Mapper<String, String>() {
-            @Override
-            public String map(String item) {
-                throw new IllegalStateException("foo!");
-            }
+        Multi.<String>just("foo", "bar").map((Function<String, String>) item -> {
+            throw new IllegalStateException("foo!");
         }).subscribe(subscriber);
         assertThat(subscriber.isComplete(), is(equalTo(false)));
         assertThat(subscriber.getLastError(), is(instanceOf(IllegalStateException.class)));
@@ -254,7 +252,7 @@ public class MultiTest {
     @Test
     public void testMapBadMapperNullValue() {
         MultiTestSubscriber<String> subscriber = new MultiTestSubscriber<>();
-        Multi.just("foo", "bar").map((Mapper<String, String>) item -> null).subscribe(subscriber);
+        Multi.just("foo", "bar").map((Function<String, String>) item -> null).subscribe(subscriber);
         assertThat(subscriber.isComplete(), is(equalTo(false)));
         assertThat(subscriber.getLastError(), is(instanceOf(NullPointerException.class)));
         assertThat(subscriber.getItems(), is(empty()));

--- a/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/jmh/ShakespearePlaysScrabbleWithHelidonReactiveOpt.java
@@ -76,10 +76,10 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
     public List<Entry<Integer, List<String>>> measureThroughput() throws Exception {
 
         //  to compute the score of a given word
-        Mapper<Integer, Integer> scoreOfALetter = letter -> letterScores[letter - 'a'];
+        Function<Integer, Integer> scoreOfALetter = letter -> letterScores[letter - 'a'];
 
         // score of the same letters in a word
-        Mapper<Entry<Integer, MutableLong>, Integer> letterScore =
+        Function<Entry<Integer, MutableLong>, Integer> letterScore =
                 entry ->
                         letterScores[entry.getKey() - 'a'] *
                         Integer.min(
@@ -110,7 +110,7 @@ public class ShakespearePlaysScrabbleWithHelidonReactiveOpt extends ShakespeareP
                             ) ;
 
         // number of blanks for a given letter
-        Mapper<Entry<Integer, MutableLong>, Long> blank =
+        Function<Entry<Integer, MutableLong>, Long> blank =
                 entry ->
                         Long.max(
                             0L,

--- a/media/common/src/main/java/io/helidon/media/common/ByteChannelBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ByteChannelBodyWriter.java
@@ -53,7 +53,7 @@ public final class ByteChannelBodyWriter implements MessageBodyWriter<ReadableBy
             MessageBodyWriterContext context) {
 
         context.contentType(MediaType.APPLICATION_OCTET_STREAM);
-        return content.mapMany(mapper);
+        return content.flatMap(mapper::map);
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/CharSequenceBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/CharSequenceBodyWriter.java
@@ -45,7 +45,7 @@ public final class CharSequenceBodyWriter implements MessageBodyWriter<CharSeque
             MessageBodyWriterContext context) {
 
         context.contentType(MediaType.TEXT_PLAIN);
-        return content.mapMany(new CharSequenceToChunks(context.charset()));
+        return content.flatMap(new CharSequenceToChunks(context.charset())::map);
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
@@ -63,7 +63,7 @@ public final class ContentReaders {
      * @return Single
      */
     public static Single<String> readString(Publisher<DataChunk> chunks, Charset charset) {
-        return readBytes(chunks).map(new BytesToString(charset));
+        return readBytes(chunks).map(new BytesToString(charset)::map);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class ContentReaders {
      */
     public static Single<String> readURLEncodedString(Publisher<DataChunk> chunks,
             Charset charset) {
-        return readString(chunks, charset).map(new StringToDecodedString(charset));
+        return readString(chunks, charset).map(new StringToDecodedString(charset)::map);
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
+++ b/media/common/src/main/java/io/helidon/media/common/ContentReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/media/common/src/main/java/io/helidon/media/common/FileBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/FileBodyWriter.java
@@ -50,7 +50,7 @@ public final class FileBodyWriter implements MessageBodyWriter<File> {
 
     @Override
     public Publisher<DataChunk> write(Single<File> content, GenericType<? extends File> type, MessageBodyWriterContext context) {
-        return content.mapMany(new FileToChunks(DEFAULT_RETRY_SCHEMA, context));
+        return content.flatMap(new FileToChunks(DEFAULT_RETRY_SCHEMA, context)::map);
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/MessageBodyWriterContext.java
+++ b/media/common/src/main/java/io/helidon/media/common/MessageBodyWriterContext.java
@@ -260,7 +260,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
                 return applyFilters(Multi.<DataChunk>empty());
             }
             if (byte[].class.equals(type.rawType())) {
-                return applyFilters(((Single<byte[]>) content).mapMany(BYTES_MAPPER));
+                return applyFilters(((Single<byte[]>) content).flatMap(BYTES_MAPPER::map));
             }
             MessageBodyWriter<T> writer;
             if (fallback != null) {
@@ -582,7 +582,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
 
         @Override
         public Publisher<DataChunk> write(Single<T> single, GenericType<? extends T> type, MessageBodyWriterContext context) {
-            return single.mapMany(function::apply);
+            return single.flatMap(function);
         }
     }
 

--- a/media/common/src/main/java/io/helidon/media/common/PathBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/PathBodyWriter.java
@@ -49,7 +49,7 @@ public final class PathBodyWriter implements MessageBodyWriter<Path> {
 
     @Override
     public Publisher<DataChunk> write(Single<Path> content, GenericType<? extends Path> type, MessageBodyWriterContext context) {
-        return content.mapMany(new PathToChunks(DEFAULT_RETRY_SCHEMA, context));
+        return content.flatMap(new PathToChunks(DEFAULT_RETRY_SCHEMA, context)::map);
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/ThrowableBodyWriter.java
@@ -49,7 +49,7 @@ public class ThrowableBodyWriter implements MessageBodyWriter<Throwable> {
                                       GenericType<? extends Throwable> type,
                                       MessageBodyWriterContext context) {
         context.contentType(MediaType.TEXT_PLAIN);
-        return content.mapMany(new ThrowableToChunks(context.charset()));
+        return content.flatMap(new ThrowableToChunks(context.charset())::map);
     }
 
     /**

--- a/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
+++ b/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
@@ -52,7 +52,7 @@ public final class JacksonBodyReader implements MessageBodyReader<Object> {
     public <U extends Object> Single<U> read(Publisher<DataChunk> publisher,
             GenericType<U> type, MessageBodyReaderContext context) {
 
-        return ContentReaders.readBytes(publisher).map(new BytesToObject<>(type, objectMapper));
+        return ContentReaders.readBytes(publisher).map(new BytesToObject<>(type, objectMapper)::map);
     }
 
     /**

--- a/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyWriter.java
+++ b/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyWriter.java
@@ -56,7 +56,7 @@ public final class JacksonBodyWriter implements MessageBodyWriter<Object> {
 
         MediaType contentType = context.findAccepted(MediaType.JSON_PREDICATE, MediaType.APPLICATION_JSON);
         context.contentType(contentType);
-        return content.mapMany(new ObjectToChunks(objectMapper, context.charset()));
+        return content.flatMap(new ObjectToChunks(objectMapper, context.charset())::map);
     }
 
     /**

--- a/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonbBodyReader.java
+++ b/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonbBodyReader.java
@@ -53,7 +53,7 @@ public class JsonbBodyReader implements MessageBodyReader<Object> {
     public <U extends Object> Single<U> read(Publisher<DataChunk> publisher,
             GenericType<U> type, MessageBodyReaderContext context) {
 
-        return ContentReaders.readBytes(publisher).map(new BytesToObject<>(type, jsonb));
+        return ContentReaders.readBytes(publisher).map(new BytesToObject<>(type, jsonb)::map);
     }
 
     /**

--- a/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonbBodyWriter.java
+++ b/media/jsonb/common/src/main/java/io/helidon/media/jsonb/common/JsonbBodyWriter.java
@@ -57,7 +57,7 @@ public class JsonbBodyWriter implements MessageBodyWriter<Object> {
 
         MediaType contentType = context.findAccepted(MediaType.JSON_PREDICATE, MediaType.APPLICATION_JSON);
         context.contentType(contentType);
-        return content.mapMany(new ObjectToChunks(jsonb, context.charset()));
+        return content.flatMap(new ObjectToChunks(jsonb, context.charset())::map);
     }
 
     /**

--- a/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonpBodyReader.java
+++ b/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonpBodyReader.java
@@ -55,7 +55,8 @@ public final class JsonpBodyReader implements MessageBodyReader<JsonStructure> {
     public <U extends JsonStructure> Single<U> read(Publisher<DataChunk> publisher, GenericType<U> type,
             MessageBodyReaderContext context) {
 
-        return ContentReaders.readBytes(publisher).map(new BytesToJsonStructure<>(jsonFactory, type, context.charset()));
+        return ContentReaders.readBytes(publisher)
+                .map(new BytesToJsonStructure<>(jsonFactory, type, context.charset())::map);
     }
 
     private static final class BytesToJsonStructure<T extends JsonStructure> implements Mapper<byte[], T> {

--- a/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonpBodyWriter.java
+++ b/media/jsonp/common/src/main/java/io/helidon/media/jsonp/common/JsonpBodyWriter.java
@@ -54,7 +54,7 @@ public class JsonpBodyWriter implements MessageBodyWriter<JsonStructure> {
 
         MediaType contentType = context.findAccepted(MediaType.JSON_PREDICATE, MediaType.APPLICATION_JSON);
         context.contentType(contentType);
-        return content.mapMany(new JsonStructureToChunks(jsonWriterFactory, context.charset()));
+        return content.flatMap(new JsonStructureToChunks(jsonWriterFactory, context.charset())::map);
     }
 
     static final class JsonStructureToChunks implements Mapper<JsonStructure, Publisher<DataChunk>> {


### PR DESCRIPTION
Organized the methods in `Multi` and `Single` to separate static, default and terminal operators. Ordered them by name which should generally reduce conflicts when multiple distinct operators are added in the future.