### PR TITLE
Changed the default context root for Websocket endpoints

### DIFF
--- a/examples/microprofile/websocket/src/main/java/io/helidon/microprofile/example/websocket/MessageBoardEndpoint.java
+++ b/examples/microprofile/websocket/src/main/java/io/helidon/microprofile/example/websocket/MessageBoardEndpoint.java
@@ -33,7 +33,7 @@ import javax.websocket.server.ServerEndpoint;
  * Class MessageBoardEndpoint.
  */
 @ServerEndpoint(
-        value = "/board",
+        value = "/websocket",
         encoders = { MessageBoardEndpoint.UppercaseEncoder.class }
 )
 public class MessageBoardEndpoint {

--- a/examples/microprofile/websocket/src/main/java/io/helidon/microprofile/example/websocket/MessageQueueResource.java
+++ b/examples/microprofile/websocket/src/main/java/io/helidon/microprofile/example/websocket/MessageQueueResource.java
@@ -36,7 +36,6 @@ public class MessageQueueResource {
      * @param s The string.
      */
     @POST
-    @Path("board")
     @Consumes("text/plain")
     public void push(String s) {
         messageQueue.push(s);

--- a/examples/microprofile/websocket/src/test/java/io/helidon/microprofile/example/websocket/MessageBoardTest.java
+++ b/examples/microprofile/websocket/src/test/java/io/helidon/microprofile/example/websocket/MessageBoardTest.java
@@ -70,7 +70,7 @@ public class MessageBoardTest {
     @Test
     public void testBoard() throws IOException, DeploymentException, InterruptedException {
         // Post messages using REST resource
-        URI restUri = URI.create("http://localhost:" + server.port() + "/rest/board");
+        URI restUri = URI.create("http://localhost:" + server.port() + "/rest");
         for (String message : messages) {
             Response res = restClient.target(restUri).request().post(Entity.text(message));
             assertThat(res.getStatus(), is(204));
@@ -78,7 +78,7 @@ public class MessageBoardTest {
         }
 
         // Now connect to message board using WS and them back
-        URI websocketUri = URI.create("ws://localhost:" + server.port() + "/websocket/board");
+        URI websocketUri = URI.create("ws://localhost:" + server.port() + "/websocket");
         CountDownLatch messageLatch = new CountDownLatch(messages.length);
         ClientEndpointConfig config = ClientEndpointConfig.Builder.create().build();
 

--- a/microprofile/websocket/pom.xml
+++ b/microprofile/websocket/pom.xml
@@ -31,6 +31,10 @@
 
     <description>Helidon MP integration with Tyrus</description>
 
+    <properties>
+        <surefire.argLine>-Dmp.initializer.allow=true</surefire.argLine>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>

--- a/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/WebSocketCdiExtension.java
+++ b/microprofile/websocket/src/main/java/io/helidon/microprofile/tyrus/WebSocketCdiExtension.java
@@ -54,7 +54,7 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_AFTER;
 public class WebSocketCdiExtension implements Extension {
     private static final Logger LOGGER = Logger.getLogger(WebSocketCdiExtension.class.getName());
 
-    private static final String DEFAULT_WEBSOCKET_PATH = "/websocket";
+    private static final String DEFAULT_WEBSOCKET_PATH = "/";
 
     static {
         HelidonFeatures.register(HelidonFlavor.MP, "WebSocket");

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketBaseTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketBaseTest.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.logging.Logger;
 
 import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.spi.CDI;
 import javax.websocket.CloseReason;
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
@@ -32,6 +33,7 @@ import javax.websocket.OnOpen;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
+import io.helidon.microprofile.server.ServerCdiExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +42,6 @@ import org.junit.jupiter.api.Test;
  */
 public abstract class WebSocketBaseTest {
 
-    static final int DEFAULT_PORT = 7001;
     static SeContainer container;
 
     @AfterAll
@@ -50,9 +51,14 @@ public abstract class WebSocketBaseTest {
 
     public abstract String context();
 
+    public int port() {
+        ServerCdiExtension cdiExtension = CDI.current().getBeanManager().getExtension(ServerCdiExtension.class);
+        return cdiExtension.port();
+    }
+
     @Test
     public void testEchoAnnot() throws Exception {
-        URI echoUri = URI.create("ws://localhost:" + DEFAULT_PORT + context() + "/echoAnnot");
+        URI echoUri = URI.create("ws://localhost:" + port() + context() + "/echoAnnot");
         EchoClient echoClient = new EchoClient(echoUri);
         echoClient.echo("hi", "how are you?");
     }

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tyrus;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.websocket.Endpoint;
+import javax.websocket.server.ServerApplicationConfig;
+import javax.websocket.server.ServerEndpointConfig;
+
+import io.helidon.microprofile.server.RoutingPath;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A test that uses an {@code EndpointApplication} subclass annotated with
+ * {@code @RoutingPath} to register Websocket endpoints. The context for
+ * Websocket endpoints is defined by the value of {@code @RoutingPath}.
+ */
+public class WebSocketEndpointAppTest extends WebSocketBaseTest {
+
+    @BeforeAll
+    static void initClass() {
+        container = SeContainerInitializer.newInstance()
+                .addBeanClasses(EndpointApplication.class)
+                .initialize();
+    }
+
+    @Override
+    public String context() {
+        return "/web";
+    }
+
+    @Test
+    public void testEchoProg() throws Exception {
+        URI echoUri = URI.create("ws://localhost:" + DEFAULT_PORT + context() + "/echoProg");
+        EchoClient echoClient = new EchoClient(echoUri);
+        echoClient.echo("hi", "how are you?");
+    }
+
+    @Dependent
+    @RoutingPath("/web")
+    public static class EndpointApplication implements ServerApplicationConfig {
+        @Override
+        public Set<ServerEndpointConfig> getEndpointConfigs(Set<Class<? extends Endpoint>> endpoints) {
+            ServerEndpointConfig.Builder builder = ServerEndpointConfig.Builder.create(
+                    EchoEndpointProg.class, "/echoProg");
+            return Collections.singleton(builder.build());
+        }
+
+        @Override
+        public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> endpoints) {
+            return Collections.singleton(EchoEndpointAnnot.class);
+        }
+    }
+}

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointAppTest.java
@@ -22,12 +22,14 @@ import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.CDI;
 import javax.websocket.Endpoint;
 import javax.websocket.server.ServerApplicationConfig;
 import javax.websocket.server.ServerEndpointConfig;
 
 import io.helidon.microprofile.server.RoutingPath;
 
+import io.helidon.microprofile.server.ServerCdiExtension;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +54,7 @@ public class WebSocketEndpointAppTest extends WebSocketBaseTest {
 
     @Test
     public void testEchoProg() throws Exception {
-        URI echoUri = URI.create("ws://localhost:" + DEFAULT_PORT + context() + "/echoProg");
+        URI echoUri = URI.create("ws://localhost:" + port() + context() + "/echoProg");
         EchoClient echoClient = new EchoClient(echoUri);
         echoClient.echo("hi", "how are you?");
     }

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketEndpointTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tyrus;
+
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * A test that registers a single annotated endpoint on the default WebSocket
+ * context. See {@code WebSocketCdiExtension#DEFAULT_WEBSOCKET_PATH}.
+ */
+public class WebSocketEndpointTest extends WebSocketBaseTest {
+
+    @BeforeAll
+    static void initClass() {
+        container = SeContainerInitializer.newInstance()
+                .addBeanClasses(EchoEndpointAnnot.class)
+                .initialize();
+    }
+
+    @Override
+    public String context() {
+        return "";
+    }
+}

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
@@ -32,7 +32,8 @@ import static javax.ws.rs.client.Entity.text;
 import static org.hamcrest.CoreMatchers.is;
 
 /**
- *
+ * A test that mixes Websocket endpoints and REST resources in the same
+ * application.
  */
 public class WebSocketRestEndpointTest extends WebSocketBaseTest {
 

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tyrus;
+
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static javax.ws.rs.client.Entity.text;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ *
+ */
+public class WebSocketRestEndpointTest extends WebSocketBaseTest {
+
+    private static Client client;
+
+    @BeforeAll
+    static void initClass() {
+        client = ClientBuilder.newClient();
+        container = SeContainerInitializer.newInstance()
+                .addBeanClasses(EchoEndpointAnnot.class, EchoResource.class)
+                .initialize();
+    }
+
+    @Override
+    public String context() {
+        return "";
+    }
+
+    @Test
+    public void testEchoRest() {
+        String echo = client.target("http://localhost:" + DEFAULT_PORT + "/echoRest")
+                .request("text/plain")
+                .post(text("echo"), String.class);
+        MatcherAssert.assertThat(echo, is("echo"));
+    }
+
+    @Path("/echoRest")
+    public static class EchoResource {
+        @POST
+        @Produces("text/plain")
+        @Consumes("text/plain")
+        public String echo(String s) {
+            return s;
+        }
+    }
+}

--- a/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
+++ b/microprofile/websocket/src/test/java/io/helidon/microprofile/tyrus/WebSocketRestEndpointTest.java
@@ -54,7 +54,7 @@ public class WebSocketRestEndpointTest extends WebSocketBaseTest {
 
     @Test
     public void testEchoRest() {
-        String echo = client.target("http://localhost:" + DEFAULT_PORT + "/echoRest")
+        String echo = client.target("http://localhost:" + port() + "/echoRest")
                 .request("text/plain")
                 .post(text("echo"), String.class);
         MatcherAssert.assertThat(echo, is("echo"));

--- a/microprofile/websocket/src/test/resources/META-INF/beans.xml
+++ b/microprofile/websocket/src/test/resources/META-INF/beans.xml
@@ -22,5 +22,5 @@
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
                            http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
        version="2.0"
-       bean-discovery-mode="annotated">
+       bean-discovery-mode="none">
 </beans>


### PR DESCRIPTION
Changed the default context root for Websocket endpoints to be "/", just like for REST. Improved testing of endpoints with and without using the default context root. One additional test that mixes REST resources and Websocket endpoints in same application.