### PR TITLE
Fix for #1618, Unable to initialize gRPC service when using helidon-m…

### DIFF
--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,17 @@ public class GrpcMetrics
     }
 
     /**
+     * Set the display name to apply to the metric.
+     *
+     * @param displayName the display name to apply to the metric
+     * @return a {@link io.helidon.grpc.metrics.GrpcMetrics} interceptor
+     * @see org.eclipse.microprofile.metrics.Metadata
+     */
+    public GrpcMetrics displayName(String displayName) {
+        return new GrpcMetrics(metricRule.displayName(displayName));
+    }
+
+    /**
      * Set the units to apply to the metric.
      *
      * @param units the units to apply to the metric
@@ -129,6 +140,16 @@ public class GrpcMetrics
      */
     public GrpcMetrics units(String units) {
         return new GrpcMetrics(metricRule.units(units));
+    }
+
+    /**
+     * Set the reusability of the metric.
+     * @param reusable {@code true} if this metric may be reused
+     * @return a {@link io.helidon.grpc.metrics.GrpcMetrics} interceptor
+     * @see org.eclipse.microprofile.metrics.Metadata
+     */
+    public GrpcMetrics reusable(boolean reusable) {
+        return new GrpcMetrics(metricRule.reusable(reusable));
     }
 
     /**
@@ -436,12 +457,25 @@ public class GrpcMetrics
         private Optional<String> description = Optional.empty();
 
         /**
+         * The display name of the metric.
+         *
+         * @see org.eclipse.microprofile.metrics.Metadata
+         */
+        private String displayName;
+
+        /**
          * The unit of the metric.
          *
          * @see org.eclipse.microprofile.metrics.Metadata
          * @see org.eclipse.microprofile.metrics.MetricUnits
          */
         private Optional<String> units = Optional.empty();
+
+        /**
+         * The reusability status of this metric.
+         * @see org.eclipse.microprofile.metrics.Metadata
+         */
+        private boolean reusable = false;
 
         /**
          * The function to use to obtain the metric name.
@@ -456,8 +490,10 @@ public class GrpcMetrics
             this.type = copy.type;
             this.tags = copy.tags;
             this.description = copy.description;
+            this.displayName = copy.displayName;
             this.units = copy.units;
             this.nameFunction = copy.nameFunction;
+            this.reusable = copy.reusable;
         }
 
         /**
@@ -478,10 +514,17 @@ public class GrpcMetrics
          */
         io.helidon.common.metrics.InternalBridge.Metadata metadata(ServiceDescriptor service, String method) {
             String name = nameFunction.orElse(this::defaultName).createName(service, method, type);
-            MetadataBuilder builder = InternalBridge.newMetadataBuilder().withName(name).withType(type);
+            MetadataBuilder builder = InternalBridge.newMetadataBuilder()
+                    .withName(name).withType(type);
 
             this.description.ifPresent(builder::withDescription);
             this.units.ifPresent(builder::withUnit);
+
+            String displayName = this.displayName;
+            builder.withDisplayName(displayName == null ? name : displayName);
+
+            builder = this.reusable
+                    ? builder.reusable() : builder.notReusable();
 
             return builder.build();
         }
@@ -502,6 +545,12 @@ public class GrpcMetrics
             return rules;
         }
 
+        private MetricsRules displayName(String displayName) {
+            MetricsRules rules = new MetricsRules(this);
+            rules.displayName = displayName;
+            return rules;
+        }
+
         private MetricsRules nameFunction(NamingFunction function) {
             MetricsRules rules = new MetricsRules(this);
             rules.nameFunction = Optional.of(function);
@@ -511,6 +560,12 @@ public class GrpcMetrics
         private MetricsRules units(String units) {
             MetricsRules rules = new MetricsRules(this);
             rules.units = Optional.of(units);
+            return rules;
+        }
+
+        private MetricsRules reusable(boolean reusable) {
+            MetricsRules rules = new MetricsRules(this);
+            rules.reusable = reusable;
             return rules;
         }
 

--- a/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics2/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,20 +97,24 @@ public class MetricsCdiExtension implements Extension {
 
         if (annotation instanceof Counted) {
             Counted counted = (Counted) annotation;
-            String metricName = getMetricName(element, clazz, lookupResult.getType(), counted.name(), counted.absolute());
+            String metricName = getMetricName(element, clazz, lookupResult.getType(), counted.name().trim(),
+                    counted.absolute());
+            String displayName = counted.displayName().trim();
             Metadata meta = new HelidonMetadata(metricName,
-                                         counted.displayName(),
-                                         counted.description(),
+                                         displayName.isEmpty() ? metricName : displayName,
+                                         counted.description().trim(),
                                          MetricType.COUNTER,
-                                         counted.unit(),
+                                         counted.unit().trim(),
                                          counted.reusable());
             registry.counter(meta, tags(counted.tags()));
             LOGGER.log(Level.FINE, () -> "Registered counter " + metricName);
         } else if (annotation instanceof Metered) {
             Metered metered = (Metered) annotation;
-            String metricName = getMetricName(element, clazz, lookupResult.getType(), metered.name(), metered.absolute());
+            String metricName = getMetricName(element, clazz, lookupResult.getType(), metered.name().trim(),
+                    metered.absolute());
+            String displayName = metered.displayName().trim();
             Metadata meta = new HelidonMetadata(metricName,
-                                         metered.displayName(),
+                                         displayName.isEmpty() ? metricName : displayName,
                                          metered.description(),
                                          MetricType.METERED,
                                          metered.unit(),
@@ -119,9 +123,11 @@ public class MetricsCdiExtension implements Extension {
             LOGGER.log(Level.FINE, () -> "Registered meter " + metricName);
         } else if (annotation instanceof Timed) {
             Timed timed = (Timed) annotation;
-            String metricName = getMetricName(element, clazz, lookupResult.getType(), timed.name(), timed.absolute());
+            String metricName = getMetricName(element, clazz, lookupResult.getType(), timed.name().trim(),
+                    timed.absolute());
+            String displayName = timed.displayName().trim();
             Metadata meta = new HelidonMetadata(metricName,
-                                         timed.displayName(),
+                                         displayName.isEmpty() ? metricName : displayName,
                                          timed.description(),
                                          MetricType.TIMER,
                                          timed.unit(),
@@ -130,16 +136,29 @@ public class MetricsCdiExtension implements Extension {
             LOGGER.log(Level.FINE, () -> "Registered timer " + metricName);
         } else if (annotation instanceof ConcurrentGauge) {
             ConcurrentGauge concurrentGauge = (ConcurrentGauge) annotation;
-            String metricName = getMetricName(element, clazz, lookupResult.getType(), concurrentGauge.name(),
+            String metricName = getMetricName(element, clazz, lookupResult.getType(), concurrentGauge.name().trim(),
                     concurrentGauge.absolute());
+            String displayName = concurrentGauge.displayName().trim();
             Metadata meta = new HelidonMetadata(metricName,
-                    concurrentGauge.displayName(),
-                    concurrentGauge.description(),
+                    displayName.isEmpty() ? metricName : displayName,
+                    concurrentGauge.description().trim(),
                     MetricType.CONCURRENT_GAUGE,
                     concurrentGauge.unit(),
                     concurrentGauge.reusable());
             registry.concurrentGauge(meta, tags(concurrentGauge.tags()));
             LOGGER.log(Level.FINE, () -> "Registered concurrent gauge " + metricName);
+        } else if (annotation instanceof Gauge) {
+            Gauge gauge = (Gauge) annotation;
+            String metricName = getMetricName(element, clazz, lookupResult.getType(), gauge.name().trim(),
+                    gauge.absolute());
+            String displayName = gauge.displayName().trim();
+            Metadata meta = new HelidonMetadata(metricName,
+                    displayName.isEmpty() ? metricName : displayName,
+                    gauge.description(),
+                    MetricType.CONCURRENT_GAUGE,
+                    gauge.unit());
+            registry.concurrentGauge(meta, tags(gauge.tags()));
+            LOGGER.log(Level.FINE, () -> "Registered gauge " + metricName);
         }
     }
 


### PR DESCRIPTION
Summary of changes:

- Add methods grpc `MetricsConfigurer` relies on to resolve the `IllegalAccesException`
- Ensure metric metadata is generated consistently; grpc code was generating metadata differently from the metric2 cdi bootstrap.  This caused issues at runtime due to mismatched metadata.
