### PR TITLE
Fixed static content handling bug 1.x

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/DataChunk.java
+++ b/common/http/src/main/java/io/helidon/common/http/DataChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,7 +235,8 @@ public interface DataChunk {
      */
     default DataChunk duplicate() {
         byte[] bytes = new byte[data().limit()];
-        DataChunk dup = DataChunk.create(data().get(bytes));
+        data().get(bytes);
+        DataChunk dup = DataChunk.create(bytes);
         dup.data().position(0);
         return dup;
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,13 +77,16 @@ class FileSystemContentHandler extends StaticContentHandler {
     }
 
     static void sendFile(Http.RequestMethod method,
-                         Path path,
+                         Path pathParam,
                          ServerRequest request,
                          ServerResponse response,
                          ContentTypeSelector contentTypeSelector,
                          String welcomePage)
             throws IOException {
 
+        LOGGER.fine(() -> "Sending static content from file: " + pathParam);
+
+        Path path = pathParam;
         // we know the file exists, though it may be a directory
         //First doHandle a directory case
         if (Files.isDirectory(path)) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import java.time.Instant;
 import java.time.chrono.ChronoZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
@@ -31,6 +33,7 @@ import io.helidon.common.http.MediaType;
  * Request {@link Handler} processing a static content.
  */
 abstract class StaticContentHandler {
+    private static final Logger LOGGER = Logger.getLogger(StaticContentHandler.class.getName());
 
     private final String welcomeFilename;
     private final ContentTypeSelector contentTypeSelector;
@@ -84,6 +87,7 @@ abstract class StaticContentHandler {
                 throw httpException;
             }
         } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Failed to access static resource", e);
             throw new HttpException("Cannot access static resource!", Http.Status.INTERNAL_SERVER_ERROR_500, e);
         }
     }


### PR DESCRIPTION
DataChunk duplicate method was incorrectly sharing ByteBuffer.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>