### PR TITLE
Update to jakarta GAV for CORS MP

### DIFF
--- a/microprofile/cors/pom.xml
+++ b/microprofile/cors/pom.xml
@@ -32,8 +32,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
A concurrent change made a change from java to jakarta necessary. (Should have been changed anyway.)