### PR TITLE
Unbundle MP CORS from MP bundle; bolster utility method

### DIFF
--- a/microprofile/bundles/helidon-microprofile/pom.xml
+++ b/microprofile/bundles/helidon-microprofile/pom.xml
@@ -75,10 +75,6 @@
             <artifactId>helidon-microprofile-tracing</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.microprofile</groupId>
-            <artifactId>helidon-microprofile-cors</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-binding</artifactId>
             <scope>runtime</scope>

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -77,6 +77,9 @@ class CorsSupportHelper {
      */
     public static String normalize(String path) {
         int length = path.length();
+        if (length == 0) {
+            return path;
+        }
         int beginIndex = path.charAt(0) == '/' ? 1 : 0;
         int endIndex = path.charAt(length - 1) == '/' ? length - 1 : length;
         return (endIndex <= beginIndex) ? "" : path.substring(beginIndex, endIndex);

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/TestUtilityMethods.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/TestUtilityMethods.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.webserver.cors;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.webserver.cors.CorsSupportHelper.normalize;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+
+public class TestUtilityMethods {
+
+    @Test
+    public void testNormalize() {
+        assertThat(normalize("something"), is("something"));
+        assertThat(normalize("/something"), is("something"));
+        assertThat(normalize("something/"), is("something"));
+        assertThat(normalize("/something/"), is("something"));
+        assertThat(normalize("/"), isEmptyString());
+        assertThat(normalize(""), isEmptyString());
+    }
+}


### PR DESCRIPTION
Resolves #1671 

Remove the MP CORS module from the MP bundle.

Guard against empty path passed to `normalize()` utility method.