### PR TITLE
Avoid setting response headers twice

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -311,12 +311,6 @@ class CorsSupportHelper {
             case CORS:
                 Optional<U> corsResponse = processCORSRequest(crossOrigin, requestAdapter,
                         responseAdapter);
-                if (corsResponse.isEmpty()) {
-                    /*
-                     * There has been no rejection of the CORS settings, so prep the response headers.
-                     */
-                    addCORSHeadersToResponse(crossOrigin, requestAdapter, responseAdapter);
-                }
                 return corsResponse;
 
             default:

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CorsTest.java
@@ -91,5 +91,6 @@ public class CorsTest extends AbstractCorsTest {
         assertThat(res.headers().first(ACCESS_CONTROL_ALLOW_METHODS), present(is("PUT")));
         assertThat(res.headers().first(ACCESS_CONTROL_ALLOW_HEADERS), notPresent());
         assertThat(res.headers().first(ACCESS_CONTROL_MAX_AGE), present(is("3600")));
+        assertThat(res.headers().all(ACCESS_CONTROL_ALLOW_ORIGIN).size(), is(1));
     }
 }


### PR DESCRIPTION
Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>

Resolves #1678 

