### PR TITLE
Fix isActive computation

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
@@ -78,12 +78,13 @@ class Aggregator implements CorsSetter<Aggregator> {
 
     /**
      * Reports whether the sources of CORS information have left CORS enabled or not. If there has been an explicit setting,
-     * use the most recent. Otherwise
+     * use the most recent. If no {@code CrossOriginConfig} instances were ever added -- either explicitly or using config --
+     * then the aggregator will never find a match among the matchables so it is as good as inactive.
      *
      * @return if CORS processing should be done
      */
     public boolean isEnabled() {
-        return isEnabled;
+        return isEnabled && !crossOriginConfigMatchables.isEmpty();
     }
 
     /**

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -139,7 +139,7 @@ public abstract class CorsSupportBase implements Service, Handler {
          * @return the updated builder
          */
         public B config(Config config) {
-            aggregator.mappedConfig(config);
+            helperBuilder.config(config);
             return me();
         }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -235,12 +235,12 @@ class CorsSupportHelper {
     }
 
     /**
-     * Reports whether this helper, due to its set-up, will affect any requests or responses.
+     * Reports whether this helper, due to its set-up, will have a chance of affecting any requests or responses.
      *
-     * @return whether the helper will have any effect on requests or responses
+     * @return whether the helper might have any effect on requests or responses
      */
     public boolean isActive() {
-        return aggregator.isEnabled();
+        return aggregator.isEnabled() || (secondaryCrossOriginLookup != EMPTY_SECONDARY_SUPPLIER);
     }
 
     /**
@@ -269,7 +269,7 @@ class CorsSupportHelper {
     public <T, U> Optional<U> processRequest(RequestAdapter<T> requestAdapter, ResponseAdapter<U> responseAdapter) {
 
         if (!isActive()) {
-            LOGGER.log(DECISION_LEVEL, () -> String.format("CORS ignoring request %s; processing is disabled", requestAdapter));
+            LOGGER.log(DECISION_LEVEL, () -> String.format("CORS ignoring request %s; processing is inactive", requestAdapter));
             requestAdapter.next();
             return Optional.empty();
         }
@@ -330,7 +330,8 @@ class CorsSupportHelper {
 
         if (!isActive()) {
             LOGGER.log(DECISION_LEVEL,
-                    () -> String.format("CORS ignoring request %s; CORS processing is dieabled", requestAdapter));
+                    () -> String.format("CORS not preparing response to request %s; CORS processing is dieabled",
+                            requestAdapter));
             return;
         }
 


### PR DESCRIPTION
Resolves #1681 

Improves the calculation of `isActive` to reflect:
-  whether there are `CrossOriginConfig` instances in the aggregator, and
-  whether a secondary source has been set up for the `CorsSupportHelper`.