### PR TITLE
CORS processing should only be enabled on successful responses

### DIFF
--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsSupportMp.java
@@ -56,7 +56,7 @@ class CorsSupportMp extends CorsSupportBase {
      */
     @Override
     protected <T, U> Optional<U> processRequest(RequestAdapter<T> requestAdapter,
-            ResponseAdapter<U> responseAdapter) {
+                                                ResponseAdapter<U> responseAdapter) {
         return super.processRequest(requestAdapter, responseAdapter);
     }
 
@@ -142,14 +142,17 @@ class CorsSupportMp extends CorsSupportBase {
 
     static class ResponseAdapterMp implements ResponseAdapter<Response> {
 
+        private final int status;
         private final MultivaluedMap<String, Object> headers;
 
         ResponseAdapterMp(ContainerResponseContext responseContext) {
             headers = responseContext.getHeaders();
+            status = responseContext.getStatus();
         }
 
         ResponseAdapterMp() {
             headers = new MultivaluedHashMap<>();
+            status = Response.Status.OK.getStatusCode();
         }
 
         @Override
@@ -179,6 +182,11 @@ class CorsSupportMp extends CorsSupportBase {
              */
             builder.replaceAll(headers);
             return builder.build();
+        }
+
+        @Override
+        public int status() {
+            return status;
         }
     }
 }

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -86,6 +86,11 @@ class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilt
         Method resourceMethod = resourceInfo.getResourceMethod();
         Class<?> resourceClass = resourceInfo.getResourceClass();
 
+        // Not available if matching failed and error response is returned
+        if (resourceClass == null || resourceMethod == null) {
+            return Optional.empty();
+        }
+
         CrossOrigin corsAnnot;
         OPTIONS optsAnnot = resourceMethod.getAnnotation(OPTIONS.class);
         Path pathAnnot = resourceMethod.getAnnotation(Path.class);

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import java.util.Set;
 
 import io.helidon.microprofile.server.Server;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,6 @@ import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_O
 import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_MAX_AGE;
 import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_REQUEST_HEADERS;
 import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_REQUEST_METHOD;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -343,5 +341,16 @@ public class CrossOriginTest {
                 .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
         assertThat(res.getStatusInfo(), is(Response.Status.OK));
         assertThat(res.getHeaders().getFirst(ACCESS_CONTROL_ALLOW_ORIGIN), is("http://foo.bar"));
+    }
+
+    @Test
+    void testErrorResponse() {
+        Response res = target.path("/app/notfound")
+                .request()
+                .header(ORIGIN, "http://foo.bar")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
+                .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
+        assertThat(res.getStatusInfo(), is(Response.Status.NOT_FOUND));
+        assertThat(res.getHeaders().containsKey(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
     }
 }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -333,5 +333,12 @@ public abstract class CorsSupportBase implements Service, Handler {
          * @return response instance
          */
         T ok();
+
+        /**
+         * Returns the status of the response.
+         *
+         * @return HTTP status code.
+         */
+        int status();
     }
 }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -60,6 +60,7 @@ import static io.helidon.webserver.cors.LogHelper.DECISION_LEVEL;
  */
 class CorsSupportHelper {
 
+    static final int SUCCESS_RANGE = 300;
     static final String ORIGIN_DENIED = "CORS origin is denied";
     static final String ORIGIN_NOT_IN_ALLOWED_LIST = "CORS origin is not in allowed list";
     static final String METHOD_NOT_IN_ALLOWED_LIST = "CORS method is not in allowed list";
@@ -333,10 +334,16 @@ class CorsSupportHelper {
      * @param <U> the type for the HTTP response as returned from the responseSetter
      */
     public <T, U> void prepareResponse(RequestAdapter<T> requestAdapter, ResponseAdapter<U> responseAdapter) {
-
         if (!isActive()) {
             LOGGER.log(DECISION_LEVEL,
-                    () -> String.format("CORS ignoring request %s; CORS processing is dieabled", requestAdapter));
+                    () -> String.format("CORS ignoring request %s; CORS processing is disabled", requestAdapter));
+            return;
+        }
+
+        // If not a successful response, skip CORS processing for response
+        if (responseAdapter.status() >= SUCCESS_RANGE) {
+            LOGGER.log(DECISION_LEVEL,
+                    () -> String.format("CORS ignoring response of status code %d", responseAdapter.status()));
             return;
         }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/ResponseAdapterSe.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/ResponseAdapterSe.java
@@ -53,4 +53,9 @@ class ResponseAdapterSe implements CorsSupportBase.ResponseAdapter<ServerRespons
         serverResponse.status(Http.Status.OK_200.code());
         return serverResponse;
     }
+
+    @Override
+    public int status() {
+        return serverResponse.status().code();
+    }
 }


### PR DESCRIPTION
CORS processing should only be enabled on successful responses. Fixes a problem with a 404 response that resulted in an NPE. Some new tests.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>