### PR TITLE
[Reactive] Verify flatMap doesn't reorder items from the same source

### DIFF
--- a/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TestSubscriber.java
@@ -83,6 +83,12 @@ class TestSubscriber<T> implements Flow.Subscriber<T> {
         if (upstream.get() == null) {
             errors.add(new IllegalStateException("onSubscribe not called before onNext!"));
         }
+        if (!errors.isEmpty()) {
+            errors.add(new IllegalStateException("onNext called after onError!"));
+        }
+        if (completions != 0) {
+            errors.add(new IllegalStateException("onNext called after onComplete!"));
+        }
         items.add(item);
     }
 


### PR DESCRIPTION
- Added an unit test that verifies `flatMap` doesn't reorder items from the same source.
- Expanded the signal verification of `TestSubscriber` to check for `onNext` after terminal events.