### PR TITLE
Improved testing for DataChunkInputStream

### DIFF
--- a/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
@@ -18,14 +18,24 @@ package io.helidon.media.common;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.http.DataChunk;
+import io.helidon.common.reactive.Multi;
+import io.helidon.common.reactive.OriginThreadPublisher;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests {@link DataChunkInputStream}.
@@ -33,9 +43,43 @@ import org.junit.jupiter.api.Test;
 public class DataChunkInputStreamTest {
 
     @Test
+    public void differentThreadWithError() throws Exception {
+        List<String> test_data = List.of("test0", "test1", "test2", "test3");
+        List<String> result = new ArrayList<>();
+        OriginThreadPublisher<String, String> pub = new OriginThreadPublisher<>() {
+        };
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        Future<?> submitFuture = executorService.submit(() -> {
+            for (int i = 0; i < test_data.size(); i++) {
+                pub.submit(test_data.get(i));
+                sleep();
+            }
+            pub.complete();
+        });
+        Future<?> receiveFuture = executorService.submit(() -> {
+            DataChunkInputStream chunkInputStream = new DataChunkInputStream(Multi.from(pub)
+                    .map(s -> DataChunk.create(s.getBytes())));
+            for (int i = 0; i < test_data.size(); i++) {
+                try {
+                    String token = new String(chunkInputStream.readNBytes(test_data.get(0).length()));
+                    System.out.println(">>> " + token);
+                    result.add(token);
+                } catch (IOException e) {
+                    fail(e);
+                }
+            }
+        });
+
+        submitFuture.get(500, TimeUnit.MILLISECONDS);
+        receiveFuture.get(500, TimeUnit.MILLISECONDS);
+        assertEquals(test_data, result);
+    }
+
+    @Test
     public void chunkWith0xFFValue() {
         final byte[] bytes = new byte[]{
-            0, 1, 2, 3, 4, 5, 6, (byte) 0xFF, 7, 8, 9, 10
+                0, 1, 2, 3, 4, 5, 6, (byte) 0xFF, 7, 8, 9, 10
         };
         InputStream is = new DataChunkInputStream(
                 new DataChunkPublisher(
@@ -44,18 +88,18 @@ public class DataChunkInputStreamTest {
             byte[] readBytes = new byte[bytes.length];
             is.read(readBytes);
             if (!Arrays.equals(bytes, readBytes)) {
-                Assertions.fail("expected: " + Arrays.toString(bytes)
+                fail("expected: " + Arrays.toString(bytes)
                         + ", actual: " + Arrays.toString(readBytes));
             }
         } catch (IOException ex) {
-            Assertions.fail(ex);
+            fail(ex);
         }
     }
 
     static class DataChunkPublisher implements Publisher<DataChunk> {
 
         private final DataChunk[] chunks;
-        private volatile int delivered = 0;
+        private int delivered = 0;
 
         public DataChunkPublisher(DataChunk[] chunks) {
             this.chunks = chunks;
@@ -66,20 +110,25 @@ public class DataChunkInputStreamTest {
             subscriber.onSubscribe(new Flow.Subscription() {
                 @Override
                 public void request(long n) {
-                    if(n > 0){
-                        for(; delivered < n && delivered < chunks.length ; delivered ++){
-                            subscriber.onNext(chunks[delivered]);
-                        }
-                        if(delivered == chunks.length){
-                            subscriber.onComplete();
-                        }
+                    for (; n > 0 && delivered < chunks.length; delivered++, n--) {
+                        subscriber.onNext(chunks[delivered]);
+                    }
+                    if (delivered == chunks.length) {
+                        subscriber.onComplete();
                     }
                 }
-
                 @Override
                 public void cancel() {
                 }
             });
+        }
+    }
+
+    static void sleep() {
+        try {
+            Thread.sleep(20);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
+++ b/media/common/src/test/java/io/helidon/media/common/DataChunkInputStreamTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class DataChunkInputStreamTest {
 
     @Test
-    public void differentThreadWithError() throws Exception {
+    public void differentThreads() throws Exception {
         List<String> test_data = List.of("test0", "test1", "test2", "test3");
         List<String> result = new ArrayList<>();
         OriginThreadPublisher<String, String> pub = new OriginThreadPublisher<>() {


### PR DESCRIPTION
New test that uses the `OriginThreadPublisher` to test the `DataChunkInputStream`. 

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>