### PR TITLE
Make clear which methods expect mapped vs. lower-level CORS config nodes

### DIFF
--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -64,7 +64,9 @@ class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilt
     CrossOriginFilter() {
         Config config = (Config) ConfigProvider.getConfig();
 
-        cors = CorsSupportMp.builder().mappedConfig(config.get(CORS_CONFIG_KEY))
+        CorsSupportMp.Builder corsBuilder = CorsSupportMp.builder();
+        config.get(CORS_CONFIG_KEY).ifExists(corsBuilder::mappedConfig);
+        cors = corsBuilder
                 .secondaryLookupSupplier(this::crossOriginFromAnnotationSupplier)
                 .build();
     }

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -64,7 +64,7 @@ class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilt
     CrossOriginFilter() {
         Config config = (Config) ConfigProvider.getConfig();
 
-        cors = CorsSupportMp.builder().config(config.get(CORS_CONFIG_KEY))
+        cors = CorsSupportMp.builder().mappedConfig(config.get(CORS_CONFIG_KEY))
                 .secondaryLookupSupplier(this::crossOriginFromAnnotationSupplier)
                 .build();
     }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
@@ -92,10 +92,21 @@ class Aggregator implements CorsSetter<Aggregator> {
         return isEnabled && !crossOriginConfigMatchables.isEmpty();
     }
 
+    Aggregator config(Config config) {
+        if (config.exists()) {
+            ConfigValue<CrossOriginConfig.Builder> configValue = config.as(CrossOriginConfig::builder);
+            if (configValue.isPresent()) {
+                CrossOriginConfig crossOriginConfig = configValue.get().build();
+                addPathlessCrossOrigin(crossOriginConfig);
+            }
+        }
+        return this;
+    }
+
     /**
-     * Add cross-origin information from a {@link Config} node.
+     * Add mapped cross-origin information from a {@link Config} node.
      *
-     * @param config {@code Config} node containing
+     * @param config {@code Config} node containing mapped {@code CrossOriginConfig} data
      * @return updated builder
      */
     Aggregator mappedConfig(Config config) {

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupport.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupport.java
@@ -26,8 +26,6 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
-import static io.helidon.webserver.cors.Aggregator.PATHLESS_KEY;
-
 /**
  * SE implementation of {@link CorsSupportBase}.
  */
@@ -93,8 +91,21 @@ public class CorsSupport extends CorsSupportBase<ServerRequest, ServerResponse, 
         if (!config.exists()) {
             throw MissingValueException.create(config.key());
         }
-        Builder builder = builder().addCrossOrigin(PATHLESS_KEY, CrossOriginConfig.builder(config).build());
-        return builder.build();
+        return builder().config(config).build();
+    }
+
+    /**
+     * Creates a new {@code CorsSupport} instance based on the provided configuration expected to contain mapped cross-origin
+     * config information.
+     *
+     * @param config node containing the mapped cross-origin information
+     * @return initialized {@code CorsSupport} instance
+     */
+    public static CorsSupport createMapped(Config config) {
+        if (!config.exists()) {
+            throw MissingValueException.create(config.key());
+        }
+        return builder().mappedConfig(config).build();
     }
 
     @Override

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -132,6 +132,18 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
         }
 
         /**
+         * Merges mapped CORS config information. Typically, the app or component will retrieve the provided {@code Config}
+         * instance from its own config.
+         *
+         * @param config the mapped CORS config information
+         * @return the updated builder
+         */
+        public B mappedConfig(Config config) {
+            helperBuilder.mappedConfig(config);
+            return me();
+        }
+
+        /**
          * Sets whether CORS support should be enabled or not.
          *
          * @param value whether to use CORS support

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -151,16 +151,6 @@ class CorsSupportHelper<Q, R> {
     }
 
     /**
-     * Creates a new instance using CORS config in the provided {@link Config}.
-     *
-     * @param config Config node containing CORS set-up
-     * @return new instance based on the config
-     */
-    public static <Q, R> CorsSupportHelper<Q, R> create(Config config) {
-        return CorsSupportHelper.<Q, R>builder().config(config).build();
-    }
-
-    /**
      * Creates a new instance that is enabled but with no path mappings.
      *
      * @return the new instance
@@ -219,6 +209,17 @@ class CorsSupportHelper<Q, R> {
          * @return updated builder
          */
         public Builder<Q, R> config(Config config) {
+            aggregator.config(config);
+            return this;
+        }
+
+        /**
+         * Adds mapped cross-origin information via config.
+         *
+         * @param config config node containing mapped CORS set-up information
+         * @return updated builder
+         */
+        public Builder<Q, R> mappedConfig(Config config) {
             aggregator.mappedConfig(config);
             return this;
         }


### PR DESCRIPTION
Resolves #1699

Add `createMapped` method to `CorsSupport` and `mappedConfig` to its builder to make explicit what is expected in the provided `Config` parameter.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>