### PR TITLE
Fix so we pick up 19.3.1 version of graalvm docker image. Pick up new…

### DIFF
--- a/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk8-graalvm-maven
@@ -23,14 +23,14 @@ RUN set -x \
     && apt-get -y install curl unzip
 
 RUN set -x && \
-    curl -O https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.zip && \
+    curl -O https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip && \
     unzip apache-maven-*-bin.zip && \
     rm apache-maven-*-bin.zip && \
     mv apache-maven-* maven
 
 RUN echo "done!"
 
-FROM helidon/jdk8-graalvm:19.2.0
+FROM helidon/jdk8-graalvm:19.3.1
 
 COPY --from=build /build/maven /usr/share/maven
 RUN ln -s /usr/share/maven/bin/mvn /bin/


### PR DESCRIPTION
…er version of maven (3.6.3)