### PR TITLE
Improve handling of missing config nodes used to init CORS objects

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
@@ -93,13 +93,14 @@ class Aggregator implements CorsSetter<Aggregator> {
     }
 
     Aggregator config(Config config) {
+        CrossOriginConfig crossOriginConfigToAdd = null;
         if (config.exists()) {
             ConfigValue<CrossOriginConfig.Builder> configValue = config.as(CrossOriginConfig::builder);
             if (configValue.isPresent()) {
-                CrossOriginConfig crossOriginConfig = configValue.get().build();
-                addPathlessCrossOrigin(crossOriginConfig);
+                 crossOriginConfigToAdd = configValue.get().build();
             }
         }
+        addPathlessCrossOrigin(crossOriginConfigToAdd != null ? crossOriginConfigToAdd : CrossOriginConfig.builder().build());
         return this;
     }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupport.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupport.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.cors;
 import java.util.Optional;
 
 import io.helidon.config.Config;
-import io.helidon.config.MissingValueException;
 import io.helidon.webserver.Handler;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
@@ -88,9 +87,6 @@ public class CorsSupport extends CorsSupportBase<ServerRequest, ServerResponse, 
      * @return initialized {@code CorsSupport} instance
      */
     public static CorsSupport create(Config config) {
-        if (!config.exists()) {
-            throw MissingValueException.create(config.key());
-        }
         return builder().config(config).build();
     }
 
@@ -102,9 +98,6 @@ public class CorsSupport extends CorsSupportBase<ServerRequest, ServerResponse, 
      * @return initialized {@code CorsSupport} instance
      */
     public static CorsSupport createMapped(Config config) {
-        if (!config.exists()) {
-            throw MissingValueException.create(config.key());
-        }
         return builder().mappedConfig(config).build();
     }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportBase.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import io.helidon.config.Config;
 
@@ -51,6 +53,8 @@ import io.helidon.config.Config;
  */
 public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B>,
         B extends CorsSupportBase.Builder<Q, R, T, B>> {
+
+    private static final Logger LOGGER = Logger.getLogger(CorsSupportBase.class.getName());
 
     private final String name;
     private final CorsSupportHelper<Q, R> helper;
@@ -127,6 +131,7 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
          * @return the updated builder
          */
         public B config(Config config) {
+            reportUseOfMissingConfig(config);
             helperBuilder.config(config);
             return me();
         }
@@ -139,6 +144,7 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
          * @return the updated builder
          */
         public B mappedConfig(Config config) {
+            reportUseOfMissingConfig(config);
             helperBuilder.mappedConfig(config);
             return me();
         }
@@ -236,6 +242,15 @@ public abstract class CorsSupportBase<Q, R, T extends CorsSupportBase<Q, R, T, B
         protected Builder<Q, R, T, B> secondaryLookupSupplier(Supplier<Optional<CrossOriginConfig>> secondaryLookupSupplier) {
             helperBuilder.secondaryLookupSupplier(secondaryLookupSupplier);
             return this;
+        }
+
+        private void reportUseOfMissingConfig(Config config) {
+            if (!config.exists()) {
+                LOGGER.log(Level.INFO,
+                        String.format(
+                                "Attempt to load %s using empty config with key '%s'; continuing with default CORS information",
+                                getClass().getSuperclass().getSimpleName(), config.key().toString()));
+            }
         }
     }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -384,6 +384,11 @@ class CorsSupportHelper<Q, R> {
         return requestType(requestAdapter, false);
     }
 
+    // Primarily for testing.
+    Aggregator aggregator() {
+        return aggregator;
+    }
+
     private boolean isRequestTypeNormal(RequestAdapter<Q> requestAdapter, boolean silent) {
         // If no origin header or same as host, then just normal
         Optional<String> originOpt = requestAdapter.firstHeader(ORIGIN);

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/MissingConfigTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/MissingConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.webserver.cors;
+
+import io.helidon.config.Config;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.helidon.webserver.cors.CustomMatchers.present;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Checks handling of missing (absent) config.
+ *
+ * Make sure that passing a missing config node to
+ */
+class MissingConfigTest {
+
+    private static final Config EMPTY = Config.empty();
+
+    @Test
+    void testCrossOriginConfig() {
+        CrossOriginConfig coc = CrossOriginConfig.create(EMPTY);
+        checkCrossOriginConfig(coc);
+    }
+
+    @Test
+    void testCorsSupport() {
+        CorsSupport cs = CorsSupport.create(EMPTY);
+        assertThat(cs.helper().isActive(), is(true));
+        Aggregator aggregator = cs.helper().aggregator();
+        assertThat(aggregator.isActive(), is(true));
+        Optional<CrossOriginConfig> cocOpt = aggregator.lookupCrossOrigin("/any/path", () -> Optional.empty());
+        assertThat(cocOpt, present());
+        checkCrossOriginConfig(cocOpt.get());
+    }
+
+    private void checkCrossOriginConfig(CrossOriginConfig coc) {
+        assertThat(coc.allowCredentials(), is(false));
+        assertThat(coc.allowMethods().length, greaterThan(0));
+        assertThat(coc.allowMethods()[0], is("*"));
+    }
+}


### PR DESCRIPTION
Resolves #1708 

If a missing config node is passed to `CorsSupport.Builder.config` (directly or indirectly via `CorsSupport.create(Config)`, create a default `CorsSupport` instance which is by design rather permissive: allow-methods = *, etc. Same for `CorsSupportMp`.

Log an `INFO` message when this happens.

Add tests for this behavior.