### PR TITLE
OutputStreamPublisher now handles close on its own.

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/OutputStreamPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,14 @@ package io.helidon.common.reactive;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Output stream that {@link java.util.concurrent.Flow.Publisher} publishes any data written to it as {@link ByteBuffer}
@@ -30,6 +34,8 @@ import java.util.concurrent.Flow;
  */
 @SuppressWarnings("WeakerAccess")
 public class OutputStreamPublisher extends OutputStream implements Flow.Publisher<ByteBuffer> {
+
+    private static final long HARD_TIMEOUT_MILLIS = Duration.ofMinutes(10).toMillis();
 
     private static final byte[] FLUSH_BUFFER = new byte[0];
 
@@ -39,6 +45,7 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
     private final RequestedCounter requested = new RequestedCounter();
 
     private final CompletableFuture<?> completionResult = new CompletableFuture<>();
+    private final AtomicBoolean written = new AtomicBoolean();
 
     @Override
     public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriberParam) {
@@ -76,13 +83,20 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
     @Override
     public void close() throws IOException {
         complete();
+
+        if (!written.get() && !completionResult.isCompletedExceptionally()) {
+            // no need to wait for
+            return;
+        }
         try {
-            completionResult.get();
+            completionResult.get(HARD_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
         } catch (ExecutionException e) {
             throw new IOException(e.getCause());
+        } catch (TimeoutException e) {
+            throw new IOException("Timed out while waiting for subscriber to read data", e);
         }
     }
 
@@ -103,7 +117,7 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
      * @param throwable represents a completion error condition that should be thrown when a {@code close()} method is invoked
      *                  on this publishing output stream. If set to {@code null}, the {@code close()} method will exit normally.
      */
-    public void signalCloseComplete(Throwable throwable) {
+    void signalCloseComplete(Throwable throwable) {
         if (throwable == null) {
             completionResult.complete(null);
         } else {
@@ -124,11 +138,22 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
     private void publish(byte[] buffer, int offset, int length) throws IOException {
         Objects.requireNonNull(buffer);
 
+        if (length > 0) {
+            written.set(true);
+        }
+
         try {
             final Flow.Subscriber<? super ByteBuffer> sub = subscriber.get();
 
+            long start = System.currentTimeMillis();
+
             while (!subscriber.isClosed() && !requested.tryDecrement()) {
                 Thread.sleep(250); // wait until some data can be sent or the stream has been closed
+
+                long diff = System.currentTimeMillis() - start;
+                if (diff > HARD_TIMEOUT_MILLIS) {
+                    throw new IOException("Timed out while waiting for subscriber to read data");
+                }
             }
 
             synchronized (invocationLock) {
@@ -155,6 +180,7 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
         subscriber.close(sub -> {
             synchronized (invocationLock) {
                 sub.onComplete();
+                signalCloseComplete(null);
             }
         });
     }
@@ -163,6 +189,7 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
         subscriber.close(sub -> {
             synchronized (invocationLock) {
                 sub.onError(t);
+                signalCloseComplete(t);
             }
         });
     }
@@ -180,6 +207,6 @@ public class OutputStreamPublisher extends OutputStream implements Flow.Publishe
     private ByteBuffer createBuffer(byte[] buffer, int offset, int length) {
         ByteBuffer byteBuffer = ByteBuffer.allocate(length - offset);
         byteBuffer.put(buffer, offset, length);
-        return (ByteBuffer) byteBuffer.clear();     // resets counters
+        return byteBuffer.clear();     // resets counters
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/OutputStreamPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/OutputStreamPublisherTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -54,7 +55,7 @@ public class OutputStreamPublisherTest {
     }
 
     @Test
-    public void testSignalCloseCompleteWithException() {
+    void testSignalCloseCompleteWithException() {
         OutputStreamPublisher publisher = new OutputStreamPublisher();
         publisher.signalCloseComplete(new IllegalStateException("foo!"));
         try {
@@ -67,9 +68,55 @@ public class OutputStreamPublisherTest {
     }
 
     @Test
-    public void testCloseOnNoDataWritten() throws IOException {
+    void testCloseOnNoDataWritten() throws IOException {
         OutputStreamPublisher publisher = new OutputStreamPublisher();
+        TestSubscriber<ByteBuffer> sub = new TestSubscriber<>();
+
+        publisher.subscribe(sub);
+
         // this should return immediately
         publisher.close();
+
+        sub.assertComplete();
+        sub.assertItemCount(0);
+    }
+
+    @Test
+    void testCancel() throws IOException {
+        OutputStreamPublisher publisher = new OutputStreamPublisher();
+        TestSubscriber<ByteBuffer> sub = new TestSubscriber<>();
+
+        publisher.subscribe(sub);
+        sub.cancel();
+
+        assertThrows(IOException.class, () -> publisher.write("Test".getBytes()));
+
+        publisher.close();
+
+        sub.assertEmpty();
+    }
+
+    @Test
+    void testError() throws IOException {
+        OutputStreamPublisher publisher = new OutputStreamPublisher();
+        TestSubscriber<ByteBuffer> sub = new TestSubscriber<>() {
+            @Override
+            public void onNext(ByteBuffer item) {
+                throw new UnitTestException();
+            }
+        };
+
+        publisher.subscribe(sub);
+        sub.request(1);
+
+        // need to make sure we do not block any method
+        assertThrows(UnitTestException.class, () -> publisher.write("Test".getBytes()));
+        publisher.close();
+    }
+
+    private static final class UnitTestException extends RuntimeException {
+        private UnitTestException() {
+            super();
+        }
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/OutputStreamPublisherTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/OutputStreamPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ public class OutputStreamPublisherTest {
         subscriber.requestMax();
         PrintWriter printer = new PrintWriter(publisher);
         printer.print("foo");
-        publisher.signalCloseComplete(null);
         printer.close();
         assertThat(subscriber.isComplete(), is(equalTo(true)));
         assertThat(subscriber.getLastError(), is(nullValue()));
@@ -65,5 +64,12 @@ public class OutputStreamPublisherTest {
             assertThat(ex.getCause(), is(not(nullValue())));
             assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
         }
+    }
+
+    @Test
+    public void testCloseOnNoDataWritten() throws IOException {
+        OutputStreamPublisher publisher = new OutputStreamPublisher();
+        // this should return immediately
+        publisher.close();
     }
 }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,6 @@ class ResponseWriter implements ContainerResponseWriter {
         @Override
         public void close() throws IOException {
             try {
-                super.signalCloseComplete(null);
                 super.close();
             } catch (ConnectionClosedException e) {
                 throw new IOException("Cannot close the connection because it's already closed.", e);


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

This was discovered by Jersey team - when using `OutputStreamPublisher`, there was an infinite blocking problem with method `close`.

