### PR TITLE
1.4: use release flag for compiler, not source/target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
                     <configuration>
-                        <release>1.8</release>
+                        <release>8</release>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
                         </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
                     <version>${version.plugin.javadoc}</version>
                     <configuration>
                         <source>8</source>
+                        <release>8</release>
                         <!-- we are not interested in each file that is generated -->
                         <quiet>true</quiet>
                         <offlineLinks>

--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <release>1.8</release>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
                         </compilerArgs>


### PR DESCRIPTION
JDK 9 added the --release flag to the compiler which is the proper way to target a Java release. This will prevent us from accidentally introducing dependencies on system libraries in Java 9+.

With this change you can no longer build the helidon-1.x branch using Java 8.

For reference:

https://openjdk.java.net/jeps/247

https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

 