### PR TITLE
Fix incorrect matching of resource methods annotated with @OPTIONS

### DIFF
--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -102,13 +102,12 @@ class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilt
             Optional<Method> optionsMethod = Arrays.stream(resourceClass.getDeclaredMethods())
                     .filter(m -> {
                         OPTIONS optsAnnot2 = m.getAnnotation(OPTIONS.class);
-                        if (optsAnnot2 != null) {
+                        Path pathAnnot2 = m.getAnnotation(Path.class);if (optsAnnot2 != null) {
                             if (pathAnnot != null) {
-                                Path pathAnnot2 = m.getAnnotation(Path.class);
                                 return pathAnnot2 != null && pathAnnot.value()
                                         .equals(pathAnnot2.value());
                             }
-                            return true;
+                            return pathAnnot2 == null;
                         }
                         return false;
                     })

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -102,7 +102,8 @@ class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilt
             Optional<Method> optionsMethod = Arrays.stream(resourceClass.getDeclaredMethods())
                     .filter(m -> {
                         OPTIONS optsAnnot2 = m.getAnnotation(OPTIONS.class);
-                        Path pathAnnot2 = m.getAnnotation(Path.class);if (optsAnnot2 != null) {
+                        Path pathAnnot2 = m.getAnnotation(Path.class);
+                        if (optsAnnot2 != null) {
                             if (pathAnnot != null) {
                                 return pathAnnot2 != null && pathAnnot.value()
                                         .equals(pathAnnot2.value());


### PR DESCRIPTION
Resolves #1743 

The Helidon-provided filter for CORS support matches a request method (e.g., `@GET`) to the corresponding method annotated with `@OPTIONS` and `@CrossOrigin`. If the request method has no `@Path` annotation, then the filter logic did not check to make sure that the candidate options method also had no path before declaring that options method a match.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>