### PR TITLE
Allows proxying of ServerRequest

### DIFF
--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/WebServerBinder.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/WebServerBinder.java
@@ -42,7 +42,7 @@ class WebServerBinder extends AbstractBinder {
     @Override
     protected void configure() {
         bindFactory(WebServerRequestReferencingFactory.class).to(ServerRequest.class)
-                                                             .proxy(false)
+                                                             .proxy(true).proxyForSameScope(false)
                                                              .in(RequestScoped.class);
         bindFactory(ReferencingFactory.<ServerRequest>referenceFactory()).to(new GenericType<Ref<ServerRequest>>() { })
                                                                          .in(RequestScoped.class);

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/WebServerBinder.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/WebServerBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR treats `ServerRequest` and `ServerResponse` the same by proxying them (unless at the same scope) which fixes #1739. 

Evidently this is also a problem in `master`. I'm not sure of the process so should I create another PR to cover this?

Apologies, I'll sign the OCA when I find some time so I know this cannot be merged yet, but created a PR to gather any feedback.