### PR TITLE
Docs: Update javadoc links in documentation to work with new javadoc layout

### DIFF
--- a/docs/se/config/01_introduction.adoc
+++ b/docs/se/config/01_introduction.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = The Configuration Component
 :description: Helidon config introduction

--- a/docs/se/config/02_config-sources.adoc
+++ b/docs/se/config/02_config-sources.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Loading Configuration: Config Sources and Parsers
 :description: A summary of Helidon config sources and parsers

--- a/docs/se/config/03_hierarchical-features.adoc
+++ b/docs/se/config/03_hierarchical-features.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Hierarchical Features
 :description: Helidon hierarchical features

--- a/docs/se/config/04_property-mapping.adoc
+++ b/docs/se/config/04_property-mapping.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Property Mapping
 :description: Helidon config property mapping

--- a/docs/se/config/05_mutability-support.adoc
+++ b/docs/se/config/05_mutability-support.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Mutability Support
 :description: Helidon mutability support

--- a/docs/se/config/06_advanced-configuration.adoc
+++ b/docs/se/config/06_advanced-configuration.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Advanced Configuration Topics
 :description: Helidon config advanced configuration

--- a/docs/se/config/07_extensions.adoc
+++ b/docs/se/config/07_extensions.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Extensions
 :description: Helidon config extensions

--- a/docs/se/config/08_supported-formats.adoc
+++ b/docs/se/config/08_supported-formats.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/config
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.config/io/helidon/config
 
 = Additional Supported Formats and Sources
 :description: Helidon config supported formats and sources

--- a/docs/se/grpc/02_configuration.adoc
+++ b/docs/se/grpc/02_configuration.adoc
@@ -17,7 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 = gRPC Server Configuration
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/grpc/server
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.grpc.server/io/helidon/grpc/server
 :pagename: grpc-server-configuration
 :description: Helidon gRPC Server Configuration
 :keywords: helidon, grpc, java, configuration

--- a/docs/se/grpc/04_service_implementation.adoc
+++ b/docs/se/grpc/04_service_implementation.adoc
@@ -17,7 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 = gRPC Service Implementation
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/grpc/server
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.grpc.server/io/helidon/grpc/server
 :pagename: grpc-server-service-implementation
 :description: Helidon gRPC Service Implementation
 :keywords: helidon, grpc, java

--- a/docs/se/grpc/22_client_configuration.adoc
+++ b/docs/se/grpc/22_client_configuration.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/grpc/server
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.grpc.client/io/helidon/grpc/client
 :pagename: grpc-client-configuration
 :description: Helidon gRPC Client Configuration
 :keywords: helidon, grpc, java, configuration

--- a/docs/se/grpc/23_client_implementation.adoc
+++ b/docs/se/grpc/23_client_implementation.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/grpc/client
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.grpc.client/io/helidon/grpc/client
 :pagename: grpc-server-client-implementation
 :description: Helidon gRPC Client Implementation
 :keywords: helidon, grpc, java

--- a/docs/se/webserver/02_configuration.adoc
+++ b/docs/se/webserver/02_configuration.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-:javadoc-base-url-api: {javadoc-base-url}?io/helidon/webserver
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.webserver/io/helidon/webserver
 :description: Helidon Reactive Webserver Configuration
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
 

--- a/docs/sitegen.yaml
+++ b/docs/sitegen.yaml
@@ -21,7 +21,7 @@ engine:
       - "asciidoctor-diagram"
     attributes:
       plantumlconfig: "_plantuml-config.txt"
-      javadoc-base-url: "./apidocs/index.html"
+      javadoc-base-url: "./apidocs/"
       helidon-version: "${project.version}"
       microprofile-openapi-version: "${version.lib.microprofile-openapi-api}"
       jandex-plugin-version: ${version.plugin.jandex}


### PR DESCRIPTION
Fix for #1730 