### PR TITLE
Fix handling of generics when reading objects

### DIFF
--- a/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
+++ b/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
@@ -15,9 +15,9 @@
  */
 package io.helidon.media.jackson.common;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.concurrent.Flow.Publisher;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
@@ -27,7 +27,11 @@ import io.helidon.media.common.ContentReaders;
 import io.helidon.media.common.MessageBodyReader;
 import io.helidon.media.common.MessageBodyReaderContext;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.concurrent.Flow.Publisher;
 
 /**
  * Message body reader supporting object binding with Jackson.
@@ -80,7 +84,15 @@ public final class JacksonBodyReader implements MessageBodyReader<Object> {
         @SuppressWarnings("unchecked")
         public T map(byte[] bytes) {
             try {
-                return objectMapper.readValue(bytes, (Class<T>) type.rawType());
+                Type t = this.type.type();
+                if (t instanceof ParameterizedType) {
+                    TypeFactory typeFactory = objectMapper.getTypeFactory();
+                    ParameterizedType pt = (ParameterizedType) t;
+                    JavaType javaType = typeFactory.constructType(pt);
+                    return objectMapper.readValue(bytes, javaType);
+                } else {
+                    return objectMapper.readValue(bytes, (Class<T>) this.type.rawType());
+                }
             } catch (final IOException wrapMe) {
                 throw new JacksonRuntimeException(wrapMe.getMessage(), wrapMe);
             }

--- a/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
+++ b/media/jackson/common/src/main/java/io/helidon/media/jackson/common/JacksonBodyReader.java
@@ -15,9 +15,11 @@
  */
 package io.helidon.media.jackson.common;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.concurrent.Flow.Publisher;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
@@ -27,11 +29,9 @@ import io.helidon.media.common.ContentReaders;
 import io.helidon.media.common.MessageBodyReader;
 import io.helidon.media.common.MessageBodyReaderContext;
 
-import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Objects;
-import java.util.concurrent.Flow.Publisher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
  * Message body reader supporting object binding with Jackson.

--- a/media/jackson/common/src/test/java/io/helidon/media/jackson/common/JacksonBodyReaderTest.java
+++ b/media/jackson/common/src/test/java/io/helidon/media/jackson/common/JacksonBodyReaderTest.java
@@ -1,0 +1,39 @@
+package io.helidon.media.jackson.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.helidon.common.GenericType;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.reactive.Single;
+import io.helidon.media.common.MessageBodyReaderContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class JacksonBodyReaderTest {
+
+    @Test
+    void testDeserializeWithGenerics() throws Exception {
+        JacksonBodyReader reader = JacksonBodyReader.create(new ObjectMapper());
+        DataChunk dataChunk = DataChunk.create("[{\"title\":\"The Stand\"}]".getBytes(StandardCharsets.UTF_8));
+        List<Book> books = reader.read(Single.just(dataChunk), new GenericType<List<Book>>() {
+        }, MessageBodyReaderContext.create())
+                .get();
+
+        Assertions.assertEquals(1, books.size());
+        Assertions.assertTrue(books.get(0) instanceof Book);
+    }
+
+    public static class Book {
+        private String title;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+    }
+}


### PR DESCRIPTION
Generics information is not currently used when deserializing objects which leads to Jackson deserializing objects as a `List` of `Map` instances causing downstream class cast exceptions. This change ensures Jackson's `JavaType` API is used to correctly deserializing objects using generics.