### PR TITLE
Fix #1802 - Allow use of filters and mappers when converting MP to He…

### DIFF
--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfig.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfig.java
@@ -52,10 +52,8 @@ public final class MpConfig {
         io.helidon.config.Config.Builder builder = io.helidon.config.Config.builder()
                 .disableEnvironmentVariablesSource()
                 .disableSystemPropertiesSource()
-                .disableMapperServices()
                 .disableCaching()
-                .disableParserServices()
-                .disableFilterServices();
+                .disableParserServices();
 
         if (mpConfig instanceof MpConfigImpl) {
             ((MpConfigImpl) mpConfig).converters()

--- a/config/config-mp/src/test/resources/META-INF/services/io.helidon.config.spi.ConfigMapperProvider
+++ b/config/config-mp/src/test/resources/META-INF/services/io.helidon.config.spi.ConfigMapperProvider
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.config.mp.MpConfigTest$TestMapperProvider


### PR DESCRIPTION
…lidon config

Fix is simple -  remove the lines disabling filters and mappers when creating the new SE configuration.

Added test to verify the mappers would be available in this scenario.
Was uncertain as to the best approach for filters (or if the mapper test is the best way to verify for that matter), so recommendations are welcome if additional testing on this is desired.