### PR TITLE
Multi onComplete* operators

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -639,6 +639,28 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
+     * Resume stream from single item if onComplete signal is intercepted. Effectively do an {@code append} to the stream.
+     *
+     * @param item one item to resume stream with
+     * @return Multi
+     */
+    default Multi<T> onCompleteResume(T item) {
+        Objects.requireNonNull(item, "item is null");
+        return onCompleteResumeWith(Multi.singleton(item));
+    }
+
+    /**
+     * Resume stream from supplied publisher if onComplete signal is intercepted.
+     *
+     * @param publisher new stream publisher
+     * @return Multi
+     */
+    default Multi<T> onCompleteResumeWith(Flow.Publisher<? extends T> publisher) {
+        Objects.requireNonNull(publisher, "publisher is null");
+        return new MultiOnCompleteResumeWith<>(this, publisher);
+    }
+
+    /**
      * Executes given {@link java.lang.Runnable} when any of signals onComplete, onCancel or onError is received.
      *
      * @param onTerminate {@link java.lang.Runnable} to be executed.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -16,6 +16,7 @@
 package io.helidon.common.reactive;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -60,6 +61,28 @@ public interface Multi<T> extends Subscribable<T> {
      */
     static <T> Multi<T> concat(Flow.Publisher<T> firstMulti, Flow.Publisher<T> secondMulti) {
         return ConcatPublisher.create(firstMulti, secondMulti);
+    }
+
+    /**
+     * Concat streams to one.
+     *
+     * @param firstMulti  first stream
+     * @param secondMulti second stream
+     * @param publishers  more publishers to concat
+     * @param <T>         item type
+     * @return Multi
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static <T> Multi<T> concat(Flow.Publisher<T> firstMulti, Flow.Publisher<T> secondMulti, Flow.Publisher<T>... publishers) {
+        if (publishers.length == 0) {
+            return concat(firstMulti, secondMulti);
+        } else if (publishers.length == 1) {
+            return concat(concat(firstMulti, secondMulti), publishers[0]);
+        } else {
+            return concat(concat(firstMulti, secondMulti), publishers[0],
+                    Arrays.copyOfRange(publishers, 1, publishers.length));
+        }
     }
 
     /**

--- a/common/reactive/src/main/java/io/helidon/common/reactive/MultiOnCompleteResumeWith.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/MultiOnCompleteResumeWith.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.Objects;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * If the completes, switch to a generated Flow.Publisher and relay its signals then on.
+ *
+ * @param <T> the element type of the flows
+ */
+final class MultiOnCompleteResumeWith<T> implements Multi<T> {
+
+    private final Multi<T> source;
+
+    private final Flow.Publisher<? extends T> fallbackPublisher;
+
+    MultiOnCompleteResumeWith(Multi<T> source, Flow.Publisher<? extends T> fallbackPublisher) {
+        this.source = source;
+        this.fallbackPublisher = fallbackPublisher;
+    }
+
+    @Override
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        source.subscribe(new OnCompleteResumeWithSubscriber<>(subscriber, fallbackPublisher));
+    }
+
+    static final class OnCompleteResumeWithSubscriber<T> implements Flow.Subscriber<T>, Flow.Subscription {
+
+        private final Flow.Subscriber<? super T> downstream;
+
+        private final Flow.Publisher<? extends T> fallbackPublisher;
+
+        private Flow.Subscription upstream;
+
+        private long received;
+
+        private final AtomicLong requested;
+
+        private final FallbackSubscriber<T> fallbackSubscriber;
+
+        OnCompleteResumeWithSubscriber(Flow.Subscriber<? super T> downstream,
+                                       Flow.Publisher<? extends T> fallbackPublisher) {
+            this.downstream = downstream;
+            this.fallbackPublisher = fallbackPublisher;
+            this.requested = new AtomicLong();
+            fallbackSubscriber = new FallbackSubscriber<>(downstream, requested);
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            SubscriptionHelper.validate(upstream, subscription);
+            upstream = subscription;
+            downstream.onSubscribe(this);
+        }
+
+        @Override
+        public void onNext(T item) {
+            received++;
+            downstream.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            upstream = SubscriptionHelper.CANCELED;
+            downstream.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            upstream = SubscriptionHelper.CANCELED;
+            long p = received;
+            if (p != 0L) {
+                SubscriptionHelper.produced(requested, p);
+            }
+
+            Flow.Publisher<? extends T> publisher;
+
+            try {
+                publisher = Objects.requireNonNull(fallbackPublisher,
+                        "The fallback function returned a null Flow.Publisher");
+            } catch (Throwable ex) {
+                downstream.onError(ex);
+                return;
+            }
+
+            publisher.subscribe(fallbackSubscriber);
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                downstream.onError(new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden"));
+            } else {
+                SubscriptionHelper.deferredRequest(fallbackSubscriber, requested, n);
+                upstream.request(n);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            upstream.cancel();
+            SubscriptionHelper.cancel(fallbackSubscriber);
+        }
+
+        static final class FallbackSubscriber<T> extends AtomicReference<Flow.Subscription>
+                implements Flow.Subscriber<T> {
+
+            private final Flow.Subscriber<? super T> downstream;
+
+            private final AtomicLong requested;
+
+            FallbackSubscriber(Flow.Subscriber<? super T> downstream, AtomicLong requested) {
+                this.downstream = downstream;
+                this.requested = requested;
+            }
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                SubscriptionHelper.deferredSetOnce(this, requested, subscription);
+            }
+
+            @Override
+            public void onNext(T item) {
+                downstream.onNext(item);
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                downstream.onError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
+        }
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -356,8 +356,39 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
      * @param onError supplier of new stream publisher
      * @return Single
      */
-    default Single<T> onErrorResumeWith(Function<? super Throwable, ? extends Single<? extends T>> onError) {
+    default Single<T> onErrorResumeWithSingle(Function<? super Throwable, ? extends Single<? extends T>> onError) {
         return new SingleOnErrorResumeWith<>(this, onError);
+    }
+
+    /**
+     * Resume stream from supplied publisher if onError signal is intercepted.
+     *
+     * @param onError supplier of new stream publisher
+     * @return Single
+     */
+    default Multi<T> onErrorResumeWith(Function<? super Throwable, ? extends Flow.Publisher<? extends T>> onError) {
+        return new MultiOnErrorResumeWith<>(Multi.from(this), onError);
+    }
+
+    /**
+     * Resume stream from single item if onComplete signal is intercepted. Effectively do an {@code append} to the stream.
+     *
+     * @param item one item to resume stream with
+     * @return Multi
+     */
+    default Multi<T> onCompleteResume(T item) {
+        Objects.requireNonNull(item, "item is null");
+        return onCompleteResumeWith(Multi.singleton(item));
+    }
+
+    /**
+     * Resume stream from supplied publisher if onComplete signal is intercepted.
+     *
+     * @param publisher new stream publisher
+     * @return Multi
+     */
+    default Multi<T> onCompleteResumeWith(Flow.Publisher<? extends T> publisher) {
+        return new MultiOnCompleteResumeWith<>(Multi.from(this), publisher);
     }
 
     /**

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Subscribable.java
@@ -15,12 +15,19 @@
  */
 package io.helidon.common.reactive;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Publisher;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Decorated publisher that allows subscribing to individual events with java functions.
+ *
  * @param <T> item type
  */
 public interface Subscribable<T> extends Publisher<T> {
@@ -37,7 +44,7 @@ public interface Subscribable<T> extends Publisher<T> {
     /**
      * Subscribe to this {@link Single} instance with the given delegate functions.
      *
-     * @param consumer onNext delegate function
+     * @param consumer      onNext delegate function
      * @param errorConsumer onError delegate function
      */
     default void subscribe(Consumer<? super T> consumer, Consumer<? super Throwable> errorConsumer) {
@@ -47,8 +54,8 @@ public interface Subscribable<T> extends Publisher<T> {
     /**
      * Subscribe to this {@link Single} instance with the given delegate functions.
      *
-     * @param consumer onNext delegate function
-     * @param errorConsumer onError delegate function
+     * @param consumer         onNext delegate function
+     * @param errorConsumer    onError delegate function
      * @param completeConsumer onComplete delegate function
      */
     default void subscribe(Consumer<? super T> consumer, Consumer<? super Throwable> errorConsumer, Runnable completeConsumer) {
@@ -58,14 +65,202 @@ public interface Subscribable<T> extends Publisher<T> {
     /**
      * Subscribe to this {@link Single} instance with the given delegate functions.
      *
-     * @param consumer onNext delegate function
-     * @param errorConsumer onError delegate function
-     * @param completeConsumer onComplete delegate function
+     * @param consumer             onNext delegate function
+     * @param errorConsumer        onError delegate function
+     * @param completeConsumer     onComplete delegate function
      * @param subscriptionConsumer onSusbcribe delegate function
      */
     default void subscribe(Consumer<? super T> consumer, Consumer<? super Throwable> errorConsumer, Runnable completeConsumer,
-            Consumer<? super Flow.Subscription> subscriptionConsumer) {
+                           Consumer<? super Flow.Subscription> subscriptionConsumer) {
 
         this.subscribe(new FunctionalSubscriber<>(consumer, errorConsumer, completeConsumer, subscriptionConsumer));
     }
+
+    /**
+     * Signals the default item if the upstream is empty.
+     *
+     * @param defaultItem the item to signal if the upstream is empty
+     * @return Subscribable
+     * @throws NullPointerException if {@code defaultItem} is {@code null}
+     */
+    Subscribable<T> defaultIfEmpty(T defaultItem);
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Flow.Publisher} to downstream.
+     *
+     * @param mapper {@link Function} receiving item as parameter and returning {@link Flow.Publisher}
+     * @param <U>    output item type
+     * @return Subscribable
+     */
+    <U> Subscribable<U> flatMap(Function<? super T, ? extends Publisher<? extends U>> mapper);
+
+    /**
+     * Transform item with supplied function and flatten resulting {@link Iterable} to downstream.
+     *
+     * @param mapper {@link Function} receiving item as parameter and returning {@link Iterable}
+     * @param <U>    output item type
+     * @return Subscribable
+     */
+    <U> Subscribable<U> flatMapIterable(Function<? super T, ? extends Iterable<? extends U>> mapper);
+
+    /**
+     * Map this {@link Subscribable} instance to a new {@link Subscribable}
+     * of another type using the given {@link Function}.
+     *
+     * @param <U>    mapped item type
+     * @param mapper mapper
+     * @return Subscribable
+     * @throws NullPointerException if mapper is {@code null}
+     */
+    <U> Subscribable<U> map(Function<? super T, ? extends U> mapper);
+
+    /**
+     * Re-emit the upstream's signals to the downstream on the given executor's thread.
+     *
+     * @param executor the executor to signal the downstream from.
+     * @return Subscribable
+     * @throws NullPointerException if {@code executor} is {@code null}
+     */
+    Subscribable<T> observeOn(Executor executor);
+
+    /**
+     * Executes given {@link java.lang.Runnable} when a cancel signal is received.
+     *
+     * @param onCancel {@link java.lang.Runnable} to be executed.
+     * @return Subscribable
+     */
+    Subscribable<T> onCancel(Runnable onCancel);
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onComplete signal is received.
+     *
+     * @param onComplete {@link java.lang.Runnable} to be executed.
+     * @return Subscribable
+     */
+    Subscribable<T> onComplete(Runnable onComplete);
+
+    /**
+     * Executes given {@link java.lang.Runnable} when onError signal is received.
+     *
+     * @param onErrorConsumer {@link java.util.function.Consumer} to be executed.
+     * @return Subscribable
+     */
+    Subscribable<T> onError(Consumer<? super Throwable> onErrorConsumer);
+
+    /**
+     * Resume stream from supplied publisher if onError signal is intercepted.
+     *
+     * @param onError supplier of new stream publisher
+     * @return Subscribable
+     */
+    Subscribable<T> onErrorResumeWith(Function<? super Throwable, ? extends Flow.Publisher<? extends T>> onError);
+
+    /**
+     * {@link java.util.function.Function} providing one item to be submitted as onNext in case of onError signal is received.
+     *
+     * @param onError Function receiving {@link java.lang.Throwable} as argument and producing one item to resume stream with.
+     * @return Subscribable
+     */
+    Subscribable<T> onErrorResume(Function<? super Throwable, ? extends T> onError);
+
+    /**
+     * Resume stream from single item if onComplete signal is
+     * intercepted. Effectively do an {@code append} to the stream.
+     *
+     * @param item one item to resume stream with
+     * @return Subscribable
+     */
+    Subscribable<T> onCompleteResume(T item);
+
+    /**
+     * Resume stream from supplied publisher if onComplete signal is intercepted.
+     *
+     * @param publisher new stream publisher
+     * @return Subscribable
+     */
+    Subscribable<T> onCompleteResumeWith(Flow.Publisher<? extends T> publisher);
+
+    /**
+     * Executes given {@link java.lang.Runnable} when any of signals onComplete,
+     * onCancel or onError is received.
+     *
+     * @param onTerminate {@link java.lang.Runnable} to be executed.
+     * @return Subscribable
+     */
+    Subscribable<T> onTerminate(Runnable onTerminate);
+
+    /**
+     * Invoke provided consumer for every item in stream.
+     *
+     * @param consumer consumer to be invoked
+     * @return Subscribable
+     */
+    Subscribable<T> peek(Consumer<? super T> consumer);
+
+    /**
+     * Retry a failing upstream at most the given number of times before giving up.
+     *
+     * @param count the number of times to retry; 0 means no retry at all
+     * @return Subscribable
+     * @throws IllegalArgumentException if {@code count} is negative
+     * @see #retryWhen(BiFunction)
+     */
+    Subscribable<T> retry(long count);
+
+    /**
+     * Retry a failing upstream if the predicate returns true.
+     *
+     * @param predicate the predicate that receives the latest failure {@link Throwable}
+     *                  the number of times the retry happened so far (0-based) and
+     *                  should return {@code true} to retry the upstream again or
+     *                  {@code false} to signal the latest failure
+     * @return Subscribable
+     * @throws NullPointerException if {@code predicate} is {@code null}
+     * @see #retryWhen(BiFunction)
+     */
+    Subscribable<T> retry(BiPredicate<? super Throwable, ? super Long> predicate);
+
+    /**
+     * Retry a failing upstream when the given function returns a publisher that
+     * signals an item.
+     * <p>
+     * If the publisher returned by the function completes, the repetition stops
+     * and this Subscribable is completed.
+     * If the publisher signals an error, the repetition stops
+     * and this Subscribable will signal this error.
+     * </p>
+     *
+     * @param whenFunction the function that receives the latest failure {@link Throwable}
+     *                     the number of times the retry happened so far (0-based) and
+     *                     should return a {@link Flow.Publisher} that should signal an item
+     *                     to retry again, complete to stop and complete this Subscribable
+     *                     or signal an error to have this Subscribable emit that error as well.
+     * @param <U>          the element type of the retry-signal sequence
+     * @return Subscribable
+     * @throws NullPointerException if {@code whenFunction} is {@code null}
+     */
+    <U> Subscribable<T> retryWhen(BiFunction<? super Throwable,
+            ? super Long, ? extends Flow.Publisher<U>> whenFunction);
+
+    /**
+     * Relay upstream items until the other source signals an item or completes.
+     *
+     * @param other the other sequence to signal the end of the main sequence
+     * @param <U>   the element type of the other sequence
+     * @return Subscribable
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    <U> Subscribable<T> takeUntil(Flow.Publisher<U> other);
+
+    /**
+     * Signals a {@link java.util.concurrent.TimeoutException} if the upstream doesn't
+     * signal the next item, error or completion within the specified time.
+     *
+     * @param timeout  the time to wait for the upstream to signal
+     * @param unit     the time unit
+     * @param executor the executor to use for waiting for the upstream signal
+     * @return Subscribable
+     * @throws NullPointerException if {@code unit} or {@code executor} is {@code null}
+     */
+    Subscribable<T> timeout(long timeout, TimeUnit unit, ScheduledExecutorService executor);
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnCompleteResumeWithTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnCompleteResumeWithTckTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.concurrent.Flow;
+
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+public class MultiOnCompleteResumeWithTckTest extends FlowPublisherVerification<Integer> {
+
+    public MultiOnCompleteResumeWithTckTest() {
+        super(new TestEnvironment(200));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFlowPublisher(long l) {
+        return Multi.<Integer>empty()
+                .onCompleteResumeWith(Multi.range(1, (int) l));
+    }
+
+    @Override
+    public Flow.Publisher<Integer> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return 10;
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnCompleteResumeWithTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiOnCompleteResumeWithTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MultiOnCompleteResumeWithTest {
+
+    @Test
+    public void nullFallbackPublisher() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        assertThrows(NullPointerException.class, () -> Multi.<Integer>empty()
+                .onCompleteResumeWith(null)
+                .subscribe(ts));
+
+    }
+
+    @Test
+    public void fallbackToError() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>empty()
+                .onCompleteResumeWith(Multi.error(new IllegalArgumentException()))
+                .subscribe(ts);
+
+
+        ts.assertFailure(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void errorSource() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>error(new IOException())
+                .onCompleteResume(666)
+                .subscribe(ts);
+
+        ts.assertItemCount(0);
+        ts.assertError(IOException.class);
+    }
+
+    @Test
+    public void emptyFallback() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>empty()
+                .onCompleteResumeWith(Multi.empty())
+                .subscribe(ts);
+
+        ts.assertResult();
+    }
+
+    @Test
+    public void appendAfterItems() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(Long.MAX_VALUE);
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>empty())
+                .onCompleteResumeWith(Multi.range(4, 2))
+                .subscribe(ts);
+
+        ts.assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void appendAfterItemsBackpressure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.concat(Multi.range(1, 3), Multi.<Integer>empty())
+                .onCompleteResumeWith(Multi.range(4, 2))
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(3)
+                .assertValuesOnly(1, 2, 3)
+                .request(2)
+                .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void multipleAppendAfterItemsBackpressure() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.concat(Multi.<Integer>empty(), Multi.just(1, 2, 3))
+                .onCompleteResumeWith(Multi.just(4, 5))
+                .onCompleteResumeWith(Multi.just(6, 7))
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .request(3)
+                .assertValuesOnly(1, 2, 3)
+                .request(2)
+                .assertValuesOnly(1, 2, 3, 4, 5)
+                .request(1)
+                .assertValuesOnly(1, 2, 3, 4, 5, 6)
+                .request(1)
+                .assertResult(1, 2, 3, 4, 5, 6, 7);
+    }
+
+    @Test
+    public void appendChain() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
+
+        Multi.<Integer>just(1, 2, 3)
+                .onCompleteResume(4)
+                .onCompleteResume(5)
+                .onCompleteResumeWith(Multi.just(6, 7))
+                .onCompleteResume(8)
+                .subscribe(ts);
+
+        ts.assertEmpty()
+                .requestMax()
+                .assertComplete()
+                .assertResult(1, 2, 3, 4, 5, 6, 7, 8);
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -381,6 +381,36 @@ public class MultiTest {
     }
 
     @Test
+    void testOnCompleteResume() {
+        List<Integer> result = Multi.just(1, 2, 3)
+                .onCompleteResume(4)
+                .collectList()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(List.of(1, 2, 3, 4))));
+    }
+
+    @Test
+    void testOnCompleteResumeWith() {
+        List<Integer> result = Multi.just(1, 2, 3)
+                .onCompleteResumeWith(Multi.just(4, 5, 6))
+                .collectList()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(List.of(1, 2, 3, 4, 5, 6))));
+    }
+
+    @Test
+    void testOnCompleteResumeWithFirst() {
+        Integer result = Multi.<Integer>empty()
+                .onCompleteResume(1)
+                .first()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(1)));
+    }
+
+    @Test
     void testFlatMap() throws ExecutionException, InterruptedException {
         final List<String> TEST_DATA = Arrays.asList("abc", "xyz");
         final List<String> EXPECTED = Arrays.asList("a", "b", "c", "x", "y", "z");

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiTest.java
@@ -16,6 +16,7 @@
 package io.helidon.common.reactive;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -29,8 +30,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import io.helidon.common.mapper.Mapper;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -504,6 +503,95 @@ public class MultiTest {
                 .get();
 
         assertThat(result, is(equalTo(EXPECTED)));
+    }
+
+    @Test
+    void testConcatVarargs() {
+        final List<Integer> TEST_DATA_1 = Arrays.asList(1, 2, 3);
+        final List<Integer> TEST_DATA_2 = Arrays.asList(11, 12, 13);
+        final List<Integer> TEST_DATA_3 = Arrays.asList(21, 22, 23);
+        final List<Integer> TEST_DATA_4 = Arrays.asList(31, 32, 33);
+        final List<Integer> TEST_DATA_5 = Arrays.asList(41, 42, 43);
+        final List<Integer> TEST_DATA_6 = Arrays.asList(51, 52, 53);
+
+        final Function<List<List<Integer>>, List<Integer>> flatMap = lists -> lists.stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        assertThat(Multi
+                .concat(Multi.from(TEST_DATA_1),
+                        Multi.just(TEST_DATA_2)
+                )
+                .collectList()
+                .await(), is(equalTo(flatMap.apply(List.of(
+                TEST_DATA_1,
+                TEST_DATA_2
+        )))));
+
+
+        assertThat(Multi
+                .concat(Multi.from(TEST_DATA_1),
+                        Multi.just(TEST_DATA_2),
+                        Multi.just(TEST_DATA_3)
+                )
+                .collectList()
+                .await(), is(equalTo(flatMap.apply(List.of(
+                TEST_DATA_1,
+                TEST_DATA_2,
+                TEST_DATA_3
+        )))));
+
+        assertThat(Multi
+                .concat(Multi.from(TEST_DATA_1),
+                        Multi.just(TEST_DATA_2),
+                        Multi.just(TEST_DATA_3),
+                        Multi.just(TEST_DATA_4)
+                )
+                .collectList()
+                .await(), is(equalTo(flatMap.apply(List.of(
+                TEST_DATA_1,
+                TEST_DATA_2,
+                TEST_DATA_3,
+                TEST_DATA_4
+        )))));
+
+
+        assertThat(Multi
+                        .concat(Multi.from(TEST_DATA_1),
+                                Multi.just(TEST_DATA_2),
+                                Multi.just(TEST_DATA_3),
+                                Multi.just(TEST_DATA_4),
+                                Multi.just(TEST_DATA_5)
+                        )
+                        .collectList()
+                        .await(),
+                is(equalTo(flatMap.apply(List.of(
+                        TEST_DATA_1,
+                        TEST_DATA_2,
+                        TEST_DATA_3,
+                        TEST_DATA_4,
+                        TEST_DATA_5
+                )))));
+
+
+        assertThat(Multi
+                        .concat(Multi.from(TEST_DATA_1),
+                                Multi.just(TEST_DATA_2),
+                                Multi.just(TEST_DATA_3),
+                                Multi.just(TEST_DATA_4),
+                                Multi.just(TEST_DATA_5),
+                                Multi.just(TEST_DATA_6)
+                        )
+                        .collectList()
+                        .await(),
+                is(equalTo(flatMap.apply(List.of(
+                        TEST_DATA_1,
+                        TEST_DATA_2,
+                        TEST_DATA_3,
+                        TEST_DATA_4,
+                        TEST_DATA_5,
+                        TEST_DATA_6
+                )))));
     }
 
     @Test

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -15,7 +15,7 @@
  */
 package io.helidon.common.reactive;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
@@ -409,6 +409,36 @@ public class SingleTest {
         assertThat(subscriber.isComplete(), is(equalTo(false)));
         assertThat(subscriber.getLastError(), is(instanceOf(IllegalStateException.class)));
         assertThat(subscriber.getItems(), is(empty()));
+    }
+
+    @Test
+    void testOnCompleteResume() {
+        List<Integer> result = Single.just(1)
+                .onCompleteResume(4)
+                .collectList()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(List.of(1, 4))));
+    }
+
+    @Test
+    void testOnCompleteResumeWith() {
+        List<Integer> result = Single.just(1)
+                .onCompleteResumeWith(Multi.just(4, 5, 6))
+                .collectList()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(List.of(1, 4, 5, 6))));
+    }
+
+    @Test
+    void testOnCompleteResumeWithFirst() {
+        Integer result = Single.<Integer>empty()
+                .onCompleteResume(1)
+                .first()
+                .await(100, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(equalTo(1)));
     }
 
     private static class SingleTestSubscriber<T> extends TestSubscriber<T> {


### PR DESCRIPTION
### Effectively append to the stream with onCompleteResume  
* Multi.onCompleteResume

```java
        List<Integer> result = Multi.just(1, 2, 3)
                .onCompleteResume(4)
                .onCompleteResume(5)
                .collectList()
                .await();

        assertThat(result, is(equalTo(List.of(1, 2, 3, 4, 5))));
```
  * Multi.onCompleteResumeWith
```java
        List<Integer> result = Multi.just(1, 2, 3)
                .onCompleteResumeWith(Multi.just(4, 5, 6))
                .collectList()
                .await();

        assertThat(result, is(equalTo(List.of(1, 2, 3, 4, 5, 6))));
```

### Methods common for `Multi` and `Single` are accessible at common ancestor `Subscribable`

```java
        Subscribable<Integer> subs = Single.just(1);

        subs = subs.onCompleteResume(2);

        List<Integer> result = Multi.from(subs)
                .collectList()
                .await();

        assertThat(result, is(equalTo(List.of(1, 2))));
```

### Concat has varargs
```java
assertThat(Multi
                        .concat(Multi.from(TEST_DATA_1),
                                Multi.just(TEST_DATA_2),
                                Multi.just(TEST_DATA_3),
                                Multi.just(TEST_DATA_4),
                                Multi.just(TEST_DATA_5),
                                Multi.just(TEST_DATA_6)
                        )
                        .collectList()
                        .await(),
                is(equalTo(flatMap.apply(List.of(
                        TEST_DATA_1,
                        TEST_DATA_2,
                        TEST_DATA_3,
                        TEST_DATA_4,
                        TEST_DATA_5,
                        TEST_DATA_6
                )))));
```
Signed-off-by: Daniel Kec <daniel.kec@oracle.com>