### PR TITLE
Change CORS config key from path-prefix to path-expr; method names also

### DIFF
--- a/examples/cors/src/main/resources/application.yaml
+++ b/examples/cors/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ restrictive-cors:
 # The the example app uses the following for overriding other settings.
 #cors:
 #  paths:
-#    - path-expr: /greeting
+#    - path-pattern: /greeting
 #      allow-origins: ["http://foo.com", "http://there.com", "http://other.com"]
 #      allow-methods: ["PUT", "DELETE"]
 

--- a/examples/cors/src/main/resources/application.yaml
+++ b/examples/cors/src/main/resources/application.yaml
@@ -28,7 +28,7 @@ restrictive-cors:
 # The the example app uses the following for overriding other settings.
 #cors:
 #  paths:
-#    - path-prefix: /greeting
+#    - path-expr: /greeting
 #      allow-origins: ["http://foo.com", "http://there.com", "http://other.com"]
 #      allow-methods: ["PUT", "DELETE"]
 

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
@@ -30,10 +30,10 @@
  *   cors:
  *     enabled: true # this is the default
  *     paths:
- *       - path-prefix: /cors1
+ *       - path-expr: /cors1
  *         allow-origins: ["*"]
  *         allow-methods: ["*"]
- *       - path-prefix: /cors2
+ *       - path-expr: /cors2
  *         allow-origins: ["http://foo.bar", "http://bar.foo"]
  *         allow-methods: ["DELETE", "PUT"]
  *         allow-headers: ["X-bar", "X-foo"]

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
@@ -30,10 +30,10 @@
  *   cors:
  *     enabled: true # this is the default
  *     paths:
- *       - path-expr: /cors1
+ *       - path-pattern: /cors1
  *         allow-origins: ["*"]
  *         allow-methods: ["*"]
- *       - path-expr: /cors2
+ *       - path-pattern: /cors2
  *         allow-origins: ["http://foo.bar", "http://bar.foo"]
  *         allow-methods: ["DELETE", "PUT"]
  *         allow-headers: ["X-bar", "X-foo"]

--- a/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cors.paths.0.path-prefix=/cors3
+cors.paths.0.path-expr=/cors3
 cors.paths.0.allow-origins=http://foo.bar, http://bar.foo
 cors.paths.0.allow-methods=DELETE, PUT

--- a/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cors.paths.0.path-expr=/cors3
+cors.paths.0.path-pattern=/cors3
 cors.paths.0.allow-origins=http://foo.bar, http://bar.foo
 cors.paths.0.allow-methods=DELETE, PUT

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
@@ -151,14 +151,14 @@ class Aggregator {
         }
 
         /**
-         * Adds cross origin information associated with a given pathExpr.
+         * Adds cross origin information associated with a given pathPattern.
          *
-         * @param pathExpr the pathExpr to which the cross origin information applies
+         * @param pathPattern the pathPattern to which the cross origin information applies
          * @param crossOrigin the cross origin information
          * @return updated builder
          */
-        Builder addCrossOrigin(String pathExpr, CrossOriginConfig crossOrigin) {
-            crossOriginConfigMatchables.add(new FixedCrossOriginConfigMatchable(pathExpr, crossOrigin));
+        Builder addCrossOrigin(String pathPattern, CrossOriginConfig crossOrigin) {
+            crossOriginConfigMatchables.add(new FixedCrossOriginConfigMatchable(pathPattern, crossOrigin));
             return this;
         }
 
@@ -262,7 +262,7 @@ class Aggregator {
      * Given a map from path expressions to matchables, finds the first map entry with a path matcher that accepts the provided
      * path and is enabled.
      *
-     * @param matchables map from pathExpressions to matchables
+     * @param matchables map from pathPatterns to matchables
      * @param normalizedPath unnormalized path (from the request) to be matched
      * @return Optional of the CrossOriginConfig
      */
@@ -297,8 +297,8 @@ class Aggregator {
     private abstract static class CrossOriginConfigMatchable {
         private final PathMatcher matcher;
 
-        CrossOriginConfigMatchable(String pathExpr) {
-            this.matcher = PathMatcher.create(pathExpr);
+        CrossOriginConfigMatchable(String pathPattern) {
+            this.matcher = PathMatcher.create(pathPattern);
         }
 
         boolean matches(String path, String method) {
@@ -318,8 +318,8 @@ class Aggregator {
     private static class FixedCrossOriginConfigMatchable extends CrossOriginConfigMatchable {
         private final CrossOriginConfig crossOriginConfig;
 
-        FixedCrossOriginConfigMatchable(String pathExpr, CrossOriginConfig crossOriginConfig) {
-            super(pathExpr);
+        FixedCrossOriginConfigMatchable(String pathPattern, CrossOriginConfig crossOriginConfig) {
+            super(pathPattern);
             this.crossOriginConfig = crossOriginConfig;
         }
 
@@ -343,8 +343,8 @@ class Aggregator {
         private final CrossOriginConfig.Builder builder;
         private CrossOriginConfig config = null;
 
-        BuildableCrossOriginConfigMatchable(String pathExpr, CrossOriginConfig.Builder builder) {
-            super(pathExpr);
+        BuildableCrossOriginConfigMatchable(String pathPattern, CrossOriginConfig.Builder builder) {
+            super(pathPattern);
             this.builder = builder;
         }
 

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
@@ -95,7 +95,7 @@ public class CrossOriginConfig {
      */
     public static final long DEFAULT_AGE = 3600;
 
-    private final String pathPrefix;
+    private final String pathExpr;
     private final boolean enabled;
     private final String[] allowOrigins;
     private final String[] allowHeaders;
@@ -105,7 +105,7 @@ public class CrossOriginConfig {
     private final long maxAgeSeconds;
 
     private CrossOriginConfig(Builder builder) {
-        this.pathPrefix = builder.pathPrefix;
+        this.pathExpr = builder.pathExpr;
         this.enabled = builder.enabled;
         this.allowOrigins = builder.origins;
         this.allowHeaders = builder.allowHeaders;
@@ -144,7 +144,7 @@ public class CrossOriginConfig {
      */
     public static Builder builder(CrossOriginConfig original) {
         return new Builder()
-                .pathPrefix(original.pathPrefix)
+                .pathExpr(original.pathExpr)
                 .enabled(original.enabled)
                 .allowCredentials(original.allowCredentials)
                 .allowHeaders(original.allowHeaders)
@@ -173,10 +173,10 @@ public class CrossOriginConfig {
     }
 
     /**
-     * @return the configured path prefix; defaults to a "match-everything" pattern
+     * @return the configured path expression; defaults to a "match-everything" pattern
      */
-    public String pathPrefix() {
-        return pathPrefix;
+    public String pathExpr() {
+        return pathExpr;
     }
 
     /**
@@ -245,8 +245,8 @@ public class CrossOriginConfig {
 
     @Override
     public String toString() {
-        return String.format("CrossOriginConfig{pathPrefix=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
-                + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathPrefix, enabled,
+        return String.format("CrossOriginConfig{pathExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
+                + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathExpr, enabled,
                 Arrays.toString(allowOrigins),
                 Arrays.toString(allowHeaders), Arrays.toString(exposeHeaders), Arrays.toString(allowMethods),
                 allowCredentials, maxAgeSeconds);
@@ -263,7 +263,7 @@ public class CrossOriginConfig {
 
         static final String[] ALLOW_ALL = {"*"};
 
-        private String pathPrefix = PATHLESS_KEY; // not typically used except when inside a MappedCrossOriginConfig
+        private String pathExpr = PATHLESS_KEY; // not typically used except when inside a MappedCrossOriginConfig
         private boolean enabled = true;
         private String[] origins = ALLOW_ALL;
         private String[] allowHeaders = ALLOW_ALL;
@@ -278,16 +278,16 @@ public class CrossOriginConfig {
         /**
          * Updates the path prefix for this cross-origin config.
          *
-         * @param pathPrefix new path prefix
+         * @param pathExpr new path prefix
          * @return updated builder
          */
-        public Builder pathPrefix(String pathPrefix) {
-            this.pathPrefix = pathPrefix;
+        public Builder pathExpr(String pathExpr) {
+            this.pathExpr = pathExpr;
             return this;
         }
 
-        String pathPrefix() {
-            return pathPrefix;
+        String pathExpr() {
+            return pathExpr;
         }
 
         @Override
@@ -350,8 +350,8 @@ public class CrossOriginConfig {
 
         @Override
         public String toString() {
-            return String.format("Builder{pathPrefix=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
-                    + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathPrefix, enabled, Arrays.toString(origins),
+            return String.format("Builder{pathPExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
+                    + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathExpr, enabled, Arrays.toString(origins),
                     Arrays.toString(allowHeaders), Arrays.toString(exposeHeaders), Arrays.toString(allowMethods),
                     allowCredentials, maxAgeSeconds);
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
@@ -350,7 +350,7 @@ public class CrossOriginConfig {
 
         @Override
         public String toString() {
-            return String.format("Builder{pathPExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
+            return String.format("Builder{pathExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
                     + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathExpr, enabled, Arrays.toString(origins),
                     Arrays.toString(allowHeaders), Arrays.toString(exposeHeaders), Arrays.toString(allowMethods),
                     allowCredentials, maxAgeSeconds);

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
@@ -95,7 +95,7 @@ public class CrossOriginConfig {
      */
     public static final long DEFAULT_AGE = 3600;
 
-    private final String pathExpr;
+    private final String pathPattern;
     private final boolean enabled;
     private final String[] allowOrigins;
     private final String[] allowHeaders;
@@ -105,7 +105,7 @@ public class CrossOriginConfig {
     private final long maxAgeSeconds;
 
     private CrossOriginConfig(Builder builder) {
-        this.pathExpr = builder.pathExpr;
+        this.pathPattern = builder.pathPattern;
         this.enabled = builder.enabled;
         this.allowOrigins = builder.origins;
         this.allowHeaders = builder.allowHeaders;
@@ -144,7 +144,7 @@ public class CrossOriginConfig {
      */
     public static Builder builder(CrossOriginConfig original) {
         return new Builder()
-                .pathExpr(original.pathExpr)
+                .pathPattern(original.pathPattern)
                 .enabled(original.enabled)
                 .allowCredentials(original.allowCredentials)
                 .allowHeaders(original.allowHeaders)
@@ -175,8 +175,8 @@ public class CrossOriginConfig {
     /**
      * @return the configured path expression; defaults to a "match-everything" pattern
      */
-    public String pathExpr() {
-        return pathExpr;
+    public String pathPattern() {
+        return pathPattern;
     }
 
     /**
@@ -245,8 +245,8 @@ public class CrossOriginConfig {
 
     @Override
     public String toString() {
-        return String.format("CrossOriginConfig{pathExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
-                + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathExpr, enabled,
+        return String.format("CrossOriginConfig{pathPattern=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
+                + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathPattern, enabled,
                 Arrays.toString(allowOrigins),
                 Arrays.toString(allowHeaders), Arrays.toString(exposeHeaders), Arrays.toString(allowMethods),
                 allowCredentials, maxAgeSeconds);
@@ -263,7 +263,7 @@ public class CrossOriginConfig {
 
         static final String[] ALLOW_ALL = {"*"};
 
-        private String pathExpr = PATHLESS_KEY; // not typically used except when inside a MappedCrossOriginConfig
+        private String pathPattern = PATHLESS_KEY; // not typically used except when inside a MappedCrossOriginConfig
         private boolean enabled = true;
         private String[] origins = ALLOW_ALL;
         private String[] allowHeaders = ALLOW_ALL;
@@ -278,16 +278,16 @@ public class CrossOriginConfig {
         /**
          * Updates the path prefix for this cross-origin config.
          *
-         * @param pathExpr new path prefix
+         * @param pathPattern new path prefix
          * @return updated builder
          */
-        public Builder pathExpr(String pathExpr) {
-            this.pathExpr = pathExpr;
+        public Builder pathPattern(String pathPattern) {
+            this.pathPattern = pathPattern;
             return this;
         }
 
-        String pathExpr() {
-            return pathExpr;
+        String pathPattern() {
+            return pathPattern;
         }
 
         @Override
@@ -350,8 +350,8 @@ public class CrossOriginConfig {
 
         @Override
         public String toString() {
-            return String.format("Builder{pathExpr=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
-                    + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathExpr, enabled, Arrays.toString(origins),
+            return String.format("Builder{pathPattern=%s, enabled=%b, origins=%s, allowHeaders=%s, exposeHeaders=%s, "
+                    + "allowMethods=%s, allowCredentials=%b, maxAgeSeconds=%d", pathPattern, enabled, Arrays.toString(origins),
                     Arrays.toString(allowHeaders), Arrays.toString(exposeHeaders), Arrays.toString(allowMethods),
                     allowCredentials, maxAgeSeconds);
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
@@ -34,7 +34,7 @@ class Loader {
             config.get("enabled")
                     .asBoolean()
                     .ifPresent(builder::enabled);
-            config.get("path-prefix")
+            config.get("path-expr")
                     .asString()
                     .ifPresent(builder::pathPrefix);
             config.get("allow-origins")

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
@@ -34,9 +34,9 @@ class Loader {
             config.get("enabled")
                     .asBoolean()
                     .ifPresent(builder::enabled);
-            config.get("path-expr")
+            config.get("path-pattern")
                     .asString()
-                    .ifPresent(builder::pathExpr);
+                    .ifPresent(builder::pathPattern);
             config.get("allow-origins")
                     .asList(String.class)
                     .ifPresent(
@@ -91,14 +91,14 @@ class Loader {
                  * process of matching request paths against paths in the mapped CORS instance will use any more specific path
                  * expressions before the wildcard.
                  */
-                if (basicBuilder.pathExpr().equals(PATHLESS_KEY)) {
+                if (basicBuilder.pathPattern().equals(PATHLESS_KEY)) {
                     allPathsBuilder = basicBuilder;
                 } else {
-                    builder.put(basicBuilder.pathExpr(), basicBuilder);
+                    builder.put(basicBuilder.pathPattern(), basicBuilder);
                 }
             } while (true);
             if (allPathsBuilder != null) {
-                builder.put(allPathsBuilder.pathExpr(), allPathsBuilder);
+                builder.put(allPathsBuilder.pathPattern(), allPathsBuilder);
             }
             return builder;
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Loader.java
@@ -36,7 +36,7 @@ class Loader {
                     .ifPresent(builder::enabled);
             config.get("path-expr")
                     .asString()
-                    .ifPresent(builder::pathPrefix);
+                    .ifPresent(builder::pathExpr);
             config.get("allow-origins")
                     .asList(String.class)
                     .ifPresent(
@@ -91,14 +91,14 @@ class Loader {
                  * process of matching request paths against paths in the mapped CORS instance will use any more specific path
                  * expressions before the wildcard.
                  */
-                if (basicBuilder.pathPrefix().equals(PATHLESS_KEY)) {
+                if (basicBuilder.pathExpr().equals(PATHLESS_KEY)) {
                     allPathsBuilder = basicBuilder;
                 } else {
-                    builder.put(basicBuilder.pathPrefix(), basicBuilder);
+                    builder.put(basicBuilder.pathExpr(), basicBuilder);
                 }
             } while (true);
             if (allPathsBuilder != null) {
-                builder.put(allPathsBuilder.pathPrefix(), allPathsBuilder);
+                builder.put(allPathsBuilder.pathExpr(), allPathsBuilder);
             }
             return builder;
         }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
@@ -138,11 +138,11 @@ public class MappedCrossOriginConfig implements Iterable<Map.Entry<String, Cross
     /**
      * Finds the {@code CrossOriginConfig} associated with the given path expression, if any.
      *
-     * @param pathExpr path expression to match on
+     * @param pathPattern path expression to match on
      * @return {@code Optional} of the corresponding basic cross-origin information
      */
-    public CrossOriginConfig get(String pathExpr) {
-        Buildable b = buildables.get(pathExpr);
+    public CrossOriginConfig get(String pathPattern) {
+        Buildable b = buildables.get(pathPattern);
         return b == null ? null : b.get();
     }
 

--- a/webserver/cors/src/test/resources/application.yaml
+++ b/webserver/cors/src/test/resources/application.yaml
@@ -22,10 +22,10 @@ client:
 
 cors-setup:
   paths:
-    - path-expr: /cors1
+    - path-pattern: /cors1
       allow-origins: ["*"]
       allow-methods: ["*"]
-    - path-expr: /cors2
+    - path-pattern: /cors2
       allow-origins: ["http://foo.bar", "http://bar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-bar", "X-foo"]

--- a/webserver/cors/src/test/resources/application.yaml
+++ b/webserver/cors/src/test/resources/application.yaml
@@ -22,10 +22,10 @@ client:
 
 cors-setup:
   paths:
-    - path-prefix: /cors1
+    - path-expr: /cors1
       allow-origins: ["*"]
       allow-methods: ["*"]
-    - path-prefix: /cors2
+    - path-expr: /cors2
       allow-origins: ["http://foo.bar", "http://bar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-bar", "X-foo"]

--- a/webserver/cors/src/test/resources/configMapperTest.yaml
+++ b/webserver/cors/src/test/resources/configMapperTest.yaml
@@ -17,10 +17,10 @@
 cors-setup:
   enabled: true # or false or omitted
   paths:
-    - path-prefix: /cors1
+    - path-expr: /cors1
       allow-origins: ["*"]
       allow-methods: ["*"]
-    - path-prefix: /cors2
+    - path-expr: /cors2
       allow-origins: ["http://foo.bar", "http://bar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-bar", "X-foo"]

--- a/webserver/cors/src/test/resources/configMapperTest.yaml
+++ b/webserver/cors/src/test/resources/configMapperTest.yaml
@@ -17,10 +17,10 @@
 cors-setup:
   enabled: true # or false or omitted
   paths:
-    - path-expr: /cors1
+    - path-pattern: /cors1
       allow-origins: ["*"]
       allow-methods: ["*"]
-    - path-expr: /cors2
+    - path-pattern: /cors2
       allow-origins: ["http://foo.bar", "http://bar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-bar", "X-foo"]

--- a/webserver/cors/src/test/resources/twoCORS.yaml
+++ b/webserver/cors/src/test/resources/twoCORS.yaml
@@ -15,7 +15,7 @@
 #
 cors-2-setup:
   paths:
-    - path-expr: /cors2
+    - path-pattern: /cors2
       allow-origins: ["http://otherfoo.bar", "http://otherbar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-otherBar", "X-otherFoo"]

--- a/webserver/cors/src/test/resources/twoCORS.yaml
+++ b/webserver/cors/src/test/resources/twoCORS.yaml
@@ -15,7 +15,7 @@
 #
 cors-2-setup:
   paths:
-    - path-prefix: /cors2
+    - path-expr: /cors2
       allow-origins: ["http://otherfoo.bar", "http://otherbar.foo"]
       allow-methods: ["DELETE", "PUT"]
       allow-headers: ["X-otherBar", "X-otherFoo"]


### PR DESCRIPTION
Resolves #1767 

The value is, in fact, used as a pattern (expression) and not a prefix.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>