### PR TITLE
Updated UCP version to always be in sync with Oracle's OJDBC8 version since the two artifacts are mutually dependent

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -109,7 +109,7 @@
         <version.lib.transaction-api>1.3.3</version.lib.transaction-api>
         <version.lib.typesafe-config>1.4.0</version.lib.typesafe-config>
         <version.lib.tyrus>1.15</version.lib.tyrus>
-        <version.lib.ucp>19.3.0.0</version.lib.ucp>
+        <version.lib.ucp>${version.lib.ojdbc8}</version.lib.ucp>
         <version.lib.validation-api>2.0.2</version.lib.validation-api>
         <version.lib.websockets-api>1.1.2</version.lib.websockets-api>
         <version.lib.weld>3.1.3.Final</version.lib.weld>


### PR DESCRIPTION
Signed-off-by: Laird Nelson <laird.nelson@oracle.com>