### PR TITLE
Redesign in Kafka tests

### DIFF
--- a/messaging/connectors/kafka/src/main/java/io/helidon/messaging/connectors/kafka/KafkaConnector.java
+++ b/messaging/connectors/kafka/src/main/java/io/helidon/messaging/connectors/kafka/KafkaConnector.java
@@ -94,7 +94,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
                 .config(MpConfig.toHelidonConfig(config))
                 .scheduler(scheduler)
                 .build();
-
+        LOGGER.fine(() -> String.format("Resource %s added", publisher));
         resources.add(publisher);
         return ReactiveStreams.fromPublisher(publisher);
     }
@@ -131,7 +131,7 @@ public class KafkaConnector implements IncomingConnectorFactory, OutgoingConnect
             }
         }
         if (failed.isEmpty()) {
-            LOGGER.fine("KafkaConnectorFactory terminated successfuly");
+            LOGGER.fine("KafkaConnector terminated successfuly");
         } else {
             // Inform about the errors
             failed.forEach(e -> LOGGER.log(Level.SEVERE, "An error happened closing resource", e));

--- a/tests/integration/kafka/src/test/resources/logging.properties
+++ b/tests/integration/kafka/src/test/resources/logging.properties
@@ -20,9 +20,11 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 
 #All log level details
 .level=SEVERE
-org.apache.kafka.level=FINE
-io.helidon.level=FINE
-com.salesforce.kafka.level=FINE
+org.apache.kafka.level=WARN
+io.helidon.messaging.level=FINE
+io.helidon.config.level=WARN
+io.helidon.microprofile.level=FINE
+com.salesforce.kafka.level=WARN
 
 # Known issue with meta.properties in embedded kafka server
 #kafka.server.BrokerMetadataCheckpoint.level=SEVERE


### PR DESCRIPTION
I didn't change functionality, but I did some changes in the tests.

There are less connections/disconnections to Kafka. CDI container is running during all the execution of the tests.