### PR TITLE
Upgrading Jersey to version 2.31

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -73,7 +73,7 @@
         <version.lib.jboss.transaction-spi>7.6.0.Final</version.lib.jboss.transaction-spi>
         <version.lib.jboss.transaction-api>1.0.0.Final</version.lib.jboss.transaction-api>
         <version.lib.jedis>3.1.0</version.lib.jedis>
-        <version.lib.jersey>2.30.1</version.lib.jersey>
+        <version.lib.jersey>2.31</version.lib.jersey>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
         <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>


### PR DESCRIPTION
A follow-up PR will look at using the new `WebClient` connector in Jersey.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>