### PR TITLE
Static content handlers now use explicit writers.

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
@@ -168,7 +168,7 @@ class ClassPathContentHandler extends StaticContentHandler {
         if (method == Http.Method.HEAD) {
             response.send();
         } else {
-            response.send(extrEntry.tempFile);
+            FileSystemContentHandler.send(response, extrEntry.tempFile);
         }
 
         return true;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
@@ -23,13 +23,20 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.logging.Logger;
 
+import io.helidon.common.GenericType;
 import io.helidon.common.http.Http;
+import io.helidon.common.reactive.Single;
+import io.helidon.media.common.DefaultMediaSupport;
+import io.helidon.media.common.MessageBodyWriter;
 
 /**
  * Serves files from the filesystem as a static WEB content.
  */
 class FileSystemContentHandler extends StaticContentHandler {
     private static final Logger LOGGER = Logger.getLogger(FileSystemContentHandler.class.getName());
+    private static final MessageBodyWriter<Path> PATH_WRITER = DefaultMediaSupport.pathWriter();
+    private static final GenericType<Path> PATH_TYPE = GenericType.create(Path.class);
+
     private final Path root;
 
     FileSystemContentHandler(String welcomeFilename, ContentTypeSelector contentTypeSelector, Path root) {
@@ -119,8 +126,12 @@ class FileSystemContentHandler extends StaticContentHandler {
         if (method == Http.Method.HEAD) {
             response.send();
         } else {
-            response.send(path);
+            send(response, path);
         }
+    }
+
+    static void send(ServerResponse response, Path path) {
+        response.send(PATH_WRITER.write(Single.just(path), PATH_TYPE, response.writerContext()));
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Related to #1588 