### PR TITLE
EmittingPublisher cleanup

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/EmittingPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/EmittingPublisher.java
@@ -157,7 +157,7 @@ public class EmittingPublisher<T> implements Flow.Publisher<T> {
                 }
                 if (state.compareAndSet(State.INIT, State.FAILED)
                         || state.compareAndSet(State.SUBSCRIBED, State.FAILED)
-                        || state.compareAndSet(State.REQUESTED, State.CANCELLED)
+                        || state.compareAndSet(State.REQUESTED, State.FAILED)
                         || state.compareAndSet(State.READY_TO_EMIT, State.FAILED)) {
                     this.error = throwable;
                     EmittingPublisher.this.subscriber = null;
@@ -184,8 +184,8 @@ public class EmittingPublisher<T> implements Flow.Publisher<T> {
                     return;
                 }
                 if (state.compareAndSet(State.INIT, State.COMPLETED)
-                        || state.compareAndSet(State.SUBSCRIBED, State.FAILED)
-                        || state.compareAndSet(State.REQUESTED, State.FAILED)
+                        || state.compareAndSet(State.SUBSCRIBED, State.COMPLETED)
+                        || state.compareAndSet(State.REQUESTED, State.COMPLETED)
                         || state.compareAndSet(State.READY_TO_EMIT, State.COMPLETED)) {
                     EmittingPublisher.this.subscriber = null;
                     subscriber.onComplete();

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTckTest.java
@@ -17,22 +17,20 @@
 package io.helidon.common.reactive;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test
 public class BufferedEmittingPublisherTckTest extends FlowPublisherVerification<Integer> {
 
-    private static ExecutorService executor;
+    private static TidyTestExecutor executor;
 
     public BufferedEmittingPublisherTckTest() {
         super(new TestEnvironment(200));
@@ -82,16 +80,18 @@ public class BufferedEmittingPublisherTckTest extends FlowPublisherVerification<
         }
     }
 
-    @Override
-    @BeforeMethod
-    public void setUp() throws Exception {
-        super.setUp();
-        executor = Executors.newCachedThreadPool();
+    @BeforeClass
+    public void beforeClass() {
+        executor = new TidyTestExecutor();
+    }
+
+    @AfterClass
+    public void afterClass() {
+        executor.shutdownNow();
     }
 
     @AfterMethod
     public void tearDown() throws InterruptedException {
-        executor.shutdownNow();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
+        executor.awaitAllFinished();
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/BufferedEmittingPublisherTckTest.java
@@ -20,12 +20,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test
@@ -81,13 +82,16 @@ public class BufferedEmittingPublisherTckTest extends FlowPublisherVerification<
         }
     }
 
-    @BeforeClass
-    public static void beforeClass() {
+    @Override
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
         executor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
-    public static void afterClass() {
-        executor.shutdown();
+    @AfterMethod
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/EmittingPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/EmittingPublisherTckTest.java
@@ -17,22 +17,21 @@
 package io.helidon.common.reactive;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test
 public class EmittingPublisherTckTest extends FlowPublisherVerification<Integer> {
 
-    private static ExecutorService executor;
+    private static TidyTestExecutor executor;
 
     public EmittingPublisherTckTest() {
         super(new TestEnvironment(200));
@@ -44,27 +43,30 @@ public class EmittingPublisherTckTest extends FlowPublisherVerification<Integer>
         CountDownLatch completeLatch = new CountDownLatch((int) l);
         EmittingPublisher<Integer> osp = EmittingPublisher.create();
         osp.onRequest((r, demand) -> {
-            for (long n = 0; n < r && n <= l; n++) {
+            boolean accepted = true;
+            for (long n = 0; n < r && n <= l && accepted; n++) {
                 final long fn = n;
                 //stochastic test of emit methods being thread-safe
-                executor.submit(() -> {
+                accepted = executor.submitAwaitable(() -> {
                     long cnt = counter.getAndDecrement();
                     if (cnt > 0) {
                         osp.emit((int) fn);
                         completeLatch.countDown();
+                        if (cnt == 1) {
+                            executor.submit(() -> {
+                                try {
+                                    completeLatch.await(2, TimeUnit.SECONDS);
+                                    osp.complete();
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
+                            });
+                        }
                     }
                 });
             }
         });
 
-        executor.submit(() -> {
-            try {
-                completeLatch.await(2, TimeUnit.SECONDS);
-                osp.complete();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        });
 
         return osp;
     }
@@ -95,16 +97,18 @@ public class EmittingPublisherTckTest extends FlowPublisherVerification<Integer>
         }
     }
 
-    @Override
-    @BeforeMethod
-    public void setUp() throws Exception {
-        super.setUp();
-        executor = Executors.newCachedThreadPool();
+    @BeforeClass
+    public void beforeClass() {
+        executor = new TidyTestExecutor();
+    }
+
+    @AfterClass
+    public void afterClass() {
+        executor.shutdownNow();
     }
 
     @AfterMethod
     public void tearDown() throws InterruptedException {
-        executor.shutdownNow();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
+        executor.awaitAllFinished();
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/EmittingPublisherTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/EmittingPublisherTckTest.java
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Test
@@ -95,13 +95,16 @@ public class EmittingPublisherTckTest extends FlowPublisherVerification<Integer>
         }
     }
 
-    @BeforeClass
-    public static void beforeClass() {
+    @Override
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
         executor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
-    public static void afterClass() {
-        executor.shutdown();
+    @AfterMethod
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTckTest.java
@@ -20,10 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -33,8 +30,9 @@ import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
 import org.reactivestreams.tck.flow.support.Function;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
@@ -42,7 +40,7 @@ import org.testng.annotations.Test;
  */
 public class MultiFromOutputStreamTckTest extends FlowPublisherVerification<ByteBuffer> {
 
-    private static ExecutorService executor;
+    private static TidyTestExecutor executor;
     private static final TestEnvironment env = new TestEnvironment(150);
 
     public MultiFromOutputStreamTckTest() {
@@ -199,16 +197,18 @@ public class MultiFromOutputStreamTckTest extends FlowPublisherVerification<Byte
         });
     }
 
-    @Override
-    @BeforeMethod
-    public void setUp() throws Exception {
-        super.setUp();
-        executor = Executors.newCachedThreadPool();
+    @BeforeClass
+    public void beforeClass() {
+        executor = new TidyTestExecutor();
+    }
+
+    @AfterClass
+    public void afterClass() {
+        executor.shutdownNow();
     }
 
     @AfterMethod
     public void tearDown() throws InterruptedException {
-        executor.shutdownNow();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
+        executor.awaitAllFinished();
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTckTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTckTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -32,19 +33,19 @@ import org.reactivestreams.Subscription;
 import org.reactivestreams.tck.TestEnvironment;
 import org.reactivestreams.tck.flow.FlowPublisherVerification;
 import org.reactivestreams.tck.flow.support.Function;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
  * {@link MultiFromOutputStream} reactive streams tck test.
  */
-public class OutputStreamMultiTckTest extends FlowPublisherVerification<ByteBuffer> {
+public class MultiFromOutputStreamTckTest extends FlowPublisherVerification<ByteBuffer> {
 
     private static ExecutorService executor;
     private static final TestEnvironment env = new TestEnvironment(150);
 
-    public OutputStreamMultiTckTest() {
+    public MultiFromOutputStreamTckTest() {
         super(env);
     }
 
@@ -198,13 +199,16 @@ public class OutputStreamMultiTckTest extends FlowPublisherVerification<ByteBuff
         });
     }
 
-    @BeforeClass
-    public static void beforeClass() {
+    @Override
+    @BeforeMethod
+    public void setUp() throws Exception {
+        super.setUp();
         executor = Executors.newCachedThreadPool();
     }
 
-    @AfterClass
-    public static void afterClass() {
-        executor.shutdown();
+    @AfterMethod
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
     }
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/MultiFromOutputStreamTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * {@link MultiFromOutputStream} test.
  */
-public class OutputStreamMultiTest {
+public class MultiFromOutputStreamTest {
 
     @Test
     void testMulti() {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/TidyTestExecutor.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/TidyTestExecutor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TidyTestExecutor extends ThreadPoolExecutor {
+
+    private static final Logger LOGGER = Logger.getLogger(TidyTestExecutor.class.getName());
+
+    private final ConcurrentLinkedQueue<Future<?>> futures = new ConcurrentLinkedQueue<>();
+    private final AtomicReference<State> state = new AtomicReference<>(State.READY);
+
+    public TidyTestExecutor() {
+        super(4,
+                Integer.MAX_VALUE,
+                60L,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>());
+        super.prestartAllCoreThreads();
+    }
+
+    public boolean submitAwaitable(final Runnable task) {
+        return state.get().submit(task, this);
+    }
+
+    private void submitInternal(final Runnable task) {
+        Future<?> future = super.submit(task);
+        futures.add(future);
+    }
+
+    public void clearAndInterruptTasks() {
+        futures.forEach(future -> future.cancel(true));
+        this.purge();
+    }
+
+    public void clearTasks() {
+        futures.forEach(future -> future.cancel(false));
+        this.purge();
+    }
+
+    public void awaitAllFinished() {
+        if (state.getAndSet(State.WAITING) == State.READY) {
+            try {
+                while (!futures.isEmpty() && !futures.stream().allMatch(Future::isDone)) {
+                    try {
+                        Thread.sleep(250);
+                    } catch (InterruptedException e) {
+                        fail(e);
+                    }
+                }
+                futures.clear();
+            } finally {
+                state.set(State.READY);
+            }
+        }
+    }
+
+    private enum State {
+        READY {
+            @Override
+            boolean submit(final Runnable runnable, TidyTestExecutor tidyTestExecutor) {
+                tidyTestExecutor.submitInternal(runnable);
+                return true;
+            }
+        },
+        WAITING {
+            @Override
+            boolean submit(final Runnable runnable, TidyTestExecutor tidyTestExecutor) {
+                LOGGER.warning("Cannot submit, executor is waiting for cleanup!");
+                return false;
+            }
+        };
+
+        abstract boolean submit(Runnable runnable, TidyTestExecutor tidyTestExecutor);
+    }
+}


### PR DESCRIPTION
* Executor in Tck tests behaved differently on Windows

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>