### PR TITLE
Set version.plugin.helidon to 2.0.0-RC1 in applications pom

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -47,7 +47,7 @@
         <version.plugin.dependency>3.0.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
-        <version.plugin.helidon>2.0.0-M3</version.plugin.helidon>
+        <version.plugin.helidon>2.0.0-RC1</version.plugin.helidon>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>


### PR DESCRIPTION
Finishes integration of  build-tools 2.0.0-RC1

FYI, this change has already been added to the 2.0.0-RC1 release respin.
