### PR TITLE
Properly stop wiremock after rest-client tcks

### DIFF
--- a/jersey/common/src/main/java/module-info.java
+++ b/jersey/common/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnectorProvider.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonConnectorProvider.java
@@ -27,7 +27,7 @@ import org.glassfish.jersey.client.spi.ConnectorProvider;
 /**
  * Provider for Helidon WebClient {@link Connector} that utilizes the Helidon HTTP Client to send and receive
  * HTTP request and responses.
- * <p/>
+ * <p>
  * The following properties are only supported at construction of this class:
  * <ul>
  * <li>{@link org.glassfish.jersey.client.ClientProperties#CONNECT_TIMEOUT}</li>

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonEntity.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonEntity.java
@@ -29,8 +29,9 @@ import javax.ws.rs.ProcessingException;
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.IoMulti;
 import io.helidon.common.reactive.Multi;
-import io.helidon.common.reactive.MultiFromOutputStream;
+import io.helidon.common.reactive.OutputStreamMulti;
 import io.helidon.common.reactive.Single;
 import io.helidon.media.common.ContentWriters;
 import io.helidon.media.common.MessageBodyWriter;
@@ -120,7 +121,7 @@ class HelidonEntity {
                     stage = requestBuilder.submit(channel);
                     break;
                 case OUTPUT_STREAM_MULTI:
-                    final MultiFromOutputStream publisher = new MultiFromOutputStream() {};
+                    final OutputStreamMulti publisher = IoMulti.outputStreamMulti();
                     requestContext.setStreamProvider(contentLength -> publisher);
                     executorService.execute((ProcessingRunnable) () -> {
                         requestContext.writeEntity();

--- a/jersey/connector/src/main/java/module-info.java
+++ b/jersey/connector/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/connector/src/main/java/module-info.java
+++ b/jersey/connector/src/main/java/module-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * Eclipse Microprofile Tracing implementation for helidon microprofile.
+ * A {@link org.glassfish.jersey.client.spi.Connector} that utilizes the Helidon HTTP Client to send and receive
+ *  * HTTP request and responses.
  */
 module io.helidon.jersey.connector {
     requires jersey.client;

--- a/jersey/connector/src/main/java/module-info.java
+++ b/jersey/connector/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,17 @@
  */
 
 /**
- * Utilities for Jersey handling.
+ * Eclipse Microprofile Tracing implementation for helidon microprofile.
  */
-module io.helidon.jersey.common {
-    requires java.logging;
-    requires java.annotation;
-
-    requires io.helidon.common;
-
-    requires java.ws.rs;
+module io.helidon.jersey.connector {
+    requires jersey.client;
     requires jersey.common;
-    requires jersey.server;
+    requires jakarta.activation;
+    requires java.logging;
+    requires java.ws.rs;
+    requires io.helidon.common.reactive;
+    requires io.helidon.webclient;
+    requires io.netty.codec.http;
 
-    exports io.helidon.jersey.common;
+    exports io.helidon.jersey.connector;
 }

--- a/microprofile/tests/tck/tck-rest-client/pom.xml
+++ b/microprofile/tests/tck/tck-rest-client/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,10 +64,11 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>uk.co.deliverymind</groupId>
+                <groupId>uk.co.automatictester</groupId>
                 <artifactId>wiremock-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>start</id>
                         <phase>test-compile</phase>
                         <goals>
                             <goal>run</goal>
@@ -71,6 +77,13 @@
                             <dir>target/classes</dir>
                             <params>--port=8765</params>
                         </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>
-        <version.plugin.wiremock>2.7.0</version.plugin.wiremock>
+        <version.plugin.wiremock>2.14.0</version.plugin.wiremock>
 
         <javadoc.link.jackson-annotations>https://fasterxml.github.io/jackson-annotations/javadoc/2.9/</javadoc.link.jackson-annotations>
         <javadoc.link.jackson-core>https://fasterxml.github.io/jackson-core/javadoc/2.9/</javadoc.link.jackson-core>
@@ -590,7 +590,7 @@
                     <version>${version.plugin.archetype}</version>
                 </plugin>
                 <plugin>
-                    <groupId>uk.co.deliverymind</groupId>
+                    <groupId>uk.co.automatictester</groupId>
                     <artifactId>wiremock-maven-plugin</artifactId>
                     <version>${version.plugin.wiremock}</version>
                 </plugin>


### PR DESCRIPTION
  * Bump wiremock maven plugin to version which supports stop goal
  * Switch from MultiFromOutputStream to IoMulti
  * Fix javadoc
  * Add module-info

see automatictester/wiremock-maven-plugin/issues/10

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>