### PR TITLE
Update NOTICE.txt and include in artifacts

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,7 +2,7 @@
                            Project Helidon
                            ===============
 
-Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,4 +22,6 @@ Third Party Dependencies
 
 This project includes or depends on code from third party projects.
 Attributions are contained in 3RD-PARTY.txt 
+
+https://github.com/oracle/helidon/blob/${project.version}/3RD-PARTY.txt
 

--- a/pom.xml
+++ b/pom.xml
@@ -653,8 +653,10 @@
                                 <resource>
                                     <directory>${top.parent.basedir}</directory>
                                     <targetPath>META-INF/</targetPath>
+                                    <filtering>true</filtering>
                                     <includes>
                                         <include>LICENSE.txt</include>
+                                        <include>NOTICE.txt</include>
                                     </includes>
                                 </resource>
                             </resources>


### PR DESCRIPTION
We already includes LICENSE.txt. This adds NOTICE.txt (which is pretty small).

Also updates NOTICE.txt to have a URL to our third party attribution file (to avoid including that in our artifacts since it is not-so-small).
