### PR TITLE
Revert "Minor gRPC fixes (2.0)"

### DIFF
--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -43,7 +43,6 @@ import org.eclipse.microprofile.metrics.MetadataBuilder;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 
@@ -53,6 +52,11 @@ import org.eclipse.microprofile.metrics.Timer;
 @Priority(InterceptorPriorities.TRACING + 1)
 public class GrpcMetrics
         implements ServerInterceptor, ServiceDescriptor.Configurer, MethodDescriptor.Configurer {
+
+    static {
+        HelidonFeatures.register("gRPC Server", "Metrics");
+        HelidonFeatures.register("gRPC Client", "Metrics");
+    }
 
     /**
      * The registry of vendor metrics.
@@ -65,19 +69,6 @@ public class GrpcMetrics
      */
     private static final MetricRegistry APP_REGISTRY =
             RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.APPLICATION);
-
-    static {
-        HelidonFeatures.register("gRPC Server", "Metrics");
-        HelidonFeatures.register("gRPC Client", "Metrics");
-
-        VENDOR_REGISTRY.meter(org.eclipse.microprofile.metrics.Metadata.builder()
-                .withName("grpc.requests.meter")
-                .withDisplayName("Meter for overall gRPC requests")
-                .withDescription("Each gRPC request will mark the meter to see overall throughput")
-                .withType(MetricType.METERED)
-                .withUnit(MetricUnits.NONE)
-                .build());
-    }
 
     /**
      * The context key name to use to obtain rules to use when applying metrics.

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -367,6 +367,22 @@ public final class MetricsSupport implements Service {
                 .withUnit(MetricUnits.NONE)
                 .build());
 
+        vendor.counter(Metadata.builder()
+                .withName("grpc.requests.count")
+                .withDisplayName("Total number of gRPC requests")
+                .withDescription("Each gRPC request (regardless of the method) will increase this counter")
+                .withType(MetricType.COUNTER)
+                .withUnit(MetricUnits.NONE)
+                .build());
+
+        vendor.meter(Metadata.builder()
+                .withName("grpc.requests.meter")
+                .withDisplayName("Meter for overall gRPC requests")
+                .withDescription("Each gRPC request will mark the meter to see overall throughput")
+                .withType(MetricType.METERED)
+                .withUnit(MetricUnits.NONE)
+                .build());
+
         rules.any((req, res) -> {
             totalCount.inc();
             totalMeter.mark();

--- a/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcProxyProducer.java
+++ b/microprofile/grpc/client/src/main/java/io/helidon/microprofile/grpc/client/GrpcProxyProducer.java
@@ -41,7 +41,28 @@ class GrpcProxyProducer {
     /**
      * A CDI producer method that produces a client proxy for a gRPC service that
      * will connect to the server using the channel specified via {@link GrpcChannel}
-     * annotation on the proxy interface or injection point, or the default {@link Channel}.
+     * annotation on the proxy interface, or the default {@link Channel}.
+     * <p>
+     * This is not a real producer method but is used as a stub by the gRPC client
+     * CDI extension to create real producers as injection points are discovered.
+     *
+     * @param injectionPoint the injection point where the client proxy is to be injected
+     * @return a gRPC client proxy
+     */
+    @GrpcProxy
+    static Object proxyUsingDefaultChannel(InjectionPoint injectionPoint, ChannelProducer producer) {
+        Class<?> type = ModelHelper.getGenericType(injectionPoint.getType());
+        String channelName = type.isAnnotationPresent(GrpcChannel.class)
+                ? type.getAnnotation(GrpcChannel.class).name()
+                : GrpcChannelsProvider.DEFAULT_CHANNEL_NAME;
+        Channel channel = producer.findChannel(channelName);
+        GrpcProxyBuilder<?> builder = GrpcProxyBuilder.create(channel, type);
+        return builder.build();
+    }
+
+    /**
+     * A CDI producer method that produces a client proxy for a gRPC service that
+     * will connect to the server using a named {@link Channel}.
      * <p>
      * This is not a real producer method but is used as a stub by the gRPC client
      * CDI extension to create real producers as injection points are discovered.
@@ -53,19 +74,9 @@ class GrpcProxyProducer {
     @GrpcChannel(name = GrpcChannelsProvider.DEFAULT_CHANNEL_NAME)
     static Object proxyUsingNamedChannel(InjectionPoint injectionPoint, ChannelProducer producer) {
         Class<?> type = ModelHelper.getGenericType(injectionPoint.getType());
-
-        String channelName;
-        if (injectionPoint.getAnnotated().isAnnotationPresent(GrpcChannel.class)) {
-            channelName = injectionPoint.getAnnotated().getAnnotation(GrpcChannel.class).name();
-        } else {
-            channelName = type.isAnnotationPresent(GrpcChannel.class)
-                    ? type.getAnnotation(GrpcChannel.class).name()
-                    : GrpcChannelsProvider.DEFAULT_CHANNEL_NAME;
-        }
-
-        Channel channel = producer.findChannel(channelName);
+        GrpcChannel channelName = injectionPoint.getAnnotated().getAnnotation(GrpcChannel.class);
+        Channel channel = producer.findChannel(channelName.name());
         GrpcProxyBuilder<?> builder = GrpcProxyBuilder.create(channel, type);
-
         return builder.build();
     }
 


### PR DESCRIPTION
Reverts oracle/helidon#1951

I prematurely merged the original PR. The pipeline tests were not automatically run which I did not notice when I saw all the green checkmarks for the no-op wercker jobs. But the changes caused failures in pipeline jobs for other PRs.