### PR TITLE
Add tolerance to several tests; change tolerance used in pipeline jobs

### DIFF
--- a/metrics2/metrics2/pom.xml
+++ b/metrics2/metrics2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@
                             <configuration>
                                 <systemPropertyVariables>
                                     <helidon.concurrentGauge.minRequiredSeconds>45</helidon.concurrentGauge.minRequiredSeconds>
-                                    <helidon.histogram.tolerance>0.01</helidon.histogram.tolerance>
+                                    <helidon.histogram.tolerance>0.025</helidon.histogram.tolerance>
                                 </systemPropertyVariables>
                             </configuration>
                     </plugin>

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,14 +199,14 @@ class HelidonHistogramTest {
         assertThat(metricData.getJsonNumber("count").longValue(), is(200L));
         assertThat(metricData.getJsonNumber("min").longValue(), is(0L));
         assertThat(metricData.getJsonNumber("max").longValue(), is(99L));
-        withTolerance("mean", metricData.getJsonNumber("mean").doubleValue(), 50.6349);
-        withTolerance("stddev", metricData.getJsonNumber("stddev").doubleValue(), 29.4389);
-        assertThat(metricData.getJsonNumber("p50").intValue(), is(48));
-        assertThat(metricData.getJsonNumber("p75").intValue(), is(75));
-        assertThat(metricData.getJsonNumber("p95").intValue(), is(96));
-        assertThat(metricData.getJsonNumber("p98").intValue(), is(98));
-        assertThat(metricData.getJsonNumber("p99").intValue(), is(98));
-        assertThat(metricData.getJsonNumber("p999").intValue(), is(99));
+        assertThat("mean", metricData.getJsonNumber("mean").doubleValue(), is(withinTolerance(50.6349)));
+        assertThat("stddev", metricData.getJsonNumber("stddev").doubleValue(), is(withinTolerance(29.4389)));
+        assertThat("p50", metricData.getJsonNumber("p50").intValue(), is(withinTolerance(48)));
+        assertThat("p75", metricData.getJsonNumber("p75").intValue(), is(withinTolerance(75)));
+        assertThat("p95", metricData.getJsonNumber("p95").intValue(), is(withinTolerance(96)));
+        assertThat("p98", metricData.getJsonNumber("p98").intValue(), is(withinTolerance(98)));
+        assertThat("p99", metricData.getJsonNumber("p99").intValue(), is(withinTolerance(98)));
+        assertThat("p999", metricData.getJsonNumber("p999").intValue(), is(withinTolerance(99)));
     }
 
     @Test
@@ -229,21 +229,17 @@ class HelidonHistogramTest {
 
     private void testSnapshot(int factor, String description, Snapshot snapshot, double mean, double stddev) {
         assertAll("Testing statistical values for " + description,
-                  () -> withTolerance("median", snapshot.getMedian(), factor * 48),
-                  () -> withTolerance("75th percentile", snapshot.get75thPercentile(), factor * 75),
-                  () -> withTolerance("95th percentile", snapshot.get95thPercentile(), factor * 96),
-                  () -> withTolerance("78th percentile", snapshot.get98thPercentile(), factor * 98),
-                  () -> withTolerance("99th percentile", snapshot.get99thPercentile(), factor * 98),
-                  () -> withTolerance("999th percentile", snapshot.get999thPercentile(), factor * 99),
-                  () -> withTolerance("mean", snapshot.getMean(), mean),
-                  () -> withTolerance("stddev", snapshot.getStdDev(), stddev),
+                  () -> assertThat("median", snapshot.getMedian(), is(withinTolerance(factor * 48))),
+                  () -> assertThat("75th percentile", snapshot.get75thPercentile(), is(withinTolerance(factor * 75))),
+                  () -> assertThat("95th percentile", snapshot.get95thPercentile(), is(withinTolerance(factor * 96))),
+                  () -> assertThat("78th percentile", snapshot.get98thPercentile(), is(withinTolerance(factor * 98))),
+                  () -> assertThat("99th percentile", snapshot.get99thPercentile(), is(withinTolerance(factor * 98))),
+                  () -> assertThat("999th percentile", snapshot.get999thPercentile(), is(withinTolerance(factor * 99))),
+                  () -> assertThat("mean", snapshot.getMean(), is(withinTolerance(mean))),
+                  () -> assertThat("stddev", snapshot.getStdDev(), is(withinTolerance(stddev))),
                   () -> assertThat("min", snapshot.getMin(), is(0L)),
                   () -> assertThat("max", snapshot.getMax(), is(factor * 99L)),
                   () -> assertThat("size", snapshot.size(), is(200))
         );
-    }
-
-    private void withTolerance(String field, double actual, double expectedValue) {
-        assertThat(field, expectedValue, is(withinTolerance(actual)));
     }
 }

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMeterTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonMeterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.metrics.HelidonMetricsMatcher.withinTolerance;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -95,22 +96,22 @@ class HelidonMeterTest {
 
     @Test
     void testMeanRate() {
-        withTolerance("mean rate", meter.getMeanRate(), 100);
+        assertThat("mean rate", meter.getMeanRate(),  is(withinTolerance(100)));
     }
 
     @Test
     void testOneMinuteRate() {
-        withTolerance("one minute rate", meter.getOneMinuteRate(), 100);
+        assertThat("one minute rate", meter.getOneMinuteRate(),  is(withinTolerance(100)));
     }
 
     @Test
     void testFiveMinuteRate() {
-        withTolerance("five minute rate", meter.getFiveMinuteRate(), 100);
+        assertThat("five minute rate", meter.getFiveMinuteRate(),  is(withinTolerance(100)));
     }
 
     @Test
     void testFifteenMinuteRate() {
-        withTolerance("fifteen minute rate", meter.getFifteenMinuteRate(), 100);
+        assertThat("fifteen minute rate", meter.getFifteenMinuteRate(),  is(withinTolerance(100)));
     }
 
     @Test
@@ -146,14 +147,5 @@ class HelidonMeterTest {
         assertThat(data, containsString("# TYPE application_requests_fifteen_min_rate_per_second gauge\n"
                                                 + "application_requests_fifteen_min_rate_per_second "));
 
-    }
-
-    private void withTolerance(String field, double actual, double expectedValue) {
-        double min = expectedValue * 0.98;
-        double max = expectedValue * 1.02;
-
-        if ((actual < min) || (actual > max)) {
-            fail(field + ": expected: <" + expectedValue + ">, but actual value was: <" + actual + ">");
-        }
     }
 }

--- a/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonTimerTest.java
+++ b/metrics2/metrics2/src/test/java/io/helidon/metrics/HelidonTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.metrics.HelidonMetricsMatcher.withinTolerance;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -152,14 +153,14 @@ class HelidonTimerTest {
         Snapshot snapshot = dataSetTimer.getSnapshot();
 
         assertAll("Testing statistical values for snapshot",
-                  () -> withTolerance("median", snapshot.getMedian(), 480),
-                  () -> withTolerance("75th percentile", snapshot.get75thPercentile(), 750),
-                  () -> withTolerance("95th percentile", snapshot.get95thPercentile(), 960),
-                  () -> withTolerance("78th percentile", snapshot.get98thPercentile(), 980),
-                  () -> withTolerance("99th percentile", snapshot.get99thPercentile(), 980),
-                  () -> withTolerance("999th percentile", snapshot.get999thPercentile(), 990),
-                  () -> withTolerance("mean", snapshot.getMean(), 506.3),
-                  () -> withTolerance("stddev", snapshot.getStdDev(), 294.3),
+                  () -> assertThat("median", snapshot.getMedian(), is(withinTolerance(480))),
+                  () -> assertThat("75th percentile", snapshot.get75thPercentile(), is(withinTolerance(750))),
+                  () -> assertThat("95th percentile", snapshot.get95thPercentile(), is(withinTolerance(960))),
+                  () -> assertThat("78th percentile", snapshot.get98thPercentile(), is(withinTolerance(980))),
+                  () -> assertThat("99th percentile", snapshot.get99thPercentile(), is(withinTolerance(980))),
+                  () -> assertThat("999th percentile", snapshot.get999thPercentile(), is(withinTolerance(990))),
+                  () -> assertThat("mean", snapshot.getMean(), is(withinTolerance(506.3))),
+                  () -> assertThat("stddev", snapshot.getStdDev(), is(withinTolerance(294.3))),
                   () -> assertThat("min", snapshot.getMin(), Matchers.is(0L)),
                   () -> assertThat("max", snapshot.getMax(), Matchers.is(990L)),
                   () -> assertThat("size", snapshot.size(), Matchers.is(200))
@@ -178,18 +179,18 @@ class HelidonTimerTest {
         JsonObject metricData = json.getJsonObject("response_time");
 
         assertThat(metricData, notNullValue());
-        assertThat(metricData.getJsonNumber("count").longValue(), Matchers.is(200L));
-        assertThat(metricData.getJsonNumber("min").longValue(), Matchers.is(0L));
-        assertThat(metricData.getJsonNumber("max").longValue(), Matchers.is(990L));
-        withTolerance("mean", metricData.getJsonNumber("mean").doubleValue(), 506.349);
-        withTolerance("stddev", metricData.getJsonNumber("stddev").doubleValue(), 294.389);
-        assertThat(metricData.getJsonNumber("p50").intValue(), Matchers.is(480));
-        assertThat(metricData.getJsonNumber("p75").intValue(), Matchers.is(750));
-        assertThat(metricData.getJsonNumber("p95").intValue(), Matchers.is(960));
-        assertThat(metricData.getJsonNumber("p98").intValue(), Matchers.is(980));
-        assertThat(metricData.getJsonNumber("p99").intValue(), Matchers.is(980));
-        assertThat(metricData.getJsonNumber("p999").intValue(), Matchers.is(990));
-        assertThat(metricData.getJsonNumber("meanRate").intValue(), is(200));
+        assertThat("count", metricData.getJsonNumber("count").longValue(), is(withinTolerance(200L)));
+        assertThat("min", metricData.getJsonNumber("min").longValue(), is(withinTolerance(0L)));
+        assertThat("max", metricData.getJsonNumber("max").longValue(), is(withinTolerance(990L)));
+        assertThat("mean", metricData.getJsonNumber("mean").doubleValue(),  is(withinTolerance(506.349)));
+        assertThat("stddev", metricData.getJsonNumber("stddev").doubleValue(),  is(withinTolerance(294.389)));
+        assertThat(metricData.getJsonNumber("p50").intValue(), is(withinTolerance(480)));
+        assertThat(metricData.getJsonNumber("p75").intValue(), is(withinTolerance(750)));
+        assertThat(metricData.getJsonNumber("p95").intValue(), is(withinTolerance(960)));
+        assertThat(metricData.getJsonNumber("p98").intValue(), is(withinTolerance(980)));
+        assertThat(metricData.getJsonNumber("p99").intValue(), is(withinTolerance(980)));
+        assertThat(metricData.getJsonNumber("p999").intValue(), is(withinTolerance(990)));
+        assertThat(metricData.getJsonNumber("meanRate").intValue(), is(withinTolerance(200)));
         assertThat(metricData.getJsonNumber("oneMinRate").intValue(), is(0));
         assertThat(metricData.getJsonNumber("fiveMinRate").intValue(), is(0));
         assertThat(metricData.getJsonNumber("fifteenMinRate").intValue(), is(0));
@@ -217,14 +218,5 @@ class HelidonTimerTest {
                                                           + "# HELP application_response_time_seconds Server response time for "
                                                           + "/index.html\n"
                                                           + "application_response_time_seconds_count 200"));
-    }
-
-    private void withTolerance(String field, double actual, double expectedValue) {
-        double min = expectedValue * 0.999;
-        double max = expectedValue * 1.001;
-
-        if ((actual < min) || (actual > max)) {
-            fail(field + ": expected: <" + expectedValue + ">, but actual value was: <" + actual + ">");
-        }
     }
 }


### PR DESCRIPTION
Partially resolves #1998 (for 1.x; 2.x is separate)

More pipeline runs were beginning to show intermittent test failures in metrics. These changes use a tolerance (instead of direct equality checks) on more tests to try to insulate the test results from variations in execution timing and speed.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>