### PR TITLE
Experimental feature support.

### DIFF
--- a/common/common/src/main/java/io/helidon/common/FeatureDescriptor.java
+++ b/common/common/src/main/java/io/helidon/common/FeatureDescriptor.java
@@ -30,6 +30,7 @@ final class FeatureDescriptor {
     private final String description;
     private final boolean nativeSupported;
     private final String nativeDescription;
+    private final boolean experimental;
 
     private FeatureDescriptor(Builder builder) {
         this.flavors = builder.flavors;
@@ -38,6 +39,7 @@ final class FeatureDescriptor {
         this.description = builder.description;
         this.nativeSupported = builder.nativeSupported;
         this.nativeDescription = builder.nativeDescription;
+        this.experimental = builder.experimental;
     }
 
     static Builder builder() {
@@ -94,6 +96,24 @@ final class FeatureDescriptor {
         return String.join("/", path());
     }
 
+    boolean experimental() {
+        return experimental;
+    }
+
+    boolean hasFlavor(HelidonFlavor expected) {
+        for (HelidonFlavor flavor : flavors) {
+            if (flavor == expected) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
     static class Builder implements io.helidon.common.Builder<FeatureDescriptor> {
         private HelidonFlavor[] flavors = new HelidonFlavor[] {HelidonFlavor.SE, HelidonFlavor.MP};
         private String name;
@@ -101,6 +121,7 @@ final class FeatureDescriptor {
         private String description = null;
         private boolean nativeSupported = true;
         private String nativeDescription = null;
+        private boolean experimental;
 
         private Builder() {
         }
@@ -160,6 +181,11 @@ final class FeatureDescriptor {
                 throw new IllegalArgumentException("Path must have at least one element");
             }
             this.path = path;
+            return this;
+        }
+
+        Builder experimental(boolean experimental) {
+            this.experimental = experimental;
             return this;
         }
     }

--- a/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
+++ b/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
  */
 public final class HelidonFeatures {
     private static final Logger LOGGER = Logger.getLogger(HelidonFeatures.class.getName());
+    private static final Logger EXPERIMENTAL = Logger.getLogger(HelidonFeatures.class.getName() + ".experimental");
     private static final AtomicBoolean PRINTED = new AtomicBoolean();
     private static final AtomicBoolean SCANNED = new AtomicBoolean();
     private static final AtomicReference<HelidonFlavor> CURRENT_FLAVOR = new AtomicReference<>();
@@ -165,8 +166,9 @@ public final class HelidonFeatures {
                                                            ROOT_FEATURE_NODES.get(currentFlavor).get(feature.path()[0])));
 
             if (!allExperimental.isEmpty()) {
-                LOGGER.info("You are using experimental features. These APIs may change, please follow changelog!");
-                allExperimental.forEach(it -> LOGGER.info("\tExperimental feature: " + it.name() + " (" + it.stringPath() + ")"));
+                EXPERIMENTAL.info("You are using experimental features. These APIs may change, please follow changelog!");
+                allExperimental
+                        .forEach(it -> EXPERIMENTAL.info("\tExperimental feature: " + it.name() + " (" + it.stringPath() + ")"));
             }
         }
     }

--- a/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
+++ b/common/common/src/main/java/io/helidon/common/HelidonFeatures.java
@@ -158,7 +158,24 @@ public final class HelidonFeatures {
                     .forEach(feature -> printDetails(feature.name(),
                                                      ROOT_FEATURE_NODES.get(currentFlavor).get(feature.path()[0]),
                                                      0));
+        } else {
+            List<FeatureDescriptor> allExperimental = new LinkedList<>();
+            FEATURES.get(currentFlavor)
+                    .forEach(feature -> gatherExperimental(allExperimental,
+                                                           ROOT_FEATURE_NODES.get(currentFlavor).get(feature.path()[0])));
+
+            if (!allExperimental.isEmpty()) {
+                LOGGER.info("You are using experimental features. These APIs may change, please follow changelog!");
+                allExperimental.forEach(it -> LOGGER.info("\tExperimental feature: " + it.name() + " (" + it.stringPath() + ")"));
+            }
         }
+    }
+
+    private static void gatherExperimental(List<FeatureDescriptor> allExperimental, Node node) {
+        if (node.descriptor != null && node.descriptor.experimental()) {
+            allExperimental.add(node.descriptor);
+        }
+        node.children().values().forEach(it -> gatherExperimental(allExperimental, it));
     }
 
     /**
@@ -253,11 +270,12 @@ public final class HelidonFeatures {
             // start on index 10 or a tab spaces after tree
             int len = prefix.length() + name.length();
             String suffix;
-            if (len <= 8) {
-                suffix = " ".repeat(10 - len);
+            if (len <= 18) {
+                suffix = " ".repeat(20 - len);
             } else {
                 suffix = "\t";
             }
+            String experimental = feat.experimental() ? "Experimental - " : "";
             String nativeDesc = "";
             if (!feat.nativeSupported()) {
                 nativeDesc = " (NOT SUPPORTED in native image)";
@@ -266,7 +284,7 @@ public final class HelidonFeatures {
                     nativeDesc = " (Native image: " + feat.nativeDescription() + ")";
                 }
             }
-            System.out.println(prefix + name + suffix + feat.description() + nativeDesc);
+            System.out.println(prefix + name + suffix + experimental + feat.description() + nativeDesc);
         }
 
         node.children.forEach((childName, childNode) -> {


### PR DESCRIPTION
Resolves #1872

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

When not printing details, you get the following:
```
2020.06.16 19:33:38 INFO io.helidon.common.HelidonFeatures.experimental Thread[features-thread,5,main]: You are using experimental features. These APIs may change, please follow changelog!
2020.06.16 19:33:38 INFO io.helidon.common.HelidonFeatures.experimental Thread[features-thread,5,main]: 	Experimental feature: Messaging (Messaging)
2020.06.16 19:33:38 INFO io.helidon.common.HelidonFeatures.experimental Thread[features-thread,5,main]: 	Experimental feature: Kafka Connector (Messaging/Kafka)
```
When printing details, you get the following:
```
Health              Health checks support
  Built-ins         Built in health checks
Messaging           Experimental - Reactive messaging support
  Kafka Connector   Experimental - Reactive messaging connector for Kafka (NOT SUPPORTED in native image)
Metrics             Metrics support
Security            Security support
  Integration
```