### PR TITLE
Fix new integrations/db modules

### DIFF
--- a/integrations/db/h2/pom.xml
+++ b/integrations/db/h2/pom.xml
@@ -35,6 +35,7 @@
          to have a bad module-info.  So for now we skip generating javadocs.
         -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
     <dependencies>

--- a/integrations/db/h2/pom.xml
+++ b/integrations/db/h2/pom.xml
@@ -30,8 +30,10 @@
     <description>JDBC driver for h2 with native-image support</description>
 
     <properties>
-        <spotbugs.skip>true</spotbugs.skip>
-        <maven.source.skip>true</maven.source.skip>
+        <!--
+         To build javadocs we need to have a valid module-info file. But com.oracle.substratevm:svm appears
+         to have a bad module-info.  So for now we skip generating javadocs.
+        -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -57,17 +59,6 @@
                         <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>empty-sources-jar</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>sources</classifier>
-                                    <classesDirectory>${project.build.directory}/sources</classesDirectory>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>empty-javadoc-jar</id>
                                 <phase>package</phase>
                                 <goals>
@@ -83,5 +74,5 @@
                 </plugins>
             </build>
         </profile>
-</profiles>
+    </profiles>
 </project>

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -26,12 +26,11 @@
     </parent>
 
     <artifactId>ojdbc</artifactId>
-    <name>Helidon Ingtegrations DB Oracle JDBC</name>
+    <name>Helidon Integrations DB Oracle JDBC</name>
     <description>JDBC driver for Oracle database with native-image support</description>
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>
-        <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -41,4 +40,31 @@
             <artifactId>ojdbc10</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Skip javadoc only in integrations/db/h2 to workaround bad module-info in the SVM dependency.
Generate empty javadoc in integrations/db/ojdbc