### PR TITLE
Boolean values of secure & httpOnly are ignored.

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -38,8 +38,8 @@ public class SetCookie {
     private final Duration maxAge;
     private final String domain;
     private final String path;
-    private final Boolean secure;
-    private final Boolean httpOnly;
+    private final boolean secure;
+    private final boolean httpOnly;
 
     private SetCookie(Builder builder) {
         this.name = builder.name;
@@ -105,11 +105,11 @@ public class SetCookie {
             result.append("Path=");
             result.append(path);
         }
-        if (secure != null && secure.booleanValue()) {
+        if (secure) {
             result.append(PARAM_SEPARATOR);
             result.append("Secure");
         }
-        if (httpOnly != null && httpOnly.booleanValue()) {
+        if (httpOnly) {
             result.append(PARAM_SEPARATOR);
             result.append("HttpOnly");
         }
@@ -126,8 +126,8 @@ public class SetCookie {
         private Duration maxAge;
         private String domain;
         private String path;
-        private Boolean secure;
-        private Boolean httpOnly;
+        private boolean secure;
+        private boolean httpOnly;
 
         private Builder(String name, String value) {
             Objects.requireNonNull(name, "Parameter 'name' is null!");

--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -105,11 +105,11 @@ public class SetCookie {
             result.append("Path=");
             result.append(path);
         }
-        if (secure != null) {
+        if (secure != null && secure.booleanValue()) {
             result.append(PARAM_SEPARATOR);
             result.append("Secure");
         }
-        if (httpOnly != null) {
+        if (httpOnly != null && httpOnly.booleanValue()) {
             result.append(PARAM_SEPARATOR);
             result.append("HttpOnly");
         }

--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The values of secure and httpOnly are ignored.

Expected behaviour:
When setting the variables through the builder methdos secure(false) or httpOnly(false), Secure and HttpOnly should not be appended to the cookie's value.

Issue exists in RC 2.X as well.