### PR TITLE
Native image updates

### DIFF
--- a/integrations/db/ojdbc/src/main/resources/META-INF/helidon/native-image/reflection-config.json
+++ b/integrations/db/ojdbc/src/main/resources/META-INF/helidon/native-image/reflection-config.json
@@ -1,0 +1,5 @@
+{
+    "classes": [
+        "org.hibernate.dialect.Oracle10gDialect"
+    ]
+}

--- a/integrations/db/ojdbc/src/main/resources/META-INF/native-image/io.helidon.integrations.db/ojdbc/reflect-config.json
+++ b/integrations/db/ojdbc/src/main/resources/META-INF/native-image/io.helidon.integrations.db/ojdbc/reflect-config.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "org.hibernate.dialect.Oracle10gDialect",
-    "allDeclaredConstructors": true,
-    "allDeclaredMethods": true,
-    "allPublicMethods": true,
-    "allDeclaredFields": true,
-    "allPublicFields": true
-  },
-  {
     "name": "oracle.jdbc.internal.ACProxyable",
     "methods": [
       {

--- a/tests/integration/native-image/mp-2/src/main/resources/META-INF/native-image/tests/mp-2/native-image.properties
+++ b/tests/integration/native-image/mp-2/src/main/resources/META-INF/native-image/tests/mp-2/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,4 @@
 #
 # Graal native image supports additional configuration from this property file.
 #
-Args=--report-unsupported-elements-at-runtime
-
-# Args=-H:+PrintAnalysisCallTree
-
-# -H:+RemoveSaturatedTypeFlows
-#[INFO] Total time:  01:51 min
-#[INFO] Finished at: 2020-06-10T20:05:38+02:00
-#105430864
+Args=-H:+RemoveSaturatedTypeFlows

--- a/webserver/jersey/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver-jersey/proxy-config.json
+++ b/webserver/jersey/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver-jersey/proxy-config.json
@@ -34,5 +34,13 @@
     [
         "org.glassfish.jersey.server.ExtendedUriInfo",
         "org.glassfish.hk2.api.ProxyCtl"
+    ],
+    [
+        "io.helidon.webserver.ServerRequest",
+        "org.glassfish.hk2.api.ProxyCtl"
+    ],
+    [
+        "io.helidon.webserver.ServerResponse",
+        "org.glassfish.hk2.api.ProxyCtl"
     ]
 ]

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,21 @@
 # Graal native image supports additional configuration from this property file.
 # We add required properties for Netty
 #
-Args=--initialize-at-run-time=io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf,io.netty.buffer.UnreleasableByteBuf,io.netty.handler.codec.http2.Http2ConnectionHandler,io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler,io.netty.handler.codec.http2.DefaultHttp2FrameWriter,io.netty.handler.codec.http2.Http2ServerUpgradeCodec,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine \
-  --allow-incomplete-classpath
-
-# allow incomplete classpath - the SSL engine fails with class not found
+# allow incomplete classpath  - Netty contains classes that depend on Log4j etc, so we need to allow that
+#
+Args=--allow-incomplete-classpath \
+  --initialize-at-run-time=io.netty.buffer.UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf \
+  --initialize-at-run-time=io.netty.buffer.UnreleasableByteBuf \
+  --initialize-at-run-time=io.netty.handler.codec.http2.Http2ConnectionHandler \
+  --initialize-at-run-time=io.netty.handler.codec.http2.Http2CodecUtil \
+  --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.http2.CleartextHttp2ServerUpgradeHandler \
+  --initialize-at-run-time=io.netty.handler.codec.http2.DefaultHttp2FrameWriter \
+  --initialize-at-run-time=io.netty.handler.codec.http2.Http2ServerUpgradeCodec \
+  --initialize-at-run-time=io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator \
+  --initialize-at-run-time=io.netty.handler.ssl.JettyNpnSslEngine \
+  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslEngine \
+  --initialize-at-run-time=io.netty.handler.ssl.ConscryptAlpnSslEngine \
+  --initialize-at-run-time=io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine \
+  --initialize-at-run-time=io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine \
+  --initialize-at-run-time=io.netty.util.internal.logging.Log4JLogger


### PR DESCRIPTION
Oracle hibernate dialect moved to Helidon configuration, so it does not emit a warning when not on classpath
Using different build flags for mp-2 tests, as it took too long
Added native-image config for new Jersey proxies
Updated Netty native options due to a new failure

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>