### PR TITLE
DB Archetypes: README updates for native support

### DIFF
--- a/archetypes/database-mp/src/main/resources/README.md.mustache
+++ b/archetypes/database-mp/src/main/resources/README.md.mustache
@@ -61,16 +61,12 @@ Switch property `javax.sql.DataSource.test.dataSource.url` in `microprofile-conf
 to use a TCP connection:
 
 ```
-javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test;IFEXISTS=FALSE
+javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test
 ```
 
-Next, uncomment the following dependencies in your project's pom file:
+Next, uncomment the following dependency in your project's pom file:
 
 ```
-<dependency>
-    <groupId>io.helidon.integrations.db</groupId>
-    <artifactId>ojdbc</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.integrations.db</groupId>
     <artifactId>h2</artifactId>

--- a/archetypes/database-mp/src/main/resources/README.md.mustache
+++ b/archetypes/database-mp/src/main/resources/README.md.mustache
@@ -39,3 +39,53 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 {"base":...
 . . .
 ```
+
+## GraalVM Native Support
+
+The generation of native binaries requires an installation of GraalVM 20.0.0+. For more
+information about the steps necessary to use GraalVM with Helidon
+see https://helidon.io/docs/v2/#/mp/guides/36_graalnative.
+
+The H2 Database when configured to use the in-memory mode is currently _not compatible_
+with GraalVM native.
+In order to produce a native binary, you must run the H2 Database as a separate process
+and use a network connection for access. The simplest way to do this is by starting a Docker
+container as follows:
+
+```
+docker run -d -p 1521:1521 -p 81:81 -e H2_OPTIONS='-ifNotExists' --name=h2 oscarfonts/h2
+```
+
+The resulting container will listen to port 1521 for network connections.
+Switch property `javax.sql.DataSource.test.dataSource.url` in `microprofile-config.properties`
+to use a TCP connection:
+
+```
+javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test;IFEXISTS=FALSE
+```
+
+Next, uncomment the following dependencies in your project's pom file:
+
+```
+<dependency>
+    <groupId>io.helidon.integrations.db</groupId>
+    <artifactId>ojdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.helidon.integrations.db</groupId>
+    <artifactId>h2</artifactId>
+</dependency>
+```
+
+With all these changes, re-build your project and verify that all tests are passing.
+Finally, you can build a native binary using Maven as follows:
+
+```
+mvn -Pnative-image install -DskipTests
+```
+
+The generation of the executable binary may take several minutes to complete
+depending on your hardware and operating system --with Linux typically outperforming other
+platforms. When completed, the executable file will be available
+under the `target` directory and be named after the artifact ID you have chosen during the
+project generation phase.

--- a/archetypes/database-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-mp/src/main/resources/pom.xml.mustache
@@ -45,10 +45,6 @@
         </dependency>
         <!-- dependency>
             <groupId>io.helidon.integrations.db</groupId>
-            <artifactId>ojdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.integrations.db</groupId>
             <artifactId>h2</artifactId>
         </dependency -->
         <dependency>

--- a/archetypes/database-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-mp/src/main/resources/pom.xml.mustache
@@ -43,6 +43,14 @@
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
+        <!-- dependency>
+            <groupId>io.helidon.integrations.db</groupId>
+            <artifactId>ojdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.db</groupId>
+            <artifactId>h2</artifactId>
+        </dependency -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/archetypes/database-mp/src/main/resources/src/main/resources/META-INF/microprofile-config.properties
+++ b/archetypes/database-mp/src/main/resources/src/main/resources/META-INF/microprofile-config.properties
@@ -1,8 +1,8 @@
 
 # Datasource properties
 javax.sql.DataSource.test.dataSourceClassName=org.h2.jdbcx.JdbcDataSource
-#javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test;IFEXISTS=FALSE
 javax.sql.DataSource.test.dataSource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+#javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test;IFEXISTS=FALSE
 javax.sql.DataSource.test.dataSource.user=sa
 javax.sql.DataSource.test.dataSource.password=
 

--- a/archetypes/database-mp/src/main/resources/src/main/resources/META-INF/microprofile-config.properties
+++ b/archetypes/database-mp/src/main/resources/src/main/resources/META-INF/microprofile-config.properties
@@ -2,7 +2,7 @@
 # Datasource properties
 javax.sql.DataSource.test.dataSourceClassName=org.h2.jdbcx.JdbcDataSource
 javax.sql.DataSource.test.dataSource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-#javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test;IFEXISTS=FALSE
+#javax.sql.DataSource.test.dataSource.url=jdbc:h2:tcp://localhost:1521/test
 javax.sql.DataSource.test.dataSource.user=sa
 javax.sql.DataSource.test.dataSource.password=
 

--- a/archetypes/database-se/src/main/resources/README.md.mustache
+++ b/archetypes/database-se/src/main/resources/README.md.mustache
@@ -60,16 +60,12 @@ The resulting container will listen to port 1521 for network connections.
 Switch the `url` in `application.yaml` to use a TCP connection:
 
 ```
-url: jdbc:h2:tcp://localhost:1521/test;DB_CLOSE_DELAY=-1
+url: jdbc:h2:tcp://localhost:1521/test
 ```
 
-Next, uncomment the following dependencies in your project's pom file:
+Next, uncomment the following dependency in your project's pom file:
 
 ```
-<dependency>
-    <groupId>io.helidon.integrations.db</groupId>
-    <artifactId>ojdbc</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.integrations.db</groupId>
     <artifactId>h2</artifactId>

--- a/archetypes/database-se/src/main/resources/README.md.mustache
+++ b/archetypes/database-se/src/main/resources/README.md.mustache
@@ -1,6 +1,6 @@
 # Helidon SE Database
 
-Helidon SE application that uses the dbclient API with an in-memory H2 database
+Helidon SE application that uses the dbclient API with an in-memory H2 database.
 
 ## Build and run
 
@@ -39,3 +39,51 @@ curl -H 'Accept: application/json' -X GET http://localhost:8080/metrics
 {"base":...
 . . .
 ```
+
+## GraalVM Native Support
+
+The generation of native binaries requires an installation of GraalVM 20.0.0+. For more
+information about the steps necessary to use GraalVM with Helidon
+see https://helidon.io/docs/v2/#/se/guides/36_graalnative.
+
+The H2 Database when configured to use the in-memory mode is currently _not compatible_
+with GraalVM native.
+In order to produce a native binary, you must run the H2 Database as a separate process
+and use a network connection for access. The simplest way to do this is by starting a Docker
+container as follows:
+
+```
+docker run -d -p 1521:1521 -p 81:81 -e H2_OPTIONS='-ifNotExists' --name=h2 oscarfonts/h2
+```
+
+The resulting container will listen to port 1521 for network connections.
+Switch the `url` in `application.yaml` to use a TCP connection:
+
+```
+url: jdbc:h2:tcp://localhost:1521/test;DB_CLOSE_DELAY=-1
+```
+
+Next, uncomment the following dependencies in your project's pom file:
+
+```
+<dependency>
+    <groupId>io.helidon.integrations.db</groupId>
+    <artifactId>ojdbc</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.helidon.integrations.db</groupId>
+    <artifactId>h2</artifactId>
+</dependency>
+```
+
+With all these changes, re-build your project and verify that all tests are passing.
+Finally, you can build a native binary using Maven as follows:
+
+```
+mvn -Pnative-image install -DskipTests
+```
+
+The generation of the executable binary may take a few minutes to complete depending on
+your hardware and operating system. When completed, the executable file will be available
+under the `target` directory and be named after the artifact ID you have chosen during the
+project generation phase.

--- a/archetypes/database-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-se/src/main/resources/pom.xml.mustache
@@ -96,10 +96,6 @@
         </dependency>
         <!-- dependency>
             <groupId>io.helidon.integrations.db</groupId>
-            <artifactId>ojdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.integrations.db</groupId>
             <artifactId>h2</artifactId>
         </dependency -->
         <dependency>

--- a/archetypes/database-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-se/src/main/resources/pom.xml.mustache
@@ -94,6 +94,14 @@
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
+        <!-- dependency>
+            <groupId>io.helidon.integrations.db</groupId>
+            <artifactId>ojdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.db</groupId>
+            <artifactId>h2</artifactId>
+        </dependency -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/archetypes/database-se/src/main/resources/src/main/resources/application.yaml
+++ b/archetypes/database-se/src/main/resources/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ db:
   source: jdbc
   connection:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    # url: jdbc:h2:tcp://localhost:1521/test;DB_CLOSE_DELAY=-1
     username: sa
     password:
     poolName: h2

--- a/archetypes/database-se/src/main/resources/src/main/resources/application.yaml
+++ b/archetypes/database-se/src/main/resources/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ db:
   source: jdbc
   connection:
     url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-    # url: jdbc:h2:tcp://localhost:1521/test;DB_CLOSE_DELAY=-1
+    # url: jdbc:h2:tcp://localhost:1521/test
     username: sa
     password:
     poolName: h2


### PR DESCRIPTION
Updates to README and related files with a section describing how to run database-se/mp using an external H2 database and GraalVM native.
