### PR TITLE
Various AsciiDoctor warning fixes

### DIFF
--- a/docs/mp/guides/03_config.adoc
+++ b/docs/mp/guides/03_config.adoc
@@ -262,7 +262,7 @@ even though it is considered a default source.
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFrom-config.properties World!"
+  "message": "HelloFrom-config.properties World!" # <1>
 }
 ----
 <1> The greeting was picked up from `config.properties`, overriding the value in `META-INF/microprofile-config.properties`.
@@ -338,7 +338,7 @@ import static io.helidon.config.ConfigSources.file;
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFromConfigFile World!"
+  "message": "HelloFromConfigFile World!" # <1>
 }
 ----
 <1> The configuration property from the file `config-file.properties` takes precedence.
@@ -409,7 +409,7 @@ import static io.helidon.config.ConfigSources.directory;
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFromFileInDirectoryConf World!"
+  "message": "HelloFromFileInDirectoryConf World!" # <1>
 }
 ----
 <1> The greeting was fetched from the file named `app.greeting`.
@@ -579,7 +579,7 @@ public class GreetingProvider {
 constructor as a `String` parameter named `message`.
 
 
-===== Injecting at field level
+=== Injecting at field level
 
 You can inject configuration at the field level as shown below.  Use the `volatile` keyword
 since you cannot use `AtomicReference` with field level injection.
@@ -626,7 +626,7 @@ curl http://localhost:8080/greet
 }
 ----
 
-===== Injecting the Config object
+=== Injecting the Config object
 
 You can inject the `Config` object into the class and access it directly as shown below.
 This object is not initialized when the `GreetingProvider` constructor is called, so you need to provide
@@ -677,7 +677,7 @@ curl http://localhost:8080/greet
 ----
 
 
-===== Navigating the Config tree
+=== Navigating the Config tree
 
 Helidon offers a variety of methods to access in-memory configuration.  These can be categorized as _key access_ or _tree navigation_.
 You have been using _key access_ for all of the examples to this point.  For example `app.greeting` is accessing

--- a/docs/mp/guides/06_tracing.adoc
+++ b/docs/mp/guides/06_tracing.adoc
@@ -293,7 +293,7 @@ import org.eclipse.microprofile.opentracing.Traced; // <1>
 ...
 ----
 <1> Import the `Traced` annotation.
-<1> Enable tracing for getMessage.
+<2> Enable tracing for getMessage.
 
 [source,bash]
 .Build and run the application, then invoke the endpoints and check the response:
@@ -605,7 +605,7 @@ tracing.host=zipkin
 docker build -t helidon-tracing-mp .
 ----
 
-==== Deploy Zipkin into Kubernetes
+=== Deploy Zipkin into Kubernetes
 
 [source,yaml]
 .Create the Kubernetes YAML specification, named `zipkin.yaml`, with the following contents:
@@ -653,7 +653,7 @@ Navigate to http://localhost:9412/zipkin to validate that you can access Zipkin 
 take a few seconds before it is ready.
 
 
-==== Deploy your Helidon application into Kubernetes
+=== Deploy your Helidon application into Kubernetes
 
 [source,yaml]
 .Create the Kubernetes YAML specification, named `tracing.yaml`, with the following contents:
@@ -701,7 +701,7 @@ spec:
 kubectl apply -f ./tracing.yaml
 ----
 
-==== Access your application and the Zipkin trace
+=== Access your application and the Zipkin trace
 
 [source,bash]
 .Get the application service information:
@@ -729,7 +729,7 @@ curl http://localhost:31143/greet
 Access the Zipkin UI at http://localhost:9412/zipkin and click on the refresh icon to see the trace that was just created.
 
 
-==== Cleanup
+=== Cleanup
 
 You can now delete the Kubernetes resources that were just created during this example.
 

--- a/docs/mp/guides/10_mp-tutorial.adoc
+++ b/docs/mp/guides/10_mp-tutorial.adoc
@@ -676,17 +676,17 @@ The application logging can be customized.  The default logging provider
 Create a `logging.properties` file in `src/main/resources` with
  the following content:
 
-[source,java]
+[source,properties]
 .Example logging.properties file
 ----
 # Send messages to the console
-handlers=io.helidon.common.HelidonConsoleHandler
+handlers=io.helidon.common.HelidonConsoleHandler # <1>
 
 # HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n # <2>
 
 # Global logging level. Can be overridden by specific loggers
-.level=INFO
+.level=INFO # <3>
 ----
 
 <1> The Helidon console logging handler is configured. This handler writes to `System.out`, does not filter by level
@@ -1204,7 +1204,7 @@ There were several links to more detailed information included in the
  tutorial.  These links are repeated below and can be explored to learn 
  more details about Helidon application development.
 
-==== Related links
+== Related links
 
 * https://projects.eclipse.org/projects/technology.microprofile[Eclipse MicroProfile]
 * https://docs.jboss.org/cdi/api/2.0/index.html[Contexts and Dependency Injection Specification]

--- a/docs/mp/jpa/01_introduction.adoc
+++ b/docs/mp/jpa/01_introduction.adoc
@@ -35,10 +35,10 @@ fully managed `EntityManager` by injecting it in the same way you
 would in a Java EE application server:
 
 [source,java]
-====
+----
 @PersistenceContext
 private EntityManager em;
-====
+----
 
 The Jakarta Persistence API is a specification that governs how Java
 objects map to relational databases, and has existed since 2006.

--- a/docs/se/config/06_advanced-configuration.adoc
+++ b/docs/se/config/06_advanced-configuration.adoc
@@ -47,21 +47,19 @@ system properties can also be simplified.
 Aliases are produced for any environment variable name that matches _all_ of
 the following:
 
-<1> does not begin or end with a `'_'` character
-<2> does not contain `"__"`
-<3> contains one or more `'_'` characters
+. does not begin or end with a `'_'` character
+. does not contain `"__"`
+. contains one or more `'_'` characters
 
 For each such name, two aliases are added with the names mapped as follows:
 
-<1> Replace any `"\_dash_"` or `"\_DASH_"` substrings with `"-"`, e.g. `"APP_PAGE_dash_SIZE"`
+. Replace any `"\_dash_"` or `"\_DASH_"` substrings with `"-"`, e.g. `"APP_PAGE_dash_SIZE"`
 becomes `"APP_PAGE-SIZE"`.
-
-<2> Replace `'_'` with `'.'` and add as an alias, e.g. `"APP_GREETING"` is
+. Replace `'_'` with `'.'` and add as an alias, e.g. `"APP_GREETING"` is
 added as `"APP.GREETING"` and `"APP_PAGE-SIZE"` is added as `"APP.PAGE-SIZE"`.
 This mapping is added primarily to support mixed case config keys such as
 `"app.someCamelCaseKey"`.
-
-<3> Convert the result of step 2 to lowercase and add as an alias, e.g.
+. Convert the result of step 2 to lowercase and add as an alias, e.g.
 `"APP.GREETING"` is added as `"app.greeting"` and `"APP.PAGE-SIZE"` is added
 as `"app.page-size"`.
 

--- a/docs/se/dbclient/01_introduction.adoc
+++ b/docs/se/dbclient/01_introduction.adoc
@@ -70,6 +70,7 @@ Before you begin you must add the DB Client dependencies and configure the clien
 The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
 should declare dependency management for Helidon applications.
 
++
 For the DB Client using JDBC implementation and H2 database, you must include the following dependencies in your project:
 
 +
@@ -94,7 +95,7 @@ For the DB Client using JDBC implementation and H2 database, you must include th
 
 ----
 
-+ 
++
 
 <1> Add the Helidon DB Client
 <2> Specify JDBC or MongoDB
@@ -110,7 +111,7 @@ The DB Client must be configured before you begin. In the example below we'll us
 ----
 
 db:
-  source: "jdbc" // <1> 
+  source: "jdbc" // <1>
   connection:
     url: "jdbc:mysql://127.0.0.1:3306/pokemon?useSSL=false" // <2>
     username: "user"

--- a/docs/se/grpc/01_introduction.adoc
+++ b/docs/se/grpc/01_introduction.adoc
@@ -41,7 +41,7 @@ Here is the code for a minimalist gRPC application that runs on a default port (
                                 .build())
                 .start() // <2>
                 .toCompletableFuture()
-                .get(10, TimeUnit.SECONDS); // <3>Implement the simplest possible gRPC service. // <3>
+                .get(10, TimeUnit.SECONDS); // Implement the simplest possible gRPC service. // <3>
 
         System.out.println("gRPC Server started at: http://localhost:" + grpcServer.port()); // <4>
     }

--- a/docs/se/grpc/01_introduction.adoc
+++ b/docs/se/grpc/01_introduction.adoc
@@ -41,7 +41,7 @@ Here is the code for a minimalist gRPC application that runs on a default port (
                                 .build())
                 .start() // <2>
                 .toCompletableFuture()
-                .get(10, TimeUnit.SECONDS); // <3>Implement the simplest possible gRPC service.
+                .get(10, TimeUnit.SECONDS); // <3>Implement the simplest possible gRPC service. // <3>
 
         System.out.println("gRPC Server started at: http://localhost:" + grpcServer.port()); // <4>
     }

--- a/docs/se/guides/03_config.adoc
+++ b/docs/se/guides/03_config.adoc
@@ -257,7 +257,7 @@ even though it is considered a default source.
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFrom-config.properties World!"
+  "message": "HelloFrom-config.properties World!" # <1>
 }
 ----
 <1> The greeting was picked up from `config.properties`, overriding the value in `application.yaml`.
@@ -333,7 +333,7 @@ import static io.helidon.config.ConfigSources.file;
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFrom-config-file.properties World!"
+  "message": "HelloFrom-config-file.properties World!" # <1>
 }
 ----
 <1> The configuration property from the file `config-file.properties` takes precedence.
@@ -404,7 +404,7 @@ import static io.helidon.config.ConfigSources.directory;
 curl http://localhost:8080/greet
 ...
 {
-  "message": "HelloFromFileInDirectoryConf World!"
+  "message": "HelloFromFileInDirectoryConf World!" # <1>
 }
 ----
 <1> The greeting was fetched from the file named `app.greeting`.
@@ -548,7 +548,7 @@ the `greeting` child node of the `app` parent node.  There are many options for 
 methods as described in <<config/03_hierarchical-features.adoc,Hierarchical Config>> and <<config/06_advanced-configuration.adoc,Advanced Config>>.
 
 
-===== Accessing config using keys or navigation
+=== Accessing config using keys or navigation
 
 The simplest way to access configuration data is using a key, as shown below in the `GreetService` class.  The
 key can be composite as shown below:

--- a/docs/se/guides/04_health.adoc
+++ b/docs/se/guides/04_health.adoc
@@ -509,7 +509,7 @@ HealthSupport health = HealthSupport.builder()
 ----
 <1> Add built-in health-checks.
 <2> Add a custom liveness check.
-<2> Add a custom readiness check.
+<3> Add a custom readiness check.
 
 
 [source,bash]

--- a/docs/se/guides/05_metrics.adoc
+++ b/docs/se/guides/05_metrics.adoc
@@ -363,8 +363,8 @@ import java.util.Collections;
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
-import org.eclipse.microprofile.metrics.Meter;
-import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Meter; // <1>
+import org.eclipse.microprofile.metrics.MetricRegistry; // <1>
 
 public class GreetingCards implements Service {
 
@@ -542,8 +542,8 @@ import java.util.Random;
 import javax.json.Json;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
-import org.eclipse.microprofile.metrics.Histogram;
-import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Histogram; // <1>
+import org.eclipse.microprofile.metrics.MetricRegistry; // <1>
 
 public class GreetingCards implements Service {
 
@@ -580,8 +580,8 @@ public class GreetingCards implements Service {
 <1> Import metrics classes.
 <2> Declare a `Histogram` member variable.
 <3> Create and register the `Histogram` metric in the `MetricRegistry`.
-<5> Loop, loading the histogram with numbers.
 <4> Update the `Histogram` metric with a random number.
+<5> Loop, loading the histogram with numbers.
 
 
 [source,bash]

--- a/docs/se/guides/06_tracing.adoc
+++ b/docs/se/guides/06_tracing.adoc
@@ -164,7 +164,7 @@ import io.helidon.tracing.TracerBuilder; // <1>
 <1> Add a new import statement.
 <2> Call the new `buildServerConfig` method to build a `ServerConfiguration` object.
 <3> Build the `ServerConfiguration` object.
-<3> Build and register a `Tracer` object using the tracing configuration.
+<4> Build and register a `Tracer` object using the tracing configuration.
 
 [source,java]
 .Update the `GreetService` class; 1) Add a new import and 2) Replace the `getDefaultMessageHandler` method:
@@ -628,7 +628,7 @@ tracing:
 docker build -t helidon-tracing-se .
 ----
 
-==== Deploy Zipkin into Kubernetes
+=== Deploy Zipkin into Kubernetes
 
 [source,yaml]
 .Create the Kubernetes YAML specification, named `zipkin.yaml`, with the following contents:
@@ -675,7 +675,7 @@ Navigate to http://localhost:9412/zipkin to validate that you can access Zipkin 
 take a few seconds before it is ready.
 
 
-==== Deploy your Helidon application into Kubernetes
+=== Deploy your Helidon application into Kubernetes
 
 [source,yaml]
 .Create the Kubernetes YAML specification, named `tracing.yaml`, with the following contents:
@@ -723,7 +723,7 @@ spec:
 kubectl apply -f ./tracing.yaml
 ----
 
-==== Access your application and the Zipkin trace
+=== Access your application and the Zipkin trace
 
 [source,bash]
 .Get the application service information:
@@ -751,7 +751,7 @@ curl http://localhost:31143/greet
 Access the Zipkin UI at http://localhost:9412/zipkin and click on the refresh icon to see the trace that was just created.
 
 
-==== Cleanup
+=== Cleanup
 
 You can now delete the Kubernetes resources that were just created during this example.
 


### PR DESCRIPTION
There remain quite a few JavaDoc warnings, but after some checking it's not yet clear why they are happening. So I'm going with these fixes to the `.adoc` files.