### PR TITLE
Properly use path() when creating invocations

### DIFF
--- a/archetypes/bare-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
+++ b/archetypes/bare-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 class MainTest {
 
     private static Server server;
+    private static String serverUrl;
 
     @BeforeAll
     public static void startTheServer() {
         server = Server.create().start();
+        serverUrl = "http://localhost:" + server.port();
     }
 
     @Test
@@ -30,20 +32,23 @@ class MainTest {
         Client client = ClientBuilder.newClient();
 
         JsonObject jsonObject = client
-                .target(getConnectionString("/greet"))
+                .target(serverUrl)
+                .path("greet")
                 .request()
                 .get(JsonObject.class);
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         Response r = client
-                .target(getConnectionString("/metrics"))
+                .target(serverUrl)
+                .path("metrics")
                 .request()
                 .get();
         Assertions.assertEquals(200, r.getStatus(), "GET metrics status code");
 
         r = client
-                .target(getConnectionString("/health"))
+                .target(serverUrl)
+                .path("health")
                 .request()
                 .get();
         Assertions.assertEquals(200, r.getStatus(), "GET health status code");
@@ -53,9 +58,5 @@ class MainTest {
     static void destroyClass() {
         CDI<Object> current = CDI.current();
         ((SeContainer) current).close();
-    }
-
-    private String getConnectionString(String path) {
-        return "http://localhost:" + server.port() + path;
     }
 }

--- a/archetypes/database-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
+++ b/archetypes/database-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
@@ -21,12 +21,14 @@ import static org.hamcrest.Matchers.is;
 class MainTest {
 
     private static Server server;
+    private static String serverUrl;
     private static Client client;
 
     @BeforeAll
     public static void startTheServer() {
         client = ClientBuilder.newClient();
         server = Server.create().start();
+        serverUrl = "http://localhost:" + server.port();
     }
 
     @AfterAll
@@ -37,7 +39,8 @@ class MainTest {
 
     @Test
     void testPokemonTypes() {
-        JsonArray types = client.target(getConnectionString("/type"))
+        JsonArray types = client.target(serverUrl)
+                .path("type")
                 .request()
                 .get(JsonArray.class);
         assertThat(types.size(), is(18));
@@ -47,17 +50,20 @@ class MainTest {
     void testPokemon() {
         assertThat(getPokemonCount(), is(6));
 
-        Pokemon pokemon = client.target(getConnectionString("/pokemon/1"))
+        Pokemon pokemon = client.target(serverUrl)
+                .path("pokemon/1")
                 .request()
                 .get(Pokemon.class);
         assertThat(pokemon.getName(), is("Bulbasaur"));
 
-        pokemon = client.target(getConnectionString("/pokemon/name/Charmander"))
+        pokemon = client.target(serverUrl)
+                .path("pokemon/name/Charmander")
                 .request()
                 .get(Pokemon.class);
         assertThat(pokemon.getType(), is(10));
 
-        Response response = client.target(getConnectionString("/pokemon/1"))
+        Response response = client.target(serverUrl)
+                .path("pokemon/1")
                 .request()
                 .get();
         assertThat(response.getStatus(), is(200));
@@ -66,13 +72,15 @@ class MainTest {
         test.setType(1);
         test.setId(100);
         test.setName("Test");
-        response = client.target(getConnectionString("/pokemon"))
+        response = client.target(serverUrl)
+                .path("pokemon")
                 .request()
                 .post(Entity.entity(test, MediaType.APPLICATION_JSON));
         assertThat(response.getStatus(), is(204));
         assertThat(getPokemonCount(), is(7));
 
-        response = client.target(getConnectionString("/pokemon/100"))
+        response = client.target(serverUrl)
+                .path("pokemon/100")
                 .request()
                 .delete();
         assertThat(response.getStatus(), is(204));
@@ -81,24 +89,23 @@ class MainTest {
 
     @Test
     void testHealthMetrics() {
-        Response response = client.target(getConnectionString("/health"))
+        Response response = client.target(serverUrl)
+                .path("health")
                 .request()
                 .get();
         assertThat(response.getStatus(), is(200));
-        response = client.target(getConnectionString("/metrics"))
+        response = client.target(serverUrl)
+                .path("metrics")
                 .request()
                 .get();
         assertThat(response.getStatus(), is(200));
     }
 
     private int getPokemonCount() {
-        JsonArray pokemons = client.target(getConnectionString("/pokemon"))
+        JsonArray pokemons = client.target(serverUrl)
+                .path("pokemon")
                 .request()
                 .get(JsonArray.class);
         return pokemons.size();
-    }
-
-    private String getConnectionString(String path) {
-        return "http://localhost:" + server.port() + path;
     }
 }

--- a/archetypes/quickstart-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/src/test/java/__pkg__/MainTest.java.mustache
@@ -18,11 +18,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class MainTest {
+
     private static Server server;
+    private static String serverUrl;
 
     @BeforeAll
     public static void startTheServer() throws Exception {
         server = Server.create().start();
+        serverUrl = "http://localhost:" + server.port();
     }
 
     @Test
@@ -30,40 +33,46 @@ class MainTest {
         Client client = ClientBuilder.newClient();
 
         JsonObject jsonObject = client
-                .target(getConnectionString("/greet"))
+                .target(serverUrl)
+                .path("greet")
                 .request()
                 .get(JsonObject.class);
         Assertions.assertEquals("Hello World!", jsonObject.getString("message"),
                 "default message");
 
         jsonObject = client
-                .target(getConnectionString("/greet/Joe"))
+                .target(serverUrl)
+                .path("greet/Joe")
                 .request()
                 .get(JsonObject.class);
         Assertions.assertEquals("Hello Joe!", jsonObject.getString("message"),
                 "hello Joe message");
 
         Response r = client
-                .target(getConnectionString("/greet/greeting"))
+                .target(serverUrl)
+                .path("greet/greeting")
                 .request()
                 .put(Entity.entity("{\"greeting\" : \"Hola\"}", MediaType.APPLICATION_JSON));
         Assertions.assertEquals(204, r.getStatus(), "PUT status code");
 
         jsonObject = client
-                .target(getConnectionString("/greet/Jose"))
+                .target(serverUrl)
+                .path("greet/Jose")
                 .request()
                 .get(JsonObject.class);
         Assertions.assertEquals("Hola Jose!", jsonObject.getString("message"),
                 "hola Jose message");
 
         r = client
-                .target(getConnectionString("/metrics"))
+                .target(serverUrl)
+                .path("metrics")
                 .request()
                 .get();
         Assertions.assertEquals(200, r.getStatus(), "GET metrics status code");
 
         r = client
-                .target(getConnectionString("/health"))
+                .target(serverUrl)
+                .path("health")
                 .request()
                 .get();
         Assertions.assertEquals(200, r.getStatus(), "GET health status code");
@@ -73,9 +82,5 @@ class MainTest {
     static void destroyClass() {
         CDI<Object> current = CDI.current();
         ((SeContainer) current).close();
-    }
-
-    private String getConnectionString(String path) {
-        return "http://localhost:" + server.port() + path;
     }
 }


### PR DESCRIPTION
Fixes issue #1949. Properly use path() when creating an invocation using the JAX-RS API. Note that this PR does not address the closing of `Response`'s. Although technically correct, it isn't really a problem in tests and tends to make the code less readable.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>