### PR TITLE
Added <relativePath/> to avoid warnings 

### DIFF
--- a/archetypes/bare-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-mp/src/main/resources/pom.xml.mustache
@@ -7,6 +7,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>

--- a/archetypes/bare-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-se/src/main/resources/pom.xml.mustache
@@ -7,6 +7,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>

--- a/archetypes/database-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-mp/src/main/resources/pom.xml.mustache
@@ -8,6 +8,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>

--- a/archetypes/database-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-se/src/main/resources/pom.xml.mustache
@@ -23,6 +23,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>

--- a/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
@@ -25,6 +25,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-mp</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>

--- a/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
@@ -7,6 +7,7 @@
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
         <version>{{helidonVersion}}</version>
+        <relativePath/>
     </parent>
     <groupId>{{groupId}}</groupId>
     <artifactId>{{artifactId}}</artifactId>


### PR DESCRIPTION
Added <relativePath/> to avoid warnings when a pom exists in parent directory.
Fixes #2088

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>