### PR TITLE
Single add forSingle and exceptionallyAccept

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
@@ -295,7 +295,15 @@ public class CompletionAwaitable<T> implements CompletionStage<T>, Awaitable<T> 
     }
 
     /**
-     * {@inheritDoc}
+     * Returns a new CompletionAwaitable that, when this stage completes
+     * exceptionally, is executed with this stage's exception as the
+     * argument to the supplied consumer. Otherwise, if this stage
+     * completes normally, then the returned stage also completes
+     * normally with the same value.
+     *
+     * @param consumer the consumer to invoke if this CompletionAwaitable completed
+     *                 exceptionally
+     * @return the new CompletionAwaitable
      */
     public CompletionAwaitable<T> exceptionallyAccept(final Consumer<Throwable> consumer) {
         return this.handle((item, t) -> {

--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
@@ -294,6 +294,26 @@ public class CompletionAwaitable<T> implements CompletionStage<T>, Awaitable<T> 
         return new CompletionAwaitable<T>(() -> completionStage, this);
     }
 
+    /**
+     * Returns a new CompletionStage that, when this stage completes
+     * exceptionally, is executed with this stage's exception as the
+     * argument to the supplied consumer. Otherwise, if this stage
+     * completes normally, then the returned stage also completes
+     * normally with the same value.
+     *
+     * @param consumer the consumer to invoke if this CompletionStage completed
+     *                 exceptionally
+     * @return the new CompletionStage
+     */
+    public CompletionAwaitable<T> exceptionally(final Consumer<Throwable> consumer) {
+        return this.handle((item, t) -> {
+            if (t != null) {
+                consumer.accept(t);
+            }
+            return item;
+        });
+    }
+
     @Override
     public CompletableFuture<T> toCompletableFuture() {
         return originalStage.get().toCompletableFuture();

--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
@@ -294,39 +294,13 @@ public class CompletionAwaitable<T> implements CompletionStage<T>, Awaitable<T> 
         return new CompletionAwaitable<T>(() -> completionStage, this);
     }
 
-    /**
-     * Returns a new CompletionStage that, when this stage completes
-     * exceptionally, is executed with this stage's exception as the
-     * argument to the supplied consumer. Otherwise, if this stage
-     * completes normally, then the returned stage also completes
-     * normally with the same value.
-     *
-     * @param consumer the consumer to invoke if this CompletionStage completed
-     *                 exceptionally
-     * @return the new CompletionStage
-     */
-    public CompletionAwaitable<T> exceptionally(final Consumer<Throwable> consumer) {
+    public CompletionAwaitable<T> exceptionallyAccept(final Consumer<Throwable> consumer) {
         return this.handle((item, t) -> {
             if (t != null) {
                 consumer.accept(t);
             }
             return item;
         });
-    }
-
-    /**
-     * Returns a new CompletionStage that, when this stage completes
-     * exceptionally, is executed with this stage's exception as the
-     * argument to the supplied consumer. Otherwise, if this stage
-     * completes normally, then the returned stage also completes
-     * normally with the same value.
-     *
-     * @param consumer the consumer to invoke if this CompletionStage completed
-     *                 exceptionally
-     * @return the new CompletionStage
-     */
-    public CompletionAwaitable<T> onError(final Consumer<Throwable> consumer) {
-        return this.exceptionally(consumer);
     }
 
     @Override

--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
@@ -294,6 +294,9 @@ public class CompletionAwaitable<T> implements CompletionStage<T>, Awaitable<T> 
         return new CompletionAwaitable<T>(() -> completionStage, this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public CompletionAwaitable<T> exceptionallyAccept(final Consumer<Throwable> consumer) {
         return this.handle((item, t) -> {
             if (t != null) {

--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionAwaitable.java
@@ -314,6 +314,21 @@ public class CompletionAwaitable<T> implements CompletionStage<T>, Awaitable<T> 
         });
     }
 
+    /**
+     * Returns a new CompletionStage that, when this stage completes
+     * exceptionally, is executed with this stage's exception as the
+     * argument to the supplied consumer. Otherwise, if this stage
+     * completes normally, then the returned stage also completes
+     * normally with the same value.
+     *
+     * @param consumer the consumer to invoke if this CompletionStage completed
+     *                 exceptionally
+     * @return the new CompletionStage
+     */
+    public CompletionAwaitable<T> onError(final Consumer<Throwable> consumer) {
+        return this.exceptionally(consumer);
+    }
+
     @Override
     public CompletableFuture<T> toCompletableFuture() {
         return originalStage.get().toCompletableFuture();

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -660,6 +660,16 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
     }
 
     /**
+     * Terminal stage, invokes provided consumer when Single is completed.
+     *
+     * @param consumer consumer to be invoked
+     * @return Single completed when the stream terminates
+     */
+    default CompletionAwaitable<Void> forSingle(Consumer<T> consumer) {
+        return this.thenAccept(consumer);
+    }
+
+    /**
      * Cancel upstream.
      *
      * @return new {@link Single} for eventually received single value.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -815,5 +815,5 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
      *                 exceptionally
      * @return the new CompletionStage
      */
-    CompletionAwaitable<T> exceptionallyAccept(final Consumer<Throwable> consumer);
+    CompletionAwaitable<T> exceptionallyAccept(Consumer<Throwable> consumer);
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -803,4 +803,17 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
 
     @Override
     CompletionAwaitable<T> exceptionally(Function<Throwable, ? extends T> fn);
+
+    /**
+     * Returns a new CompletionStage that, when this stage completes
+     * exceptionally, is executed with this stage's exception as the
+     * argument to the supplied consumer. Otherwise, if this stage
+     * completes normally, then the returned stage also completes
+     * normally with the same value.
+     *
+     * @param consumer the consumer to invoke if this CompletionStage completed
+     *                 exceptionally
+     * @return the new CompletionStage
+     */
+    CompletionAwaitable<T> exceptionallyAccept(final Consumer<Throwable> consumer);
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -391,7 +391,7 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
     }
 
     /**
-     * Executes given {@link java.lang.Runnable} when onError signal is received.
+     * Executes given {@link java.util.function.Consumer} when onError signal is received.
      *
      * @param onErrorConsumer {@link java.util.function.Consumer} to be executed.
      * @return Single

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -805,15 +805,15 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
     CompletionAwaitable<T> exceptionally(Function<Throwable, ? extends T> fn);
 
     /**
-     * Returns a new CompletionStage that, when this stage completes
+     * Returns a new CompletionAwaitable that, when this stage completes
      * exceptionally, is executed with this stage's exception as the
      * argument to the supplied consumer. Otherwise, if this stage
      * completes normally, then the returned stage also completes
      * normally with the same value.
      *
-     * @param consumer the consumer to invoke if this CompletionStage completed
+     * @param consumer the consumer to invoke if this CompletionAwaitable completed
      *                 exceptionally
-     * @return the new CompletionStage
+     * @return the new CompletionAwaitable
      */
     CompletionAwaitable<T> exceptionallyAccept(Consumer<Throwable> consumer);
 }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -570,7 +570,7 @@ public class SingleTest {
                 .forSingle(s -> {
                     throw testException;
                 })
-                .exceptionally(result::complete);
+                .exceptionallyAccept(result::complete);
 
         assertThat(Single.create(result).await(300, TimeUnit.MILLISECONDS).getCause(), is(testException));
         assertThat(onCancelCnt.get(), is(0));
@@ -599,10 +599,21 @@ public class SingleTest {
 
         RuntimeException testException = new RuntimeException("BOOM!!!");
         Single.error(testException)
-                .exceptionally(exceptionallyFuture::complete)
+                .exceptionallyAccept(exceptionallyFuture::complete)
                 .await(300, TimeUnit.MILLISECONDS);
 
         assertThat(Single.create(exceptionallyFuture).await(300, TimeUnit.MILLISECONDS), is(testException));
+    }
+
+    @Test
+    void testExceptionallyWithoutException() {
+        CompletableFuture<Throwable> exceptionallyFuture = new CompletableFuture<>();
+
+        String result = Single.just(TEST_PAYLOAD)
+                .exceptionallyAccept(exceptionallyFuture::complete)
+                .await(300, TimeUnit.MILLISECONDS);
+
+        assertThat(result, is(TEST_PAYLOAD));
     }
 
     private static class SingleTestSubscriber<T> extends TestSubscriber<T> {

--- a/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/SingleTest.java
@@ -17,6 +17,7 @@ package io.helidon.common.reactive;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow.Subscriber;
@@ -25,7 +26,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +37,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -170,14 +171,14 @@ public class SingleTest {
         try {
             Single.just("foo").map(null);
             fail("NullPointerException should be thrown");
-        } catch(NullPointerException ex) {
+        } catch (NullPointerException ex) {
         }
     }
 
     @Test
     public void testMapBadMapperNullValue() {
         SingleTestSubscriber<String> subscriber = new SingleTestSubscriber<>();
-        Single.just("bar").map((s) -> (String)null).subscribe(subscriber);
+        Single.just("bar").map((s) -> (String) null).subscribe(subscriber);
         assertThat(subscriber.isComplete(), is(equalTo(false)));
         assertThat(subscriber.getLastError(), is(instanceOf(NullPointerException.class)));
         assertThat(subscriber.getItems(), is(empty()));
@@ -238,7 +239,7 @@ public class SingleTest {
     public void testFlatMap() {
         SingleTestSubscriber<String> subscriber = new SingleTestSubscriber<>();
         Single.just("f.o.o")
-                .flatMap((str) ->  new TestPublisher<>(str.split("\\.")))
+                .flatMap((str) -> new TestPublisher<>(str.split("\\.")))
                 .subscribe(subscriber);
         assertThat(subscriber.isComplete(), is(equalTo(true)));
         assertThat(subscriber.getLastError(), is(nullValue()));
@@ -283,7 +284,7 @@ public class SingleTest {
         try {
             Single.just("bar").flatMap(null);
             fail("NullPointerException should have been thrown");
-        } catch(NullPointerException ex) {
+        } catch (NullPointerException ex) {
         }
     }
 
@@ -304,8 +305,8 @@ public class SingleTest {
         };
         try {
             single.get(1, TimeUnit.SECONDS);
-        } catch(ExecutionException ex) {
-           assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
         }
     }
 
@@ -313,8 +314,8 @@ public class SingleTest {
     public void testEmptyToFuture() throws InterruptedException, TimeoutException {
         try {
             Single.<Object>empty().get(1, TimeUnit.SECONDS);
-        } catch(ExecutionException ex) {
-           assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
         }
     }
 
@@ -338,8 +339,8 @@ public class SingleTest {
         };
         try {
             single.get(1, TimeUnit.SECONDS);
-        } catch(ExecutionException ex) {
-           assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), is(instanceOf(IllegalStateException.class)));
         }
     }
 
@@ -487,6 +488,121 @@ public class SingleTest {
         onErrCnt.await(5, TimeUnit.MILLISECONDS);
         assertThat("",
                 onErrCnt.getCount(), is(equalTo(1L)));
+    }
+
+    @Test
+    void testForSingle() {
+        AtomicInteger onCancelCnt = new AtomicInteger(0);
+        AtomicInteger onCompleteCnt = new AtomicInteger(0);
+        AtomicInteger onErrorCnt = new AtomicInteger(0);
+        CompletableFuture<String> result = new CompletableFuture<>();
+
+        Single.just(TEST_PAYLOAD)
+                .onCancel(onCancelCnt::incrementAndGet)
+                .onComplete(onCompleteCnt::incrementAndGet)
+                .onError(t -> onErrorCnt.incrementAndGet())
+                .forSingle(result::complete);
+
+        assertThat(Single.create(result).await(300, TimeUnit.MILLISECONDS), is(TEST_PAYLOAD));
+        assertThat(onCancelCnt.get(), is(0));
+        assertThat(onErrorCnt.get(), is(0));
+        assertThat(onCompleteCnt.get(), is(1));
+    }
+
+    @Test
+    void testForSingleErrorAwait() throws InterruptedException {
+        AtomicInteger onCancelCnt = new AtomicInteger(0);
+        AtomicInteger onCompleteCnt = new AtomicInteger(0);
+        CountDownLatch onErrorCnt = new CountDownLatch(1);
+        CompletableFuture<String> result = new CompletableFuture<>();
+
+        RuntimeException testException = new RuntimeException("BOOM!!!");
+
+        CompletionException actualException = assertThrows(CompletionException.class,
+                () -> Single.<String>error(testException)
+                        .onCancel(onCancelCnt::incrementAndGet)
+                        .onComplete(onCompleteCnt::incrementAndGet)
+                        .onError(t -> onErrorCnt.countDown())
+                        .forSingle(result::complete)
+                        .await(300, TimeUnit.MILLISECONDS));
+
+        assertThat(onErrorCnt.await(300, TimeUnit.MILLISECONDS), is(true));
+        assertThat(actualException.getCause(), is(testException));
+        assertThat(result.isDone(), is(false));
+        assertThat(onCancelCnt.get(), is(0));
+        assertThat(onCompleteCnt.get(), is(0));
+    }
+
+    @Test
+    void testForSingleErrorNoAwait() throws InterruptedException {
+        AtomicInteger onCancelCnt = new AtomicInteger(0);
+        AtomicInteger onCompleteCnt = new AtomicInteger(0);
+        CountDownLatch onErrorCnt = new CountDownLatch(1);
+        CompletableFuture<String> result = new CompletableFuture<>();
+
+        RuntimeException testException = new RuntimeException("BOOM!!!");
+
+        Single.<String>error(testException)
+                .onCancel(onCancelCnt::incrementAndGet)
+                .onComplete(onCompleteCnt::incrementAndGet)
+                .onError(t -> onErrorCnt.countDown())
+                .forSingle(result::complete);
+
+        assertThat(onErrorCnt.await(300, TimeUnit.MILLISECONDS), is(true));
+        assertThat(result.isDone(), is(false));
+        assertThat(onCancelCnt.get(), is(0));
+        assertThat(onCompleteCnt.get(), is(0));
+    }
+
+    @Test
+    void testForSingleException() {
+        AtomicInteger onCancelCnt = new AtomicInteger(0);
+        AtomicInteger onCompleteCnt = new AtomicInteger(0);
+        AtomicInteger onErrorCnt = new AtomicInteger(0);
+        CompletableFuture<Throwable> result = new CompletableFuture<>();
+
+        RuntimeException testException = new RuntimeException("BOOM!!!");
+
+        Single.just(TEST_PAYLOAD)
+                .onCancel(onCancelCnt::incrementAndGet)
+                .onComplete(onCompleteCnt::incrementAndGet)
+                .onError(t -> onErrorCnt.incrementAndGet())
+                .forSingle(s -> {
+                    throw testException;
+                })
+                .exceptionally(result::complete);
+
+        assertThat(Single.create(result).await(300, TimeUnit.MILLISECONDS).getCause(), is(testException));
+        assertThat(onCancelCnt.get(), is(0));
+        assertThat(onErrorCnt.get(), is(0));
+        assertThat(onCompleteCnt.get(), is(1));
+    }
+
+    @Test
+    void testTraditionalExceptionallyWithFunction() {
+        CompletableFuture<Throwable> exceptionallyFuture = new CompletableFuture<>();
+
+        RuntimeException testException = new RuntimeException("BOOM!!!");
+        Single.error(testException)
+                .exceptionally(value -> {
+                    exceptionallyFuture.complete(value);
+                    return null;
+                })
+                .await(300, TimeUnit.MILLISECONDS);
+
+        assertThat(Single.create(exceptionallyFuture).await(300, TimeUnit.MILLISECONDS), is(testException));
+    }
+
+    @Test
+    void testExceptionallyWithConsumer() {
+        CompletableFuture<Throwable> exceptionallyFuture = new CompletableFuture<>();
+
+        RuntimeException testException = new RuntimeException("BOOM!!!");
+        Single.error(testException)
+                .exceptionally(exceptionallyFuture::complete)
+                .await(300, TimeUnit.MILLISECONDS);
+
+        assertThat(Single.create(exceptionallyFuture).await(300, TimeUnit.MILLISECONDS), is(testException));
     }
 
     private static class SingleTestSubscriber<T> extends TestSubscriber<T> {


### PR DESCRIPTION
Add terminal operation `forEach` equivalent to Single:
```java
Single.just("test")
                .forSingle(s -> System.out.println(">>>" + s));
>>>test
``` 

Add `exceptionallyAccept` which takes consumer as parameter to `CompletionAwaitable` so there is no need to return something all the time, so instead of:
```java
        Single.error(testException)
                .exceptionally(t -> {
                    t.printStackTrace();
                    return null;
                })
```
Is possible:
```java
        Single.error(testException)
                .exceptionallyAccept(Throwable::printStackTrace);
``` 

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>