### PR TITLE
Flush streamed datachunk one by one

### DIFF
--- a/media/common/src/main/java/io/helidon/media/common/CharSequenceBodyStreamWriter.java
+++ b/media/common/src/main/java/io/helidon/media/common/CharSequenceBodyStreamWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.media.common;
+
+import java.util.concurrent.Flow;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.Multi;
+
+final class CharSequenceBodyStreamWriter implements MessageBodyStreamWriter<CharSequence> {
+
+    private static final CharSequenceBodyStreamWriter DEFAULT = new CharSequenceBodyStreamWriter();
+
+    private CharSequenceBodyStreamWriter() {
+    }
+
+    static CharSequenceBodyStreamWriter create() {
+        return DEFAULT;
+    }
+
+    @Override
+    public Flow.Publisher<DataChunk> write(final Flow.Publisher<? extends CharSequence> publisher,
+                                           final GenericType<? extends CharSequence> type,
+                                           final MessageBodyWriterContext context) {
+        context.contentType(MediaType.TEXT_PLAIN);
+        return Multi.create(publisher).map(s -> DataChunk.create(true, context.charset().encode(s.toString())));
+    }
+
+    @Override
+    public PredicateResult accept(final GenericType<?> type, final MessageBodyWriterContext context) {
+        return PredicateResult.supports(CharSequence.class, type);
+    }
+}

--- a/media/common/src/main/java/io/helidon/media/common/DefaultMediaSupport.java
+++ b/media/common/src/main/java/io/helidon/media/common/DefaultMediaSupport.java
@@ -89,6 +89,15 @@ public class DefaultMediaSupport implements MediaSupport {
     }
 
     /**
+     * Return {@link CharSequence} stream writer instance.
+     *
+     * @return {@link CharSequence} writer
+     */
+    public static MessageBodyStreamWriter<CharSequence> charSequenceStreamWriter() {
+        return CharSequenceBodyStreamWriter.create();
+    }
+
+    /**
      * Create a new instance of {@link ReadableByteChannel} writer.
      *
      * @return {@link ReadableByteChannel} writer
@@ -148,6 +157,11 @@ public class DefaultMediaSupport implements MediaSupport {
                        pathWriter(),
                        fileWriter(),
                        throwableBodyWriter);
+    }
+
+    @Override
+    public Collection<MessageBodyStreamWriter<?>> streamWriters() {
+        return List.of(charSequenceStreamWriter());
     }
 
     /**

--- a/media/common/src/main/java/io/helidon/media/common/MessageBodyContext.java
+++ b/media/common/src/main/java/io/helidon/media/common/MessageBodyContext.java
@@ -76,7 +76,7 @@ public abstract class MessageBodyContext implements MessageBodyFilters {
         AFTER_ONNEXT,
 
         /**
-         * Emitted after {@link Subscriber#onError(Throwable)}.
+         * Emitted before {@link Subscriber#onError(Throwable)}.
          */
         BEFORE_ONERROR,
 

--- a/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyStreamWriter.java
+++ b/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyStreamWriter.java
@@ -26,7 +26,6 @@ import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.reactive.Multi;
-import io.helidon.common.reactive.Single;
 import io.helidon.media.common.MessageBodyStreamWriter;
 import io.helidon.media.common.MessageBodyWriterContext;
 import io.helidon.media.jsonp.JsonpBodyWriter.JsonStructureToChunks;
@@ -65,18 +64,17 @@ class JsonpBodyStreamWriter implements MessageBodyStreamWriter<JsonStructure> {
                 jsonWriterFactory,
                 context.charset());
 
-        return Single.just(DataChunk.create(ARRAY_JSON_BEGIN_BYTES))
-                .onCompleteResumeWith(Multi.create(publisher)
-                                              .map(jsonToChunks)
-                                              .flatMap(it -> {
-                                                  if (first.getAndSet(false)) {
-                                                      // first record, do not prepend a comma
-                                                      return Single.just(it);
-                                                  } else {
-                                                      // any subsequent record starts with a comma
-                                                      return Multi.just(DataChunk.create(COMMA_BYTES), it);
-                                                  }
-                                              }))
+        return Multi.create(publisher)
+                .map(jsonToChunks)
+                .flatMap(it -> {
+                    if (first.getAndSet(false)) {
+                        // first record, do not prepend a comma
+                        return Multi.just(DataChunk.create(ARRAY_JSON_BEGIN_BYTES), it);
+                    } else {
+                        // any subsequent record starts with a comma
+                        return Multi.just(DataChunk.create(COMMA_BYTES), it);
+                    }
+                })
                 .onCompleteResume(DataChunk.create(ARRAY_JSON_END_BYTES));
     }
 }

--- a/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyStreamWriter.java
+++ b/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyStreamWriter.java
@@ -61,8 +61,9 @@ class JsonpBodyStreamWriter implements MessageBodyStreamWriter<JsonStructure> {
         // we do not have join operator
         AtomicBoolean first = new AtomicBoolean(true);
 
-        JsonStructureToChunks jsonToChunks = new JsonStructureToChunks(jsonWriterFactory,
-                                                                       context.charset());
+        JsonStructureToChunks jsonToChunks = new JsonStructureToChunks(true,
+                jsonWriterFactory,
+                context.charset());
 
         return Single.just(DataChunk.create(ARRAY_JSON_BEGIN_BYTES))
                 .onCompleteResumeWith(Multi.create(publisher)

--- a/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyWriter.java
+++ b/media/jsonp/src/main/java/io/helidon/media/jsonp/JsonpBodyWriter.java
@@ -60,10 +60,17 @@ class JsonpBodyWriter implements MessageBodyWriter<JsonStructure> {
     static final class JsonStructureToChunks implements Mapper<JsonStructure, DataChunk> {
         private final JsonWriterFactory factory;
         private final Charset charset;
+        private boolean flush = false;
 
         JsonStructureToChunks(JsonWriterFactory factory, Charset charset) {
             this.factory = factory;
             this.charset = charset;
+        }
+
+        JsonStructureToChunks(boolean flush, JsonWriterFactory factory, Charset charset) {
+            this.factory = factory;
+            this.charset = charset;
+            this.flush = flush;
         }
 
         @Override
@@ -71,7 +78,7 @@ class JsonpBodyWriter implements MessageBodyWriter<JsonStructure> {
             CharBuffer buffer = new CharBuffer();
             try (JsonWriter writer = factory.createWriter(buffer)) {
                 writer.write(item);
-                return DataChunk.create(false, buffer.encode(charset));
+                return DataChunk.create(flush, buffer.encode(charset));
             }
         }
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -81,11 +81,11 @@ class BareResponseImpl implements BareResponse {
     private volatile boolean isWebSocketUpgrade = false;
 
     /**
-     * @param ctx                    the channel handler context
-     * @param request                the request
+     * @param ctx the channel handler context
+     * @param request the request
      * @param requestContentConsumed whether the request content is consumed
-     * @param thread                 the outbound event loop thread which will be used to write the response
-     * @param requestId              the correlation ID that is added to the log statements
+     * @param thread the outbound event loop thread which will be used to write the response
+     * @param requestId the correlation ID that is added to the log statements
      */
     BareResponseImpl(ChannelHandlerContext ctx,
                      HttpRequest request,
@@ -241,7 +241,7 @@ class BareResponseImpl implements BareResponse {
      * Write last HTTP content. If length optimization is active and a first chunk is cached,
      * switch content encoding and write response.
      *
-     * @param throwable   A throwable.
+     * @param throwable A throwable.
      * @param closeAction Close action listener.
      */
     private void writeLastContent(final Throwable throwable, final ChannelFutureListener closeAction) {
@@ -349,34 +349,34 @@ class BareResponseImpl implements BareResponse {
     }
 
     private ChannelFuture sendData(DataChunk data) {
-        LOGGER.finest(() -> log("Sending data chunk"));
+            LOGGER.finest(() -> log("Sending data chunk"));
 
-        DefaultHttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(data.data()));
+            DefaultHttpContent httpContent = new DefaultHttpContent(Unpooled.wrappedBuffer(data.data()));
 
-        LOGGER.finest(() -> log("Sending data chunk on event loop thread."));
+            LOGGER.finest(() -> log("Sending data chunk on event loop thread."));
 
-        ChannelFuture channelFuture;
-        if (data.flush()) {
-            channelFuture = ctx.writeAndFlush(httpContent);
-        } else {
-            channelFuture = ctx.write(httpContent);
-        }
+            ChannelFuture channelFuture;
+            if (data.flush()) {
+                channelFuture = ctx.writeAndFlush(httpContent);
+            } else {
+                channelFuture = ctx.write(httpContent);
+            }
 
-        return channelFuture
-                .addListener(future -> {
-                    data.writeFuture().ifPresent(writeFuture -> {
-                        // Complete write future based con channel future
-                        if (future.isSuccess()) {
-                            writeFuture.complete(data);
-                        } else {
-                            writeFuture.completeExceptionally(future.cause());
-                        }
-                    });
-                    data.release();
-                    LOGGER.finest(() -> log("Data chunk sent with result: " + future.isSuccess()));
-                })
-                .addListener(completeOnFailureListener("Failure when sending a content!"))
-                .addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+            return channelFuture
+                    .addListener(future -> {
+                        data.writeFuture().ifPresent(writeFuture -> {
+                            // Complete write future based con channel future
+                            if (future.isSuccess()) {
+                                writeFuture.complete(data);
+                            } else {
+                                writeFuture.completeExceptionally(future.cause());
+                            }
+                        });
+                        data.release();
+                        LOGGER.finest(() -> log("Data chunk sent with result: " + future.isSuccess()));
+                    })
+                    .addListener(completeOnFailureListener("Failure when sending a content!"))
+                    .addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
     }
 
     private String log(String s) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Response.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Response.java
@@ -37,6 +37,7 @@ import io.helidon.media.common.MessageBodyWriterContext;
 import io.helidon.tracing.config.SpanTracingConfig;
 import io.helidon.tracing.config.TracingConfigUtil;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -45,6 +46,9 @@ import io.opentracing.Tracer;
  * The basic implementation of {@link ServerResponse}.
  */
 abstract class Response implements ServerResponse {
+
+    static final String STREAM_STATUS = "stream-status";
+    static final String STREAM_RESULT = "stream-result";
 
     private static final String TRACING_CONTENT_WRITE = "content-write";
 
@@ -244,7 +248,7 @@ abstract class Response implements ServerResponse {
 
     @Override
     public Response registerFilter(Function<Publisher<DataChunk>, Publisher<DataChunk>> function) {
-        writerContext.registerFilter(p -> function.apply(p));
+        writerContext.registerFilter(function::apply);
         return this;
     }
 
@@ -291,6 +295,17 @@ abstract class Response implements ServerResponse {
         private Span span;
         private volatile boolean sent;
 
+        private synchronized void sendErrorHeadersIfNeeded() {
+            if (headers != null && !sent) {
+                status(500);
+                //We are not using CombinedHttpHeaders
+                headers()
+                        .add(HttpHeaderNames.TRAILER.toString(), STREAM_STATUS + "," + STREAM_RESULT);
+                sent = true;
+                headers.send();
+            }
+        }
+
         private synchronized void sendHeadersIfNeeded() {
             if (headers != null && !sent) {
                 sent = true;
@@ -313,6 +328,9 @@ abstract class Response implements ServerResponse {
                     break;
                 case BEFORE_ONNEXT:
                     sendHeadersIfNeeded();
+                    break;
+                case BEFORE_ONERROR:
+                    sendErrorHeadersIfNeeded();
                     break;
                 case AFTER_ONERROR:
                     if (span != null) {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -192,10 +192,8 @@ public class SocketHttpClient implements AutoCloseable {
             if (ending && "".equalsIgnoreCase(t)) {
                 break;
             }
-            if (!ending && "0".equalsIgnoreCase(t)) {
+            if (!ending && ("0".equalsIgnoreCase(t))) {
                 ending = true;
-            } else {
-                ending = false;
             }
         }
         return sb.toString();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
So items are propagated to the client one by one:
![recording](https://user-images.githubusercontent.com/1773630/86471235-4e262980-bd3d-11ea-8a39-83906b6849f4.gif)


Signed-off-by: Daniel Kec <daniel.kec@oracle.com>