### PR TITLE
Change Dockerfiles to use maven.test.skip (not skipTests)

### DIFF
--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.jlink.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.jlink.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.jlink.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.jlink.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
@@ -8,7 +8,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/employee-app/Dockerfile
+++ b/examples/employee-app/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/grpc/opentracing/Dockerfile
+++ b/examples/grpc/opentracing/Dockerfile
@@ -24,10 +24,10 @@ WORKDIR /helidon
 # the pom
 RUN mkdir common
 ADD common/pom.xml common/pom.xml
-RUN mvn -f common/pom.xml install -DskipTests
+RUN mvn -f common/pom.xml install -Dmaven.test.skip
 RUN mkdir opentracing
 ADD opentracing/pom.xml opentracing/pom.xml
-RUN mvn -f opentracing/pom.xml package -DskipTests
+RUN mvn -f opentracing/pom.xml package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/integrations/cdi/datasource-hikaricp/Dockerfile
+++ b/examples/integrations/cdi/datasource-hikaricp/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/integrations/cdi/jedis/Dockerfile
+++ b/examples/integrations/cdi/jedis/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/integrations/cdi/oci-objectstorage/Dockerfile
+++ b/examples/integrations/cdi/oci-objectstorage/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build to create the custom Java Runtime Image
 # Incremental docker builds will resume here when you change sources

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -Pnative-image -Dnative.image.skip -DskipTests
+RUN mvn package -Pnative-image -Dnative.image.skip -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/todo-app/backend/Dockerfile
+++ b/examples/todo-app/backend/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/todo-app/frontend/Dockerfile
+++ b/examples/todo-app/frontend/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests -Dskip.npm
+RUN mvn package -Dmaven.test.skip -Dskip.npm
 
 # Create a second layer to cache the "NPM World" under node_modules
 # Incremental docker builds will always resume after that, unless you update

--- a/examples/translator-app/backend/Dockerfile
+++ b/examples/translator-app/backend/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources

--- a/examples/webserver/opentracing/Dockerfile
+++ b/examples/webserver/opentracing/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /helidon
 # Incremental docker builds will always resume after that, unless you update
 # the pom
 ADD pom.xml .
-RUN mvn package -DskipTests
+RUN mvn package -Dmaven.test.skip
 
 # Do the Maven build!
 # Incremental docker builds will resume here when you change sources


### PR DESCRIPTION
See issue #2128

This changes  Dockerfiles to use `maven.test.skip` when priming dependencies into the local maven cache to avoid attempting test compilation.