### PR TITLE
Security can now be disabled.

### DIFF
--- a/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcMpService.java
+++ b/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcMpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,15 @@ import io.helidon.security.providers.oidc.OidcSupport;
 public final class OidcMpService implements MpService {
     @Override
     public void configure(MpServiceContext mpServiceContext) {
-        mpServiceContext.serverRoutingBuilder()
-                .register(OidcSupport.create(mpServiceContext.helidonConfig()));
+        // only configure if security is enabled
+        if (mpServiceContext.helidonConfig()
+                .get("security.enabled")
+                .asBoolean()
+                .orElse(true)) {
+
+            mpServiceContext.serverRoutingBuilder()
+                    .register(OidcSupport.create(mpServiceContext.helidonConfig()));
+        }
 
     }
 }

--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import io.helidon.common.http.Http;
@@ -94,6 +95,7 @@ public final class WebSecurity implements Service {
      */
     public static final String CONTEXT_ADD_HEADERS = "security.addHeaders";
 
+    private static final Logger LOGGER = Logger.getLogger(WebSecurity.class.getName());
     private static final AtomicInteger SECURITY_COUNTER = new AtomicInteger();
 
     private final Security security;
@@ -320,6 +322,10 @@ public final class WebSecurity implements Service {
 
     @Override
     public void update(Routing.Rules routing) {
+        if (!security.enabled()) {
+            LOGGER.info("Security is disabled. Not registering any security handlers");
+            return;
+        }
         routing.any(this::registerContext);
 
         if (null != config) {

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -425,7 +425,7 @@ public class Security {
         private boolean tracingEnabled = true;
         private SecurityTime serverTime = SecurityTime.builder().build();
         private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create();
-        private boolean enabled;
+        private boolean enabled = true;
 
         private Builder() {
         }

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,9 +102,11 @@ public class Security {
     private final SecurityTime serverTime;
     private final Supplier<ExecutorService> executorService;
     private final Config securityConfig;
+    private final boolean enabled;
 
     @SuppressWarnings("unchecked")
     private Security(Builder builder) {
+        this.enabled = builder.enabled;
         this.instanceUuid = UUID.randomUUID().toString();
         this.serverTime = builder.serverTime;
         this.executorService = builder.executorService;
@@ -112,6 +114,13 @@ public class Security {
         this.securityTracer = SecurityUtil.getTracer(builder.tracingEnabled, builder.tracer);
         this.subjectMappingProvider = Optional.ofNullable(builder.subjectMappingProvider);
         this.securityConfig = builder.config;
+
+        if (!enabled) {
+            // security is disabled
+            audit(instanceUuid, SecurityAuditEvent.info(
+                    AuditEvent.SECURITY_TYPE_PREFIX + ".configure",
+                    "Security is disabled."));
+        }
 
         //providers
         List<NamedProvider<AuthorizationProvider>> atzProviders = new LinkedList<>();
@@ -387,6 +396,16 @@ public class Security {
     }
 
     /**
+     * Whether security is enabled or disabled.
+     * Disabled security behaves as if no security is configured.
+     *
+     * @return {@code true} if security is enabled
+     */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /**
      * Builder pattern class for helping create {@link Security} in a convenient way.
      */
     public static final class Builder implements io.helidon.common.Builder<Security> {
@@ -406,6 +425,7 @@ public class Security {
         private boolean tracingEnabled = true;
         private SecurityTime serverTime = SecurityTime.builder().build();
         private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create();
+        private boolean enabled;
 
         private Builder() {
         }
@@ -801,13 +821,27 @@ public class Security {
         }
 
         /**
+         * Security can be disabled using configuration, or explicitly.
+         * By default, security instance is enabled.
+         * Disabled security instance will not perform any checks and allow
+         * all requests (as if it is not configured in Helidon at all).
+         *
+         * @param enabled set to {@code false} to disable security
+         * @return updated builder instance
+         */
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        /**
          * Builds configured Security instance.
          *
          * @return built instance.
          */
         @Override
         public Security build() {
-            if (allProviders.isEmpty()) {
+            if (allProviders.isEmpty() && enabled) {
                 LOGGER.warning("Security component is NOT configured with any security providers.");
             }
 
@@ -826,10 +860,21 @@ public class Security {
                         .completedFuture(AuthorizationResponse.permit()), "default");
             }
 
+            if (!enabled) {
+                providerSelectionPolicy(FirstProviderSelectionPolicy::new);
+            }
+
             return new Security(this);
         }
 
         private void fromConfig(Config config) {
+            config.get("enabled").asBoolean().ifPresent(this::enabled);
+
+            if (!enabled) {
+                LOGGER.info("Security is disabled, ignoring provider configuration");
+                return;
+            }
+
             config.get("environment.server-time").as(SecurityTime::create).ifPresent(this::serverTime);
             executorSupplier(ThreadPoolSupplier.create(config.get("environment.executor-service")));
 


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #2132  for Helidon 1.x

You can configure 
```
security:
  enabled: false
```

To disable security.
There will be an all-permitting authorization provider and an authentication provider that authenticates all requests as `ANONYMOUS`.
Security will not be enforced in Helidon SE and in Helidon MP all authorization will be ignored.