### PR TITLE
Security can now be disabled.

### DIFF
--- a/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcCdiExtension.java
+++ b/microprofile/oidc/src/main/java/io/helidon/microprofile/oidc/OidcCdiExtension.java
@@ -39,8 +39,13 @@ public final class OidcCdiExtension implements Extension {
     }
 
     private void registerOidcSupport(@Observes @Initialized(ApplicationScoped.class) Object adv, BeanManager bm) {
-        ServerCdiExtension server = bm.getExtension(ServerCdiExtension.class);
+        if (config.get("security.enabled")
+                .asBoolean()
+                .orElse(true)) {
+            // only configure if security is enabled
+            ServerCdiExtension server = bm.getExtension(ServerCdiExtension.class);
 
-        server.serverRoutingBuilder().register(OidcSupport.create(config));
+            server.serverRoutingBuilder().register(OidcSupport.create(config));
+        }
     }
 }

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
@@ -86,9 +86,20 @@ public class SecurityCdiExtension implements Extension {
             securityBuilder.addAuthorizationProvider(AbacProvider.create());
         }
 
-        Security security = securityBuilder.build();
+        Security tmpSecurity = securityBuilder.build();
         // free it and make sure we fail if somebody wants to update security afterwards
         securityBuilder = null;
+
+        if (!tmpSecurity.enabled()) {
+            // security is disabled, we need to set up some basic stuff - injection, security context etc.
+            LOGGER.info("Security is disabled.");
+            tmpSecurity = Security.builder()
+                    .enabled(false)
+                    .build();
+        }
+
+        // we need an effectively final instance to use in lambda
+        Security security = tmpSecurity;
 
         JaxRsCdiExtension jaxrs = bm.getExtension(JaxRsCdiExtension.class);
         ServerCdiExtension server = bm.getExtension(ServerCdiExtension.class);

--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurity.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import io.helidon.common.http.Http;
@@ -92,6 +93,7 @@ public final class WebSecurity implements Service {
      */
     public static final String CONTEXT_ADD_HEADERS = "security.addHeaders";
 
+    private static final Logger LOGGER = Logger.getLogger(WebSecurity.class.getName());
     private static final AtomicInteger SECURITY_COUNTER = new AtomicInteger();
 
     private final Security security;
@@ -318,6 +320,10 @@ public final class WebSecurity implements Service {
 
     @Override
     public void update(Routing.Rules routing) {
+        if (!security.enabled()) {
+            LOGGER.info("Security is disabled. Not registering any security handlers");
+            return;
+        }
         routing.any(this::registerContext);
 
         if (null != config) {

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -103,9 +103,11 @@ public class Security {
     private final SecurityTime serverTime;
     private final Supplier<ExecutorService> executorService;
     private final Config securityConfig;
+    private final boolean enabled;
 
     @SuppressWarnings("unchecked")
     private Security(Builder builder) {
+        this.enabled = builder.enabled;
         this.instanceUuid = UUID.randomUUID().toString();
         this.serverTime = builder.serverTime;
         this.executorService = builder.executorService;
@@ -113,6 +115,13 @@ public class Security {
         this.securityTracer = SecurityUtil.getTracer(builder.tracingEnabled, builder.tracer);
         this.subjectMappingProvider = Optional.ofNullable(builder.subjectMappingProvider);
         this.securityConfig = builder.config;
+
+        if (!enabled) {
+            //security is disabled
+            audit(instanceUuid, SecurityAuditEvent.info(
+                    AuditEvent.SECURITY_TYPE_PREFIX + ".configure",
+                    "Security is disabled."));
+        }
 
         //providers
         List<NamedProvider<AuthorizationProvider>> atzProviders = new LinkedList<>();
@@ -388,6 +397,17 @@ public class Security {
     }
 
     /**
+     * Whether security is enabled or disabled.
+     * Disabled security does not check authorization and authenticates all users as
+     * {@link io.helidon.security.SecurityContext#ANONYMOUS}.
+     *
+     * @return {@code true} if security is enabled
+     */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /**
      * Builder pattern class for helping create {@link Security} in a convenient way.
      */
     public static final class Builder implements io.helidon.common.Builder<Security> {
@@ -407,6 +427,7 @@ public class Security {
         private boolean tracingEnabled = true;
         private SecurityTime serverTime = SecurityTime.builder().build();
         private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create();
+        private boolean enabled;
 
         private Set<String> providerNames = new HashSet<>();
 
@@ -811,13 +832,27 @@ public class Security {
         }
 
         /**
+         * Security can be disabled using configuration, or explicitly.
+         * By default, security instance is enabled.
+         * Disabled security instance will not perform any checks and allow
+         * all requests.
+         *
+         * @param enabled set to {@code false} to disable security
+         * @return updated builder instance
+         */
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        /**
          * Builds configured Security instance.
          *
          * @return built instance.
          */
         @Override
         public Security build() {
-            if (allProviders.isEmpty()) {
+            if (allProviders.isEmpty() && enabled) {
                 LOGGER.warning("Security component is NOT configured with any security providers.");
             }
 
@@ -835,10 +870,21 @@ public class Security {
                 addAuthorizationProvider(new DefaultAtzProvider(), "default");
             }
 
+            if (!enabled) {
+                providerSelectionPolicy(FirstProviderSelectionPolicy::new);
+            }
+
             return new Security(this);
         }
 
         private void fromConfig(Config config) {
+            config.get("enabled").asBoolean().ifPresent(this::enabled);
+
+            if (!enabled) {
+                LOGGER.info("Security is disabled, ignoring provider configuration");
+                return;
+            }
+
             config.get("environment.server-time").as(SecurityTime::create).ifPresent(this::serverTime);
             executorSupplier(ThreadPoolSupplier.create(config.get("environment.executor-service")));
 

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -427,7 +427,7 @@ public class Security {
         private boolean tracingEnabled = true;
         private SecurityTime serverTime = SecurityTime.builder().build();
         private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create();
-        private boolean enabled;
+        private boolean enabled = true;
 
         private Set<String> providerNames = new HashSet<>();
 


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #2132  for Helidon 2.x

You can configure 
```
security:
  enabled: false
```

To disable security.
There will be an all-permitting authorization provider and an authentication provider that authenticates all requests as `ANONYMOUS`.
Security will not be enforced in Helidon SE and in Helidon MP all authorization will be ignored.