### PR TITLE
Update microprofile examples to use microprofile-config.properties

### DIFF
--- a/examples/microprofile/hello-world-explicit/README.md
+++ b/examples/microprofile/hello-world-explicit/README.md
@@ -13,5 +13,8 @@ Then try the endpoints:
 
 ```
 curl -X GET http://localhost:7001/helloworld
-curl -X GET http://localhost:7001/helloworld/another
+curl -X GET http://localhost:7001/helloworld/earth
 ```
+
+By default the server will use a dynamic port, see the messages displayed
+when the application starts.

--- a/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/Main.java
+++ b/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/Main.java
@@ -28,16 +28,12 @@ public class Main {
     }
 
     /**
-     * Starts server and initializes CDI container manually.
+     * Starts server manually.
      *
      * @param args command line arguments (ignored)
      */
     public static void main(String[] args) {
         Server server = Server.builder()
-                // Provide a MicroProfile config instance (in this case the default...)
-                .config(ConfigProviderResolver.instance()
-                                .getBuilder()
-                                .build())
                 .host("localhost")
                 // use a random free port
                 .port(0)
@@ -50,7 +46,5 @@ public class Main {
         System.out.println("Metrics available on       " + endpoint + "/metrics");
         System.out.println("Heatlh checks available on " + endpoint + "/health");
 
-        // the easiest possible explicit way to start an application:
-        // Server.create(HelloWorldApplication.class).start();
     }
 }

--- a/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/Main.java
+++ b/examples/microprofile/hello-world-explicit/src/main/java/io/helidon/microprofile/example/helloworld/explicit/Main.java
@@ -18,8 +18,6 @@ package io.helidon.microprofile.example.helloworld.explicit;
 
 import io.helidon.microprofile.server.Server;
 
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-
 /**
  * Explicit example.
  */

--- a/examples/microprofile/hello-world-explicit/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/hello-world-explicit/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,7 @@
 # limitations under the License.
 #
 
-app:
-  name: "Hello World Application"
-  someInt: 147
-  uri: "http://www.google.com"
-  ints: [12, 12, 32, 12, 44]
+app.name=Hello World Application
+app.uri=https://www.example.com
 
-server.port: 7001
-
+my.property=propertyValue

--- a/examples/microprofile/hello-world-implicit/README.md
+++ b/examples/microprofile/hello-world-implicit/README.md
@@ -15,5 +15,6 @@ Then try the endpoints:
 
 ```
 curl -X GET http://localhost:7001/helloworld
-curl -X GET http://localhost:7001/helloworld/another
+curl -X GET http://localhost:7001/helloworld/earth
+curl -X GET http://localhost:7001/another
 ```

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
@@ -54,22 +54,6 @@ public class AnotherResource {
     private Provider<Integer> provider;
 
     @Inject
-    @ConfigProperty(name = "app.ints")
-    private List<Integer> ints;
-
-    @Inject
-    @ConfigProperty(name = "app.ints")
-    private Optional<List<Integer>> optionalInts;
-
-    @Inject
-    @ConfigProperty(name = "app.ints")
-    private Provider<List<Integer>> providedInts;
-
-    @Inject
-    @ConfigProperty(name = "app.ints")
-    private int[] intsArray;
-
-    @Inject
     @ConfigProperty(name = "app")
     private Map<String, String> detached;
 
@@ -96,13 +80,9 @@ public class AnotherResource {
                 + ", empty=" + empty
                 + ", full=" + full
                 + ", provider=" + provider + "(" + provider.get() + ")"
-                + ", ints=" + ints
-                + ", optionalInts=" + optionalInts
-                + ", providedInts=" + providedInts + "(" + providedInts.get() + ")"
                 + ", detached=" + detached
                 + ", microprofileConfig=" + mpConfig
                 + ", helidonConfig=" + helidonConfig
-                + ", intsArray=" + Arrays.toString(intsArray)
                 + '}';
     }
 }

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
@@ -54,6 +54,22 @@ public class AnotherResource {
     private Provider<Integer> provider;
 
     @Inject
+    @ConfigProperty(name = "app.ints")
+    private List<Integer> ints;
+
+    @Inject
+    @ConfigProperty(name = "app.ints")
+    private Optional<List<Integer>> optionalInts;
+
+    @Inject
+    @ConfigProperty(name = "app.ints")
+    private Provider<List<Integer>> providedInts;
+
+    @Inject
+    @ConfigProperty(name = "app.ints")
+    private int[] intsArray;
+
+    @Inject
     @ConfigProperty(name = "app")
     private Map<String, String> detached;
 
@@ -80,9 +96,13 @@ public class AnotherResource {
                 + ", empty=" + empty
                 + ", full=" + full
                 + ", provider=" + provider + "(" + provider.get() + ")"
+                + ", ints=" + ints
+                + ", optionalInts=" + optionalInts
+                + ", providedInts=" + providedInts + "(" + providedInts.get() + ")"
                 + ", detached=" + detached
                 + ", microprofileConfig=" + mpConfig
                 + ", helidonConfig=" + helidonConfig
+                + ", intsArray=" + Arrays.toString(intsArray)
                 + '}';
     }
 }

--- a/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
+++ b/examples/microprofile/hello-world-implicit/src/main/java/io/helidon/microprofile/example/helloworld/implicit/AnotherResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018,2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/microprofile/hello-world-implicit/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/hello-world-implicit/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
 # limitations under the License.
 #
 
-app:
-  name: "Hello World Application"
-  someInt: 147
-  uri: "http://www.google.com"
-  ints: [12, 12, 32, 12, 44]
+app.name=Hello World Application
+app.someInt=147
+app.uri=https://www.example.com
 
-my.property: "propertyValue"
+server.port=7001
+

--- a/examples/microprofile/hello-world-implicit/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/microprofile/hello-world-implicit/src/main/resources/META-INF/microprofile-config.properties
@@ -17,6 +17,8 @@
 app.name=Hello World Application
 app.someInt=147
 app.uri=https://www.example.com
+app.someInt=147
+app.ints=12,12,32,12,44
 
 server.port=7001
 


### PR DESCRIPTION
Changed these two examples to use microprofile-config.properties (and not application.yaml).

This required removing the integer array in config (supported by yaml, not properties).
