### PR TITLE
Make sure request scope is propagated to newly created threads in FT

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceCommand.java
@@ -41,6 +41,8 @@ import org.eclipse.microprofile.metrics.Histogram;
 import org.glassfish.jersey.process.internal.RequestContext;
 import org.glassfish.jersey.process.internal.RequestScope;
 
+import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE;
+import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy.THREAD;
 import static io.helidon.microprofile.faulttolerance.CircuitBreakerHelper.State;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceExtension.isFaultToleranceMetricsEnabled;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceMetrics.BREAKER_CALLS_FAILED_TOTAL;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -168,8 +168,8 @@ public class FaultToleranceExtension implements Extension {
      * via CDI to propagate request contexts to newly created threads, but Jersey
      * only registers this type as a bean if it can find an injection point (see
      * org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider#afterDiscoveryObserver).
-     * Here we define a dummy bean with such an injection point for Jersey to find.
-     *
+     * Here we define a dummy bean with such an injection point for Jersey to
+     * create and register a CDI bean for RequestScope.
      */
     private static class JerseyRequestScopeAsCdiBean {
         @Inject

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloResource.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloResource.java
@@ -20,6 +20,9 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
+import io.helidon.webserver.ServerRequest;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
 /**
  * HelloResource class.
  */
@@ -27,6 +30,9 @@ import javax.ws.rs.Path;
 public class HelloResource {
 
     private HelloBean helloBean;
+
+    @Inject
+    private ServerRequestSupplier supplier;
 
     /**
      * Constructor.
@@ -45,6 +51,7 @@ public class HelloResource {
      */
     @GET
     @Path("/hello")
+    @Retry
     public String getHello() {
         return helloBean.getHello();
     }
@@ -56,6 +63,7 @@ public class HelloResource {
      */
     @GET
     @Path("/helloTimeout")
+    @Retry
     public String getHelloTimeout() {
         return helloBean.getHelloTimeout();
     }
@@ -68,7 +76,16 @@ public class HelloResource {
      */
     @GET
     @Path("/helloAsync")
+    @Retry
     public String getHelloAsync() throws Exception {
         return helloBean.getHelloAsync().toCompletableFuture().get();
+    }
+
+    @GET
+    @Path("/remoteAddress")
+    @Retry
+    public String getRemoteAddress() {
+        ServerRequest serverRequest = supplier.get();
+        return serverRequest.remoteAddress();
     }
 }

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ServerRequestSupplier.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ServerRequestSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.hello;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.core.Context;
+import java.util.function.Supplier;
+
+import io.helidon.webserver.ServerRequest;
+
+@RequestScoped
+public class ServerRequestSupplier implements Supplier<ServerRequest> {
+
+    @Context
+    private ServerRequest serverRequest;
+
+    @Override
+    public ServerRequest get() {
+        return serverRequest;
+    }
+}

--- a/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
+++ b/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
@@ -73,7 +73,7 @@ class HelloTest {
     }
 
     @Test
-    void testRemoteAAddress() {
+    void testRemoteAddress() {
         WebTarget target = baseTarget.path("/remoteAddress");
         assertThat(target.request().get().getStatus(), is(200));
     }

--- a/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
+++ b/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
@@ -72,6 +72,12 @@ class HelloTest {
         assertOk(target.request().get(), "Hello World");
     }
 
+    @Test
+    void testRemoteAAddress() {
+        WebTarget target = baseTarget.path("/remoteAddress");
+        assertThat(target.request().get().getStatus(), is(200));
+    }
+
     private void assertOk(Response response, String expectedMessage) {
         assertThat(response.getStatus(), is(200));
         assertThat(response.readEntity(String.class), is(expectedMessage));


### PR DESCRIPTION
After discussing the solution with @jansupol, I believe this is currently the simplest way to support this. We do need to create a dummy CDI bean with an injection point for Jersey to make its `RequestScope` type available via CDI. Using that and some other CDI classes, we ensure all injections (`@Context` or `@Inject` ones) are available in newly created threads.

One of the functional tests has been updated to verify this fix.