### PR TITLE
Fixes a few problems in metrics

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonConcurrentGauge.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonConcurrentGauge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,11 +100,15 @@ final class HelidonConcurrentGauge extends MetricImpl implements ConcurrentGauge
         sb.append(nameCurrent).append(prometheusTags(metricID.getTags()))
                 .append(" ").append(prometheusValue()).append('\n');
         final String nameMin = name + "_min";
-        prometheusType(sb, nameMin, metadata().getType());
+        if (withHelpType) {
+            prometheusType(sb, nameMin, metadata().getType());
+        }
         sb.append(nameMin).append(prometheusTags(metricID.getTags()))
                 .append(" ").append(getMin()).append('\n');
         final String nameMax = name + "_max";
-        prometheusType(sb, nameMax, metadata().getType());
+        if (withHelpType) {
+            prometheusType(sb, nameMax, metadata().getType());
+        }
         sb.append(nameMax).append(prometheusTags(metricID.getTags()))
                 .append(" ").append(getMax()).append('\n');
     }

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,9 @@ final class HelidonMeter extends MetricImpl implements Meter {
                 .append("\n");
 
         nameUnits = prometheusNameWithUnits(name, Optional.empty()) + "_rate_per_second";
-        prometheusType(sb, nameUnits, "gauge");
+        if (withHelpType) {
+            prometheusType(sb, nameUnits, "gauge");
+        }
         sb.append(nameUnits)
                 .append(tags)
                 .append(" ")
@@ -101,7 +103,9 @@ final class HelidonMeter extends MetricImpl implements Meter {
                 .append("\n");
 
         nameUnits = prometheusNameWithUnits(name, Optional.empty()) + "_one_min_rate_per_second";
-        prometheusType(sb, nameUnits, "gauge");
+        if (withHelpType) {
+            prometheusType(sb, nameUnits, "gauge");
+        }
         sb.append(nameUnits)
                 .append(tags)
                 .append(" ")
@@ -109,7 +113,9 @@ final class HelidonMeter extends MetricImpl implements Meter {
                 .append("\n");
 
         nameUnits = prometheusNameWithUnits(name, Optional.empty()) + "_five_min_rate_per_second";
-        prometheusType(sb, nameUnits, "gauge");
+        if (withHelpType) {
+            prometheusType(sb, nameUnits, "gauge");
+        }
         sb.append(nameUnits)
                 .append(tags)
                 .append(" ")
@@ -117,7 +123,9 @@ final class HelidonMeter extends MetricImpl implements Meter {
                 .append("\n");
 
         nameUnits = prometheusNameWithUnits(name, Optional.empty()) + "_fifteen_min_rate_per_second";
-        prometheusType(sb, nameUnits, "gauge");
+        if (withHelpType) {
+            prometheusType(sb, nameUnits, "gauge");
+        }
         sb.append(nameUnits)
                 .append(tags)
                 .append(" ")

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -397,7 +397,7 @@ public final class MetricsSupport implements Service {
                     String type = registry.type();
 
                     rules.get(context + "/" + type, (req, res) -> getAll(req, res, registry))
-                            .get(context + "/" + type + "/{metric}", (req, res) -> getOne(req, res, registry))
+                            .get(context + "/" + type + "/{metric}", (req, res) -> getByName(req, res, registry))
                             .options(context + "/" + type, (req, res) -> optionsAll(req, res, registry))
                             .options(context + "/" + type + "/{metric}", (req, res) -> optionsOne(req, res, registry));
                 });
@@ -421,20 +421,16 @@ public final class MetricsSupport implements Service {
         configureEndpoint(rules);
     }
 
-    private void getOne(ServerRequest req, ServerResponse res, Registry registry) {
+    private void getByName(ServerRequest req, ServerResponse res, Registry registry) {
         String metricName = req.path().param("metric");
 
         registry.getOptionalMetricEntry(metricName)
                 .ifPresentOrElse(entry -> {
                     MediaType mediaType = findBestAccepted(req.headers());
                     if (mediaType == MediaType.APPLICATION_JSON) {
-                        JsonObjectBuilder builder = JSON.createObjectBuilder();
-                        entry.getValue().jsonData(builder, entry.getKey());
-                        sendJson(res, builder.build());
+                        sendJson(res, jsonDataByName(registry, metricName));
                     } else if (mediaType == MediaType.TEXT_PLAIN) {
-                        final StringBuilder sb = new StringBuilder();
-                        entry.getValue().prometheusData(sb, entry.getKey(), true);
-                        res.send(sb.toString());
+                        res.send(prometheusDataByName(registry, metricName));
                     } else {
                         res.status(Http.Status.NOT_ACCEPTABLE_406);
                         res.send();
@@ -443,6 +439,26 @@ public final class MetricsSupport implements Service {
                     res.status(Http.Status.NOT_FOUND_404);
                     res.send();
                 });
+    }
+
+    static JsonObject jsonDataByName(Registry registry, String metricName) {
+        JsonObjectBuilder builder = new MetricsSupport.MergingJsonObjectBuilder(JSON.createObjectBuilder());
+        for (Map.Entry<MetricID, HelidonMetric> metricEntry : registry.getMetricsByName(metricName)) {
+            metricEntry.getValue()
+                    .jsonData(builder, metricEntry.getKey());
+        }
+        return builder.build();
+    }
+
+    static String prometheusDataByName(Registry registry, String metricName) {
+        final StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        for (Map.Entry<MetricID, HelidonMetric> metricEntry : registry.getMetricsByName(metricName)) {
+            metricEntry.getValue()
+                    .prometheusData(sb, metricEntry.getKey(), isFirst);
+            isFirst = false;
+        }
+        return sb.toString();
     }
 
     private static void sendJson(ServerResponse res, JsonObject object) {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/Registry.java
@@ -387,6 +387,18 @@ public class Registry extends MetricRegistry {
         return getOptionalMetric(new MetricID(metricName, tags), clazz);
     }
 
+    List<Map.Entry<MetricID, HelidonMetric>> getMetricsByName(String metricName) {
+        List<MetricID> metricIDs = allMetricIDsByName.get(metricName);
+        if (metricIDs == null) {
+            return Collections.EMPTY_LIST;
+        }
+        List<Map.Entry<MetricID, HelidonMetric>> result = new ArrayList<>();
+        for (MetricID metricID : metricIDs) {
+            result.add(new AbstractMap.SimpleEntry<>(metricID, allMetrics.get(metricID)));
+        }
+        return result;
+    }
+
     /**
      * Get internal map entry given a metric name. Synchronized for atomic access of more than
      * one internal map.


### PR DESCRIPTION
Resolves #2239 

I found two additional problems in our metrics implementation as I was working on adding MP Metrics 2.3 support, leading to the following groups of changes:

1. Internally, each metric implementation emits its own Prometheus/OpenMetrics output. The invoking code tells those metrics whether to include `HELP` and `TYPE` information. `HelidonMeter` and `HelidonConcurrentGauge` which have "sub-metrics" did not honor that flag for all their sub-metrics. These changes fix that.

2. Added a `getMetricsByName` method to `Registry` which returns a `List` of `MetricID`/`Metric` pairs that match a given name. 

3. Changed the `MetricsSupport#getOne` method, to which `/metrics/registryName/metricName` requests were routed, to `#getByName` and changed its implementation to use the new method created in 2 so it fetches and reports on _all_ metrics that match the name, not just one.

Re: # 3, here is how the spec indicates what the output should be:

> /metrics/<scope>/<metric_name> | GET | JSON, OpenMetrics | Returns the metric that matches the metric name for the respective scope
-- | -- | -- | --

It's in the middle of a table describing what the output should be for various paths and it does say "the metric" so it does not seem ambiguous about the case where multiple metrics share the same name. But the 2.3 optional TCK includes at least one test that depends on _all_ metrics matching a name being returned. I am including that change here, rather than in the later PR with all the 2.3 support, to highlight this change. (The 2.2 TCK and all tests and examples passed locally with this change in place.)
