### PR TITLE
Kafka message default ack npe fix

### DIFF
--- a/messaging/kafka/src/main/java/io/helidon/messaging/connectors/kafka/KafkaMessage.java
+++ b/messaging/kafka/src/main/java/io/helidon/messaging/connectors/kafka/KafkaMessage.java
@@ -18,6 +18,7 @@ package io.helidon.messaging.connectors.kafka;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
@@ -118,7 +119,7 @@ public interface KafkaMessage<K, V> extends Message<V> {
      */
     static <K, V> KafkaMessage<K, V> of(K key, V payload) {
         Objects.requireNonNull(payload);
-        return new KafkaProducerMessage<>(key, payload, null);
+        return new KafkaProducerMessage<>(key, payload, () -> CompletableFuture.completedFuture(null));
     }
 
     /**
@@ -131,6 +132,6 @@ public interface KafkaMessage<K, V> extends Message<V> {
      */
     static <K, V> KafkaMessage<K, V> of(V payload) {
         Objects.requireNonNull(payload);
-        return new KafkaProducerMessage<>(null, payload, null);
+        return new KafkaProducerMessage<>(null, payload, () -> CompletableFuture.completedFuture(null));
     }
 }

--- a/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/MessageTest.java
+++ b/tests/integration/kafka/src/test/java/io/helidon/messaging/connectors/kafka/MessageTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c)  2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.messaging.connectors.kafka;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.Test;
+
+class MessageTest {
+
+    private static final String TEST_VALUE = "test";
+
+    @Test
+    void defaultMessageAck() {
+        assertComplete(Message.of(TEST_VALUE).ack());
+        assertComplete(Message.of(TEST_VALUE, () -> CompletableFuture.completedFuture(null)).ack());
+    }
+
+    @Test
+    void defaultKafkaMessageAck() {
+        assertComplete(KafkaMessage.of(TEST_VALUE).ack());
+        assertComplete(KafkaMessage.of(TEST_VALUE, () -> CompletableFuture.completedFuture(null)).ack());
+        assertComplete(KafkaMessage.of(TEST_VALUE, TEST_VALUE).ack());
+    }
+
+    private void assertComplete(CompletionStage<Void> stage) {
+        try {
+            stage.toCompletableFuture().get(10, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+}


### PR DESCRIPTION
As @tkote reported on Slack, when `KafkaMessage` is created with `KafkaMessage.of(key, value)`, only 5 messages are sent and no more is ever requested.
Problem is caused by wrong initialization of the ack future supplier.
```java
    static <K, V> KafkaMessage<K, V> of(K key, V payload) {
        Objects.requireNonNull(payload);
        return new KafkaProducerMessage<>(key, payload, null);
    }
```
So Kafka ack callback silently dies and nothing is ever requested again:
```java
        CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0]))
                .whenComplete((success, exception) -> {
                    if (exception == null) {
                        message.ack().whenComplete((a, b) -> {
                            // Atomically increment
                            // or reset backpressureCounter if incrementing would reach threshold
                            if (backpressureCounter.getAndUpdate(n -> ++n == backpressure ? 0 : n)
                                    >= backpressure - 1) {
                                // configured backpressure threshold reached
                                subscription.request(backpressure);
                            }
                        });
                    }
                });
```

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>