### PR TITLE
Support MP health 2.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -80,7 +80,7 @@
         <version.lib.junit>5.6.2</version.lib.junit>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.microprofile-config>1.4</version.lib.microprofile-config>
-        <version.lib.microprofile-health>2.1</version.lib.microprofile-health>
+        <version.lib.microprofile-health>2.2</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>2.3.2</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -53,6 +53,10 @@
                     <groupId>jakarta.inject</groupId>
                     <artifactId>jakarta.inject-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/microprofile/health/pom.xml
+++ b/microprofile/health/pom.xml
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
@@ -56,20 +56,6 @@ public class HealthCdiExtension implements Extension {
         }
     };
 
-    private static final Readiness READINESS_LITERAL = new Readiness() {
-        @Override
-        public Class<? extends Annotation> annotationType() {
-            return Readiness.class;
-        }
-    };
-
-    private static final Liveness LIVENESS_LITERAL = new Liveness() {
-        @Override
-        public Class<? extends Annotation> annotationType() {
-            return Liveness.class;
-        }
-    };
-
     private static final BuiltInHealthCheck BUILT_IN_HEALTH_CHECK_LITERAL = new BuiltInHealthCheck() {
         @Override
         public Class<? extends Annotation> annotationType() {
@@ -115,12 +101,12 @@ public class HealthCdiExtension implements Extension {
                 .filter(hc -> !builtInHealthChecks.contains(hc))
                 .forEach(builder::add);
 
-        cdi.select(HealthCheck.class, LIVENESS_LITERAL)
+        cdi.select(HealthCheck.class, Liveness.Literal.INSTANCE)
                 .stream()
                 .filter(hc -> !builtInHealthChecks.contains(hc))
                 .forEach(builder::addLiveness);
 
-        cdi.select(HealthCheck.class, READINESS_LITERAL)
+        cdi.select(HealthCheck.class, Readiness.Literal.INSTANCE)
                 .stream()
                 .filter(hc -> !builtInHealthChecks.contains(hc))
                 .forEach(builder::addReadiness);


### PR DESCRIPTION
Resolves #2259 

Minor adaptation to MicroProfile Health 2.2

There are very few substantive changes in the spec from 2.1 to 2.2. Even the changes in the PR are not really required, but they save us a tiny bit of code and illustrate in our code base the use of two (minor) additions to the MP health API.

I searched our code base for other opportunities to use other changes in MP health and found none. 

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>