### PR TITLE
Allow cancellation of Future's wrapped in Single's and vice versa

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/CompletionSingle.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/CompletionSingle.java
@@ -36,7 +36,7 @@ public abstract class CompletionSingle<T> extends CompletionAwaitable<T> impleme
     }
 
     protected CompletableFuture<T> toNullableStage() {
-        SingleToFuture<T> subscriber = new SingleToFuture<>(true);
+        SingleToFuture<T> subscriber = new SingleToFuture<>(this, true);
         this.subscribe(subscriber);
         return subscriber;
     }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -649,7 +649,7 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
      */
     default CompletionStage<T> toStage() {
         try {
-            SingleToFuture<T> subscriber = new SingleToFuture<>(false);
+            SingleToFuture<T> subscriber = new SingleToFuture<>(this, false);
             this.subscribe(subscriber);
             return subscriber;
         } catch (Throwable ex) {

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleFromCompletionStage.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleFromCompletionStage.java
@@ -37,4 +37,11 @@ final class SingleFromCompletionStage<T> extends CompletionSingle<T> {
     public void subscribe(Flow.Subscriber<? super T> subscriber) {
         MultiFromCompletionStage.subscribe(subscriber, source, nullMeansEmpty);
     }
+
+    @Override
+    public Single<T> cancel() {
+        Single<T> single = super.cancel();
+        source.toCompletableFuture().cancel(true);
+        return single;
+    }
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/SingleToFuture.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/SingleToFuture.java
@@ -28,8 +28,10 @@ final class SingleToFuture<T> extends CompletableFuture<T> implements Subscriber
 
     private final AtomicReference<Subscription> ref = new AtomicReference<>();
     private final boolean completeWithoutValue;
+    private final Single<T> source;
 
-    SingleToFuture(boolean completeWithoutValue) {
+    SingleToFuture(Single<T> source, boolean completeWithoutValue) {
+        this.source = source;
         this.completeWithoutValue = completeWithoutValue;
     }
 
@@ -41,6 +43,7 @@ final class SingleToFuture<T> extends CompletableFuture<T> implements Subscriber
             if (s != null) {
                 s.cancel();
             }
+            source.cancel();
         }
         return cancelled;
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
@@ -57,11 +57,7 @@ public class CancellationTest {
         AtomicBoolean cancelled = new AtomicBoolean(false);
         Single<Object> single = Single.create(new CompletableFuture<>());
         CompletableFuture<Object> future = single.toStage().toCompletableFuture();
-        single.whenComplete((o, t) -> {
-            if (t instanceof CancellationException) {
-                cancelled.set(true);
-            }
-        });
+        single.onCancel(() -> cancelled.set(true));
         single.cancel();
         future.cancel(true);        // should cancel single
         assertThat(cancelled.get(), is(true));

--- a/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
@@ -58,7 +58,6 @@ public class CancellationTest {
         Single<Object> single = Single.create(new CompletableFuture<>());
         CompletableFuture<Object> future = single.toStage().toCompletableFuture();
         single.onCancel(() -> cancelled.set(true));
-        single.cancel();
         future.cancel(true);        // should cancel single
         assertThat(cancelled.get(), is(true));
     }

--- a/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/CancellationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Tests cancellation of {@code Future} and {@code Single}.
+ */
+public class CancellationTest {
+
+    /**
+     * Test cancellation of underlying {@code CompletableFuture} when wrapped
+     * by a {@code Single}.
+     */
+    @Test
+    public void testCompletableFutureCancel() {
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        Single<Object> single = Single.create(future, true);
+        future.whenComplete((o, t) -> {
+            if (t instanceof CancellationException) {
+                cancelled.set(true);
+            }
+        });
+        single.cancel();        // should cancel future
+        assertThat(cancelled.get(), is(true));
+    }
+
+    /**
+     * Test cancellation of {@code Single} after it has been converted to
+     * a {@code CompletableFuture}.
+     */
+    @Test
+    public void testSingleCancel() {
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        Single<Object> single = Single.create(new CompletableFuture<>());
+        CompletableFuture<Object> future = single.toStage().toCompletableFuture();
+        single.whenComplete((o, t) -> {
+            if (t instanceof CancellationException) {
+                cancelled.set(true);
+            }
+        });
+        single.cancel();
+        future.cancel(true);        // should cancel single
+        assertThat(cancelled.get(), is(true));
+    }
+}


### PR DESCRIPTION
Allow cancellation of Future's wrapped in Single's and vice versa. This form of cancellations are necessary to implement FT MP. New test.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>