### PR TITLE
Set junit4 version where used. Fixes #2289

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -78,6 +78,7 @@
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
         <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>
         <version.lib.junit>5.6.2</version.lib.junit>
+        <version.lib.junit4>4.12</version.lib.junit4>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.microprofile-config>1.4</version.lib.microprofile-config>
         <version.lib.microprofile-health>2.2</version.lib.microprofile-health>

--- a/microprofile/tests/arquillian/pom.xml
+++ b/microprofile/tests/arquillian/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>${version.lib.junit4}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes #2289 

I did not put the junit 4 version in dependency management since Helidon uses Junit 5. Instead the version is specified in the one place where it is needed.
