### PR TITLE
Security now has higer priority

### DIFF
--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityMpService.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityMpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package io.helidon.microprofile.security;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
+import javax.annotation.Priority;
+
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.microprofile.server.spi.MpService;
@@ -36,6 +38,7 @@ import io.helidon.security.providers.abac.AbacProvider;
  * You can configure security using application.yaml (or any other default
  * configuration for helidon config).
  */
+@Priority(15) // priority lower than tracing, higher than routing of services
 public class SecurityMpService implements MpService {
     private static final Logger LOGGER = Logger.getLogger(SecurityMpService.class.getName());
 

--- a/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
+++ b/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,18 +151,21 @@ public final class AbacProvider extends SynchronousProvider implements Authoriza
             if (customObject.isPresent()) {
                 attributes.add(new RuntimeAttribute(validator, customObject.get()));
             } else {
-                OptionalHelper.from(abacConfig.map(it -> it.get(configKey))).ifPresentOrElse(
-                        attribConfig -> {
-                            attributes.add(new RuntimeAttribute(validator, validator.fromConfig(attribConfig)));
-                        },
-                        () -> {
-                            List<Annotation> annotationConfig = new ArrayList<>();
-                            for (SecurityLevel securityLevel : epConfig.securityLevels()) {
-                                for (Class<? extends Annotation> annotation : annotations) {
-                                    List<? extends Annotation> list = securityLevel
-                                            .combineAnnotations(annotation,
-                                                                EndpointConfig.AnnotationScope.values());
-                                    annotationConfig.addAll(list);
+                // we should only configure this validator if
+                // - configuration for its key exists in abacConfig
+                // - or we have an annotation configured that it supports
+                OptionalHelper.from(abacConfig.flatMap(it -> it.get(configKey).asNode().asOptional()))
+                        .ifPresentOrElse(attribConfig -> {
+                                             attributes.add(new RuntimeAttribute(validator, validator.fromConfig(attribConfig)));
+                                         },
+                                         () -> {
+                                             List<Annotation> annotationConfig = new ArrayList<>();
+                                             for (SecurityLevel securityLevel : epConfig.securityLevels()) {
+                                                 for (Class<? extends Annotation> annotation : annotations) {
+                                                     List<? extends Annotation> list = securityLevel
+                                                             .combineAnnotations(annotation,
+                                                                                 EndpointConfig.AnnotationScope.values());
+                                                     annotationConfig.addAll(list);
                                 }
                             }
 


### PR DESCRIPTION
Abac now correctly handles validator config

Security MP service must have higher priority than services exposing endpoints (such as metrics, health), so we can protect these endpoints.

In addition when an endpoint was protected using abac, each validator tried to read the configuration and time validator threw an exception.

Resolves #2296 
Resolves #2297 
For 1.x