### PR TITLE
Security CDI extension has higher priority

### DIFF
--- a/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
+++ b/microprofile/health/src/main/java/io/helidon/microprofile/health/HealthCdiExtension.java
@@ -23,6 +23,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
@@ -42,6 +43,8 @@ import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
+
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * Health extension.
@@ -70,7 +73,7 @@ public class HealthCdiExtension implements Extension {
                 .add(ApplicationScoped.Literal.INSTANCE);
     }
 
-    void registerHealth(@Observes @Initialized(ApplicationScoped.class) Object adv) {
+    void registerHealth(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object adv) {
         org.eclipse.microprofile.config.Config config = ConfigProvider.getConfig();
         Config helidonConfig = MpConfig.toHelidonConfig(config).get("health");
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -34,7 +34,9 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Default;
@@ -94,6 +96,7 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 import static io.helidon.microprofile.metrics.MetricUtil.LookupResult;
 import static io.helidon.microprofile.metrics.MetricUtil.getMetricName;
 import static io.helidon.microprofile.metrics.MetricUtil.lookupAnnotation;
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * MetricsCdiExtension class.
@@ -117,7 +120,7 @@ public class MetricsCdiExtension implements Extension {
             .withName(SYNTHETIC_SIMPLE_TIMER_METRIC_NAME)
             .withDisplayName(SYNTHETIC_SIMPLE_TIMER_METRIC_NAME + " for all REST endpoints")
             .withDescription("The number of invocations and total response time of RESTful resource methods since the start"
-                    + " of the server.")
+                                     + " of the server.")
             .withType(MetricType.SIMPLE_TIMER)
             .withUnit(MetricUnits.NANOSECONDS)
             .notReusable()
@@ -157,13 +160,13 @@ public class MetricsCdiExtension implements Extension {
                                               counted.absolute());
             String displayName = counted.displayName().trim();
             Metadata meta = Metadata.builder()
-                .withName(metricName)
-                .withDisplayName(displayName.isEmpty() ? metricName : displayName)
-                .withDescription(counted.description().trim())
-                .withType(MetricType.COUNTER)
-                .withUnit(counted.unit().trim())
-                .reusable(counted.reusable())
-                .build();
+                    .withName(metricName)
+                    .withDisplayName(displayName.isEmpty() ? metricName : displayName)
+                    .withDescription(counted.description().trim())
+                    .withType(MetricType.COUNTER)
+                    .withUnit(counted.unit().trim())
+                    .reusable(counted.reusable())
+                    .build();
             registry.counter(meta, tags(counted.tags()));
             LOGGER.log(Level.FINE, () -> "Registered counter " + metricName);
         } else if (annotation instanceof Metered) {
@@ -172,13 +175,13 @@ public class MetricsCdiExtension implements Extension {
                                               metered.absolute());
             String displayName = metered.displayName().trim();
             Metadata meta = Metadata.builder()
-                .withName(metricName)
-                .withDisplayName(displayName.isEmpty() ? metricName : displayName)
-                .withDescription(metered.description().trim())
-                .withType(MetricType.METERED)
-                .withUnit(metered.unit().trim())
-                .reusable(metered.reusable())
-                .build();
+                    .withName(metricName)
+                    .withDisplayName(displayName.isEmpty() ? metricName : displayName)
+                    .withDescription(metered.description().trim())
+                    .withType(MetricType.METERED)
+                    .withUnit(metered.unit().trim())
+                    .reusable(metered.reusable())
+                    .build();
             registry.meter(meta, tags(metered.tags()));
             LOGGER.log(Level.FINE, () -> "Registered meter " + metricName);
         } else if (annotation instanceof Timed) {
@@ -187,34 +190,34 @@ public class MetricsCdiExtension implements Extension {
                                               timed.absolute());
             String displayName = timed.displayName().trim();
             Metadata meta = Metadata.builder()
-                .withName(metricName)
-                .withDisplayName(displayName.isEmpty() ? metricName : displayName)
-                .withDescription(timed.description().trim())
-                .withType(MetricType.TIMER)
-                .withUnit(timed.unit().trim())
-                .reusable(timed.reusable())
-                .build();
+                    .withName(metricName)
+                    .withDisplayName(displayName.isEmpty() ? metricName : displayName)
+                    .withDescription(timed.description().trim())
+                    .withType(MetricType.TIMER)
+                    .withUnit(timed.unit().trim())
+                    .reusable(timed.reusable())
+                    .build();
             registry.timer(meta, tags(timed.tags()));
             LOGGER.log(Level.FINE, () -> "Registered timer " + metricName);
         } else if (annotation instanceof ConcurrentGauge) {
             ConcurrentGauge concurrentGauge = (ConcurrentGauge) annotation;
             String metricName = getMetricName(element, clazz, lookupResult.getType(), concurrentGauge.name().trim(),
-                    concurrentGauge.absolute());
+                                              concurrentGauge.absolute());
             String displayName = concurrentGauge.displayName().trim();
             Metadata meta = Metadata.builder()
-                .withName(metricName)
-                .withDisplayName(displayName.isEmpty() ? metricName : displayName)
-                .withDescription(concurrentGauge.description().trim())
-                .withType(MetricType.CONCURRENT_GAUGE)
-                .withUnit(concurrentGauge.unit().trim())
-                .reusable(concurrentGauge.reusable())
-                .build();
+                    .withName(metricName)
+                    .withDisplayName(displayName.isEmpty() ? metricName : displayName)
+                    .withDescription(concurrentGauge.description().trim())
+                    .withType(MetricType.CONCURRENT_GAUGE)
+                    .withUnit(concurrentGauge.unit().trim())
+                    .reusable(concurrentGauge.reusable())
+                    .build();
             registry.concurrentGauge(meta, tags(concurrentGauge.tags()));
             LOGGER.log(Level.FINE, () -> "Registered concurrent gauge " + metricName);
         } else if (annotation instanceof SimplyTimed) {
             SimplyTimed simplyTimed = (SimplyTimed) annotation;
             String metricName = getMetricName(element, clazz, lookupResult.getType(), simplyTimed.name().trim(),
-                    simplyTimed.absolute());
+                                              simplyTimed.absolute());
             String displayName = simplyTimed.displayName().trim();
             Metadata meta = Metadata.builder()
                     .withName(metricName)
@@ -300,7 +303,7 @@ public class MetricsCdiExtension implements Extension {
      * @param pat annotated type instance being processed
      */
     private void registerMetrics(@Observes @WithAnnotations({Counted.class, Metered.class, Timed.class,
-            ConcurrentGauge.class, SimplyTimed.class})
+                                                                    ConcurrentGauge.class, SimplyTimed.class})
                                          ProcessAnnotatedType<?> pat) {
         // Filter out interceptors
         AnnotatedType<?> type = pat.getAnnotatedType();
@@ -366,8 +369,9 @@ public class MetricsCdiExtension implements Extension {
      * @param pat the {@code ProcessAnnotatedType} for the type containing the JAX-RS annotated methods
      */
     private void recordSimplyTimedForRestResources(@Observes
-            @WithAnnotations({GET.class, PUT.class, POST.class, HEAD.class, OPTIONS.class, DELETE.class, PATCH.class})
-            ProcessAnnotatedType<?> pat) {
+                                                   @WithAnnotations({GET.class, PUT.class, POST.class, HEAD.class, OPTIONS.class,
+                                                                            DELETE.class, PATCH.class})
+                                                           ProcessAnnotatedType<?> pat) {
 
         // Filter out interceptors
         AnnotatedType<?> type = pat.getAnnotatedType();
@@ -377,9 +381,9 @@ public class MetricsCdiExtension implements Extension {
         }
 
         LOGGER.log(Level.FINE,
-                () -> "Processing SyntheticSimplyTimed annotation for " + pat.getAnnotatedType()
-                        .getJavaClass()
-                        .getName());
+                   () -> "Processing SyntheticSimplyTimed annotation for " + pat.getAnnotatedType()
+                           .getJavaClass()
+                           .getName());
 
         // Register metrics based on annotations
         AnnotatedTypeConfigurator<?> configurator = pat.configureAnnotatedType();
@@ -392,7 +396,7 @@ public class MetricsCdiExtension implements Extension {
 
         // Process methods keeping non-private declared on this class
         configurator.filterMethods(method -> !Modifier.isPrivate(method.getJavaMember()
-                .getModifiers()))
+                                                                         .getModifiers()))
                 .forEach(method -> {
                     JAX_RS_ANNOTATIONS.forEach(annotation -> {
                         Method m = method.getAnnotated()
@@ -406,7 +410,7 @@ public class MetricsCdiExtension implements Extension {
                                 lookupResult.getType() != MetricUtil.MatchingType.METHOD
                                         || clazz.equals(m.getDeclaringClass()))) {
                             LOGGER.log(Level.FINE, () -> String.format("Adding @SyntheticSimplyTimed to %s#%s", clazz.getName(),
-                                    m.getName()));
+                                                                       m.getName()));
 
                             // Add the synthetic annotation to this method's configurator.
                             method.add(LiteralSyntheticSimplyTimed.getInstance());
@@ -430,12 +434,14 @@ public class MetricsCdiExtension implements Extension {
     static SimpleTimer syntheticSimpleTimer(Method method) {
         String classTagValue = method.getDeclaringClass().getName();
         // By spec, the synthetic SimpleTimers are always in the base registry.
-        return syntheticSimpleTimer(getRegistryForSyntheticSimpleTimers(), classTagValue, methodTagValueForSyntheticSimpleTimer(method));
+        return syntheticSimpleTimer(getRegistryForSyntheticSimpleTimers(),
+                                    classTagValue,
+                                    methodTagValueForSyntheticSimpleTimer(method));
     }
 
     private static SimpleTimer syntheticSimpleTimer(MetricRegistry registry, String classTagValue, String methodTagValue) {
         return registry.simpleTimer(SYNTHETIC_SIMPLE_TIMER_METADATA,
-                new Tag[] {new Tag("class", classTagValue), new Tag("method", methodTagValue)});
+                                    new Tag[] {new Tag("class", classTagValue), new Tag("method", methodTagValue)});
     }
 
     private static String methodTagValueForSyntheticSimpleTimer(Method method) {
@@ -529,20 +535,17 @@ public class MetricsCdiExtension implements Extension {
                                                   metric.name(), metric.absolute());
                 T instance = getReference(bm, entry.getValue().getBaseType(), entry.getKey());
                 Metadata md = Metadata.builder()
-                    .withName(metricName)
-                    .withDisplayName(metric.displayName())
-                    .withDescription(metric.description())
-                    .withType(getMetricType(instance))
-                    .withUnit(metric.unit())
-                    .reusable(false)
-                    .build();
+                        .withName(metricName)
+                        .withDisplayName(metric.displayName())
+                        .withDescription(metric.description())
+                        .withType(getMetricType(instance))
+                        .withUnit(metric.unit())
+                        .reusable(false)
+                        .build();
                 registry.register(md, instance);
             }
         });
         producers.clear();
-
-        // and now configure webserver features
-        registerWithServer(bm);
     }
 
     private void registerSyntheticSimplyTimedMetrics(@Observes AfterDeploymentValidation adv) {
@@ -567,7 +570,10 @@ public class MetricsCdiExtension implements Extension {
         }
     }
 
-    private void registerWithServer(BeanManager bm) {
+    // register metrics with server after security and when
+    // application scope is initialized
+    void registerMetrics(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object adv,
+                         BeanManager bm) {
         Set<String> vendorMetricsAdded = new HashSet<>();
         Config config = ((Config) ConfigProvider.getConfig()).get("metrics");
 
@@ -702,13 +708,13 @@ public class MetricsCdiExtension implements Extension {
                                           bm);
                 Gauge gaugeAnnotation = site.getAnnotated().getAnnotation(Gauge.class);
                 Metadata md = Metadata.builder()
-                    .withName(gaugeID.getName())
-                    .withDisplayName(gaugeAnnotation.displayName())
-                    .withDescription(gaugeAnnotation.description())
-                    .withType(MetricType.GAUGE)
-                    .withUnit(gaugeAnnotation.unit())
-                    .reusable(false)
-                    .build();
+                        .withName(gaugeID.getName())
+                        .withDisplayName(gaugeAnnotation.displayName())
+                        .withDescription(gaugeAnnotation.description())
+                        .withType(MetricType.GAUGE)
+                        .withUnit(gaugeAnnotation.unit())
+                        .reusable(false)
+                        .build();
                 LOGGER.log(Level.FINE, () -> String.format("Registering gauge with metadata %s", md.toString()));
                 registry.register(md, dg, gaugeID.getTagsAsList().toArray(new Tag[0]));
             } catch (Throwable t) {

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
@@ -51,7 +51,7 @@ import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 
-import static javax.interceptor.Interceptor.Priority.PLATFORM_AFTER;
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * Portable extension to allow construction of a Jandex index (to pass to
@@ -102,7 +102,7 @@ public class OpenApiCdiExtension implements Extension {
         this.config = config;
     }
 
-    void registerOpenApi(@Observes @Priority(PLATFORM_AFTER) @Initialized(ApplicationScoped.class) Object event, BeanManager bm) {
+    void registerOpenApi(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object event, BeanManager bm) {
         try {
             Config openapiNode = config.get(OpenAPISupport.Builder.CONFIG_KEY);
             OpenAPISupport openApiSupport = new MPOpenAPIBuilder()

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/OpenApiCdiExtension.java
@@ -35,7 +35,6 @@ import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
@@ -102,7 +101,7 @@ public class OpenApiCdiExtension implements Extension {
         this.config = config;
     }
 
-    void registerOpenApi(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object event, BeanManager bm) {
+    void registerOpenApi(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object event) {
         try {
             Config openapiNode = config.get(OpenAPISupport.Builder.CONFIG_KEY);
             OpenAPISupport openApiSupport = new MPOpenAPIBuilder()

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
@@ -43,7 +43,7 @@ import io.helidon.security.providers.abac.AbacProvider;
 import io.helidon.security.spi.AuthenticationProvider;
 import io.helidon.security.spi.AuthorizationProvider;
 
-import static javax.interceptor.Interceptor.Priority.PLATFORM_AFTER;
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
 
 /**
@@ -69,7 +69,9 @@ public class SecurityCdiExtension implements Extension {
         securityBuilder.config(config.get("security"));
     }
 
-    private void registerSecurity(@Observes @Initialized(ApplicationScoped.class) @Priority(PLATFORM_AFTER) Object adv,
+    // security must have priority higher than metrics, openapi and healt
+    // so we can protect these endpoints
+    private void registerSecurity(@Observes @Priority(LIBRARY_BEFORE) @Initialized(ApplicationScoped.class) Object adv,
                                   BeanManager bm) {
 
         if (securityBuilder.noProvider(AuthenticationProvider.class)) {

--- a/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
+++ b/security/providers/abac/src/main/java/io/helidon/security/providers/abac/AbacProvider.java
@@ -151,8 +151,10 @@ public final class AbacProvider extends SynchronousProvider implements Authoriza
             if (customObject.isPresent()) {
                 attributes.add(new RuntimeAttribute(validator, customObject.get()));
             } else {
-                abacConfig.map(it -> it.get(configKey)).ifPresentOrElse(
-                        attribConfig -> {
+                // only configure this validator if its config key exists
+                // or it has a supported annotation
+                abacConfig.flatMap(it -> it.get(configKey).asNode().asOptional())
+                        .ifPresentOrElse(attribConfig -> {
                             attributes.add(new RuntimeAttribute(validator, validator.fromConfig(attribConfig)));
                         },
                         () -> {

--- a/tests/integration/security/gh2297/pom.xml
+++ b/tests/integration/security/gh2297/pom.xml
@@ -18,24 +18,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
+        <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
         <version>2.0.2-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <packaging>pom</packaging>
-    <artifactId>helidon-tests-integration-security</artifactId>
-    <name>Helidon Integration Tests Security</name>
+    <artifactId>helidon-tests-integration-security-gh2297</artifactId>
+    <name>Helidon Tests Integration Security GH-2297</name>
 
     <description>
-        Security integration tests
+        Integration test for issue https://github.com/oracle/helidon/issues/2297
     </description>
 
-    <modules>
-        <module>gh1487</module>
-        <module>gh2297</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/tests/integration/security/gh2297/src/main/java/io/helidon/tests/integration/security/gh2297/Resource.java
+++ b/tests/integration/security/gh2297/src/main/java/io/helidon/tests/integration/security/gh2297/Resource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+package io.helidon.tests.integration.security.gh2297;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * JAX-RS Resource.
+ */
+@Path("/greet")
+public class Resource {
+    /**
+     * Simple hello world endpoint.
+     *
+     * @return returns hello
+     */
+    @GET
+    public String hello() {
+        return "Hello World";
+    }
+}

--- a/tests/integration/security/gh2297/src/main/java/io/helidon/tests/integration/security/gh2297/Resource.java
+++ b/tests/integration/security/gh2297/src/main/java/io/helidon/tests/integration/security/gh2297/Resource.java
@@ -1,6 +1,19 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package io.helidon.tests.integration.security.gh2297;
 
 import javax.ws.rs.GET;

--- a/tests/integration/security/gh2297/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/security/gh2297/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/security/gh2297/src/main/resources/application.yaml
+++ b/tests/integration/security/gh2297/src/main/resources/application.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server.port: 0
+security:
+  providers:
+    - abac:
+    - http-basic-auth:
+        realm: "helidon"
+        users:
+          - login: "success"
+            password: "password"
+            roles: ["admin"]
+          - login: "fail"
+            password: "password"
+  web-server:
+    paths:
+      - path: "/metrics[/{*}]"
+        authenticate: true
+        authorize: true
+        abac:
+          roles-allowed:
+            user:
+              - admin

--- a/tests/integration/security/gh2297/src/main/resources/logging.properties
+++ b/tests/integration/security/gh2297/src/main/resources/logging.properties
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+AUDIT.level=FINEST
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.microprofile.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO
+#org.glassfish.jersey.level=INFO
+#org.jboss.weld=INFO

--- a/tests/integration/security/gh2297/src/test/java/io/helidon/tests/integration/security/gh2297/ProtectedMetricsTest.java
+++ b/tests/integration/security/gh2297/src/test/java/io/helidon/tests/integration/security/gh2297/ProtectedMetricsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.gh2297;
+
+import java.util.Base64;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.server.Server;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit test for gh2297.
+ */
+class ProtectedMetricsTest {
+    private static Server server;
+    private static Client client;
+    private static WebTarget resourceTarget;
+    private static WebTarget metricTarget;
+
+    @BeforeAll
+    static void initClass() {
+        server = Server.create()
+                .start();
+
+        client = ClientBuilder.newClient();
+
+        int port = server.port();
+        String baseUri = "http://localhost:" + port;
+        resourceTarget = client.target(baseUri + "/greet");
+        metricTarget = client.target(baseUri + "/metrics/base");
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        if (server != null) {
+            server.stop();
+        }
+
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testResourceEndpoint() {
+        String response = resourceTarget.request()
+                .get(String.class);
+
+        assertThat(response, is("Hello World"));
+    }
+
+    @Test
+    void testMetricsEndpointNoUser() {
+        Response response = metricTarget.request()
+                .get();
+
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testMetricEndpointSuccess() {
+        Response response = metricTarget.request()
+                .header("Authorization", basic("success"))
+                .get();
+
+        assertThat(response.getStatus(), is(Http.Status.OK_200.code()));
+    }
+
+    @Test
+    void testMetricEndpointForbidden() {
+        Response response = metricTarget.request()
+                .header("Authorization", basic("fail"))
+                .get();
+
+        assertThat(response.getStatus(), is(Http.Status.FORBIDDEN_403.code()));
+    }
+
+    private String basic(String user) {
+        String uap = user + ":password";
+        return "basic " + Base64.getEncoder().encodeToString(uap.getBytes());
+    }
+}


### PR DESCRIPTION
Abac now correctly handles validator config

Security MP service must have higher priority than services exposing endpoints (such as metrics, health), so we can protect these endpoints.

In addition when an endpoint was protected using abac, each validator tried to read the configuration and time validator threw an exception.

Resolves #2296
Resolves #2297
For 2.x


I have modified priorities of services that configure endpoint to be library before, so they are configured before application (metrics, health, openapi) and security, which must be configured before them (to be able to protect these endpoints)