### PR TITLE
Support for non-String parameters in JAX-RS for native image

### DIFF
--- a/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
+++ b/integrations/graal/native-image-extension/src/main/java/io/helidon/integrations/graal/nativeimage/extension/HelidonReflectionFeature.java
@@ -77,6 +77,20 @@ public class HelidonReflectionFeature implements Feature {
     private static final String AT_ENTITY = "javax.persistence.Entity";
     private static final String AT_REGISTER_REST_CLIENT = "org.eclipse.microprofile.rest.client.inject.RegisterRestClient";
 
+    private static final Map<Class<?>, Class<?>> PRIMITIVES_TO_OBJECT = new HashMap<>();
+
+    static {
+        PRIMITIVES_TO_OBJECT.put(byte.class, Byte.class);
+        PRIMITIVES_TO_OBJECT.put(char.class, Character.class);
+        PRIMITIVES_TO_OBJECT.put(double.class, Double.class);
+        PRIMITIVES_TO_OBJECT.put(float.class, Float.class);
+        PRIMITIVES_TO_OBJECT.put(int.class, Integer.class);
+        PRIMITIVES_TO_OBJECT.put(long.class, Long.class);
+        PRIMITIVES_TO_OBJECT.put(short.class, Short.class);
+        PRIMITIVES_TO_OBJECT.put(boolean.class, Boolean.class);
+        PRIMITIVES_TO_OBJECT.put(void.class, Void.class);
+    }
+
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
         return ENABLED;
@@ -223,7 +237,6 @@ public class HelidonReflectionFeature implements Feature {
                 .filter(Objects::nonNull)
                 .forEach(allTypes::add);
 
-
         // now let's find all static methods `valueOf` and `fromString`
         for (Class<?> type : allTypes) {
             try {
@@ -289,35 +302,13 @@ public class HelidonReflectionFeature implements Feature {
     }
 
     private static Class<?> toObjectType(Class<?> primitiveClass) {
-        if (primitiveClass == byte.class) {
-            return Byte.class;
+        Class<?> type = PRIMITIVES_TO_OBJECT.get(primitiveClass);
+
+        if (type == null) {
+            traceParsing(() -> "Failed to understand primitive type: " + primitiveClass);
+            type = Object.class;
         }
-        if (primitiveClass == char.class) {
-            return Character.class;
-        }
-        if (primitiveClass == double.class) {
-            return Double.class;
-        }
-        if (primitiveClass == float.class) {
-            return Float.class;
-        }
-        if (primitiveClass == int.class) {
-            return Integer.class;
-        }
-        if (primitiveClass == long.class) {
-            return Long.class;
-        }
-        if (primitiveClass == short.class) {
-            return Short.class;
-        }
-        if (primitiveClass == boolean.class) {
-            return Boolean.class;
-        }
-        if (primitiveClass == void.class) {
-            return Void.class;
-        }
-        traceParsing(() -> "Failed to understand primitive type: " + primitiveClass);
-        return Object.class;
+        return type;
     }
 
     private void addAnnotatedWithReflected(BeforeAnalysisContext context) {

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/JaxRsResource.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/JaxRsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Configuration;
@@ -160,5 +161,17 @@ public class JaxRsResource {
     @Produces(MediaType.APPLICATION_JSON)
     public TestDto jsonBinding() {
         return new TestDto("json-b");
+    }
+
+    @GET
+    @Path("/queryparam")
+    public String queryParam(@QueryParam("long") Long longParam) {
+        return String.valueOf(longParam);
+    }
+
+    @GET
+    @Path("/queryparam2")
+    public String queryParam(@QueryParam("boolean") Boolean booleanParam) {
+        return String.valueOf(booleanParam);
     }
 }

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
@@ -190,6 +190,9 @@ public final class Mp1Main {
         invoke(collector, "Rest client JSON-P", "json-p", aBean::restClientJsonP);
         // + JSON-B
         invoke(collector, "Rest client JSON-B", "json-b", aBean::restClientJsonB);
+        // + query params
+        invoke(collector, "Rest client Query param long", "1020", () -> aBean.restClientQuery(1020L));
+        invoke(collector, "Rest client Query param boolean", "true", () -> aBean.restClientQuery(true));
 
         // Message from rest client, originating in BeanClass.BeanType
         invoke(collector, "Rest client bean type", "Properties message", aBean::restClientBeanType);

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/RestClientIface.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/RestClientIface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import javax.json.JsonObject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -45,4 +46,12 @@ public interface RestClientIface {
     @Path("/jsonb")
     @Produces(MediaType.APPLICATION_JSON)
     TestDto jsonBinding();
+
+    @GET
+    @Path("/queryparam")
+    String queryParam(@QueryParam("long") Long longParam);
+
+    @GET
+    @Path("/queryparam2")
+    String queryParam(@QueryParam("boolean") Boolean booleanParam);
 }

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/TestBean.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/TestBean.java
@@ -1,5 +1,17 @@
 /*
  * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.helidon.tests.integration.nativeimage.mp1;
 
@@ -78,6 +90,16 @@ public class TestBean {
         return restClient()
                 .jsonBinding()
                 .getMessage();
+    }
+
+    public String restClientQuery(Long param) {
+        return restClient()
+                .queryParam(param);
+    }
+
+    public String restClientQuery(Boolean param) {
+        return restClient()
+                .queryParam(param);
     }
 
     @Fallback(fallbackMethod = "fallbackTo")


### PR DESCRIPTION
Support for non-String parameters (query, header, path) in JAX-RS for native image

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Resolves #2291 


Also added a test to `Mp1` native image integration test.