### PR TITLE
Integrate Helidon Build Tools v2.1.0

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -47,7 +47,8 @@
         <version.plugin.dependency>3.1.2</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
-        <version.plugin.helidon>2.0.2</version.plugin.helidon>
+        <version.plugin.helidon>2.1.0</version.plugin.helidon>
+        <version.plugin.helidon-cli>2.1.0</version.plugin.helidon-cli>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>
@@ -171,6 +172,11 @@
                     <groupId>io.helidon.build-tools</groupId>
                     <artifactId>helidon-maven-plugin</artifactId>
                     <version>${version.plugin.helidon}</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.helidon.build-tools</groupId>
+                    <artifactId>helidon-cli-maven-plugin</artifactId>
+                    <version>${version.plugin.helidon-cli}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.xolstice.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>2.19.1</version.plugin.failsafe>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
-        <version.plugin.helidon-build-tools>2.0.2</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>2.1.0</version.plugin.helidon-build-tools>
         <version.plugin.hibernate-enhance>${version.lib.hibernate}</version.plugin.hibernate-enhance>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>1.0.6</version.plugin.jandex>


### PR DESCRIPTION
Integrate Helidon Build Tools v2.1.0
Add new plugin management section for the helidon-cli-maven-plugin in the application parent pom.