### PR TITLE
Update MediaType, lazy non known type, read-only parameters map

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -337,9 +337,7 @@ public final class MediaType implements AcceptPredicate<MediaType> {
         return CHARSET_ATTRIBUTE.equals(attribute) ? Ascii.toLowerCase(value) : value;
     }
 
-    private static MediaType create(String type, String subtype,
-            Map<String, String> parameters) {
-
+    private static MediaType create(String type, String subtype, Map<String, String> parameters) {
         Objects.requireNonNull(type, "Parameter 'type' is null!");
         Objects.requireNonNull(subtype, "Parameter 'subtype' is null!");
         Objects.requireNonNull(parameters, "Parameter 'parameters' is null!");
@@ -351,24 +349,27 @@ public final class MediaType implements AcceptPredicate<MediaType> {
             throw new IllegalStateException(
                     "A wildcard type cannot be used with a non-wildcard subtype");
         }
-        Map<String, String> normalizedParameters = new HashMap<>();
-        for (Map.Entry<String, String> entry : parameters.entrySet()) {
-            String attribute = Tokenizer.normalize(TOKEN_MATCHER, entry.getKey());
-            normalizedParameters.put(attribute, normalizeParameterValue(attribute, entry.getValue()));
-        }
 
         MediaType mediaType = null;
-
-        // Return one of the constants if the media type is a known type.
-        if (normalizedParameters.isEmpty()) {
+        Map<String, String> normalizedParameters = null;
+        if (parameters.isEmpty()) {
+            // Return one of the constants if the media type is a known type.
             mediaType = KNOWN_TYPES.get(normalizedType + '/' + normalizedSubtype);
+        } else {
+            normalizedParameters = new HashMap<>();
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                String attribute = Tokenizer.normalize(TOKEN_MATCHER, entry.getKey());
+                normalizedParameters.put(attribute, normalizeParameterValue(attribute, entry.getValue()));
+            }
         }
         if (mediaType == null) {
-            mediaType = MediaType.builder()
+            MediaType.Builder builder = MediaType.builder()
                     .type(normalizedType)
-                    .subtype(normalizedSubtype)
-                    .parameters(normalizedParameters)
-                    .build();
+                    .subtype(normalizedSubtype);
+            if (normalizedParameters != null) {
+                builder.parameters(normalizedParameters);
+            }
+            mediaType = builder.build();
         }
         return mediaType;
     }

--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
  * @see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7">HTTP/1.1 section 3.7</a>
  */
 public final class MediaType implements AcceptPredicate<MediaType> {
-    // must be first, as this is used to create instances of media types
+
     private static final Map<String, MediaType> KNOWN_TYPES = new HashMap<>();
 
     /**
@@ -41,113 +41,168 @@ public final class MediaType implements AcceptPredicate<MediaType> {
     /**
      * A {@link MediaType} constant representing wildcard media type.
      */
-    public static final MediaType WILDCARD = KNOWN_TYPES.put(
-            AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE,
-            new MediaType(AcceptPredicate.WILDCARD_VALUE, AcceptPredicate.WILDCARD_VALUE));
+    public static final MediaType WILDCARD;
 
     // Common media type constants
+
     /**
      * A {@link MediaType} constant representing {@code application/xml} media type.
      */
-    public static final MediaType APPLICATION_XML = KNOWN_TYPES.put("application/xml",
-            new MediaType("application", "xml"));
+    public static final MediaType APPLICATION_XML;
+
     /**
      * A {@link MediaType} constant representing {@code application/atom+xml} media type.
      */
-    public static final MediaType APPLICATION_ATOM_XML = KNOWN_TYPES.put("application/atom+xml",
-            new MediaType("application", "atom+xml"));
+    public static final MediaType APPLICATION_ATOM_XML;
+
     /**
      * A {@link MediaType} constant representing {@code application/xhtml+xml} media type.
      */
-    public static final MediaType APPLICATION_XHTML_XML = KNOWN_TYPES.put("application/xhtml+xml",
-            new MediaType("application", "xhtml+xml"));
+    public static final MediaType APPLICATION_XHTML_XML;
+
     /**
      * A {@link MediaType} constant representing {@code application/svg+xml} media type.
      */
-    public static final MediaType APPLICATION_SVG_XML = KNOWN_TYPES.put("application/svg+xml",
-            new MediaType("application", "svg+xml"));
+    public static final MediaType APPLICATION_SVG_XML;
+
     /**
      * A {@link MediaType} constant representing {@code application/json} media type.
      */
-    public static final MediaType APPLICATION_JSON = KNOWN_TYPES.put("application/json",
-            new MediaType("application", "json"));
+    public static final MediaType APPLICATION_JSON;
+
     /**
      * A {@link MediaType} constant representing {@code application/stream+json} media type.
      */
-    public static final MediaType APPLICATION_STREAM_JSON = KNOWN_TYPES.put("application/stream+json",
-            new MediaType("application", "stream+json"));
+    public static final MediaType APPLICATION_STREAM_JSON;
+
     /**
      * A {@link MediaType} constant representing {@code application/x-www-form-urlencoded} media type.
      */
-    public static final MediaType APPLICATION_FORM_URLENCODED = KNOWN_TYPES.put("application/x-www-form-urlencoded",
-            new MediaType("application", "x-www-form-urlencoded"));
+    public static final MediaType APPLICATION_FORM_URLENCODED;
+
     /**
      * A {@link MediaType} constant representing {@code multipart/form-data} media type.
      */
-    public static final MediaType MULTIPART_FORM_DATA = KNOWN_TYPES.put("multipart/form-data",
-            new MediaType("multipart", "form-data"));
+    public static final MediaType MULTIPART_FORM_DATA;
+
     /**
      * A {@link MediaType} constant representing {@code application/octet-stream} media type.
      */
-    public static final MediaType APPLICATION_OCTET_STREAM = KNOWN_TYPES.put("application/octet-stream",
-            new MediaType("application", "octet-stream"));
+    public static final MediaType APPLICATION_OCTET_STREAM;
+
     /**
      * A {@link MediaType} constant representing {@code text/plain} media type.
      */
-    public static final MediaType TEXT_PLAIN = KNOWN_TYPES.put("text/plain",
-            new MediaType("text", "plain"));
+    public static final MediaType TEXT_PLAIN;
+
     /**
      * A {@link MediaType} constant representing {@code text/xml} media type.
      */
-    public static final MediaType TEXT_XML = KNOWN_TYPES.put("text/xml",
-            new MediaType("text", "xml"));
+    public static final MediaType TEXT_XML;
+
     /**
      * A {@link MediaType} constant representing {@code text/html} media type.
      */
-    public static final MediaType TEXT_HTML = KNOWN_TYPES.put("text/html",
-            new MediaType("text", "html"));
+    public static final MediaType TEXT_HTML;
+
     /**
      * A {@link MediaType} constant representing OpenAPI yaml.
      * <p>
      * See https://github.com/opengeospatial/WFS_FES/issues/117#issuecomment-402188280
      */
-    public static final MediaType APPLICATION_OPENAPI_YAML = KNOWN_TYPES.put("application/vnd.oai.openapi",
-            new MediaType("application", "vnd.oai.openapi"));
+    public static final MediaType APPLICATION_OPENAPI_YAML;
+
     /**
      * A {@link MediaType} constant representing OpenAPI json.
      */
-    public static final MediaType APPLICATION_OPENAPI_JSON = KNOWN_TYPES.put("application/vnd.oai.openapi+json",
-            new MediaType("application", "vnd.oai.openapi+json"));
+    public static final MediaType APPLICATION_OPENAPI_JSON;
 
     /**
      * A {@link MediaType} constant representing "x" YAML as application.
      */
-    public static final MediaType APPLICATION_X_YAML = KNOWN_TYPES.put("application/x-yaml",
-            new MediaType("application", "x-yaml"));
+    public static final MediaType APPLICATION_X_YAML;
 
     /**
      * A {@link MediaType} constant representing pseudo-registered YAML. (It is not actually registered.)
      */
-    public static final MediaType APPLICATION_YAML = KNOWN_TYPES.put("application/yaml",
-            new MediaType("application", "yaml"));
+    public static final MediaType APPLICATION_YAML;
 
     /**
      * A {@link MediaType} constant representing "x" YAML as text.
      */
-    public static final MediaType TEXT_X_YAML = KNOWN_TYPES.put("text-x-yaml",
-            new MediaType("text", "x-yaml"));
+    public static final MediaType TEXT_X_YAML;
 
     /**
      * A {@link MediaType} constant representing pseudo-registered YAML as text.
      */
-    public static final MediaType TEXT_YAML = KNOWN_TYPES.put("text-yaml",
-            new MediaType("text", "yaml"));
+    public static final MediaType TEXT_YAML;
 
     /**
      * A {@link MediaType} constant representing {@code application/javascript} media type.
      */
-    public static final MediaType APPLICATION_JAVASCRIPT = KNOWN_TYPES.put("application/javascript",
-            new MediaType("application", "javascript"));
+    public static final MediaType APPLICATION_JAVASCRIPT;
+
+    static {
+        WILDCARD = new MediaType(AcceptPredicate.WILDCARD_VALUE, AcceptPredicate.WILDCARD_VALUE);
+        KNOWN_TYPES.put(AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE, WILDCARD);
+
+        APPLICATION_XML = new MediaType("application", "xml");
+        KNOWN_TYPES.put("application/xml", APPLICATION_XML);
+
+        APPLICATION_ATOM_XML = new MediaType("application", "atom+xml");
+        KNOWN_TYPES.put("application/atom+xml", APPLICATION_ATOM_XML);
+
+        APPLICATION_XHTML_XML = new MediaType("application", "xhtml+xml");
+        KNOWN_TYPES.put("application/xhtml+xml", APPLICATION_XHTML_XML);
+
+        APPLICATION_SVG_XML = new MediaType("application", "svg+xml");
+        KNOWN_TYPES.put("application/svg+xml", APPLICATION_SVG_XML);
+
+        APPLICATION_JSON = new MediaType("application", "json");
+        KNOWN_TYPES.put("application/json", APPLICATION_JSON);
+
+        APPLICATION_STREAM_JSON = new MediaType("application", "stream+json");
+        KNOWN_TYPES.put("application/stream+json", APPLICATION_STREAM_JSON);
+
+        APPLICATION_FORM_URLENCODED = new MediaType("application", "x-www-form-urlencoded");
+        KNOWN_TYPES.put("application/x-www-form-urlencoded", APPLICATION_FORM_URLENCODED);
+
+        MULTIPART_FORM_DATA = new MediaType("multipart", "form-data");
+        KNOWN_TYPES.put("multipart/form-data", MULTIPART_FORM_DATA);
+
+        APPLICATION_OCTET_STREAM = new MediaType("application", "octet-stream");
+        KNOWN_TYPES.put("application/octet-stream", APPLICATION_OCTET_STREAM);
+
+        TEXT_PLAIN = new MediaType("text", "plain");
+        KNOWN_TYPES.put("text/plain", TEXT_PLAIN);
+
+        TEXT_XML = new MediaType("text", "xml");
+        KNOWN_TYPES.put("text/xml", TEXT_XML);
+
+        TEXT_HTML = new MediaType("text", "html");
+        KNOWN_TYPES.put("text/html", TEXT_HTML);
+
+        APPLICATION_OPENAPI_YAML = new MediaType("application", "vnd.oai.openapi");
+        KNOWN_TYPES.put("application/vnd.oai.openapi", APPLICATION_OPENAPI_YAML);
+
+        APPLICATION_OPENAPI_JSON = new MediaType("application", "vnd.oai.openapi+json");
+        KNOWN_TYPES.put("application/vnd.oai.openapi+json", APPLICATION_OPENAPI_JSON);
+
+        APPLICATION_X_YAML = new MediaType("application", "x-yaml");
+        KNOWN_TYPES.put("application/x-yaml", APPLICATION_X_YAML);
+
+        APPLICATION_YAML = new MediaType("application", "yaml");
+        KNOWN_TYPES.put("application/yaml", APPLICATION_YAML);
+
+        TEXT_X_YAML = new MediaType("text", "x-yaml");
+        KNOWN_TYPES.put("text-x-yaml", TEXT_X_YAML);
+
+        TEXT_YAML = new MediaType("text", "yaml");
+        KNOWN_TYPES.put("text-yaml", TEXT_YAML);
+
+        APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
+        KNOWN_TYPES.put("application/javascript", APPLICATION_JAVASCRIPT);
+    }
 
     // Common predicates
     /**
@@ -299,8 +354,9 @@ public final class MediaType implements AcceptPredicate<MediaType> {
         }
 
         MediaType mediaType = null;
+
         // Return one of the constants if the media type is a known type.
-        if (!normalizedParameters.isEmpty()) {
+        if (normalizedParameters.isEmpty()) {
             mediaType = KNOWN_TYPES.get(normalizedType + '/' + normalizedSubtype);
         }
         if (mediaType == null) {

--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -144,6 +144,7 @@ public final class MediaType implements AcceptPredicate<MediaType> {
 
     static {
         Map<String, MediaType> knownTypes = new HashMap<>();
+
         WILDCARD = new MediaType(AcceptPredicate.WILDCARD_VALUE, AcceptPredicate.WILDCARD_VALUE);
         knownTypes.put(AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE, WILDCARD);
 
@@ -204,7 +205,7 @@ public final class MediaType implements AcceptPredicate<MediaType> {
         APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
         knownTypes.put("application/javascript", APPLICATION_JAVASCRIPT);
 
-        KNOWN_TYPES = knownTypes;
+        KNOWN_TYPES = Collections.unmodifiableMap(knownTypes);
     }
 
     // Common predicates

--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -41,89 +41,113 @@ public final class MediaType implements AcceptPredicate<MediaType> {
     /**
      * A {@link MediaType} constant representing wildcard media type.
      */
-    public static final MediaType WILDCARD = createMediaType();
+    public static final MediaType WILDCARD = KNOWN_TYPES.put(
+            AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE,
+            new MediaType(AcceptPredicate.WILDCARD_VALUE, AcceptPredicate.WILDCARD_VALUE));
 
     // Common media type constants
     /**
      * A {@link MediaType} constant representing {@code application/xml} media type.
      */
-    public static final MediaType APPLICATION_XML = createMediaType("application", "xml");
+    public static final MediaType APPLICATION_XML = KNOWN_TYPES.put("application/xml",
+            new MediaType("application", "xml"));
     /**
      * A {@link MediaType} constant representing {@code application/atom+xml} media type.
      */
-    public static final MediaType APPLICATION_ATOM_XML = createMediaType("application", "atom+xml");
+    public static final MediaType APPLICATION_ATOM_XML = KNOWN_TYPES.put("application/atom+xml",
+            new MediaType("application", "atom+xml"));
     /**
      * A {@link MediaType} constant representing {@code application/xhtml+xml} media type.
      */
-    public static final MediaType APPLICATION_XHTML_XML = createMediaType("application", "xhtml+xml");
+    public static final MediaType APPLICATION_XHTML_XML = KNOWN_TYPES.put("application/xhtml+xml",
+            new MediaType("application", "xhtml+xml"));
     /**
      * A {@link MediaType} constant representing {@code application/svg+xml} media type.
      */
-    public static final MediaType APPLICATION_SVG_XML = createMediaType("application", "svg+xml");
+    public static final MediaType APPLICATION_SVG_XML = KNOWN_TYPES.put("application/svg+xml",
+            new MediaType("application", "svg+xml"));
     /**
      * A {@link MediaType} constant representing {@code application/json} media type.
      */
-    public static final MediaType APPLICATION_JSON = createMediaType("application", "json");
+    public static final MediaType APPLICATION_JSON = KNOWN_TYPES.put("application/json",
+            new MediaType("application", "json"));
     /**
      * A {@link MediaType} constant representing {@code application/stream+json} media type.
      */
-    public static final MediaType APPLICATION_STREAM_JSON = createMediaType("application", "stream+json");
+    public static final MediaType APPLICATION_STREAM_JSON = KNOWN_TYPES.put("application/stream+json",
+            new MediaType("application", "stream+json"));
     /**
      * A {@link MediaType} constant representing {@code application/x-www-form-urlencoded} media type.
      */
-    public static final MediaType APPLICATION_FORM_URLENCODED = createMediaType("application", "x-www-form-urlencoded");
+    public static final MediaType APPLICATION_FORM_URLENCODED = KNOWN_TYPES.put("application/x-www-form-urlencoded",
+            new MediaType("application", "x-www-form-urlencoded"));
     /**
      * A {@link MediaType} constant representing {@code multipart/form-data} media type.
      */
-    public static final MediaType MULTIPART_FORM_DATA = createMediaType("multipart", "form-data");
+    public static final MediaType MULTIPART_FORM_DATA = KNOWN_TYPES.put("multipart/form-data",
+            new MediaType("multipart", "form-data"));
     /**
      * A {@link MediaType} constant representing {@code application/octet-stream} media type.
      */
-    public static final MediaType APPLICATION_OCTET_STREAM = createMediaType("application", "octet-stream");
+    public static final MediaType APPLICATION_OCTET_STREAM = KNOWN_TYPES.put("application/octet-stream",
+            new MediaType("application", "octet-stream"));
     /**
      * A {@link MediaType} constant representing {@code text/plain} media type.
      */
-    public static final MediaType TEXT_PLAIN = createMediaType("text", "plain");
+    public static final MediaType TEXT_PLAIN = KNOWN_TYPES.put("text/plain",
+            new MediaType("text", "plain"));
     /**
      * A {@link MediaType} constant representing {@code text/xml} media type.
      */
-    public static final MediaType TEXT_XML = createMediaType("text", "xml");
+    public static final MediaType TEXT_XML = KNOWN_TYPES.put("text/xml",
+            new MediaType("text", "xml"));
     /**
      * A {@link MediaType} constant representing {@code text/html} media type.
      */
-    public static final MediaType TEXT_HTML = createMediaType("text", "html");
+    public static final MediaType TEXT_HTML = KNOWN_TYPES.put("text/html",
+            new MediaType("text", "html"));
     /**
      * A {@link MediaType} constant representing OpenAPI yaml.
      * <p>
      * See https://github.com/opengeospatial/WFS_FES/issues/117#issuecomment-402188280
      */
-    public static final MediaType APPLICATION_OPENAPI_YAML = createMediaType("application", "vnd.oai.openapi");
+    public static final MediaType APPLICATION_OPENAPI_YAML = KNOWN_TYPES.put("application/vnd.oai.openapi",
+            new MediaType("application", "vnd.oai.openapi"));
     /**
      * A {@link MediaType} constant representing OpenAPI json.
      */
-    public static final MediaType APPLICATION_OPENAPI_JSON = createMediaType("application", "vnd.oai.openapi+json");
+    public static final MediaType APPLICATION_OPENAPI_JSON = KNOWN_TYPES.put("application/vnd.oai.openapi+json",
+            new MediaType("application", "vnd.oai.openapi+json"));
 
     /**
      * A {@link MediaType} constant representing "x" YAML as application.
      */
-    public static final MediaType APPLICATION_X_YAML = createMediaType("application", "x-yaml");
+    public static final MediaType APPLICATION_X_YAML = KNOWN_TYPES.put("application/x-yaml",
+            new MediaType("application", "x-yaml"));
 
     /**
      * A {@link MediaType} constant representing pseudo-registered YAML. (It is not actually registered.)
      */
-    public static final MediaType APPLICATION_YAML = createMediaType("application", "yaml");
+    public static final MediaType APPLICATION_YAML = KNOWN_TYPES.put("application/yaml",
+            new MediaType("application", "yaml"));
 
     /**
      * A {@link MediaType} constant representing "x" YAML as text.
      */
-    public static final MediaType TEXT_X_YAML = createMediaType("text", "x-yaml");
+    public static final MediaType TEXT_X_YAML = KNOWN_TYPES.put("text-x-yaml",
+            new MediaType("text", "x-yaml"));
 
     /**
      * A {@link MediaType} constant representing pseudo-registered YAML as text.
      */
-    public static final MediaType TEXT_YAML = createMediaType("text", "yaml");
+    public static final MediaType TEXT_YAML = KNOWN_TYPES.put("text-yaml",
+            new MediaType("text", "yaml"));
 
-    private static final MediaType APPLICATION_JAVASCRIPT = createMediaType("application", "javascript");
+    /**
+     * A {@link MediaType} constant representing {@code application/javascript} media type.
+     */
+    public static final MediaType APPLICATION_JAVASCRIPT = KNOWN_TYPES.put("application/javascript",
+            new MediaType("application", "javascript"));
 
     // Common predicates
     /**
@@ -155,6 +179,12 @@ public final class MediaType implements AcceptPredicate<MediaType> {
     private final String type;
     private final String subtype;
     private final Map<String, String> parameters;
+
+    private MediaType(String type, String subtype) {
+        this.type = type;
+        this.subtype = subtype;
+        this.parameters = Map.of();
+    }
 
     private MediaType(Builder builder) {
         this.type = builder.type;
@@ -244,18 +274,6 @@ public final class MediaType implements AcceptPredicate<MediaType> {
         return new Builder();
     }
 
-    private static MediaType createMediaType() {
-        MediaType mediaType = MediaType.builder().build();
-        KNOWN_TYPES.put("", mediaType);
-        return mediaType;
-    }
-
-    private static MediaType createMediaType(String type, String subtype) {
-        MediaType mediaType = MediaType.create(type, subtype);
-        KNOWN_TYPES.put(type + '/' + subtype, mediaType);
-        return mediaType;
-    }
-
     private static String normalizeParameterValue(String attribute, String value) {
         return CHARSET_ATTRIBUTE.equals(attribute) ? Ascii.toLowerCase(value) : value;
     }
@@ -274,19 +292,25 @@ public final class MediaType implements AcceptPredicate<MediaType> {
             throw new IllegalStateException(
                     "A wildcard type cannot be used with a non-wildcard subtype");
         }
-        Map<String, String> builder = new HashMap<>();
+        Map<String, String> normalizedParameters = new HashMap<>();
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             String attribute = Tokenizer.normalize(TOKEN_MATCHER, entry.getKey());
-            builder.put(attribute, normalizeParameterValue(attribute, entry.getValue()));
+            normalizedParameters.put(attribute, normalizeParameterValue(attribute, entry.getValue()));
         }
 
+        MediaType mediaType = null;
         // Return one of the constants if the media type is a known type.
-        return Optional.ofNullable(builder.isEmpty() ? KNOWN_TYPES.get(normalizedType + '/' + normalizedSubtype) : null)
-                .orElseGet(() -> MediaType.builder()
-                        .type(normalizedType)
-                        .subtype(normalizedSubtype)
-                        .parameters(builder)
-                        .build());
+        if (!normalizedParameters.isEmpty()) {
+            mediaType = KNOWN_TYPES.get(normalizedType + '/' + normalizedSubtype);
+        }
+        if (mediaType == null) {
+            mediaType = MediaType.builder()
+                    .type(normalizedType)
+                    .subtype(normalizedSubtype)
+                    .parameters(normalizedParameters)
+                    .build();
+        }
+        return mediaType;
     }
 
     /**

--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -31,7 +31,7 @@ import java.util.function.Predicate;
  */
 public final class MediaType implements AcceptPredicate<MediaType> {
 
-    private static final Map<String, MediaType> KNOWN_TYPES = new HashMap<>();
+    private static final Map<String, MediaType> KNOWN_TYPES;
 
     /**
      * The media type {@value CHARSET_PARAMETER} parameter name.
@@ -143,65 +143,68 @@ public final class MediaType implements AcceptPredicate<MediaType> {
     public static final MediaType APPLICATION_JAVASCRIPT;
 
     static {
+        Map<String, MediaType> knownTypes = new HashMap<>();
         WILDCARD = new MediaType(AcceptPredicate.WILDCARD_VALUE, AcceptPredicate.WILDCARD_VALUE);
-        KNOWN_TYPES.put(AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE, WILDCARD);
+        knownTypes.put(AcceptPredicate.WILDCARD_VALUE + '/' + AcceptPredicate.WILDCARD_VALUE, WILDCARD);
 
         APPLICATION_XML = new MediaType("application", "xml");
-        KNOWN_TYPES.put("application/xml", APPLICATION_XML);
+        knownTypes.put("application/xml", APPLICATION_XML);
 
         APPLICATION_ATOM_XML = new MediaType("application", "atom+xml");
-        KNOWN_TYPES.put("application/atom+xml", APPLICATION_ATOM_XML);
+        knownTypes.put("application/atom+xml", APPLICATION_ATOM_XML);
 
         APPLICATION_XHTML_XML = new MediaType("application", "xhtml+xml");
-        KNOWN_TYPES.put("application/xhtml+xml", APPLICATION_XHTML_XML);
+        knownTypes.put("application/xhtml+xml", APPLICATION_XHTML_XML);
 
         APPLICATION_SVG_XML = new MediaType("application", "svg+xml");
-        KNOWN_TYPES.put("application/svg+xml", APPLICATION_SVG_XML);
+        knownTypes.put("application/svg+xml", APPLICATION_SVG_XML);
 
         APPLICATION_JSON = new MediaType("application", "json");
-        KNOWN_TYPES.put("application/json", APPLICATION_JSON);
+        knownTypes.put("application/json", APPLICATION_JSON);
 
         APPLICATION_STREAM_JSON = new MediaType("application", "stream+json");
-        KNOWN_TYPES.put("application/stream+json", APPLICATION_STREAM_JSON);
+        knownTypes.put("application/stream+json", APPLICATION_STREAM_JSON);
 
         APPLICATION_FORM_URLENCODED = new MediaType("application", "x-www-form-urlencoded");
-        KNOWN_TYPES.put("application/x-www-form-urlencoded", APPLICATION_FORM_URLENCODED);
+        knownTypes.put("application/x-www-form-urlencoded", APPLICATION_FORM_URLENCODED);
 
         MULTIPART_FORM_DATA = new MediaType("multipart", "form-data");
-        KNOWN_TYPES.put("multipart/form-data", MULTIPART_FORM_DATA);
+        knownTypes.put("multipart/form-data", MULTIPART_FORM_DATA);
 
         APPLICATION_OCTET_STREAM = new MediaType("application", "octet-stream");
-        KNOWN_TYPES.put("application/octet-stream", APPLICATION_OCTET_STREAM);
+        knownTypes.put("application/octet-stream", APPLICATION_OCTET_STREAM);
 
         TEXT_PLAIN = new MediaType("text", "plain");
-        KNOWN_TYPES.put("text/plain", TEXT_PLAIN);
+        knownTypes.put("text/plain", TEXT_PLAIN);
 
         TEXT_XML = new MediaType("text", "xml");
-        KNOWN_TYPES.put("text/xml", TEXT_XML);
+        knownTypes.put("text/xml", TEXT_XML);
 
         TEXT_HTML = new MediaType("text", "html");
-        KNOWN_TYPES.put("text/html", TEXT_HTML);
+        knownTypes.put("text/html", TEXT_HTML);
 
         APPLICATION_OPENAPI_YAML = new MediaType("application", "vnd.oai.openapi");
-        KNOWN_TYPES.put("application/vnd.oai.openapi", APPLICATION_OPENAPI_YAML);
+        knownTypes.put("application/vnd.oai.openapi", APPLICATION_OPENAPI_YAML);
 
         APPLICATION_OPENAPI_JSON = new MediaType("application", "vnd.oai.openapi+json");
-        KNOWN_TYPES.put("application/vnd.oai.openapi+json", APPLICATION_OPENAPI_JSON);
+        knownTypes.put("application/vnd.oai.openapi+json", APPLICATION_OPENAPI_JSON);
 
         APPLICATION_X_YAML = new MediaType("application", "x-yaml");
-        KNOWN_TYPES.put("application/x-yaml", APPLICATION_X_YAML);
+        knownTypes.put("application/x-yaml", APPLICATION_X_YAML);
 
         APPLICATION_YAML = new MediaType("application", "yaml");
-        KNOWN_TYPES.put("application/yaml", APPLICATION_YAML);
+        knownTypes.put("application/yaml", APPLICATION_YAML);
 
         TEXT_X_YAML = new MediaType("text", "x-yaml");
-        KNOWN_TYPES.put("text-x-yaml", TEXT_X_YAML);
+        knownTypes.put("text-x-yaml", TEXT_X_YAML);
 
         TEXT_YAML = new MediaType("text", "yaml");
-        KNOWN_TYPES.put("text-yaml", TEXT_YAML);
+        knownTypes.put("text-yaml", TEXT_YAML);
 
         APPLICATION_JAVASCRIPT = new MediaType("application", "javascript");
-        KNOWN_TYPES.put("application/javascript", APPLICATION_JAVASCRIPT);
+        knownTypes.put("application/javascript", APPLICATION_JAVASCRIPT);
+
+        KNOWN_TYPES = knownTypes;
     }
 
     // Common predicates


### PR DESCRIPTION
Update MediaType.create
 - return a known type only if there is no parameters
 - change MediaType.KNOWN_TYPES from Map<MediaType,MediaType> to Map<String, MediaType>
 - build a key as a String of the form type/subtype,
   this is a minor optimization for known types that avoids creating a MediaType instance as a key
- replace use of Optional with plain if conditions

Update MediaType static fields initialization
- replace createContentType with a dedicated constructor to avoid the calls to `createContentType/create/builder` and the creation of an instance of `Builder`
- use a static initializer to populate the `KNOWN_TYPE` map

Make parameters a read-only map
 - Optimize for empty parameters and use Map.of()
 - otherwise wrap it with Collections.unmodifiableMap()