### PR TITLE
Update to later release of MP OpenTracing

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -86,7 +86,7 @@
         <version.lib.microprofile-metrics-api>2.3.2</version.lib.microprofile-metrics-api>
         <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-fault-tolerance-api>2.0.2</version.lib.microprofile-fault-tolerance-api>
-        <version.lib.microprofile-tracing>1.3.1</version.lib.microprofile-tracing>
+        <version.lib.microprofile-tracing>1.3.3</version.lib.microprofile-tracing>
         <version.lib.microprofile-rest-client>1.3.3</version.lib.microprofile-rest-client>
         <version.lib.microprofile-reactive-messaging-api>1.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>1.0.1</version.lib.microprofile-reactive-streams-operators-api>


### PR DESCRIPTION
Resolves #2312 

Changes in MP OpenTracing 1.3.3 seem confined to some minor mechanical changes in the TCK.

No changes were needed to our code except updating the dependency version.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>