### PR TITLE
Fix issue with gRPC clients and services where method signatures have types with nested generics

### DIFF
--- a/microprofile/grpc/client/src/test/java/io/helidon/microprofile/grpc/client/GrpcClientProxyBuilderTest.java
+++ b/microprofile/grpc/client/src/test/java/io/helidon/microprofile/grpc/client/GrpcClientProxyBuilderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.grpc.client;
+
+import java.util.Collection;
+import java.util.concurrent.CompletionStage;
+
+import io.helidon.microprofile.grpc.core.Unary;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class GrpcClientProxyBuilderTest {
+    @Test
+    public void shouldCreateProxyForMethodWithWithNestedGenerics() {
+        TestService service = GrpcClientProxyBuilder.create(TestService.class).build();
+        assertThat(service, is(notNullValue()));
+    }
+
+    public interface TestService {
+       @Unary
+       CompletionStage<Collection<String>> getBooks();
+    }
+}

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ModelHelper.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ModelHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,11 +268,21 @@ public final class ModelHelper {
      */
     public static Class<?> getGenericType(Type type) {
         if (type instanceof Class) {
-            return (Class) type;
+            return (Class<?>) type;
         } else if (type instanceof ParameterizedType) {
             ParameterizedType parameterizedType = (ParameterizedType) type;
             if (parameterizedType.getRawType() instanceof Class) {
-                return (Class) parameterizedType.getActualTypeArguments()[0];
+                Type t = parameterizedType.getActualTypeArguments()[0];
+                if (t instanceof Class) {
+                    return (Class<?>) t;
+                } else if (t instanceof ParameterizedType) {
+                    // the type is a nested generic e.g. List<Map<String, Integer>>
+                    // we're only interested in the outer type, in the example above List
+                    return (Class<?>) ((ParameterizedType) t).getRawType();
+                } else {
+                    throw new IllegalArgumentException("Type parameter " + type.toString() + " not a class or "
+                            + "parameterized type whose raw type is a class");
+                }
             }
         } else if (type instanceof GenericArrayType) {
             GenericArrayType array = (GenericArrayType) type;

--- a/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilderTest.java
+++ b/microprofile/grpc/server/src/test/java/io/helidon/microprofile/grpc/server/GrpcServiceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
  */
 
 package io.helidon.microprofile.grpc.server;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
@@ -64,6 +68,13 @@ public class GrpcServiceBuilderTest {
         ServiceDescriptor descriptor = modeller.build();
 
         assertThat(descriptor.name(), is("ServiceOne/foo"));
+    }
+
+    @Test
+    public void shouldCreateDescriptorFoServiceWithNestedGenericParameters() {
+        GrpcServiceBuilder modeller = GrpcServiceBuilder.create(ServiceSix.class, beanManager);
+        ServiceDescriptor descriptor = modeller.build();
+        assertThat(descriptor.name(), is(ServiceSix.class.getSimpleName()));
     }
 
     @Test
@@ -305,6 +316,14 @@ public class GrpcServiceBuilderTest {
         public void unary(String param, StreamObserver<ServiceFive> observer) {
             observer.onNext(this);
             observer.onCompleted();
+        }
+    }
+
+    @RpcService
+    public static class ServiceSix {
+        @RpcMethod(type = io.grpc.MethodDescriptor.MethodType.UNARY)
+        public List<Map<Integer, String>> unary(List<Map<Integer, String>> param) {
+            return Collections.singletonList(Collections.singletonMap(1, "One"));
         }
     }
 }


### PR DESCRIPTION
This is a back-port of fix applied to 2.x in PR #2283
