### PR TITLE
Limit module visibility by making several classes package private

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class AsynchronousAntn extends MethodAntn implements Asynchronous {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public AsynchronousAntn(Class<?> beanClass, Method method) {
+    AsynchronousAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class AsynchronousAntn.
  */
-public class AsynchronousAntn extends MethodAntn implements Asynchronous {
+class AsynchronousAntn extends MethodAntn implements Asynchronous {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ class BulkheadAntn extends MethodAntn implements Bulkhead {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public BulkheadAntn(Class<?> beanClass, Method method) {
+    BulkheadAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class BulkheadAntn.
  */
-public class BulkheadAntn extends MethodAntn implements Bulkhead {
+class BulkheadAntn extends MethodAntn implements Bulkhead {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
@@ -33,7 +33,7 @@ class CircuitBreakerAntn extends MethodAntn implements CircuitBreaker {
      * @param beanClass The bean class.
      * @param method The method.
      */
-    public CircuitBreakerAntn(Class<?> beanClass, Method method) {
+    CircuitBreakerAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class CircuitBreakerAntn.
  */
-public class CircuitBreakerAntn extends MethodAntn implements CircuitBreaker {
+class CircuitBreakerAntn extends MethodAntn implements CircuitBreaker {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandBinding.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,5 +35,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @InterceptorBinding
-public @interface CommandBinding {
+@interface CommandBinding {
 }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandInterceptor.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CommandInterceptor.java
@@ -29,7 +29,7 @@ import javax.interceptor.InvocationContext;
 @Interceptor
 @CommandBinding
 @Priority(Interceptor.Priority.PLATFORM_AFTER + 10)
-public class CommandInterceptor {
+class CommandInterceptor {
 
     private static final Logger LOGGER = Logger.getLogger(CommandInterceptor.class.getName());
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
@@ -26,7 +26,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class FallbackAntn.
  */
-public class FallbackAntn extends MethodAntn implements Fallback {
+class FallbackAntn extends MethodAntn implements Fallback {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
@@ -34,7 +34,7 @@ class FallbackAntn extends MethodAntn implements Fallback {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public FallbackAntn(Class<?> beanClass, Method method) {
+    FallbackAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/LiteralCommandBinding.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/LiteralCommandBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/LiteralCommandBinding.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/LiteralCommandBinding.java
@@ -21,7 +21,7 @@ import javax.enterprise.util.AnnotationLiteral;
 /**
  * Class LiteralCommandBinding.
  */
-public class LiteralCommandBinding extends AnnotationLiteral<CommandBinding> implements CommandBinding {
+class LiteralCommandBinding extends AnnotationLiteral<CommandBinding> implements CommandBinding {
     private static final long serialVersionUID = 1L;
 
     private static final CommandBinding INSTANCE = new LiteralCommandBinding();

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import static io.helidon.microprofile.faulttolerance.FaultToleranceParameter.get
 /**
  * Class MethodAntn.
  */
-public abstract class MethodAntn {
+abstract class MethodAntn {
     private static final Logger LOGGER = Logger.getLogger(MethodAntn.class.getName());
 
     private final Method method;
@@ -72,7 +72,7 @@ public abstract class MethodAntn {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public MethodAntn(Class<?> beanClass, Method method) {
+    MethodAntn(Class<?> beanClass, Method method) {
         this.beanClass = beanClass;
         this.method = method;
     }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -90,7 +90,7 @@ import static io.helidon.microprofile.faulttolerance.ThrowableMapper.mapTypes;
  * of this class is created for each method invocation. Some state is shared across
  * all invocations of a method, including for circuit breakers and bulkheads.
  */
-public class MethodInvoker implements FtSupplier<Object> {
+class MethodInvoker implements FtSupplier<Object> {
     private static final Logger LOGGER = Logger.getLogger(MethodInvoker.class.getName());
 
     /**

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -283,7 +283,7 @@ class MethodInvoker implements FtSupplier<Object> {
      * @param context The invocation context.
      * @param introspector The method introspector.
      */
-    public MethodInvoker(InvocationContext context, MethodIntrospector introspector) {
+    MethodInvoker(InvocationContext context, MethodIntrospector introspector) {
         this.context = context;
         this.introspector = introspector;
         this.method = context.getMethod();

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class RetryAntn.
  */
-public class RetryAntn extends MethodAntn implements Retry {
+class RetryAntn extends MethodAntn implements Retry {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class RetryAntn extends MethodAntn implements Retry {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public RetryAntn(Class<?> beanClass, Method method) {
+    RetryAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
@@ -25,7 +25,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefiniti
 /**
  * Class TimeoutAntn.
  */
-public class TimeoutAntn extends MethodAntn implements Timeout {
+class TimeoutAntn extends MethodAntn implements Timeout {
 
     /**
      * Constructor.

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class TimeoutAntn extends MethodAntn implements Timeout {
      * @param beanClass Bean class.
      * @param method The method.
      */
-    public TimeoutAntn(Class<?> beanClass, Method method) {
+    TimeoutAntn(Class<?> beanClass, Method method) {
         super(beanClass, method);
     }
 


### PR DESCRIPTION
Limit module visibility by making several classes package private. None of these classes should be used directly by Helidon applications, but this is a backward incompatible change nonetheless. Having said that, the latest FT implementation is already different enough to the old one based on Hystrix/Failsafe that it makes little sense to use deprecation in this case.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>