### PR TITLE
Updates Fault Tolerance MP docs

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ScheduledThreadPoolSupplier.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ScheduledThreadPoolSupplier.java
@@ -79,6 +79,15 @@ public final class ScheduledThreadPoolSupplier implements Supplier<ScheduledExec
         return builder().build();
     }
 
+    /**
+     * Returns size of core pool.
+     *
+     * @return size of core pool.
+     */
+    public int corePoolSize() {
+        return corePoolSize;
+    }
+
     ScheduledThreadPoolExecutor getThreadPool() {
         ScheduledThreadPoolExecutor result;
         result = new ScheduledThreadPoolExecutor(corePoolSize,

--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,15 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
     @Override
     public ExecutorService get() {
         return lazyValue.get();
+    }
+
+    /**
+     * Returns size of core pool.
+     *
+     * @return size of core pool.
+     */
+    public int corePoolSize() {
+        return corePoolSize;
     }
 
     /**

--- a/docs/mp/faulttolerance/01_overview.adoc
+++ b/docs/mp/faulttolerance/01_overview.adoc
@@ -22,6 +22,8 @@
 :description: Fault Tolerance Introduction
 :keywords: helidon, webserver, faulttolerance, mp
 :fault-tolerance-spec-url: https://github.com/eclipse/microprofile-fault-tolerance
+:scheduled-executor-config: https://helidon.io/docs/v2/apidocs/io.helidon.common.configurable/io/helidon/common/configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
+:executor-config: https://helidon.io/docs/v2/apidocs/io.helidon.common.configurable/io/helidon/common/configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
 
 Fault Tolerance is part of the MicroProfile set of {fault-tolerance-spec-url}[specifications]. This API defines mostly
 annotations that improve application robustness by providing support to conveniently handle
@@ -30,30 +32,27 @@ service restarts, network delays, temporal infrastructure instabilities, etc.
 
 == Fault Tolerance in Helidon
 
-Fault Tolerance method annotations are internally implemented using _commands_.
-Essentially, each Fault Tolerance method invocation runs under the supervision
-of one of these commands. Command execution can be affected by certain properties:
-some defined by the Fault Tolerance specification and others internal to Helidon.
+The latest implementation of MP Fault Tolerance is built on top of Helidon's SE
+Fault Tolerance. Thus, some configuration for Helidon SE Fault
+Tolerance also applies to MP. The next section describes some
+configuration properties that are of particular interest to MP applications.
 
-== Fault Tolerance Configuration
-This section describes a few configuration parameters that are specific to Helidon's Fault
-Tolerance implementation. See the {fault-tolerance-spec-url}[Fault Tolerance MicroProfile API] for more information.
+=== Configuration
 
-The following is a list of config properties supported by Helidon that are
-_not_ part of the Fault Tolerance specification:
+Helidon's implementation uses two types of thread pools: normal and scheduled. The default
+core size of these executors is 16; however, that can be configured using an `application.yaml`
+file as follows:
 
-- `fault-tolerance.commandThreadPoolSize`: Asynchronous commands require the use of a
-separate thread pool. Threads created in this pool are named `helidon-ft-async-<N>`.
-This config property controls the size of such a pool. The default size is 8.
+[source,yaml]
+----
+executor:
+  core-pool-size: 8
 
-- `fault-tolerance.threadWaitingPeriod`: A thread that has been interrupted but
-is still running (e.g. in a busy loop) has to be waited for. This config property
-controls the maximum waiting time in milliseconds. Default value is 2000 milliseconds.
+scheduled-executor:
+  core-pool-size: 8
+----
 
-- `fault-tolerance.bulkheadTaskQueueingPeriod`: Time to wait
-for a task to be queued on a bulkhead. Default value is 2000 milliseconds.
+The complete set of properties available to configure these executors is in
+{executor-config}[ServerThreadPoolSupplier] and
+{scheduled-executor-config}[ScheduledThreadPoolSupplier].
 
-- `fault-tolerance.delayCorrection`: This is an internal correction applied to
-a `@Retry` delay that accounts for the execution of some internal logic in
-Helidon. This value will be subtracted from the actual delay. Default is
-250 milliseconds.

--- a/docs/mp/faulttolerance/01_overview.adoc
+++ b/docs/mp/faulttolerance/01_overview.adoc
@@ -22,8 +22,8 @@
 :description: Fault Tolerance Introduction
 :keywords: helidon, webserver, faulttolerance, mp
 :fault-tolerance-spec-url: https://github.com/eclipse/microprofile-fault-tolerance
-:scheduled-executor-config: https://helidon.io/docs/v2/apidocs/io.helidon.common.configurable/io/helidon/common/configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
-:executor-config: https://helidon.io/docs/v2/apidocs/io.helidon.common.configurable/io/helidon/common/configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
+:scheduled-executor-config: {javadoc-base-url}io.helidon.common.configurable/io/helidon/common/configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
+:executor-config: {javadoc-base-url}io.helidon.common.configurable/io/helidon/common/configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
 
 Fault Tolerance is part of the MicroProfile set of {fault-tolerance-spec-url}[specifications]. This API defines mostly
 annotations that improve application robustness by providing support to conveniently handle
@@ -51,6 +51,9 @@ executor:
 scheduled-executor:
   core-pool-size: 8
 ----
+
+NOTE: There is currently _no support_ to configure these executor properties via a
+`microprofile-config.properties` file.
 
 The complete set of properties available to configure these executors is in
 {executor-config}[ServerThreadPoolSupplier] and

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -70,6 +70,10 @@ public class FaultToleranceExtension implements Extension {
 
     private Set<BeanMethod> registeredMethods;
 
+    private ThreadPoolSupplier threadPoolSupplier;
+
+    private ScheduledThreadPoolSupplier scheduledThreadPoolSupplier;
+
     /**
      * A bean method class that pairs a class and a method.
      */
@@ -267,16 +271,18 @@ public class FaultToleranceExtension implements Extension {
 
         // Initialize executors for MP FT - default size of 16
         io.helidon.config.Config config = io.helidon.config.Config.create();
-        FaultTolerance.scheduledExecutor(ScheduledThreadPoolSupplier.builder()
+        scheduledThreadPoolSupplier = ScheduledThreadPoolSupplier.builder()
                 .threadNamePrefix("ft-mp-schedule-")
                 .corePoolSize(16)
                 .config(config.get("scheduled-executor"))
-                .build());
-        FaultTolerance.executor(ThreadPoolSupplier.builder()
+                .build();
+        FaultTolerance.scheduledExecutor(scheduledThreadPoolSupplier);
+        threadPoolSupplier = ThreadPoolSupplier.builder()
                 .threadNamePrefix("ft-mp-")
                 .corePoolSize(16)
                 .config(config.get("executor"))
-                .build());
+                .build();
+        FaultTolerance.executor(threadPoolSupplier);
     }
 
     /**
@@ -320,6 +326,24 @@ public class FaultToleranceExtension implements Extension {
                 || MethodAntn.isAnnotationPresent(beanClass, method, Timeout.class)
                 || MethodAntn.isAnnotationPresent(beanClass, method, Asynchronous.class)
                 || MethodAntn.isAnnotationPresent(beanClass, method, Fallback.class);
+    }
+
+    /**
+     * Access {@code ThreadPoolSupplier} configured by this extension.
+     *
+     * @return a thread pool supplier.
+     */
+    public ThreadPoolSupplier threadPoolSupplier() {
+        return threadPoolSupplier;
+    }
+
+    /**
+     * Access {@code ScheduledThreadPoolSupplier} configured by this extension.
+     *
+     * @return a scheduled thread pool supplier.
+     */
+    public ScheduledThreadPoolSupplier scheduledThreadPoolSupplier() {
+        return scheduledThreadPoolSupplier;
     }
 
     /**

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/ThreadPoolConfigTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/ThreadPoolConfigTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Tests to verify that the default thread pool sizes can be set via config.
+ * Default size for the pools in MPT FT is 16, but the application.yaml file
+ * in this test directory sets it to 8.
+ *
+ * See {@code test/resources/application.yaml}.
+ */
+public class ThreadPoolConfigTest extends FaultToleranceTest {
+
+    private final FaultToleranceExtension extension;
+
+    public ThreadPoolConfigTest() {
+        extension = CDI.current().getBeanManager().getExtension(FaultToleranceExtension.class);
+    }
+
+    @Test
+    public void testThreadPoolDefaultSize() {
+        assertThat(extension.threadPoolSupplier().corePoolSize(), is(8));
+
+    }
+
+    @Test
+    public void testScheduledThreadPool() {
+        assertThat(extension.scheduledThreadPoolSupplier().corePoolSize(), is(8));
+    }
+}

--- a/microprofile/fault-tolerance/src/test/resources/application.yaml
+++ b/microprofile/fault-tolerance/src/test/resources/application.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+executor:
+  core-pool-size: 8
+
+scheduled-executor:
+  core-pool-size: 8


### PR DESCRIPTION
Updates Fault Tolerance MP docs with config information for new implementation. Created a couple of new tests to verify that thread pool sizes can be configured using an `application.yaml` file.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>