### PR TITLE
Third party license file updates

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,3 +1,4 @@
+Third Party Attributions
 
 The following software (or subsets of the software) are dependencies
 of this product. They are identified by the Helidon module(s) that use

--- a/etc/THIRD_PARTY_LICENSES.xml
+++ b/etc/THIRD_PARTY_LICENSES.xml
@@ -1,25 +1,16 @@
-
-The following software (or subsets of the software) are dependencies
-of this product. They are identified by the Helidon module(s) that use
-them.
-
-The first section ("Third Party Runtime Dependencies") contains dependencies
-that might be used at runtime by a Helidon application.
-
-The second section ("Third Party Attributions for Examples, Tests, Builds, etc")
-contains dependencies that are used in examples and to test and build Helidon.
-They are likely not needed at runtime by a Helidon application.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Third Party Runtime Dependencies
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Brave OpenTracing Java Bridge for Zipkin 0.35.0 The OpenZipkin Authors
-Apache 2.0
-Used by: [helidon-tracing-zipkin]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Zipkin OpenTracing Brave (io.opentracing.brave:brave-opentracing)
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<attribution-document>
+    <dependencies>
+        <dependency>
+            <id>71839</id>
+            <name>Brave OpenTracing Java Bridge for Zipkin</name>
+            <version>0.35.0</version>
+            <licensor>The OpenZipkin Authors</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-tracing-zipkin</consumer>
+            </consumers>
+            <attribution>Zipkin OpenTracing Brave (io.opentracing.brave:brave-opentracing)
   Copyright 2016-2019 The OpenZipkin Authors
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -30,13 +21,18 @@ io.zipkin.brave:brave
 Copyright 2013-2019 The OpenZipkin Authors
 Apache License Version 2.0
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Dropwizard Metrics 4.1.2 Coda Hale and Yammer, Inc.
-Apache 2.0
-Used by: [helidon-dbclient-metrics-jdbc]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
+</attribution>
+        </dependency>
+        <dependency>
+            <id>76789</id>
+            <name>Dropwizard Metrics</name>
+            <version>4.1.2</version>
+            <licensor>Coda Hale and Yammer, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-dbclient-metrics-jdbc</consumer>
+            </consumers>
+            <attribution>Copyright 2010-2013 Coda Hale and Yammer, Inc., 2014-2017 Dropwizard Team
 
 This product includes software developed by Coda Hale and Yammer, Inc.
 
@@ -55,7 +51,7 @@ SLF4J
   Copyright (c) 2004-2019 QOS.ch
 The MIT License SPDX short identifier: MIT
  
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
  
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -72,13 +68,20 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Eclipse Yasson 1.0.8 Eclipse Foundation
-Multiple Licenses
-Used by: [helidon-media-jsonb, helidon-microprofile, helidon-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</attribution>
+        </dependency>
+        <dependency>
+            <id>84155</id>
+            <name>Eclipse Yasson</name>
+            <version>1.0.8</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Multiple Licenses</licenseName>
+            <consumers>
+                <consumer>helidon-media-jsonb</consumer>
+                <consumer>helidon-microprofile</consumer>
+                <consumer>helidon-openapi</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/yasson.git.  (The EPL license is reproduced below).
 2.  All past Contributors to Yasson disclaim all warranties and conditions, express and
     implied, including warranties or conditions of title and non-infringement, and
@@ -193,13 +196,18 @@ Fourth Party Dependencies
 "JSON-P Default Provider" (org.glassfish:jakarta.json)
   Copyright (c) 2011,2019 Oracle and/or its affiliates. All rights reserved.
   Multi License: Eclipse Public License - v 2.0, GPL Version 2 + CPE
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-EclipseLink 2.7.5 Eclipse Foundation
-Multiple Licenses
-Used by: [helidon-integrations-cdi-eclipselink]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-  Copyright (c) 1998,2019 Oracle and/or its affiliates. All rights reserved.
+</attribution>
+        </dependency>
+        <dependency>
+            <id>82058</id>
+            <name>EclipseLink</name>
+            <version>2.7.5</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Multiple Licenses</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-eclipselink</consumer>
+            </consumers>
+            <attribution>  Copyright (c) 1998,2019 Oracle and/or its affiliates. All rights reserved.
   Copyright (c) 1998,2018 Oracle and/or its affiliates, IBM Corporation. All rights reserved.
   Copyright (c) 1998,2018 IBM and/or its affiliates. All rights reserved.
   Copyright (c) 2000, 2015 -2011 INRIA, France Telecom
@@ -289,13 +297,18 @@ Fourth Party Dependencies
   Eclipse Public License - 2.0
   Eclipse Distribution License - v 1.0 
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Google APIs Client Library for Java 1.30.5 Google Inc
-Apache 2.0
-Used by: [helidon-security-providers-google-login]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Google APIs Client Library for Java (com.google.api-client:google-api-client)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71336</id>
+            <name>Google APIs Client Library for Java</name>
+            <version>1.30.5</version>
+            <licensor>Google Inc</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-security-providers-google-login</consumer>
+            </consumers>
+            <attribution>Google APIs Client Library for Java (com.google.api-client:google-api-client)
   Copyright 2010,2015 Google Inc.
   Copyright 2015, Google Inc. All rights reserved.
 --------------------------------------------
@@ -309,7 +322,7 @@ Fourth Party Dependencies
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -389,13 +402,18 @@ Copyright (c) Tatu Saloranta, tatu.saloranta@iki.fi
   Apache License Version 2
 --------------------------------------------
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Guava 28.1 Google
-Apache 2.0
-Used by: [helidon-security-providers-google-login]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-google guava v28.1
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71656</id>
+            <name>Guava</name>
+            <version>28.1</version>
+            <licensor>Google</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-security-providers-google-login</consumer>
+            </consumers>
+            <attribution>google guava v28.1
 
 COPYRIGHT: Copyright (C) 2008 The Guava Authors
 
@@ -560,13 +578,18 @@ Fourth Party Dependency Copyright :
 Copyright (C) 2011 Google Inc. * * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except * in compliance with the License. You may obtain a copy of the License at * * http://www.apache.org/licenses/LICENSE-2.0 * * Unless required by applicable law or agreed to in writing, software distributed under the License * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express * or implied. See the License for the specific language governing permissions and limitations under * the License.
    
    
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-H2 1.4.199 h2database.com
-Multiple Licenses
-Used by: [h2]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>72082</id>
+            <name>H2</name>
+            <version>1.4.199</version>
+            <licensor>h2database.com</licensor>
+            <licenseName>Multiple Licenses</licenseName>
+            <consumers>
+                <consumer>h2</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     http://www.h2database.com (The EPL license is reproduced below).
 2.  All past Contributors to H2 disclaim all warranties and conditions, express and
     implied, including warranties or conditions of title and non-infringement, and
@@ -582,13 +605,18 @@ com.h2database » h2 1.4.199
 COPYRIGHT:
 Copyright 2004-2019 H2 Group.
 License Identifier: EPL-1.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Hibernate ORM 5.4.18.Final Red Hat, Inc.
-LGPL v.2.1
-Used by: [helidon-integrations-cdi-hibernate]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Hibernate ORM
+</attribution>
+        </dependency>
+        <dependency>
+            <id>83110</id>
+            <name>Hibernate ORM</name>
+            <version>5.4.18.Final</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>LGPL v.2.1</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-hibernate</consumer>
+            </consumers>
+            <attribution>Hibernate ORM
 
 Copyright (c) 2008, Red Hat Middleware LLC or third-party contributors as
 indicated by the @author tags or express copyright attribution
@@ -628,14 +656,14 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
+    * Neither the name of the &lt;organization&gt; nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DISCLAIMED. IN NO EVENT SHALL &lt;COPYRIGHT HOLDER&gt; BE LIABLE FOR ANY
 DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
 LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
@@ -769,13 +797,20 @@ Byte Buddy (net.bytebuddy:byte-buddy)
  * limitations under the License.
  */
 ---------------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-HikariCP 3.4.1 Zaxxer.com
-Apache 2.0
-Used by: [helidon-dbclient-jdbc, helidon-dbclient-metrics-jdbc, helidon-integrations-cdi-datasource-hikaricp]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-3rd Party Name : HikariCP
+</attribution>
+        </dependency>
+        <dependency>
+            <id>72000</id>
+            <name>HikariCP</name>
+            <version>3.4.1</version>
+            <licensor>Zaxxer.com</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-dbclient-jdbc</consumer>
+                <consumer>helidon-dbclient-metrics-jdbc</consumer>
+                <consumer>helidon-integrations-cdi-datasource-hikaricp</consumer>
+            </consumers>
+            <attribution>3rd Party Name : HikariCP
 3rd Party License : Apache 2.0
 
 3rd Party Copyright:
@@ -804,7 +839,7 @@ SLF4J source code and binaries are distributed under the MIT license.
 
 Begin license text.
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -838,13 +873,18 @@ SLF4j 1.7.28 - CopyRight
  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-HttpComponents HttpClient 4.5.10 Apache
-Apache 2.0
-Used by: [helidon-security-providers-google-login]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Apache HttpComponents HttpClient 4.5.8
+  </attribution>
+        </dependency>
+        <dependency>
+            <id>71771</id>
+            <name>HttpComponents HttpClient</name>
+            <version>4.5.10</version>
+            <licensor>Apache</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-security-providers-google-login</consumer>
+            </consumers>
+            <attribution>Apache HttpComponents HttpClient 4.5.8
 Copyright: Copyright 1999-2019 The Apache Software Foundation
 LICENSE: Apache 2.0
 License Identifier: Apache-2.0
@@ -887,10 +927,10 @@ LICENSE: Apache 2.0 https://github.com/apache/commons-logging/blob/LOGGING_1_2/L
 =========================================================================
 
 This project includes Public Suffix List copied from
-<https://publicsuffix.org/list/effective_tld_names.dat>
+&lt;https://publicsuffix.org/list/effective_tld_names.dat&gt;
 licensed under the terms of the Mozilla Public License, v. 2.0
 
-Full license text: <http://mozilla.org/MPL/2.0/>
+Full license text: &lt;http://mozilla.org/MPL/2.0/&gt;
 License Identifier: MPL-2.0
 ==============================================================================
 Fourth Party Dependency  Name : ehcache-core
@@ -978,13 +1018,18 @@ Fourth Party Dependency Copyright : Copyright
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-JBoss Transaction SPI 7.6.0.Final Red Hat Middleware LLC
-LGPL v.2.1
-Used by: [helidon-integrations-cdi-jta]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-You are receiving a copy of JBoss Transaction SPI in both source and object code
+</attribution>
+        </dependency>
+        <dependency>
+            <id>77883</id>
+            <name>JBoss Transaction SPI</name>
+            <version>7.6.0.Final</version>
+            <licensor>Red Hat Middleware LLC</licensor>
+            <licenseName>LGPL v.2.1</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+            </consumers>
+            <attribution>You are receiving a copy of JBoss Transaction SPI in both source and object code
 in the following JAR (identify the JAR jboss-transaction-spi-7.6.0.Final.jar). The
 terms of the Oracle license do NOT apply to the JBoss Transaction SPI program;
 it is licensed under the following license, separately from the Oracle programs you receive. 
@@ -1038,130 +1083,135 @@ Copyright 2016, Red Hat, Inc., and individual contributors
 Copyright 2017, Red Hat, Inc., and individual contributors
 Apache License, version 2.0
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-JGit 4.9.9.201903122025-r Eclipse Foundation
-Eclipse Distribution License 1.0
-Used by: [helidon-config-git]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-JGit (org.eclipse.jgit:org.eclipse.jgit)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71923</id>
+            <name>JGit</name>
+            <version>4.9.9.201903122025-r</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Distribution License 1.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-git</consumer>
+            </consumers>
+            <attribution>JGit (org.eclipse.jgit:org.eclipse.jgit)
   Copyright (C) 2011,2013 Google Inc., and others.
-  Copyright (C) 2010, 2013, Mathias Kinzler <mathias.kinzler@sap.com>
-  Copyright (C) 2015, Ivan Motsch <ivan.motsch@bsiag.com>
-  Copyright (C) 2010, Matt Fischer <matt.fischer@garmin.com>
-  Copyright (C) 2006- 2007, Shawn O. Pearce <spearce@spearce.org>
-  Copyright (C) 2009, Alex Blewitt <alex.blewitt@gmail.com>
-  Copyright (C) 2009,2010 Constantine Plotnikov <constantine.plotnikov@gmail.com>
-  Copyright (C) 2010, Chrisian Halstrick <christian.halstrick@sap.com> and
-  Copyright (C) 2011, Stefan Lay <stefan.lay@.com>
+  Copyright (C) 2010, 2013, Mathias Kinzler &lt;mathias.kinzler@sap.com&gt;
+  Copyright (C) 2015, Ivan Motsch &lt;ivan.motsch@bsiag.com&gt;
+  Copyright (C) 2010, Matt Fischer &lt;matt.fischer@garmin.com&gt;
+  Copyright (C) 2006- 2007, Shawn O. Pearce &lt;spearce@spearce.org&gt;
+  Copyright (C) 2009, Alex Blewitt &lt;alex.blewitt@gmail.com&gt;
+  Copyright (C) 2009,2010 Constantine Plotnikov &lt;constantine.plotnikov@gmail.com&gt;
+  Copyright (C) 2010, Chrisian Halstrick &lt;christian.halstrick@sap.com&gt; and
+  Copyright (C) 2011, Stefan Lay &lt;stefan.lay@.com&gt;
   Copyright (C) 2018, Google LLC.
-  Copyright (C) 2008, Imran M Yousuf <imyousuf@smartitengineering.com>
-  Copyright (C) 2015, Patrick Steinhardt <ps@pks.im>
-  Copyright (C) 2010, Jens Baumgart <jens.baumgart@sap.com>
-  Copyright (C) 2014, Axel Richard <axel.richard@obeo.fr>
-  Copyright (C) 2011, Abhishek Bhatnagar <abhatnag@redhat.com>
-  Copyright (C) 2008, Mike Ralphson <mike@abacus.co.uk>
-  Copyright (C) 2009, Mykola Nikishov <mn@mn.com.ua>
+  Copyright (C) 2008, Imran M Yousuf &lt;imyousuf@smartitengineering.com&gt;
+  Copyright (C) 2015, Patrick Steinhardt &lt;ps@pks.im&gt;
+  Copyright (C) 2010, Jens Baumgart &lt;jens.baumgart@sap.com&gt;
+  Copyright (C) 2014, Axel Richard &lt;axel.richard@obeo.fr&gt;
+  Copyright (C) 2011, Abhishek Bhatnagar &lt;abhatnag@redhat.com&gt;
+  Copyright (C) 2008, Mike Ralphson &lt;mike@abacus.co.uk&gt;
+  Copyright (C) 2009, Mykola Nikishov &lt;mn@mn.com.ua&gt;
   Copyright (C) 2008-2011 2012, Google Inc.
-  Copyright (C) 2008- 2009, Shawn O. Pearce <spearce@spearce.org>
-  Copyright (C) 2014 Laurent Goujon <lgoujon@twitter.com>
-  Copyright (C) 2011- 2013, Chris Aniszczyk <caniszczyk@gmail.com>
-  Copyright (C) 2009,2017 Christian Halstrick <christian.halstrick@sap.com>
-  Copyright (C) 2010- 2012, Christian Halstrick <christian.halstrick@sap.com>
-  Copyright (C) 2014, André de Oliveira <andre.oliveira@liferay.com>
-  Copyright (C) 2010,2013 Stefan Lay <stefan.lay@sap.com> and
-  Copyright (C) 2008,2009 Jonas Fonseca <fonseca@diku.dk>
-  Copyright (C) 2010, Chris Aniszczyk <caniszczyk@gmail.com> and
-  Copyright (C) 2009, Mark Struberg <struberg@yahoo.de>
-  Copyright (C) 2013,2014 Gustaf Lundh <gustaf.lundh@sonymobile.com>
+  Copyright (C) 2008- 2009, Shawn O. Pearce &lt;spearce@spearce.org&gt;
+  Copyright (C) 2014 Laurent Goujon &lt;lgoujon@twitter.com&gt;
+  Copyright (C) 2011- 2013, Chris Aniszczyk &lt;caniszczyk@gmail.com&gt;
+  Copyright (C) 2009,2017 Christian Halstrick &lt;christian.halstrick@sap.com&gt;
+  Copyright (C) 2010- 2012, Christian Halstrick &lt;christian.halstrick@sap.com&gt;
+  Copyright (C) 2014, André de Oliveira &lt;andre.oliveira@liferay.com&gt;
+  Copyright (C) 2010,2013 Stefan Lay &lt;stefan.lay@sap.com&gt; and
+  Copyright (C) 2008,2009 Jonas Fonseca &lt;fonseca@diku.dk&gt;
+  Copyright (C) 2010, Chris Aniszczyk &lt;caniszczyk@gmail.com&gt; and
+  Copyright (C) 2009, Mark Struberg &lt;struberg@yahoo.de&gt;
+  Copyright (C) 2013,2014 Gustaf Lundh &lt;gustaf.lundh@sonymobile.com&gt;
   Copyright (C) 2009, Google, Inc.
-  Copyright (C) 2008, Charles O'Farrell <charleso@charleso.org>
+  Copyright (C) 2008, Charles O'Farrell &lt;charleso@charleso.org&gt;
   Copyright (C) 2009,2013 Robin Rosenberg
-  Copyright (C) 2009, Vasyl' Vavrychuk <vvavrychuk@gmail.com>
-  Copyright (C) 2008, Roger C. Soares <rogersoares@intelinet.com.br>
-  Copyright (C) 2007-2008 2009, Robin Rosenberg <robin.rosenberg@dewire.com>
-  Copyright (C) 2010,2015 Christian Halstrick <christian.halstrick@sap.com> and
-  Copyright (C) 2011,2014 Robin Stocker <robin@nibor.org>
+  Copyright (C) 2009, Vasyl' Vavrychuk &lt;vvavrychuk@gmail.com&gt;
+  Copyright (C) 2008, Roger C. Soares &lt;rogersoares@intelinet.com.br&gt;
+  Copyright (C) 2007-2008 2009, Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
+  Copyright (C) 2010,2015 Christian Halstrick &lt;christian.halstrick@sap.com&gt; and
+  Copyright (C) 2011,2014 Robin Stocker &lt;robin@nibor.org&gt;
   Copyright (C) 2015,2017 Ericsson
-  Copyright (C) 2008, Thad Hughes <thadh@thad.corp.google.com>
-  Copyright (C) 2009,2017 Matthias Sohn <matthias.sohn@sap.com>
-  Copyright (C) 2010- 2014, Stefan Lay <stefan.lay@sap.com>
-  Copyright (C) 2016, Laurent Delaigue <laurent.delaigue@obeo.fr>
-  Copyright (C) 2011, Tomasz Zarna <Tomasz.Zarna@pl.ibm.com>
+  Copyright (C) 2008, Thad Hughes &lt;thadh@thad.corp.google.com&gt;
+  Copyright (C) 2009,2017 Matthias Sohn &lt;matthias.sohn@sap.com&gt;
+  Copyright (C) 2010- 2014, Stefan Lay &lt;stefan.lay@sap.com&gt;
+  Copyright (C) 2016, Laurent Delaigue &lt;laurent.delaigue@obeo.fr&gt;
+  Copyright (C) 2011, Tomasz Zarna &lt;Tomasz.Zarna@pl.ibm.com&gt;
   Copyright (C) 2013, CloudBees, Inc.
   Copyright (c) 2014, Konrad Kügler
   Copyright (C) 2012- 2013, Robin Rosenberg
-  Copyright 2017 Marc Stevens <marc@marc-stevens.nl>, Dan Shumow <danshu@microsoft.com>
-  Copyright (C) 2010-2011 2012, Robin Stocker <robin@nibor.org>
-  Copyright (C) 2006,2015 Shawn O. Pearce <spearce@spearce.org>
+  Copyright 2017 Marc Stevens &lt;marc@marc-stevens.nl&gt;, Dan Shumow &lt;danshu@microsoft.com&gt;
+  Copyright (C) 2010-2011 2012, Robin Stocker &lt;robin@nibor.org&gt;
+  Copyright (C) 2006,2015 Shawn O. Pearce &lt;spearce@spearce.org&gt;
   Copyright (C) 2008- 2011, Google Inc.
   Copyright (C) 2010,2017 Red Hat Inc.
-  Copyright (C) 2009, Tor Arne Vestbø <torarnv@gmail.com>
-  Copyright (C) 2011, Philipp Thun <philipp.thun@sap.com>
-  Copyright (C) 2014, Arthur Daussy <arthur.daussy@obeo.fr>
-  Copyright (C) 2011, Roberto Tyley <roberto.tyley@gmail.com>
+  Copyright (C) 2009, Tor Arne Vestbø &lt;torarnv@gmail.com&gt;
+  Copyright (C) 2011, Philipp Thun &lt;philipp.thun@sap.com&gt;
+  Copyright (C) 2014, Arthur Daussy &lt;arthur.daussy@obeo.fr&gt;
+  Copyright (C) 2011, Roberto Tyley &lt;roberto.tyley@gmail.com&gt;
   Copyright (C) 2008,2017 Google Inc.
   Copyright (C) 2017 Two Sigma Open Source
-  Copyright (C) 2010, Mathias Kinzler <mathias.kinzler@sap.com> and
-  Copyright (C) 2009,2013 Sasa Zivkov <sasa.zivkov@sap.com>
+  Copyright (C) 2010, Mathias Kinzler &lt;mathias.kinzler@sap.com&gt; and
+  Copyright (C) 2009,2013 Sasa Zivkov &lt;sasa.zivkov@sap.com&gt;
   Copyright (C) 2008- 2009, Google Inc.
   Copyright (C) 2011, GEBIT Solutions
-  Copyright (C) 2008, Marek Zawirski <marek.zawirski@gmail.com>
-  Copyright (C) 2008, Florian Köberle <florianskarten@web.de>
-  Copyright (C) 2012, Daniel Megert <daniel_megert@ch.ibm.com>
+  Copyright (C) 2008, Marek Zawirski &lt;marek.zawirski@gmail.com&gt;
+  Copyright (C) 2008, Florian Köberle &lt;florianskarten@web.de&gt;
+  Copyright (C) 2012, Daniel Megert &lt;daniel_megert@ch.ibm.com&gt;
   Copyright (C) 2008-2010 2013, Google Inc.
-  Copyright (C) 2015, Ivan Motsch <ivan.motsch@bsiag.com>,
-  Copyright (C) 2006- 2017, Shawn O. Pearce <spearce@spearce.org>
+  Copyright (C) 2015, Ivan Motsch &lt;ivan.motsch@bsiag.com&gt;,
+  Copyright (C) 2006- 2017, Shawn O. Pearce &lt;spearce@spearce.org&gt;
   Copyright (C) 2013, Gunnar Wagenknecht
   Copyright (C) 2011,2012 Google Inc. and others.
   Copyright (C) 2010, Garmin International
-  Copyright (C) 2011, Chris Aniszczyk <zx@redhat.com>
+  Copyright (C) 2011, Chris Aniszczyk &lt;zx@redhat.com&gt;
   Copyright (C) 2008- 2016, Google Inc.
   Copyright (C) 2011,2012 IBM Corporation and others.
-  Copyright (C) 2008, Shawn O. Pearce <spearce@spearce.org>,
-  Copyright (C) 2009, Robin Rosenberg <robin.rosenberg@gmail.com>
-  Copyright (C) 2006-2007 2008, Robin Rosenberg <robin.rosenberg@dewire.com>
-  Copyright (C) 2014,2017 Andrey Loskutov <loskutov@gmx.de>
-  Copyright (C) 2008- 2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
-  Copyright (C) 2010, Stefan Lay <stefan.lay@sap.com>
+  Copyright (C) 2008, Shawn O. Pearce &lt;spearce@spearce.org&gt;,
+  Copyright (C) 2009, Robin Rosenberg &lt;robin.rosenberg@gmail.com&gt;
+  Copyright (C) 2006-2007 2008, Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
+  Copyright (C) 2014,2017 Andrey Loskutov &lt;loskutov@gmx.de&gt;
+  Copyright (C) 2008- 2009, Johannes E. Schindelin &lt;johannes.schindelin@gmx.de&gt;
+  Copyright (C) 2010, Stefan Lay &lt;stefan.lay@sap.com&gt;
   Copyright (C) 2007 The Guava Authors
-  Copyright (C) 2007,2013 Robin Rosenberg <robin.rosenberg@dewire.com>
-  Copyright (C) 2008, Florian Koeberle <florianskarten@web.de>
-  Copyright (C) 2006-2007 2010, Robin Rosenberg <robin.rosenberg@dewire.com>
-  Copyright (C) 2010,2013 Mathias Kinzler <mathias.kinzler@sap.com>
-  Copyright (C) 2012,2016 Matthias Sohn <matthias.sohn@sap.com> and
-  Copyright (C) 2007, Dave Watson <dwatson@mimvista.com>
+  Copyright (C) 2007,2013 Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
+  Copyright (C) 2008, Florian Koeberle &lt;florianskarten@web.de&gt;
+  Copyright (C) 2006-2007 2010, Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
+  Copyright (C) 2010,2013 Mathias Kinzler &lt;mathias.kinzler@sap.com&gt;
+  Copyright (C) 2012,2016 Matthias Sohn &lt;matthias.sohn@sap.com&gt; and
+  Copyright (C) 2007, Dave Watson &lt;dwatson@mimvista.com&gt;
   Copyright (C) 2008-2009 2010, Google Inc.
-  Copyright (C) 2015, Kaloyan Raev <kaloyan.r@zend.com>
-  Copyright (C) 2009, Yann Simon <yann.simon.fr@gmail.com>
-  Copyright (C) 2010- 2012, Matthias Sohn <matthias.sohn@sap.com>
+  Copyright (C) 2015, Kaloyan Raev &lt;kaloyan.r@zend.com&gt;
+  Copyright (C) 2009, Yann Simon &lt;yann.simon.fr@gmail.com&gt;
+  Copyright (C) 2010- 2012, Matthias Sohn &lt;matthias.sohn@sap.com&gt;
   Copyright (C) 2012 Christian Halstrick
   Copyright (C) 2012, Research In Motion Limited
-  Copyright (C) 2011, Christoph Brill <egore911@egore911.de>
-  Copyright (C) 2011, Ketan Padegaonkar <ketanpadegaonkar@gmail.com>
-  Copyright (C) 2010,2013 Marc Strapetz <marc.strapetz@syntevo.com>
+  Copyright (C) 2011, Christoph Brill &lt;egore911@egore911.de&gt;
+  Copyright (C) 2011, Ketan Padegaonkar &lt;ketanpadegaonkar@gmail.com&gt;
+  Copyright (C) 2010,2013 Marc Strapetz &lt;marc.strapetz@syntevo.com&gt;
   Copyright (C) 2008, 2017, Google Inc.
-  Copyright (C) 2011- 2013, Robin Rosenberg <robin.rosenberg@dewire.com>
-  Copyright (C) 2010,2017 Chris Aniszczyk <caniszczyk@gmail.com>
-  Copyright (C) 2006- 2008, Shawn O. Pearce <spearce@spearce.org>
+  Copyright (C) 2011- 2013, Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
+  Copyright (C) 2010,2017 Chris Aniszczyk &lt;caniszczyk@gmail.com&gt;
+  Copyright (C) 2006- 2008, Shawn O. Pearce &lt;spearce@spearce.org&gt;
   Copyright (C) 2009,2010 JetBrains s.r.o.
   Copyright (C) 2011,2017 GitHub Inc.
-  Copyright (C) 2017, Thomas Wolf <thomas.wolf@paranor.ch>
+  Copyright (C) 2017, Thomas Wolf &lt;thomas.wolf@paranor.ch&gt;
   Copyright (C) 2017, Obeo (mathieu.cartaud@obeo.fr)
   Copyright (c) 2017:
-  Copyright (C) 2006- 2012, Shawn O. Pearce <spearce@spearce.org>
+  Copyright (C) 2006- 2012, Shawn O. Pearce &lt;spearce@spearce.org&gt;
   Copyright (C) 2014,2015 Obeo.
-  Copyright (C) 2017, David Pursehouse <david.pursehouse@gmail.com>
-  Copyright (C) 2010, Christian Halstrick <christian.halstrick@sap.com>,
-  Copyright (C) 2009, Johannes Schindelin <johannes.schindelin@gmx.de>
-  Copyright (C) 2014, Alexey Kuznetsov <axet@me.com>
-  Copyright (C) 2014, Sasa Zivkov <sasa.zivkov@sap.com>, SAP AG
+  Copyright (C) 2017, David Pursehouse &lt;david.pursehouse@gmail.com&gt;
+  Copyright (C) 2010, Christian Halstrick &lt;christian.halstrick@sap.com&gt;,
+  Copyright (C) 2009, Johannes Schindelin &lt;johannes.schindelin@gmx.de&gt;
+  Copyright (C) 2014, Alexey Kuznetsov &lt;axet@me.com&gt;
+  Copyright (C) 2014, Sasa Zivkov &lt;sasa.zivkov@sap.com&gt;, SAP AG
   Copyright (C) 2011, 2012, IBM Corporation and others.
-  Copyright (C) 2008, Robin Rosenberg <robin.rosenberg.lists@dewire.com>
-  Copyright (C) 2017, Wim Jongman <wim.jongman@remainsoftware.com>
-  Copyright (C) 2016, Mark Ingram <markdingram@gmail.com>
-  Copyright (C) 2009, Igor Fedorenko <igor@ifedorenko.com>
-  Copyright (C) 2006- 2007, Robin Rosenberg <robin.rosenberg@dewire.com>
+  Copyright (C) 2008, Robin Rosenberg &lt;robin.rosenberg.lists@dewire.com&gt;
+  Copyright (C) 2017, Wim Jongman &lt;wim.jongman@remainsoftware.com&gt;
+  Copyright (C) 2016, Mark Ingram &lt;markdingram@gmail.com&gt;
+  Copyright (C) 2009, Igor Fedorenko &lt;igor@ifedorenko.com&gt;
+  Copyright (C) 2006- 2007, Robin Rosenberg &lt;robin.rosenberg@dewire.com&gt;
 --------------------------------------------
 Eclipse Distribution License - v 1.0
 Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
@@ -1235,7 +1285,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -1278,13 +1328,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------
 License Identifier: Apache-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jaeger Tracing Client 1.1.0 The Jaeger Authors
-Apache 2.0
-Used by: [helidon-tracing-jaeger]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jaeger Tracing Client
+</attribution>
+        </dependency>
+        <dependency>
+            <id>72650</id>
+            <name>Jaeger Tracing Client</name>
+            <version>1.1.0</version>
+            <licensor>The Jaeger Authors</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-tracing-jaeger</consumer>
+            </consumers>
+            <attribution>Jaeger Tracing Client
   Copyright (c) 2018, The Jaeger Authors
   Apache License Version 2.0
 --------------------------------------------
@@ -1297,7 +1352,7 @@ Fourth Party Dependencies
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -1363,13 +1418,22 @@ Apache License Version 2.0
   Copyright 2017-2019 The OpenTracing Authors
   Apache License Version 2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Activation API (JAF) 1.2.2 Oracle
-Eclipse Distribution License 1.0
-Used by: [helidon-integrations-cdi-jpa, helidon-microprofile-fault-tolerance, helidon-microprofile-grpc-server, helidon-microprofile-metrics, helidon-microprofile-tracing]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80115</id>
+            <name>Jakarta Activation API (JAF)</name>
+            <version>1.2.2</version>
+            <licensor>Oracle</licensor>
+            <licenseName>Eclipse Distribution License 1.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+                <consumer>helidon-microprofile-grpc-server</consumer>
+                <consumer>helidon-microprofile-metrics</consumer>
+                <consumer>helidon-microprofile-tracing</consumer>
+            </consumers>
+            <attribution>Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
 --------------------------------------------
 This content is produced and maintained by Jakarta Activation project.
 
@@ -1430,13 +1494,35 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Annotations API 1.3.5 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-bundles-config, helidon-common-service-loader, helidon-config, helidon-config-hocon, helidon-config-mp, helidon-config-tests-module-mappers-1-base, helidon-config-tests-module-mappers-2-override, helidon-config-tests-module-parsers-1-override, helidon-config-tests-test-bundle, helidon-config-yaml, helidon-grpc-core, helidon-integrations-cdi-datasource, helidon-integrations-cdi-datasource-hikaricp, helidon-integrations-cdi-datasource-ucp, helidon-integrations-cdi-jpa, helidon-integrations-cdi-jta, helidon-microprofile-fault-tolerance, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80293</id>
+            <name>Jakarta Annotations API</name>
+            <version>1.3.5</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-bundles-config</consumer>
+                <consumer>helidon-common-service-loader</consumer>
+                <consumer>helidon-config</consumer>
+                <consumer>helidon-config-hocon</consumer>
+                <consumer>helidon-config-mp</consumer>
+                <consumer>helidon-config-tests-module-mappers-1-base</consumer>
+                <consumer>helidon-config-tests-module-mappers-2-override</consumer>
+                <consumer>helidon-config-tests-module-parsers-1-override</consumer>
+                <consumer>helidon-config-tests-test-bundle</consumer>
+                <consumer>helidon-config-yaml</consumer>
+                <consumer>helidon-grpc-core</consumer>
+                <consumer>helidon-integrations-cdi-datasource</consumer>
+                <consumer>helidon-integrations-cdi-datasource-hikaricp</consumer>
+                <consumer>helidon-integrations-cdi-datasource-ucp</consumer>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/common-annotations-api (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta Annotations API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -1489,13 +1575,40 @@ permitted.
 License Identifier: EPL-2.0
 -----------------------------------------------------------------------
 
-                  
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta CDI-API 2.0.2 Red Hat, Inc.
-Apache 2.0
-Used by: [helidon-integrations-cdi-datasource, helidon-integrations-cdi-datasource-hikaricp, helidon-integrations-cdi-datasource-ucp, helidon-integrations-cdi-delegates, helidon-integrations-cdi-eclipselink, helidon-integrations-cdi-hibernate, helidon-integrations-cdi-jedis, helidon-integrations-cdi-jpa, helidon-integrations-cdi-jta, helidon-integrations-cdi-jta-weld, helidon-integrations-cdi-oci-objectstorage, helidon-integrations-cdi-reference-counted-context, helidon-microprofile-config, helidon-microprofile-fault-tolerance, helidon-microprofile-grpc-client, helidon-microprofile-grpc-core, helidon-microprofile-grpc-metrics, helidon-microprofile-grpc-server, helidon-microprofile-metrics, helidon-microprofile-server, helidon-microprofile-tracing, helidon-microprofile-websocket, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2010, 2016, Red Hat, Inc., and individual contributors
+                  </attribution>
+        </dependency>
+        <dependency>
+            <id>79718</id>
+            <name>Jakarta CDI-API</name>
+            <version>2.0.2</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-datasource</consumer>
+                <consumer>helidon-integrations-cdi-datasource-hikaricp</consumer>
+                <consumer>helidon-integrations-cdi-datasource-ucp</consumer>
+                <consumer>helidon-integrations-cdi-delegates</consumer>
+                <consumer>helidon-integrations-cdi-eclipselink</consumer>
+                <consumer>helidon-integrations-cdi-hibernate</consumer>
+                <consumer>helidon-integrations-cdi-jedis</consumer>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+                <consumer>helidon-integrations-cdi-jta-weld</consumer>
+                <consumer>helidon-integrations-cdi-oci-objectstorage</consumer>
+                <consumer>helidon-integrations-cdi-reference-counted-context</consumer>
+                <consumer>helidon-microprofile-config</consumer>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+                <consumer>helidon-microprofile-grpc-client</consumer>
+                <consumer>helidon-microprofile-grpc-core</consumer>
+                <consumer>helidon-microprofile-grpc-metrics</consumer>
+                <consumer>helidon-microprofile-grpc-server</consumer>
+                <consumer>helidon-microprofile-metrics</consumer>
+                <consumer>helidon-microprofile-server</consumer>
+                <consumer>helidon-microprofile-tracing</consumer>
+                <consumer>helidon-microprofile-websocket</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>Copyright 2010, 2016, Red Hat, Inc., and individual contributors
   Copyright 2008,2018 Red Hat, Inc., and individual contributors
   Copyright  2019 Eclipse Foundation.
   Copyright 2010,2013 2015, Red Hat, Inc., and individual contributors
@@ -1545,23 +1658,23 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Dependency Injection" 1.0 (jakarta.inject:jakarta.inject-api)
   Copyright (C) 2009 The JSR-330 Expert Group
-  Copyright 2019 Eclipse Foundation.<br>
+  Copyright 2019 Eclipse Foundation.&lt;br&gt;
   Apache License Version 2
 --------------------------------------------
 "Jakarta Expression Language API" (jakarta.el:jakarta.el-api)
   Copyright (c) 1997,2018 Oracle and/or its affiliates and others.
-  Copyright 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   Copyright 2004 The Apache Software Foundation
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta Interceptors" (jakarta.interceptor:jakarta.interceptor-api)
   Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta Enterprise Beans" (jakarta.ejb:jakarta.ejb-api)
@@ -1867,8 +1980,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    &lt;one line to give the program's name and a brief idea of what it does.&gt;
+    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -1906,7 +2019,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
+  &lt;signature of Ty Coon&gt;, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into
@@ -1932,13 +2045,28 @@ based on this library.  If you modify this library, you may extend this
 exception to your version of the library, but you are not obligated to
 do so.  If you do not wish to do so, delete this exception statement
 from your version.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Dependency Injection API (@Inject) 1.0 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-grpc-core, helidon-integrations-cdi-datasource-hikaricp, helidon-integrations-cdi-datasource-ucp, helidon-jersey-client, helidon-jersey-connector, helidon-jersey-server, helidon-microprofile-config, helidon-security-integration-jersey, helidon-security-integration-jersey-client, helidon-security-providers-oidc, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Dependency Injection API (@Inject) (jakarta.inject:jakarta.inject-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>79716</id>
+            <name>Jakarta Dependency Injection API (@Inject)</name>
+            <version>1.0</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-grpc-core</consumer>
+                <consumer>helidon-integrations-cdi-datasource-hikaricp</consumer>
+                <consumer>helidon-integrations-cdi-datasource-ucp</consumer>
+                <consumer>helidon-jersey-client</consumer>
+                <consumer>helidon-jersey-connector</consumer>
+                <consumer>helidon-jersey-server</consumer>
+                <consumer>helidon-microprofile-config</consumer>
+                <consumer>helidon-security-integration-jersey</consumer>
+                <consumer>helidon-security-integration-jersey-client</consumer>
+                <consumer>helidon-security-providers-oidc</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>Jakarta Dependency Injection API (@Inject) (jakarta.inject:jakarta.inject-api)
   Copyright (C) 2009 The JSR-330 Expert Group
   Copyright 2019 Eclipse Foundation.
 --------------------------------------------
@@ -1972,13 +2100,19 @@ https://github.com/eclipse-ee4j/injection-api
 --------------------------------------------
 License Identifier: Apache-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Expression Language (EL) 3.0.3 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-security-abac-policy-el, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80294</id>
+            <name>Jakarta Expression Language (EL)</name>
+            <version>3.0.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-security-abac-policy-el</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/el-ri/ (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta EL disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2038,13 +2172,24 @@ permitted.
 License Identifier: EPL-2.0
 -------------------------------------------------------------------------
 
-                   
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Interceptors API 1.2.5 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile-access-log, helidon-microprofile-jwt-auth, helidon-microprofile-messaging, helidon-microprofile-openapi, helidon-microprofile-security, helidon-microprofile-server, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+                   </attribution>
+        </dependency>
+        <dependency>
+            <id>80465</id>
+            <name>Jakarta Interceptors API</name>
+            <version>1.2.5</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-access-log</consumer>
+                <consumer>helidon-microprofile-jwt-auth</consumer>
+                <consumer>helidon-microprofile-messaging</consumer>
+                <consumer>helidon-microprofile-openapi</consumer>
+                <consumer>helidon-microprofile-security</consumer>
+                <consumer>helidon-microprofile-server</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
      https://github.com/eclipse-ee4j/interceptor-api (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta Interceptors API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2096,13 +2241,19 @@ Fourth Party Dependencies
   Copyright (c) 1997,2018 Oracle and/or its affiliates. All rights reserved.
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta JSON Binding API (JSON-B) 1.0-1.0.2 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-grpc-core, helidon-microprofile]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80486</id>
+            <name>Jakarta JSON Binding API (JSON-B)</name>
+            <version>1.0-1.0.2</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-grpc-core</consumer>
+                <consumer>helidon-microprofile</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jsonb-api/api (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta JSON Binding API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2157,13 +2308,26 @@ Jakarta JSON Processing API (JSON-P) (jakarta.json:jakarta.json-api)
   Copyright (c) 2011,2019 Oracle and/or its affiliates. All rights reserved.
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Json Processing API (JSON-P) 1.1.6 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-dbclient-jsonp, helidon-dbclient-mongodb, helidon-graal-native-image-extension, helidon-media-jsonb, helidon-media-jsonp, helidon-microprofile-server, helidon-mp-graal-native-image-extension, helidon-openapi, helidon-security-jwt]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80492</id>
+            <name>Jakarta Json Processing API (JSON-P)</name>
+            <version>1.1.6</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-dbclient-jsonp</consumer>
+                <consumer>helidon-dbclient-mongodb</consumer>
+                <consumer>helidon-graal-native-image-extension</consumer>
+                <consumer>helidon-media-jsonb</consumer>
+                <consumer>helidon-media-jsonp</consumer>
+                <consumer>helidon-microprofile-server</consumer>
+                <consumer>helidon-mp-graal-native-image-extension</consumer>
+                <consumer>helidon-openapi</consumer>
+                <consumer>helidon-security-jwt</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jsonp/api (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta JSON Process API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2227,7 +2391,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "jakarta.ws.rs-api" (jakarta.ws.rs:jakarta.ws.rs-api)
@@ -2240,13 +2404,19 @@ Fourth Party Dependencies
   Copyright (c) 2011,2019 Oracle and/or its affiliates. All rights reserved.
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Persistence API (JPA API) 2.2.3 Eclipse Foundation
-Multiple Licenses
-Used by: [helidon-integrations-cdi-hibernate, helidon-integrations-cdi-jpa]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-  Copyright (c) 2008,2019 Oracle and/or its affiliates. All rights reserved.
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80848</id>
+            <name>Jakarta Persistence API (JPA API)</name>
+            <version>2.2.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Multiple Licenses</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-hibernate</consumer>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+            </consumers>
+            <attribution>  Copyright (c) 2008,2019 Oracle and/or its affiliates. All rights reserved.
   Copyright 2019 Eclipse Foundation. All rights reserved.
 
 Redistribution and use in source and binary forms, with or
@@ -2281,13 +2451,21 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Restful Web Services JAX-RS API 2.1.6 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile-cors, helidon-microprofile-rest-client, helidon-security-integration-jersey, helidon-security-integration-jersey-client]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80844</id>
+            <name>Jakarta Restful Web Services JAX-RS API</name>
+            <version>2.1.6</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-cors</consumer>
+                <consumer>helidon-microprofile-rest-client</consumer>
+                <consumer>helidon-security-integration-jersey</consumer>
+                <consumer>helidon-security-integration-jersey-client</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jaxrs-api (The EPL license is reproduced below).
 2.  All past Contributors to Jakarta RESTful Web Services disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2312,7 +2490,7 @@ Jakarta Activation API (JAF) (jakarta.activation:jakarta.activation-api)
 --------------------------------------------
 Jakarta XML Binding API (JAX-B) (jakarta.xml.bind:jakarta.xml.bind-api)
   Copyright (c) 2003,2020 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019, 2020 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019, 2020 Eclipse Foundation. All rights reserved.&lt;br&gt;
   Eclipse Distribution License - v 1.0
 
 Eclipse Distribution License - v 1.0
@@ -2352,13 +2530,22 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta Transactions API (JTA API) 1.3.3 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-integrations-cdi-eclipselink, helidon-integrations-cdi-hibernate, helidon-integrations-cdi-jpa, helidon-integrations-cdi-jta, helidon-integrations-cdi-jta-weld]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80846</id>
+            <name>Jakarta Transactions API (JTA API)</name>
+            <version>1.3.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-eclipselink</consumer>
+                <consumer>helidon-integrations-cdi-hibernate</consumer>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+                <consumer>helidon-integrations-cdi-jta-weld</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jta-api (The EPL license is reproduced below).
 2.  All past Contributors to Jakarta Transactions API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2383,13 +2570,19 @@ Jakarta Contexts and Dependency Injection API (CDI API) (jakarta.enterprise:jaka
   Apache License Version 2.0
 --------------------------------------------
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta WebSocket 1.1.2 Oracle
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile-websocket, helidon-webserver-tyrus]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>73016</id>
+            <name>Jakarta WebSocket</name>
+            <version>1.1.2</version>
+            <licensor>Oracle</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-websocket</consumer>
+                <consumer>helidon-webserver-tyrus</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/websocket-api (The EPL license is reproduced below).
 2.  All past Contributors to the Jakarta WebSocket API disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -2752,8 +2945,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    &lt;one line to give the program's name and a brief idea of what it does.&gt;
+    Copyright (C) &lt;year&gt;  &lt;name of author&gt;
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -2791,7 +2984,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
+  &lt;signature of Ty Coon&gt;, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into
@@ -2819,15 +3012,24 @@ do so.  If you do not wish to do so, delete this exception statement
 from your version.
 
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta XML Binding API (JAX-B) 2.3.3 Eclipse Foundation
-Eclipse Distribution License 1.0
-Used by: [helidon-integrations-cdi-jpa, helidon-jersey-client, helidon-jersey-connector, helidon-jersey-server, helidon-security-integration-jersey]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jakarta XML Binding API (JAX-B) (jakarta.xml.bind:jakarta.xml.bind-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>79723</id>
+            <name>Jakarta XML Binding API (JAX-B)</name>
+            <version>2.3.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Distribution License 1.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-jersey-client</consumer>
+                <consumer>helidon-jersey-connector</consumer>
+                <consumer>helidon-jersey-server</consumer>
+                <consumer>helidon-security-integration-jersey</consumer>
+            </consumers>
+            <attribution>Jakarta XML Binding API (JAX-B) (jakarta.xml.bind:jakarta.xml.bind-api)
   Copyright (c) 2003,2020 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019, 2020 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019, 2020 Eclipse Foundation. All rights reserved.&lt;br&gt;
 --------------------------------------------
 This content is produced and maintained by the Jakarta XML Binding
 project.
@@ -2910,13 +3112,18 @@ Fourth Party Dependencies
   Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
 Eclipse Distribution License - v 1.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jedis 3.1.0 Jonathan Leibiusky
-MIT
-Used by: [helidon-integrations-cdi-jedis]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Jedis (redis.clients:jedis)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71997</id>
+            <name>Jedis</name>
+            <version>3.1.0</version>
+            <licensor>Jonathan Leibiusky</licensor>
+            <licenseName>MIT</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jedis</consumer>
+            </consumers>
+            <attribution>Jedis (redis.clients:jedis)
 --------------------------------------------
 Copyright (c) 2010 Jonathan Leibiusky
 MIT
@@ -2954,13 +3161,27 @@ Fourth Party Dependencies
   Apache License Version 2.0
 License Identifier: Apache-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Config API 1.4 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-config-mp, helidon-integrations-cdi-datasource, helidon-integrations-cdi-datasource-hikaricp, helidon-integrations-cdi-datasource-ucp, helidon-integrations-cdi-jedis, helidon-integrations-cdi-oci-objectstorage, helidon-microprofile-cdi, helidon-microprofile-fault-tolerance, helidon-microprofile-health, helidon-microprofile-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Config API (org.eclipse.microprofile.config:microprofile-config-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>81151</id>
+            <name>MicroProfile Config API</name>
+            <version>1.4</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-mp</consumer>
+                <consumer>helidon-integrations-cdi-datasource</consumer>
+                <consumer>helidon-integrations-cdi-datasource-hikaricp</consumer>
+                <consumer>helidon-integrations-cdi-datasource-ucp</consumer>
+                <consumer>helidon-integrations-cdi-jedis</consumer>
+                <consumer>helidon-integrations-cdi-oci-objectstorage</consumer>
+                <consumer>helidon-microprofile-cdi</consumer>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+                <consumer>helidon-microprofile-health</consumer>
+                <consumer>helidon-microprofile-openapi</consumer>
+            </consumers>
+            <attribution>MicroProfile Config API (org.eclipse.microprofile.config:microprofile-config-api)
 Copyright (c) Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -2971,13 +3192,18 @@ Copyright (c) OSGi Alliance (2013, 2014). All Rights Reserved.
  Copyright (c) OSGi Alliance (2013). All Rights Reserved.
 Apache License Version 2.0
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Fault Tolerance API 2.1.1 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-microprofile-fault-tolerance]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-microProfile-fault-tolerance-api (org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>86016</id>
+            <name>MicroProfile Fault Tolerance API</name>
+            <version>2.1.1</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+            </consumers>
+            <attribution>microProfile-fault-tolerance-api (org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api)
   Copyright (c) 2017-2019 Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -2991,7 +3217,7 @@ PackageName: Eclipse Microprofile
 PackageHomePage: http://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
-PackageCopyrightText: <text>
+PackageCopyrightText: &lt;text&gt;
 Emily Jiang, emijiang@uk.ibm.com
 Neil Young, neil_young@uk.ibm.com
 Gordon Hutchison, Gordon.Hutchison@gmail.com
@@ -3001,7 +3227,7 @@ Tom Evans, tevans@uk.ibm.com
 Martin Kouba, mkouba@redhat.com
 Gaurav Gupta gaurav.gupta.jc@gmail.com
 Ondrej Mihalyi ondrej.mihalyi@gmail.com
-</text>
+&lt;/text&gt;
 --------------------------------------------
 Fourth Party Dependencies
 --------------------------------------------
@@ -3009,13 +3235,19 @@ Fourth Party Dependencies
   Copyright (c) OSGi Alliance (2013, 2014). All Rights Reserved.
   Copyright (c) OSGi Alliance (2013). All Rights Reserved.
 -------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Health API 2.2 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-health, helidon-microprofile-health]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Health API (org.eclipse.microprofile.health:microprofile-health-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>86012</id>
+            <name>MicroProfile Health API</name>
+            <version>2.2</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-health</consumer>
+                <consumer>helidon-microprofile-health</consumer>
+            </consumers>
+            <attribution>MicroProfile Health API (org.eclipse.microprofile.health:microprofile-health-api)
   Copyright (c) 2017,2019 Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -3029,22 +3261,27 @@ PackageName: Eclipse Microprofile
 PackageHomePage: http://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
-PackageCopyrightText: <text>
+PackageCopyrightText: &lt;text&gt;
 Heiko Braun hbraun@redhat.com
-</text>
+&lt;/text&gt;
 --------------------------------------------
 Fourth Party Dependencies
 --------------------------------------------
 "org.osgi:org.osgi.annotation.versioning" 1.0.0 (org.osgi:org.osgi.annotation.versioning)
   Copyright (c) OSGi Alliance (2013, 2014). All Rights Reserved.
   Copyright (c) OSGi Alliance (2013). All Rights Reserved.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile JWT Auth 1.1.1 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-microprofile-jwt-auth]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile JWT Auth API (org.eclipse.microprofile.jwt:microprofile-jwt-auth-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>55618</id>
+            <name>MicroProfile JWT Auth</name>
+            <version>1.1.1</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-jwt-auth</consumer>
+            </consumers>
+            <attribution>MicroProfile JWT Auth API (org.eclipse.microprofile.jwt:microprofile-jwt-auth-api)
   Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -3054,13 +3291,19 @@ License Identifier: Apache-2.0
   Copyright (c) OSGi Alliance (2013, 2014). All Rights Reserved.
   Copyright (c) OSGi Alliance (2013). All Rights Reserved.
 License Identifier: Apache-2.0
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Metrics API 2.3.2 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-metrics, helidon-microprofile-fault-tolerance]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Metrics API (org.eclipse.microprofile.metrics:microprofile-metrics-api)
+--------------------------------------------</attribution>
+        </dependency>
+        <dependency>
+            <id>86011</id>
+            <name>MicroProfile Metrics API</name>
+            <version>2.3.2</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-metrics</consumer>
+                <consumer>helidon-microprofile-fault-tolerance</consumer>
+            </consumers>
+            <attribution>MicroProfile Metrics API (org.eclipse.microprofile.metrics:microprofile-metrics-api)
     Copyright (c) 2017,2020 Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -3083,7 +3326,7 @@ PackageName: Eclipse Microprofile
 PackageHomePage: http://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
-PackageCopyrightText: <text>
+PackageCopyrightText: &lt;text&gt;
 Heiko Rupp hrupp@redhat.com,
 Raymond Lam lamr@ca.ibm.com,
 Brennan Nichyporuk brennan.nichyporuk@gmail.com,
@@ -3111,13 +3354,18 @@ MicroProfile Config API
 Copyright (c) Contributors to the Eclipse Foundation
 Apache License Version 2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile OpenAPI 1.1.2 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile OpenAPI
+</attribution>
+        </dependency>
+        <dependency>
+            <id>62787</id>
+            <name>MicroProfile OpenAPI</name>
+            <version>1.1.2</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-openapi</consumer>
+            </consumers>
+            <attribution>MicroProfile OpenAPI
   Copyright (c) 2017,2019 Contributors to the Eclipse Foundation
   Copyright (c) 2017 Contributors to the Eclipse Foundation
   Copyright 2017 SmartBear Software
@@ -3146,13 +3394,18 @@ License Identifier: Apache-2.0
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile OpenTracing API 1.3.3 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-microprofile-tracing]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile OpenTracing API (org.eclipse.microprofile.opentracing:microprofile-opentracing-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>86013</id>
+            <name>MicroProfile OpenTracing API</name>
+            <version>1.3.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-tracing</consumer>
+            </consumers>
+            <attribution>MicroProfile OpenTracing API (org.eclipse.microprofile.opentracing:microprofile-opentracing-api)
   Copyright (c) 2017,2019 Contributors to the Eclipse Foundation
   Copyright (c) 2017,2018 Contributors to the Eclipse Foundation
   Copyright (c) 2017 Contributors to the Eclipse Foundation
@@ -3168,10 +3421,10 @@ PackageName: Eclipse Microprofile
 PackageHomePage: http://www.eclipse.org/microprofile
 PackageLicenseDeclared: Apache-2.0
 
-PackageCopyrightText: <text>
+PackageCopyrightText: &lt;text&gt;
 Steve Fontes steve.m.fontes@gmail.com,
 Kevin Grigorenko kevin.grigorenko@us.ibm.com
-</text>
+&lt;/text&gt;
 
 --------------------------------------------
 Fourth Party Dependencies
@@ -3181,13 +3434,20 @@ OSGI Annotation Versioning 1.X
   Copyright (c) OSGi Alliance (2013). All Rights Reserved.
 Apache License Version 2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Reactive Messaging API and TCK 1.0 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-messaging, helidon-messaging-kafka, helidon-microprofile-messaging]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
- Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+</attribution>
+        </dependency>
+        <dependency>
+            <id>77085</id>
+            <name>MicroProfile Reactive Messaging API and TCK</name>
+            <version>1.0</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-messaging</consumer>
+                <consumer>helidon-messaging-kafka</consumer>
+                <consumer>helidon-microprofile-messaging</consumer>
+            </consumers>
+            <attribution> Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
 --------------------------------------------
 License Identifier: Apache-2.0
 --------------------------------------------
@@ -3570,7 +3830,7 @@ Further resources on the 2-clause BSD license
 Note: This license has also been called the "Simplified BSD License" and the
 "FreeBSD License". See also the 3-clause BSD License.
 
-Copyright <YEAR> <COPYRIGHT HOLDER>
+Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -3594,13 +3854,19 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Reactive Streams Operators 1.0.1 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-messaging, helidon-microprofile-reactive-streams]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Eclipse MicroProfile Reactive Streams Operators
+</attribution>
+        </dependency>
+        <dependency>
+            <id>75146</id>
+            <name>MicroProfile Reactive Streams Operators</name>
+            <version>1.0.1</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-messaging</consumer>
+                <consumer>helidon-microprofile-reactive-streams</consumer>
+            </consumers>
+            <attribution>Eclipse MicroProfile Reactive Streams Operators
   Copyright (c) 2018 Contributors to the Eclipse Foundation
 --------------------------------------------
 This product includes software developed at
@@ -3720,24 +3986,34 @@ understands and acknowledges that Creative Commons is not a party to this
 document and has no duty or obligation with respect to this CC0 or use of the
 Work.
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Rest Client 1.3.3 Eclipse Foundation
-Apache 2.0
-Used by: [helidon-microprofile-tracing]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Rest Client
+</attribution>
+        </dependency>
+        <dependency>
+            <id>70798</id>
+            <name>MicroProfile Rest Client</name>
+            <version>1.3.3</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-tracing</consumer>
+            </consumers>
+            <attribution>MicroProfile Rest Client
   Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
 Apache License  Version 2.0
 --------------------------------------------
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MongoDB ReactiveStreams Driver 1.11.0 MongoDB, Inc.
-Apache 2.0
-Used by: [helidon-dbclient-mongodb]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MongoDB Reactive Streams Driver (org.mongodb:mongodb-driver-reactivestreams)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>79719</id>
+            <name>MongoDB ReactiveStreams Driver</name>
+            <version>1.11.0</version>
+            <licensor>MongoDB, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-dbclient-mongodb</consumer>
+            </consumers>
+            <attribution>MongoDB Reactive Streams Driver (org.mongodb:mongodb-driver-reactivestreams)
   Copyright 2014,2017 MongoDB, Inc.
 --------------------------------------------
 Apache MongoDB-Java-Driver-Reactivestreams
@@ -3879,7 +4155,7 @@ Work.
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -3927,26 +4203,37 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGEN
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Narayana Transaction Processing 5.9.3.Final Red Hat, Inc.
-LGPL v.2.1
-Used by: [helidon-integrations-cdi-jta, helidon-integrations-cdi-jta-weld]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-You are receiving a copy of Narayana Transaction Processing in both source and
+</attribution>
+        </dependency>
+        <dependency>
+            <id>60783</id>
+            <name>Narayana Transaction Processing</name>
+            <version>5.9.3.Final</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>LGPL v.2.1</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+                <consumer>helidon-integrations-cdi-jta-weld</consumer>
+            </consumers>
+            <attribution>You are receiving a copy of Narayana Transaction Processing in both source and
 object code in the following JAR (org.jboss.narayana.jta;cdi.jar). The terms of
 the Oracle license do NOT apply to the Narayana Transaction Processing  program;
 it is licensed under the following license, separately from the Oracle programs
 you receive. 
 --------------------------------------------------------------------------------
 License Identifier: LGPL-2.1-only
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-OkHttp 3.14.1 Square, Inc.
-Apache 2.0
-Used by: [helidon-tracing-jaeger]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
- OkHttp (com.squareup.okhttp3:okhttp)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>66212</id>
+            <name>OkHttp</name>
+            <version>3.14.1</version>
+            <licensor>Square, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-tracing-jaeger</consumer>
+            </consumers>
+            <attribution> OkHttp (com.squareup.okhttp3:okhttp)
   Copyright (C) 2012,2019 Square, Inc.
   Copyright 2013 Twitter, Inc.
   Copyright (C) 2010,2012 The Android Open Source Project
@@ -3958,26 +4245,46 @@ Fourth Party Dependencies
   Copyright 2014 Square Inc.
   Copyright (C) 2014,2019 Square, Inc.
 Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-OpenTracing API for Java 0.33.0 Opentracing.Io
-Apache 2.0
-Used by: [helidon-dbclient-tracing, helidon-security, helidon-security-integration-jersey, helidon-tracing, helidon-tracing-jaeger, helidon-tracing-tracer-resolver, helidon-tracing-zipkin, helidon-webclient-tracing, helidon-webserver, helidon-webserver-jersey]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-opentracing-util: 0.33.0, Apache 2.0
+</attribution>
+        </dependency>
+        <dependency>
+            <id>76790</id>
+            <name>OpenTracing API for Java</name>
+            <version>0.33.0</version>
+            <licensor>Opentracing.Io</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-dbclient-tracing</consumer>
+                <consumer>helidon-security</consumer>
+                <consumer>helidon-security-integration-jersey</consumer>
+                <consumer>helidon-tracing</consumer>
+                <consumer>helidon-tracing-jaeger</consumer>
+                <consumer>helidon-tracing-tracer-resolver</consumer>
+                <consumer>helidon-tracing-zipkin</consumer>
+                <consumer>helidon-webclient-tracing</consumer>
+                <consumer>helidon-webserver</consumer>
+                <consumer>helidon-webserver-jersey</consumer>
+            </consumers>
+            <attribution>opentracing-util: 0.33.0, Apache 2.0
 opentracing-mock: 0.33.0, Apache 2.0
 opentracing-api: 0.33.0, Apache 2.0
 opentracing-noop: 0.33.0, Apache 2.0
 Copyright 2016-2019 The OpenTracing Authors
 ---------------------------------------------------------
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Project Tyrus 1.17 Oracle
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile-websocket, helidon-webserver-tyrus]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Tyrus 
+</attribution>
+        </dependency>
+        <dependency>
+            <id>85887</id>
+            <name>Project Tyrus</name>
+            <version>1.17</version>
+            <licensor>Oracle</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-websocket</consumer>
+                <consumer>helidon-webserver-tyrus</consumer>
+            </consumers>
+            <attribution>Tyrus 
   Copyright (c) 2007,2020 Oracle and/or its affiliates. All rights reserved.
 
 This content is produced and maintained by the Eclipse Tyrus project.
@@ -4090,13 +4397,18 @@ org.osgi.core
   Apache License, 2.0
 --------------------------------------------
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Prometheus Java Simpleclient 0.6.0 The Prometheus Authors
-Apache 2.0
-Used by: [helidon-metrics-prometheus]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Prometheus Simpleclient 0.6.0:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>64957</id>
+            <name>Prometheus Java Simpleclient</name>
+            <version>0.6.0</version>
+            <licensor>The Prometheus Authors</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-metrics-prometheus</consumer>
+            </consumers>
+            <attribution>Prometheus Simpleclient 0.6.0:
 Copyright 2012 Andrew Wang (andrew@umbrant.com)
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -4127,13 +4439,21 @@ Ocelli project by Netflix Inc. (https://github.com/Netflix/ocelli/).
 
 LICENSE: Apache 2.0
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Simple Logging Facade for Java (SLF4J) 1.7.26 QOS.ch
-MIT
-Used by: [helidon-microprofile-cdi, helidon-microprofile-grpc-metrics, helidon-microprofile-grpc-server, helidon-tracing-jaeger]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-SLF4J API Module (org.slf4j:slf4j-api)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>64618</id>
+            <name>Simple Logging Facade for Java (SLF4J)</name>
+            <version>1.7.26</version>
+            <licensor>QOS.ch</licensor>
+            <licenseName>MIT</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-cdi</consumer>
+                <consumer>helidon-microprofile-grpc-metrics</consumer>
+                <consumer>helidon-microprofile-grpc-server</consumer>
+                <consumer>helidon-tracing-jaeger</consumer>
+            </consumers>
+            <attribution>SLF4J API Module (org.slf4j:slf4j-api)
 SLF4J JDK14 Binding (org.slf4j:slf4j-jdk14)
 SLF4J Simple (org.slf4j:slf4j-simple)
 --------------------------------------------
@@ -4160,13 +4480,18 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-SmallRye OpenAPI 1.2.0 Red Hat, Inc.
-Apache 2.0
-Used by: [helidon-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
- Copyright 2018 Red Hat, Inc.
+</attribution>
+        </dependency>
+        <dependency>
+            <id>76793</id>
+            <name>SmallRye OpenAPI</name>
+            <version>1.2.0</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-openapi</consumer>
+            </consumers>
+            <attribution> Copyright 2018 Red Hat, Inc.
   Copyright 2017,2019 Red Hat, Inc, and individual contributors.
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -4216,15 +4541,21 @@ Fourth Party Runtime Dependencies
 
 
 
+</attribution>
+        </dependency>
+        <dependency>
+            <id>63165</id>
+            <name>SnakeYAML</name>
+            <version>1.24</version>
+            <licensor>SnakeYAML.org</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-yaml</consumer>
+                <consumer>helidon-openapi</consumer>
+            </consumers>
+            <attribution>SnakeYaml 1.24
 
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-SnakeYAML 1.24 SnakeYAML.org
-Apache 2.0
-Used by: [helidon-config-yaml, helidon-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-SnakeYaml 1.24
-
-No notice only copyright info at  url : https://bitbucket.org/asomov/snakeyaml/src/2ab6273059255189c1594c1995903ba2f5818531/src/etc/header.txt?at=default&fileviewer=file-view-default
+No notice only copyright info at  url : https://bitbucket.org/asomov/snakeyaml/src/2ab6273059255189c1594c1995903ba2f5818531/src/etc/header.txt?at=default&amp;fileviewer=file-view-default
 
 Copyright (c) 2008, http://www.snakeyaml.org
 
@@ -4242,24 +4573,37 @@ limitations under the License.
 
 LICENSE: Apache 2.0
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Typesafe config 1.4.0 Typesafe Inc.
-Apache 2.0
-Used by: [helidon-config-etcd, helidon-config-hocon, helidon-config-tests-test-bundle]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Typesafe Config
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71873</id>
+            <name>Typesafe config</name>
+            <version>1.4.0</version>
+            <licensor>Typesafe Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-etcd</consumer>
+                <consumer>helidon-config-hocon</consumer>
+                <consumer>helidon-config-tests-test-bundle</consumer>
+            </consumers>
+            <attribution>Typesafe Config
 config (com.typesafe:config)
-  Copyright (C) 2011-2015 Typesafe Inc. <http://typesafe.com>
+  Copyright (C) 2011-2015 Typesafe Inc. &lt;http://typesafe.com&gt;
 --------------------------------------------
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Weld APIs 3.1.SP2 Red Hat, Inc.
-Apache 2.0
-Used by: [helidon-integrations-cdi-jta-weld, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Weld APIs (org.jboss.weld:weld-api, weld-spi)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>81027</id>
+            <name>Weld APIs</name>
+            <version>3.1.SP2</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jta-weld</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>Weld APIs (org.jboss.weld:weld-api, weld-spi)
   Copyright 2009 Sun Microsystems, Inc. All rights reserved.
   Copyright 2008,2018 Red Hat, Inc., and individual contributors
   Copyright 2010,2016 Red Hat, Inc., and individual contributors
@@ -4317,13 +4661,19 @@ another country, of encryption software. BEFORE using any encryption software,
 please check the country's laws, regulations and policies concerning the import,
 possession, or use, and re-export of encryption software, to see if this is
 permitted.
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Weld SE (Core) 3.1.4.Final Red Hat, Inc.
-Apache 2.0
-Used by: [helidon-integrations-cdi-jta-weld, weld-se-core]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Weld SE (Core)
+--------------------------------------------</attribution>
+        </dependency>
+        <dependency>
+            <id>82739</id>
+            <name>Weld SE (Core)</name>
+            <version>3.1.4.Final</version>
+            <licensor>Red Hat, Inc.</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-jta-weld</consumer>
+                <consumer>weld-se-core</consumer>
+            </consumers>
+            <attribution>Weld SE (Core)
   Copyright 2009, Red Hat, Inc. and/or its affiliates, and individual
   Copyright 2008,2016 Red Hat Middleware LLC, and individual contributors
   Copyright 2009 Sun Microsystems, Inc. All rights reserved.
@@ -4382,20 +4732,25 @@ http://www.apache.org/licenses/LICENSE-2.0
 --------------------------------------------
 "Jakarta Dependency Injection" (jakarta.inject:jakarta.inject-api)
   Copyright (C) 2009 The JSR-330 Expert Group
-  Copyright 2019 Eclipse Foundation.<br>
+  Copyright 2019 Eclipse Foundation.&lt;br&gt;
   Apache License Version 2
 
 This program and the accompanying materials are made available under the terms
 of the Apache License, Version 2.0 which is available at
 https://www.apache.org/licenses/LICENSE-2.0.
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Zipkin Reporter Java 2.12.0 The OpenZipkin Authors
-Apache 2.0
-Used by: [helidon-tracing-zipkin]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Zipkin Reporter for Java
+</attribution>
+        </dependency>
+        <dependency>
+            <id>76857</id>
+            <name>Zipkin Reporter Java</name>
+            <version>2.12.0</version>
+            <licensor>The OpenZipkin Authors</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-tracing-zipkin</consumer>
+            </consumers>
+            <attribution>Zipkin Reporter for Java
 Zipkin Sender: URLConnection (io.zipkin.reporter2:zipkin-sender-urlconnection)
 Zipkin Reporter: Core (io.zipkin.reporter2:zipkin-reporter)
   Copyright 2016-2019 The OpenZipkin Authors
@@ -4442,13 +4797,18 @@ Spring Framework: Beans 2.5.6 (org.springframework:spring-beans)
 "RabbitMQ Java Client" 4.11.3 (com.rabbitmq:amqp-client)
 Copyright (c) 2007-Present Pivotal Software, Inc.  All rights reserved.
 Apache License version 2.0 
-  
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-classgraph 4.8.87 Luke Hutchinson
-MIT
-Used by: [helidon-graal-native-image-extension]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-ClassGraph (io.github.classgraph:classgraph)
+  </attribution>
+        </dependency>
+        <dependency>
+            <id>85953</id>
+            <name>classgraph</name>
+            <version>4.8.87</version>
+            <licensor>Luke Hutchinson</licensor>
+            <licenseName>MIT</licenseName>
+            <consumers>
+                <consumer>helidon-graal-native-image-extension</consumer>
+            </consumers>
+            <attribution>ClassGraph (io.github.classgraph:classgraph)
   Copyright (c) 2019,2020 Luke Hutchison
   Copyright (c) 2019 @jacobg, Luke Hutchison
   Copyright (c) 2019 Luke Hutchison, with significant contributions from Davy De Durpel
@@ -4460,7 +4820,7 @@ ClassGraph (io.github.classgraph:classgraph)
 --------------------------------------------
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -4480,13 +4840,18 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-etcd4j 2.17.0 Jurriaan Mous
-Apache 2.0
-Used by: [helidon-config-etcd]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-etcd4j (org.mousio:etcd4j)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71926</id>
+            <name>etcd4j</name>
+            <version>2.17.0</version>
+            <licensor>Jurriaan Mous</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-etcd</consumer>
+            </consumers>
+            <attribution>etcd4j (org.mousio:etcd4j)
   Copyright (c) 2015, Jurriaan Mous and contributors as indicated by the @author tags.
   Apache License Version 2.0
 --------------------------------------------
@@ -4499,7 +4864,7 @@ Fourth Party Dependencies
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -4527,7 +4892,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   Copyright 2015,2016 The Netty Project
   Copyright (c) 2011, Joe Walnes and contributors
   Copyright 2012,2017 The Netty Project
-  Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+  Copyright (c) 2008-2009 Bjoern Hoehrmann &lt;bjoern@hoehrmann.de&gt;
   Copyright 2011,2018 The Netty Project
   Copyright (c) 2004-2011 QOS.ch
   Copyright 2014,2018 The Netty Project
@@ -4549,13 +4914,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   Copyright 2001-2019 The Apache Software Foundation
   Apache License Version 2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-grpc-java 1.27.1 The gRPC Authors
-Apache 2.0
-Used by: [helidon-config-etcd, helidon-grpc-core, io.grpc]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-grpc-java (io.grpc:grpc-*)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>77273</id>
+            <name>grpc-java</name>
+            <version>1.27.1</version>
+            <licensor>The gRPC Authors</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-config-etcd</consumer>
+                <consumer>helidon-grpc-core</consumer>
+                <consumer>io.grpc</consumer>
+            </consumers>
+            <attribution>grpc-java (io.grpc:grpc-*)
   Copyright 2014,2019 The gRPC Authors
   Copyright 2018, gRPC Authors All rights reserved.
   Copyright 2014 The gRPC Authors
@@ -4573,7 +4945,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -----------------------------------------------------------------------
 This product contains a modified portion of 'OkHttp', an open source
-HTTP & SPDY client for Android and Java applications, which can be obtained
+HTTP &amp; SPDY client for Android and Java applications, which can be obtained
 at:
 
   * LICENSE:
@@ -4656,7 +5028,7 @@ Fourth Party Dependencies
   Copyright 2012,2017 The Netty Project
   Copyright (c) 2011, Joe Walnes and contributors
   Copyright 2012,2019 The Netty Project
-  Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+  Copyright (c) 2008-2009 Bjoern Hoehrmann &lt;bjoern@hoehrmann.de&gt;
   Apache License Version 2.0
 --------------------------------------------
 "proto-google-common-protos" (com.google.api.grpc:proto-google-common-protos)
@@ -4742,13 +5114,19 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jackson-databind 2.11.1 FasterXML, LLC
-Apache 2.0
-Used by: [helidon-media-jackson, helidon-security-providers-google-login]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-TOP LEVEL COMPONENT NAMES: com.fasterxml.jackson.core:jackson-databind
+</attribution>
+        </dependency>
+        <dependency>
+            <id>82433</id>
+            <name>jackson-databind</name>
+            <version>2.11.1</version>
+            <licensor>FasterXML, LLC</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-media-jackson</consumer>
+                <consumer>helidon-security-providers-google-login</consumer>
+            </consumers>
+            <attribution>TOP LEVEL COMPONENT NAMES: com.fasterxml.jackson.core:jackson-databind
 Copyright © 2008–2019 FasterXML. All rights reserved.
 ----------------------------------------------------------------------
 License Identifier: Apache-2.0
@@ -4763,21 +5141,38 @@ LICENSE: Apache 2.0
 -----------------jackson-annotations 2.11.0 -----------------------
 COPYRIGHT: Copyright (c) 2007- 2020 Tatu Saloranta, tatu.saloranta@iki.fi
 LICENSE: Apache 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jandex 2.1.1.Final Apache
-Apache 2.0
-Used by: [helidon-integrations-cdi-eclipselink, helidon-integrations-cdi-hibernate, helidon-integrations-cdi-jpa, helidon-integrations-cdi-jta, helidon-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-License URL - http://www.apache.org/licenses/LICENSE-2.0
+</attribution>
+        </dependency>
+        <dependency>
+            <id>63739</id>
+            <name>jandex</name>
+            <version>2.1.1.Final</version>
+            <licensor>Apache</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-eclipselink</consumer>
+                <consumer>helidon-integrations-cdi-hibernate</consumer>
+                <consumer>helidon-integrations-cdi-jpa</consumer>
+                <consumer>helidon-integrations-cdi-jta</consumer>
+                <consumer>helidon-openapi</consumer>
+            </consumers>
+            <attribution>License URL - http://www.apache.org/licenses/LICENSE-2.0
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-hk2 2.31 GlassFish
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-integrations-cdi-oci-objectstorage, helidon-jersey-client, helidon-jersey-connector, helidon-jersey-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80772</id>
+            <name>jersey-hk2</name>
+            <version>2.31</version>
+            <licensor>GlassFish</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-integrations-cdi-oci-objectstorage</consumer>
+                <consumer>helidon-jersey-client</consumer>
+                <consumer>helidon-jersey-connector</consumer>
+                <consumer>helidon-jersey-server</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -4842,7 +5237,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "OSGi resource locator" (org.glassfish.hk2:osgi-resource-locator)
@@ -4903,17 +5298,22 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------
 "Javassist" (org.javassist:javassist)
   Copyright (C) 1999- Shigeru Chiba. All Rights Reserved.
-  Copyright (C) 1999- Shigeru Chiba. All Rights Reserved.</i>]]></bottom>
+  Copyright (C) 1999- Shigeru Chiba. All Rights Reserved.&lt;/i&gt;]]&gt;&lt;/bottom&gt;
   Copyright (C) 2004 Bill Burke. All Rights Reserved.
 License Identifier: Apache-2.0
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-media-json-binding 2.31 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80773</id>
+            <name>jersey-media-json-binding</name>
+            <version>2.31</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -4943,7 +5343,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "OSGi resource locator" (org.glassfish.hk2:osgi-resource-locator)
@@ -4962,7 +5362,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "JSON-B API" (jakarta.json.bind:jakarta.json.bind-api)
   Copyright (c) 2015,2019 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All Rights Reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All Rights Reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta Activation" (com.sun.activation:jakarta.activation)
@@ -5000,13 +5400,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
   Copyright (c) 2019 Payara Services and/or its affiliates. All rights reserved.
   Eclipse Public License v. 2.0, Eclipse Distribution License v. 1.0
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-media-json-processing 2.31 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-jersey-media-jsonp]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+--------------------------------------------</attribution>
+        </dependency>
+        <dependency>
+            <id>80774</id>
+            <name>jersey-media-json-processing</name>
+            <version>2.31</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-jersey-media-jsonp</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -5036,7 +5441,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "javax.inject:1 as OSGi bundle" (org.glassfish.hk2.external:jakarta.inject)
@@ -5085,13 +5490,20 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-mp-rest-client 2.31 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-jersey-client, helidon-jersey-connector, helidon-microprofile-rest-client]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80771</id>
+            <name>jersey-mp-rest-client</name>
+            <version>2.31</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-jersey-client</consumer>
+                <consumer>helidon-jersey-connector</consumer>
+                <consumer>helidon-microprofile-rest-client</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -5135,7 +5547,7 @@ org.glassfish.jersey.media:jersey-media-jaxb
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "HK2" (org.glassfish.hk2)
@@ -5149,7 +5561,7 @@ org.glassfish.jersey.media:jersey-media-jaxb
 --------------------------------------------
 "JSON-B API" (jakarta.json.bind:jakarta.json.bind-api)
   Copyright (c) 2015,2019 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All Rights Reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All Rights Reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-
 --------------------------------------------
 "Jakarta JSON Processing Media for Jakarta RESTful Web Services" (org.glassfish:jsonp-jaxrs)
@@ -5162,7 +5574,7 @@ org.glassfish.jersey.media:jersey-media-jaxb
 --------------------------------------------
 "Jakarta Interceptors" (jakarta.interceptor:jakarta.interceptor-api)
   Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
-  Copyright 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 Jakarta Expression Language API (EL) (jakarta.el:jakarta.el-api)
@@ -5225,7 +5637,7 @@ Gunnar Morling gunnar@hibernate.org
 License Identifier: Apache-2.0
 --------------------------------------------
 "Jakarta Bean Validation API" (jakarta.validation:jakarta.validation-api)
-  Copyright &#169; 2019 Eclipse Foundation.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation.&lt;br&gt;
   Apache License Version 2.0
 
 Test dependencies:
@@ -5244,7 +5656,7 @@ Jakarta Contexts and Dependency Injection API (CDI API) (jakarta.enterprise:jaka
 --------------------------------------------
 "Jakarta XML Binding API" (jakarta.xml.bind:jakarta.xml.bind-api)
   Copyright (c) 2003,2020 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019, 2020 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019, 2020 Eclipse Foundation. All rights reserved.&lt;br&gt;
   Copyright (c) 2018 Payara Foundation and/or its affiliates.
 
 Eclipse Distribution License - v 1.0
@@ -5299,13 +5711,18 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   Copyright (C) 2004 Bill Burke. All Rights Reserved.
  Apache License 2.0
 
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-server 2.31 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-jersey-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+</attribution>
+        </dependency>
+        <dependency>
+            <id>80768</id>
+            <name>jersey-server</name>
+            <version>2.31</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-jersey-server</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -5393,7 +5810,7 @@ Fourth Party Dependencies
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta Activation" (com.sun.activation:jakarta.activation)
@@ -5428,7 +5845,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------
 "Jakarta XML Binding API" (jakarta.xml.bind:jakarta.xml.bind-api)
   Copyright (c) 2003,2020 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019, 2020 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019, 2020 Eclipse Foundation. All rights reserved.&lt;br&gt;
   Eclipse Distribution License - v 1.0
 --------------------------------------------
 "Jakarta Activation API jar" (jakarta.activation:jakarta.activation-api)
@@ -5436,7 +5853,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   Eclipse Distribution License - v 1.0
 --------------------------------------------
 "Jakarta Bean Validation API" (jakarta.validation:jakarta.validation-api)
-  Copyright &#169; 2019 Eclipse Foundation.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation.&lt;br&gt;
   Apache License Version 2.0
 
 # Notices for Eclipse Jakarta Bean Validation
@@ -5482,13 +5899,18 @@ Test dependencies:
  * [JCommander](https://github.com/cbeust/jcommander) - Apache License 2.0
  * [SnakeYAML](https://bitbucket.org/asomov/snakeyaml/src) - Apache License 2.0
 License Identifier: Apache-2.0
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-jersey-weld2-se 2.31 Eclipse Foundation
-Eclipse Public License 2.0 + GPL v.2 with CPE
-Used by: [helidon-microprofile-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-1.  The follow files are available in source code form under the Eclipse Public License at:
+--------------------------------------------</attribution>
+        </dependency>
+        <dependency>
+            <id>80769</id>
+            <name>jersey-weld2-se</name>
+            <version>2.31</version>
+            <licensor>Eclipse Foundation</licensor>
+            <licenseName>Eclipse Public License 2.0 + GPL v.2 with CPE</licenseName>
+            <consumers>
+                <consumer>helidon-microprofile-server</consumer>
+            </consumers>
+            <attribution>1.  The follow files are available in source code form under the Eclipse Public License at:
     https://github.com/eclipse-ee4j/jersey (The EPL license is reproduced below).
 2.  All past Contributors to the Jersey disclaim all warranties and
     conditions, express and implied, including warranties or conditions of title and
@@ -5543,7 +5965,7 @@ License Identifier: EPL-2.0
 --------------------------------------------
 "Jakarta Annotations API" (jakarta.annotation:jakarta.annotation-api)
   Copyright (c) 2005,2018 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All rights reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "javax.inject:1 as OSGi bundle" (org.glassfish.hk2.external:jakarta.inject)
@@ -5553,12 +5975,12 @@ License Identifier: EPL-2.0
 --------------------------------------------
 "JSON-B API" (jakarta.json.bind:jakarta.json.bind-api)
   Copyright (c) 2015,2019 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019 Eclipse Foundation. All Rights Reserved.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation. All Rights Reserved.&lt;br&gt;
   EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --------------------------------------------
 "Jakarta XML Binding API" (jakarta.xml.bind:jakarta.xml.bind-api)
   Copyright (c) 2003,2020 Oracle and/or its affiliates. All rights reserved.
-  Copyright &#169; 2019, 2020 Eclipse Foundation. All rights reserved.<br>
+  Copyright &amp;#169; 2019, 2020 Eclipse Foundation. All rights reserved.&lt;br&gt;
   Copyright (c) 2018 Payara Foundation and/or its affiliates.
   Eclipse Distribution License - v 1.0
 --------------------------------------------
@@ -5601,16 +6023,21 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------
 "Jakarta Bean Validation API" (jakarta.validation:jakarta.validation-api)
-  Copyright &#169; 2019 Eclipse Foundation.<br>
+  Copyright &amp;#169; 2019 Eclipse Foundation.&lt;br&gt;
   Apache License Version 2.0
 License Identifier: Apache-2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-kafka client 2.5.0 The Apache Software Foundation
-Apache 2.0
-Used by: [helidon-messaging-kafka]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Apache Kafka Clients (org.apache.kafka:kafka-clients)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>81200</id>
+            <name>kafka client</name>
+            <version>2.5.0</version>
+            <licensor>The Apache Software Foundation</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-messaging-kafka</consumer>
+            </consumers>
+            <attribution>Apache Kafka Clients (org.apache.kafka:kafka-clients)
 Copyright 2020 The Apache Software Foundation.
 
 This product includes software developed at
@@ -5674,7 +6101,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The MIT License SPDX short identifier: MIT
 
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
+Further resources on the MIT License Copyright &lt;YEAR&gt; &lt;COPYRIGHT HOLDER&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -5693,13 +6120,19 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-netty 4.1.51 The Netty Project
-Apache 2.0
-Used by: [helidon-webclient, helidon-webserver]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-The Netty Project
+</attribution>
+        </dependency>
+        <dependency>
+            <id>82984</id>
+            <name>netty</name>
+            <version>4.1.51</version>
+            <licensor>The Netty Project</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-webclient</consumer>
+                <consumer>helidon-webserver</consumer>
+            </consumers>
+            <attribution>The Netty Project
 netty-4.1.42.Final
 Copyright 2012,2019 The Netty Project
 Copyright 2011,2018 The Netty Project
@@ -5708,7 +6141,7 @@ Copyright 2012,2017 The Netty Project
 Copyright 2012,2016 The Netty Project
 Copyright 2014 Twitter, Inc.
 Copyright (c) 2011, Joe Walnes and contributors
-Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+Copyright (c) 2008-2009 Bjoern Hoehrmann &lt;bjoern@hoehrmann.de&gt;
 Copyright (c) 2004-2011 QOS.ch
 
                             The Netty Project
@@ -5732,7 +6165,7 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations
 under the License.
 
-Also, please refer to each LICENSE.<component>.txt file, which is located in
+Also, please refer to each LICENSE.&lt;component&gt;.txt file, which is located in
 the 'license' directory of the distribution file, for the license terms of the
 components that this product depends on.
 
@@ -5947,13 +6380,19 @@ THE SOFTWARE.
 --------------------------------------------------------------------------------
 License Identifier: Apache-2.0
 --------------------------------------------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-opentracing-grpc 0.2.1 Opentracing.Io
-Apache 2.0
-Used by: [helidon-grpc-client, helidon-grpc-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-io.opentracing.contrib:opentracing-grpc (io.opentracing.contrib:opentracing-grpc)
+</attribution>
+        </dependency>
+        <dependency>
+            <id>71868</id>
+            <name>opentracing-grpc</name>
+            <version>0.2.1</version>
+            <licensor>Opentracing.Io</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-grpc-client</consumer>
+                <consumer>helidon-grpc-server</consumer>
+            </consumers>
+            <attribution>io.opentracing.contrib:opentracing-grpc (io.opentracing.contrib:opentracing-grpc)
   Copyright 2017-2019 The OpenTracing Authors
 --------------------------------------------
 License Identifier: Apache-2.0
@@ -5971,13 +6410,18 @@ Fourth Party Dependencies
 "OpenTracing-noop"  (io.opentracing:opentracing-noop)
   Copyright 2016-2019 The OpenTracing Authors
   Apache License Version 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-opentracing-tracerresolver 0.1.8 opentracing-contrib
-Apache 2.0
-Used by: [helidon-tracing-tracer-resolver]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-opentracing-tracerresolver: 0.1.8, Apache 2.0
+</attribution>
+        </dependency>
+        <dependency>
+            <id>77053</id>
+            <name>opentracing-tracerresolver</name>
+            <version>0.1.8</version>
+            <licensor>opentracing-contrib</licensor>
+            <licenseName>Apache 2.0</licenseName>
+            <consumers>
+                <consumer>helidon-tracing-tracer-resolver</consumer>
+            </consumers>
+            <attribution>opentracing-tracerresolver: 0.1.8, Apache 2.0
 Copyright 2017-2019 The OpenTracing Authors
 --------------------------------------------------------------------------
 4th-party dependencies:
@@ -5985,3788 +6429,7 @@ OpenTracing API for Java: 0.33.0, Apache 2.0 (opentracing-api is used in opentra
 Copyright 2016-2019 The OpenTracing Authors
 ---------------------------------------------------------------------------
 License Identifier: Apache-2.0
-
-
-=======================================================================
-Full Text of Referenced Licenses
-=======================================================================
-
-Apache-2.0
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-EPL-1.0
-Eclipse Public License, Version 1.0 (EPL-1.0)
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
-PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
-OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-"Contribution" means:
-
-  a) in the case of the initial Contributor, the initial code and
-     documentation distributed under this Agreement, and
-  b) in the case of each subsequent Contributor:
-     i) changes to the Program, and
-     ii) additions to the Program;
-     where such changes and/or additions to the Program originate
-     from and are distributed by that particular Contributor. A
-     Contribution 'originates' from a Contributor if it was added
-     to the Program by such Contributor itself or anyone acting
-     on such Contributor's behalf. Contributions do not include
-     additions to the Program which: (i) are separate modules of
-     software distributed in conjunction with the Program under
-     their own license agreement, and (ii) are not derivative works
-     of the Program.
-
-"Contributor" means any person or entity that distributes the
-Program.
-
-"Licensed Patents" mean patent claims licensable by a Contributor
-which are necessarily infringed by the use or sale of its Contribution
-alone or when combined with the Program.
-
-"Program" means the Contributions distributed in accordance with
-this Agreement.
-
-"Recipient" means anyone who receives the Program under this
-Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-  a) Subject to the terms of this Agreement, each Contributor hereby
-     grants Recipient a non-exclusive, worldwide, royalty-free copyright
-     license to reproduce, prepare derivative works of, publicly display,
-     publicly perform, distribute and sublicense the Contribution of
-     such Contributor, if any, and such derivative works, in source code
-     and object code form.
-  b) Subject to the terms of this Agreement,
-     each Contributor hereby grants Recipient a non-exclusive, worldwide,
-     royalty-free patent license under Licensed Patents to make, use,
-     sell, offer to sell, import and otherwise transfer the Contribution
-     of such Contributor, if any, in source code and object code form.
-     This patent license shall apply to the combination of the Contribution
-     and the Program if, at the time the Contribution is added by the
-     Contributor, such addition of the Contribution causes such combination
-     to be covered by the Licensed Patents. The patent license shall not
-     apply to any other combinations which include the Contribution. No
-     hardware per se is licensed hereunder.
-  c) Recipient understands
-     that although each Contributor grants the licenses to its Contributions
-     set forth herein, no assurances are provided by any Contributor
-     that the Program does not infringe the patent or other intellectual
-     property rights of any other entity. Each Contributor disclaims any
-     liability to Recipient for claims brought by any other entity based
-     on infringement of intellectual property rights or otherwise. As a
-     condition to exercising the rights and licenses granted hereunder,
-     each Recipient hereby assumes sole responsibility to secure any
-     other intellectual property rights needed, if any. For example, if
-     a third party patent license is required to allow Recipient to
-     distribute the Program, it is Recipient's responsibility to acquire
-     that license before distributing the Program.
-  d) Each Contributor
-     represents that to its knowledge it has sufficient copyright rights
-     in its Contribution, if any, to grant the copyright license set
-     forth in this Agreement.
-
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code
-form under its own license agreement, provided that:
-
-  a)  it complies with the terms and conditions of this Agreement; and
-  b)  its license agreement:
-  i)  effectively disclaims on behalf of all
-      Contributors all warranties and conditions, express and implied,
-      including warranties or conditions of title and non-infringement,
-      and implied warranties or conditions of merchantability and fitness
-      for a particular purpose;
-  ii) effectively excludes on behalf of all
-      Contributors all liability for damages, including direct, indirect,
-      special, incidental and consequential damages, such as lost profits;
-  iii) states that any provisions which differ from this Agreement
-      are offered by that Contributor alone and not by any other party;
-      and
-  iv) states that source code for the Program is available from
-      such Contributor, and informs licensees how to obtain it in a
-      reasonable manner on or through a medium customarily used for
-      software exchange.
-
-When the Program is made available in source code form:
-
-  a) it must be made available under this Agreement; and
-  b) a copy of this Agreement must be included with each copy
-  of the Program.
-
-Contributors may not remove or alter any copyright notices contained
-within the Program.
-
-Each Contributor must identify itself as the originator of its
-Contribution, if any, in a manner that reasonably allows subsequent
-Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities
-with respect to end users, business partners and the like. While
-this license is intended to facilitate the commercial use of the
-Program, the Contributor who includes the Program in a commercial
-product offering should do so in a manner which does not create
-potential liability for other Contributors. Therefore, if a Contributor
-includes the Program in a commercial product offering, such Contributor
-("Commercial Contributor") hereby agrees to defend and indemnify
-every other Contributor ("Indemnified Contributor") against any
-losses, damages and costs (collectively "Losses") arising from
-claims, lawsuits and other legal actions brought by a third party
-against the Indemnified Contributor to the extent caused by the
-acts or omissions of such Commercial Contributor in connection with
-its distribution of the Program in a commercial product offering.
-The obligations in this section do not apply to any claims or Losses
-relating to any actual or alleged intellectual property infringement.
-In order to qualify, an Indemnified Contributor must: a) promptly
-notify the Commercial Contributor in writing of such claim, and b)
-allow the Commercial Contributor to control, and cooperate with the
-Commercial Contributor in, the defense and any related settlement
-negotiations. The Indemnified Contributor may participate in any
-such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial
-product offering, Product X. That Contributor is then a Commercial
-Contributor. If that Commercial Contributor then makes performance
-claims, or offers warranties related to Product X, those performance
-claims and warranties are such Commercial Contributor's responsibility
-alone. Under this section, the Commercial Contributor would have
-to defend claims against the other Contributors related to those
-performance claims and warranties, and if a court requires any other
-Contributor to pay any damages as a result, the Commercial Contributor
-must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
-PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
-ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
-OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
-responsible for determining the appropriateness of using and
-distributing the Program and assumes all risks associated with its
-exercise of rights under this Agreement , including but not limited
-to the risks and costs of program errors, compliance with applicable
-laws, damage to or loss of data, programs or equipment, and
-unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
-NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
-GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under
-applicable law, it shall not affect the validity or enforceability
-of the remainder of the terms of this Agreement, and without further
-action by the parties hereto, such provision shall be reformed to
-the minimum extent necessary to make such provision valid and
-enforceable.
-
-If Recipient institutes patent litigation against any entity
-(including a cross-claim or counterclaim in a lawsuit) alleging
-that the Program itself (excluding combinations of the Program with
-other software or hardware) infringes such Recipient's patent(s),
-then such Recipient's rights granted under Section 2(b) shall
-terminate as of the date such litigation is filed.
-
-All Recipient's rights under this Agreement shall terminate if it
-fails to comply with any of the material terms or conditions of
-this Agreement and does not cure such failure in a reasonable period
-of time after becoming aware of such noncompliance. If all Recipient's
-rights under this Agreement terminate, Recipient agrees to cease
-use and distribution of the Program as soon as reasonably practicable.
-However, Recipient's obligations under this Agreement and any
-licenses granted by Recipient relating to the Program shall continue
-and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement,
-but in order to avoid inconsistency the Agreement is copyrighted
-and may only be modified in the following manner. The Agreement
-Steward reserves the right to publish new versions (including
-revisions) of this Agreement from time to time. No one other than
-the Agreement Steward has the right to modify this Agreement. The
-Eclipse Foundation is the initial Agreement Steward. The Eclipse
-Foundation may assign the responsibility to serve as the Agreement
-Steward to a suitable separate entity. Each new version of the
-Agreement will be given a distinguishing version number. The Program
-(including Contributions) may always be distributed subject to the
-version of the Agreement under which it was received. In addition,
-after a new version of the Agreement is published, Contributor may
-elect to distribute the Program (including its Contributions) under
-the new version. Except as expressly stated in Sections 2(a) and
-2(b) above, Recipient receives no rights or licenses to the
-intellectual property of any Contributor under this Agreement,
-whether expressly, by implication, estoppel or otherwise. All rights
-in the Program not expressly granted under this Agreement are
-reserved.
-
-This Agreement is governed by the laws of the State of New York and
-the intellectual property laws of the United States of America. No
-party to this Agreement will bring a legal action under this Agreement
-more than one year after the cause of action arose. Each party
-waives its rights to a jury trial in any resulting litigation.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-EPL-2.0
-Eclipse Public License - v 2.0
-
-    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
-    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
-    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-"Contribution" means:
-
-  a) in the case of the initial Contributor, the initial content
-     Distributed under this Agreement, and
-
-  b) in the case of each subsequent Contributor: 
-     i) changes to the Program, and 
-     ii) additions to the Program;
-  where such changes and/or additions to the Program originate from
-  and are Distributed by that particular Contributor. A Contribution
-  "originates" from a Contributor if it was added to the Program by
-  such Contributor itself or anyone acting on such Contributor's behalf.
-  Contributions do not include changes or additions to the Program that
-  are not Modified Works.
-
-"Contributor" means any person or entity that Distributes the Program.
-
-"Licensed Patents" mean patent claims licensable by a Contributor which
-are necessarily infringed by the use or sale of its Contribution alone
-or when combined with the Program.
-
-"Program" means the Contributions Distributed in accordance with this
-Agreement.
-
-"Recipient" means anyone who receives the Program under this Agreement
-or any Secondary License (as applicable), including Contributors.
-
-"Derivative Works" shall mean any work, whether in Source Code or other
-form, that is based on (or derived from) the Program and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship.
-
-"Modified Works" shall mean any work in Source Code or other form that
-results from an addition to, deletion from, or modification of the
-contents of the Program, including, for purposes of clarity any new file
-in Source Code form that contains any contents of the Program. Modified
-Works shall not include works that contain only declarations,
-interfaces, types, classes, structures, or files of the Program solely
-in each case in order to link to, bind by name, or subclass the Program
-or Modified Works thereof.
-
-"Distribute" means the acts of a) distributing or b) making available
-in any manner that enables the transfer of a copy.
-
-"Source Code" means the form of a Program preferred for making
-modifications, including but not limited to software source code,
-documentation source, and configuration files.
-
-"Secondary License" means either the GNU General Public License,
-Version 2.0, or any later versions of that license, including any
-exceptions or additional permissions as identified by the initial
-Contributor.
-
-2. GRANT OF RIGHTS
-
-  a) Subject to the terms of this Agreement, each Contributor hereby
-  grants Recipient a non-exclusive, worldwide, royalty-free copyright
-  license to reproduce, prepare Derivative Works of, publicly display,
-  publicly perform, Distribute and sublicense the Contribution of such
-  Contributor, if any, and such Derivative Works.
-
-  b) Subject to the terms of this Agreement, each Contributor hereby
-  grants Recipient a non-exclusive, worldwide, royalty-free patent
-  license under Licensed Patents to make, use, sell, offer to sell,
-  import and otherwise transfer the Contribution of such Contributor,
-  if any, in Source Code or other form. This patent license shall
-  apply to the combination of the Contribution and the Program if, at
-  the time the Contribution is added by the Contributor, such addition
-  of the Contribution causes such combination to be covered by the
-  Licensed Patents. The patent license shall not apply to any other
-  combinations which include the Contribution. No hardware per se is
-  licensed hereunder.
-
-  c) Recipient understands that although each Contributor grants the
-  licenses to its Contributions set forth herein, no assurances are
-  provided by any Contributor that the Program does not infringe the
-  patent or other intellectual property rights of any other entity.
-  Each Contributor disclaims any liability to Recipient for claims
-  brought by any other entity based on infringement of intellectual
-  property rights or otherwise. As a condition to exercising the
-  rights and licenses granted hereunder, each Recipient hereby
-  assumes sole responsibility to secure any other intellectual
-  property rights needed, if any. For example, if a third party
-  patent license is required to allow Recipient to Distribute the
-  Program, it is Recipient's responsibility to acquire that license
-  before distributing the Program.
-
-  d) Each Contributor represents that to its knowledge it has
-  sufficient copyright rights in its Contribution, if any, to grant
-  the copyright license set forth in this Agreement.
-
-  e) Notwithstanding the terms of any Secondary License, no
-  Contributor makes additional grants to any Recipient (other than
-  those set forth in this Agreement) as a result of such Recipient's
-  receipt of the Program under the terms of a Secondary License
-  (if permitted under the terms of Section 3).
-
-3. REQUIREMENTS
-
-3.1 If a Contributor Distributes the Program in any form, then:
-
-  a) the Program must also be made available as Source Code, in
-  accordance with section 3.2, and the Contributor must accompany
-  the Program with a statement that the Source Code for the Program
-  is available under this Agreement, and informs Recipients how to
-  obtain it in a reasonable manner on or through a medium customarily
-  used for software exchange; and
-
-  b) the Contributor may Distribute the Program under a license
-  different than this Agreement, provided that such license:
-     i) effectively disclaims on behalf of all other Contributors all
-     warranties and conditions, express and implied, including
-     warranties or conditions of title and non-infringement, and
-     implied warranties or conditions of merchantability and fitness
-     for a particular purpose;
-
-     ii) effectively excludes on behalf of all other Contributors all
-     liability for damages, including direct, indirect, special,
-     incidental and consequential damages, such as lost profits;
-
-     iii) does not attempt to limit or alter the recipients' rights
-     in the Source Code under section 3.2; and
-
-     iv) requires any subsequent distribution of the Program by any
-     party to be under a license that satisfies the requirements
-     of this section 3.
-
-3.2 When the Program is Distributed as Source Code:
-
-  a) it must be made available under this Agreement, or if the
-  Program (i) is combined with other material in a separate file or
-  files made available under a Secondary License, and (ii) the initial
-  Contributor attached to the Source Code the notice described in
-  Exhibit A of this Agreement, then the Program may be made available
-  under the terms of such Secondary Licenses, and
-
-  b) a copy of this Agreement must be included with each copy of
-  the Program.
-
-3.3 Contributors may not remove or alter any copyright, patent,
-trademark, attribution notices, disclaimers of warranty, or limitations
-of liability ("notices") contained within the Program from any copy of
-the Program which they Distribute, provided that Contributors may add
-their own appropriate notices.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities
-with respect to end users, business partners and the like. While this
-license is intended to facilitate the commercial use of the Program,
-the Contributor who includes the Program in a commercial product
-offering should do so in a manner which does not create potential
-liability for other Contributors. Therefore, if a Contributor includes
-the Program in a commercial product offering, such Contributor
-("Commercial Contributor") hereby agrees to defend and indemnify every
-other Contributor ("Indemnified Contributor") against any losses,
-damages and costs (collectively "Losses") arising from claims, lawsuits
-and other legal actions brought by a third party against the Indemnified
-Contributor to the extent caused by the acts or omissions of such
-Commercial Contributor in connection with its distribution of the Program
-in a commercial product offering. The obligations in this section do not
-apply to any claims or Losses relating to any actual or alleged
-intellectual property infringement. In order to qualify, an Indemnified
-Contributor must: a) promptly notify the Commercial Contributor in
-writing of such claim, and b) allow the Commercial Contributor to control,
-and cooperate with the Commercial Contributor in, the defense and any
-related settlement negotiations. The Indemnified Contributor may
-participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial
-product offering, Product X. That Contributor is then a Commercial
-Contributor. If that Commercial Contributor then makes performance
-claims, or offers warranties related to Product X, those performance
-claims and warranties are such Commercial Contributor's responsibility
-alone. Under this section, the Commercial Contributor would have to
-defend claims against the other Contributors related to those performance
-claims and warranties, and if a court requires any other Contributor to
-pay any damages as a result, the Commercial Contributor must pay
-those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
-BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
-TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
-PURPOSE. Each Recipient is solely responsible for determining the
-appropriateness of using and distributing the Program and assumes all
-risks associated with its exercise of rights under this Agreement,
-including but not limited to the risks and costs of program errors,
-compliance with applicable laws, damage to or loss of data, programs
-or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
-SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
-PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
-EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under
-applicable law, it shall not affect the validity or enforceability of
-the remainder of the terms of this Agreement, and without further
-action by the parties hereto, such provision shall be reformed to the
-minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity
-(including a cross-claim or counterclaim in a lawsuit) alleging that the
-Program itself (excluding combinations of the Program with other software
-or hardware) infringes such Recipient's patent(s), then such Recipient's
-rights granted under Section 2(b) shall terminate as of the date such
-litigation is filed.
-
-All Recipient's rights under this Agreement shall terminate if it
-fails to comply with any of the material terms or conditions of this
-Agreement and does not cure such failure in a reasonable period of
-time after becoming aware of such noncompliance. If all Recipient's
-rights under this Agreement terminate, Recipient agrees to cease use
-and distribution of the Program as soon as reasonably practicable.
-However, Recipient's obligations under this Agreement and any licenses
-granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement,
-but in order to avoid inconsistency the Agreement is copyrighted and
-may only be modified in the following manner. The Agreement Steward
-reserves the right to publish new versions (including revisions) of
-this Agreement from time to time. No one other than the Agreement
-Steward has the right to modify this Agreement. The Eclipse Foundation
-is the initial Agreement Steward. The Eclipse Foundation may assign the
-responsibility to serve as the Agreement Steward to a suitable separate
-entity. Each new version of the Agreement will be given a distinguishing
-version number. The Program (including Contributions) may always be
-Distributed subject to the version of the Agreement under which it was
-received. In addition, after a new version of the Agreement is published,
-Contributor may elect to Distribute the Program (including its
-Contributions) under the new version.
-
-Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
-receives no rights or licenses to the intellectual property of any
-Contributor under this Agreement, whether expressly, by implication,
-estoppel or otherwise. All rights in the Program not expressly granted
-under this Agreement are reserved. Nothing in this Agreement is intended
-to be enforceable by any entity that is not a Contributor or Recipient.
-No third-party beneficiary rights are created under this Agreement.
-
-Exhibit A - Form of Secondary Licenses Notice
-
-"This Source Code may also be made available under the following 
-Secondary Licenses when the conditions for such availability set forth 
-in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
-version(s), and exceptions or additional permissions here}."
-
-  Simply including a copy of this Agreement, including this Exhibit A
-  is not sufficient to license the Source Code under Secondary Licenses.
-
-  If it is not possible or desirable to put the notice in a particular
-  file, then You may include the notice in a location (such as a LICENSE
-  file in a relevant directory) where a recipient would be likely to
-  look for such a notice.
-
-  You may add additional accurate notices of copyright ownership.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MPL-2.0
-Mozilla Public License Version 2.0
-==================================
-
-1. Definitions
---------------
-
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
-
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-    means
-
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
-
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
-
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
-    a separate file or files, that is not Covered Software.
-
-1.8. "License"
-    means this document.
-
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
-
-1.10. "Modifications"
-    means any of the following:
-
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
-
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
-
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
-
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
-
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
-
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
-
-2. License Grants and Conditions
---------------------------------
-
-2.1. Grants
-
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
-
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
-
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
-
-2.2. Effective Date
-
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
-
-2.3. Limitations on Grant Scope
-
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
-
-(a) for any code that a Contributor has removed from Covered Software;
-    or
-
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
-
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Executable Form
-
-If You distribute Covered Software in Executable Form then:
-
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under this License. Except to the extent prohibited by statute
-or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or  *
-*  statutory, including, without limitation, warranties that the       *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the     *
-*  quality and performance of the Covered Software is with You.        *
-*  Should any Covered Software prove defective in any respect, You     *
-*  (not any Contributor) assume the cost of any necessary servicing,   *
-*  repair, or correction. This disclaimer of warranty constitutes an   *
-*  essential part of this License. No use of any Covered Software is   *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Software as          *
-*  permitted above, be liable to You for any direct, indirect,         *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
-
-10.3. Modified Versions
-
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-LGPL-2.1-only
-GNU LESSER GENERAL PUBLIC LICENSE
-Version 2.1, February 1999
-
-Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
-
-[This is the first released version of the Lesser GPL. It also counts
-as the successor of the GNU Library Public License, version 2, hence
-the version number 2.1.]
-
-Preamble
-
-The licenses for most software are designed to take away your
-freedom to share and change it. By contrast, the GNU General Public
-Licenses are intended to guarantee your freedom to share and change
-free software--to make sure the software is free for all its users.
-
-This license, the Lesser General Public License, applies to some
-specially designated software packages--typically libraries--of the
-Free Software Foundation and other authors who decide to use it. You
-can use it too, but we suggest you first think carefully about whether
-this license or the ordinary General Public License is the better
-strategy to use in any particular case, based on the explanations below.
-
-When we speak of free software, we are referring to freedom of use,
-not price. Our General Public Licenses are designed to make sure that
-you have the freedom to distribute copies of free software (and charge
-for this service if you wish); that you receive source code or can get
-it if you want it; that you can change the software and use pieces of
-it in new free programs; and that you are informed that you can do
-these things.
-
-To protect your rights, we need to make restrictions that forbid
-distributors to deny you these rights or to ask you to surrender these
-rights. These restrictions translate to certain responsibilities for
-you if you distribute copies of the library or if you modify it.
-
-For example, if you distribute copies of the library, whether gratis
-or for a fee, you must give the recipients all the rights that we gave
-you. You must make sure that they, too, receive or can get the source
-code. If you link other code with the library, you must provide
-complete object files to the recipients, so that they can relink them
-with the library after making changes to the library and recompiling
-it. And you must show them these terms so they know their rights.
-
-We protect your rights with a two-step method: (1) we copyright the
-library, and (2) we offer you this license, which gives you legal
-permission to copy, distribute and/or modify the library.
-
-To protect each distributor, we want to make it very clear that
-there is no warranty for the free library. Also, if the library is
-modified by someone else and passed on, the recipients should know
-that what they have is not the original version, so that the original
-author's reputation will not be affected by problems that might be
-introduced by others.
-
-Finally, software patents pose a constant threat to the existence of
-any free program. We wish to make sure that a company cannot
-effectively restrict the users of a free program by obtaining a
-restrictive license from a patent holder. Therefore, we insist that
-any patent license obtained for a version of the library must be
-consistent with the full freedom of use specified in this license.
-
-Most GNU software, including some libraries, is covered by the
-ordinary GNU General Public License. This license, the GNU Lesser
-General Public License, applies to certain designated libraries, and
-is quite different from the ordinary General Public License. We use
-this license for certain libraries in order to permit linking those
-libraries into non-free programs.
-
-When a program is linked with a library, whether statically or using
-a shared library, the combination of the two is legally speaking a
-combined work, a derivative of the original library. The ordinary
-General Public License therefore permits such linking only if the
-entire combination fits its criteria of freedom. The Lesser General
-Public License permits more lax criteria for linking other code with
-the library.
-
-We call this license the "Lesser" General Public License because it
-does Less to protect the user's freedom than the ordinary General
-Public License. It also provides other free software developers Less
-of an advantage over competing non-free programs. These disadvantages
-are the reason we use the ordinary General Public License for many
-libraries. However, the Lesser license provides advantages in certain
-special circumstances.
-
-For example, on rare occasions, there may be a special need to
-encourage the widest possible use of a certain library, so that it becomes
-a de-facto standard. To achieve this, non-free programs must be
-allowed to use the library. A more frequent case is that a free
-library does the same job as widely used non-free libraries. In this
-case, there is little to gain by limiting the free library to free
-software only, so we use the Lesser General Public License.
-
-In other cases, permission to use a particular library in non-free
-programs enables a greater number of people to use a large body of
-free software. For example, permission to use the GNU C Library in
-non-free programs enables many more people to use the whole GNU
-operating system, as well as its variant, the GNU/Linux operating
-system.
-
-Although the Lesser General Public License is Less protective of the
-users' freedom, it does ensure that the user of a program that is
-linked with the Library has the freedom and the wherewithal to run
-that program using a modified version of the Library.
-
-The precise terms and conditions for copying, distribution and
-modification follow. Pay close attention to the difference between a
-"work based on the library" and a "work that uses the library". The
-former contains code derived from the library, whereas the latter must
-be combined with the library in order to run.
-
-GNU LESSER GENERAL PUBLIC LICENSE
-TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-0. This License Agreement applies to any software library or other
-program which contains a notice placed by the copyright holder or
-other authorized party saying it may be distributed under the terms of
-this Lesser General Public License (also called "this License").
-Each licensee is addressed as "you".
-
-A "library" means a collection of software functions and/or data
-prepared so as to be conveniently linked with application programs
-(which use some of those functions and data) to form executables.
-
-The "Library", below, refers to any such software library or work
-which has been distributed under these terms. A "work based on the
-Library" means either the Library or any derivative work under
-copyright law: that is to say, a work containing the Library or a
-portion of it, either verbatim or with modifications and/or translated
-straightforwardly into another language. (Hereinafter, translation is
-included without limitation in the term "modification".)
-
-"Source code" for a work means the preferred form of the work for
-making modifications to it. For a library, complete source code means
-all the source code for all modules it contains, plus any associated
-interface definition files, plus the scripts used to control compilation
-and installation of the library.
-
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope. The act of
-running a program using the Library is not restricted, and output from
-such a program is covered only if its contents constitute a work based
-on the Library (independent of the use of the Library in a tool for
-writing it). Whether that is true depends on what the Library does
-and what the program that uses the Library does.
-
-1. You may copy and distribute verbatim copies of the Library's
-complete source code as you receive it, in any medium, provided that
-you conspicuously and appropriately publish on each copy an
-appropriate copyright notice and disclaimer of warranty; keep intact
-all the notices that refer to this License and to the absence of any
-warranty; and distribute a copy of this License along with the
-Library.
-
-You may charge a fee for the physical act of transferring a copy,
-and you may at your option offer warranty protection in exchange for a
-fee.
-
-2. You may modify your copy or copies of the Library or any portion
-of it, thus forming a work based on the Library, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
-
-a) The modified work must itself be a software library.
-
-b) You must cause the files modified to carry prominent notices
-stating that you changed the files and the date of any change.
-
-c) You must cause the whole of the work to be licensed at no
-charge to all third parties under the terms of this License.
-
-d) If a facility in the modified Library refers to a function or a
-table of data to be supplied by an application program that uses
-the facility, other than as an argument passed when the facility
-is invoked, then you must make a good faith effort to ensure that,
-in the event an application does not supply such function or
-table, the facility still operates, and performs whatever part of
-its purpose remains meaningful.
-
-(For example, a function in a library to compute square roots has
-a purpose that is entirely well-defined independent of the
-application. Therefore, Subsection 2d requires that any
-application-supplied function or table used by this function must
-be optional: if the application does not supply it, the square
-root function must still compute square roots.)
-
-These requirements apply to the modified work as a whole. If
-identifiable sections of that work are not derived from the Library,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works. But when you
-distribute the same sections as part of a whole which is a work based
-on the Library, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote
-it.
-
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Library.
-
-In addition, mere aggregation of another work not based on the Library
-with the Library (or with a work based on the Library) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
-
-3. You may opt to apply the terms of the ordinary GNU General Public
-License instead of this License to a given copy of the Library. To do
-this, you must alter all the notices that refer to this License, so
-that they refer to the ordinary GNU General Public License, version 2,
-instead of to this License. (If a newer version than version 2 of the
-ordinary GNU General Public License has appeared, then you can specify
-that version instead if you wish.) Do not make any other change in
-these notices.
-
-Once this change is made in a given copy, it is irreversible for
-that copy, so the ordinary GNU General Public License applies to all
-subsequent copies and derivative works made from that copy.
-
-This option is useful when you wish to copy part of the code of
-the Library into a program that is not a library.
-
-4. You may copy and distribute the Library (or a portion or
-derivative of it, under Section 2) in object code or executable form
-under the terms of Sections 1 and 2 above provided that you accompany
-it with the complete corresponding machine-readable source code, which
-must be distributed under the terms of Sections 1 and 2 above on a
-medium customarily used for software interchange.
-
-If distribution of object code is made by offering access to copy
-from a designated place, then offering equivalent access to copy the
-source code from the same place satisfies the requirement to
-distribute the source code, even though third parties are not
-compelled to copy the source along with the object code.
-
-5. A program that contains no derivative of any portion of the
-Library, but is designed to work with the Library by being compiled or
-linked with it, is called a "work that uses the Library". Such a
-work, in isolation, is not a derivative work of the Library, and
-therefore falls outside the scope of this License.
-
-However, linking a "work that uses the Library" with the Library
-creates an executable that is a derivative of the Library (because it
-contains portions of the Library), rather than a "work that uses the
-library". The executable is therefore covered by this License.
-Section 6 states terms for distribution of such executables.
-
-When a "work that uses the Library" uses material from a header file
-that is part of the Library, the object code for the work may be a
-derivative work of the Library even though the source code is not.
-Whether this is true is especially significant if the work can be
-linked without the Library, or if the work is itself a library. The
-threshold for this to be true is not precisely defined by law.
-
-If such an object file uses only numerical parameters, data
-structure layouts and accessors, and small macros and small inline
-functions (ten lines or less in length), then the use of the object
-file is unrestricted, regardless of whether it is legally a derivative
-work. (Executables containing this object code plus portions of the
-Library will still fall under Section 6.)
-
-Otherwise, if the work is a derivative of the Library, you may
-distribute the object code for the work under the terms of Section 6.
-Any executables containing that work also fall under Section 6,
-whether or not they are linked directly with the Library itself.
-
-6. As an exception to the Sections above, you may also combine or
-link a "work that uses the Library" with the Library to produce a
-work containing portions of the Library, and distribute that work
-under terms of your choice, provided that the terms permit
-modification of the work for the customer's own use and reverse
-engineering for debugging such modifications.
-
-You must give prominent notice with each copy of the work that the
-Library is used in it and that the Library and its use are covered by
-this License. You must supply a copy of this License. If the work
-during execution displays copyright notices, you must include the
-copyright notice for the Library among them, as well as a reference
-directing the user to the copy of this License. Also, you must do one
-of these things:
-
-a) Accompany the work with the complete corresponding
-machine-readable source code for the Library including whatever
-changes were used in the work (which must be distributed under
-Sections 1 and 2 above); and, if the work is an executable linked
-with the Library, with the complete machine-readable "work that
-uses the Library", as object code and/or source code, so that the
-user can modify the Library and then relink to produce a modified
-executable containing the modified Library. (It is understood
-that the user who changes the contents of definitions files in the
-Library will not necessarily be able to recompile the application
-to use the modified definitions.)
-
-b) Use a suitable shared library mechanism for linking with the
-Library. A suitable mechanism is one that (1) uses at run time a
-copy of the library already present on the user's computer system,
-rather than copying library functions into the executable, and (2)
-will operate properly with a modified version of the library, if
-the user installs one, as long as the modified version is
-interface-compatible with the version that the work was made with.
-
-c) Accompany the work with a written offer, valid for at
-least three years, to give the same user the materials
-specified in Subsection 6a, above, for a charge no more
-than the cost of performing this distribution.
-
-d) If distribution of the work is made by offering access to copy
-from a designated place, offer equivalent access to copy the above
-specified materials from the same place.
-
-e) Verify that the user has already received a copy of these
-materials or that you have already sent this user a copy.
-
-For an executable, the required form of the "work that uses the
-Library" must include any data and utility programs needed for
-reproducing the executable from it. However, as a special exception,
-the materials to be distributed need not include anything that is
-normally distributed (in either source or binary form) with the major
-components (compiler, kernel, and so on) of the operating system on
-which the executable runs, unless that component itself accompanies
-the executable.
-
-It may happen that this requirement contradicts the license
-restrictions of other proprietary libraries that do not normally
-accompany the operating system. Such a contradiction means you cannot
-use both them and the Library together in an executable that you
-distribute.
-
-7. You may place library facilities that are a work based on the
-Library side-by-side in a single library together with other library
-facilities not covered by this License, and distribute such a combined
-library, provided that the separate distribution of the work based on
-the Library and of the other library facilities is otherwise
-permitted, and provided that you do these two things:
-
-a) Accompany the combined library with a copy of the same work
-based on the Library, uncombined with any other library
-facilities. This must be distributed under the terms of the
-Sections above.
-
-b) Give prominent notice with the combined library of the fact
-that part of it is a work based on the Library, and explaining
-where to find the accompanying uncombined form of the same work.
-
-8. You may not copy, modify, sublicense, link with, or distribute
-the Library except as expressly provided under this License. Any
-attempt otherwise to copy, modify, sublicense, link with, or
-distribute the Library is void, and will automatically terminate your
-rights under this License. However, parties who have received copies,
-or rights, from you under this License will not have their licenses
-terminated so long as such parties remain in full compliance.
-
-9. You are not required to accept this License, since you have not
-signed it. However, nothing else grants you permission to modify or
-distribute the Library or its derivative works. These actions are
-prohibited by law if you do not accept this License. Therefore, by
-modifying or distributing the Library (or any work based on the
-Library), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Library or works based on it.
-
-10. Each time you redistribute the Library (or any work based on the
-Library), the recipient automatically receives a license from the
-original licensor to copy, distribute, link with or modify the Library
-subject to these terms and conditions. You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties with
-this License.
-
-11. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License. If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Library at all. For example, if a patent
-license would not permit royalty-free redistribution of the Library by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Library.
-
-If any portion of this section is held invalid or unenforceable under any
-particular circumstance, the balance of the section is intended to apply,
-and the section as a whole is intended to apply in other circumstances.
-
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system which is
-implemented by public license practices. Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-12. If the distribution and/or use of the Library is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Library under this License may add
-an explicit geographical distribution limitation excluding those countries,
-so that distribution is permitted only in or among countries not thus
-excluded. In such case, this License incorporates the limitation as if
-written in the body of this License.
-
-13. The Free Software Foundation may publish revised and/or new
-versions of the Lesser General Public License from time to time.
-Such new versions will be similar in spirit to the present version,
-but may differ in detail to address new problems or concerns.
-
-Each version is given a distinguishing version number. If the Library
-specifies a version number of this License which applies to it and
-"any later version", you have the option of following the terms and
-conditions either of that version or of any later version published by
-the Free Software Foundation. If the Library does not specify a
-license version number, you may choose any version ever published by
-the Free Software Foundation.
-
-14. If you wish to incorporate parts of the Library into other free
-programs whose distribution conditions are incompatible with these,
-write to the author to ask for permission. For software which is
-copyrighted by the Free Software Foundation, write to the Free
-Software Foundation; we sometimes make exceptions for this. Our
-decision will be guided by the two goals of preserving the free status
-of all derivatives of our free software and of promoting the sharing
-and reuse of software generally.
-
-NO WARRANTY
-
-15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
-WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
-EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
-OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
-KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
-LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
-THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
-AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
-FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
-CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
-LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
-RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
-FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
-SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGES.
-
-END OF TERMS AND CONDITIONS
-
-How to Apply These Terms to Your New Libraries
-
-If you develop a new library, and you want it to be of the greatest
-possible use to the public, we recommend making it free software that
-everyone can redistribute and change. You can do so by permitting
-redistribution under these terms (or, alternatively, under the terms of the
-ordinary General Public License).
-
-To apply these terms, attach the following notices to the library. It is
-safest to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least the
-"copyright" line and a pointer to where the full notice is found.
-
-
-Copyright (C) 
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
-Also add information on how to contact you by electronic and paper mail.
-
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the library, if
-necessary. Here is a sample; alter the names:
-
-Yoyodyne, Inc., hereby disclaims all copyright interest in the
-library `Frob' (a library for tweaking knobs) written by James Random Hacker.
-
-, 1 April 1990
-Ty Coon, President of Vice
-
-That's all there is to it!
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Third Party Attributions for Examples, Tests, Builds, etc
-
-The following software (or subsets of the software) is used when building
-Helidon, or in the examples and tests. They are generally not required by
-users of Helidon and not required during runtime.
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Arquillian 1.4.0.Final RedHat, Inc., JBoss community
-Apache 2.0
-Used by: [helidon-arquillian, tck-jwt-auth, tck-metrics, tck-metrics2]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2008 Red Hat Inc. and/or its affiliates and other contributors
-Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
-Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
-Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
---------------------------------------------
-License Identifier: Apache-2.0
---------------------------------------------
---------------------------------------------
-"AOP alliance" 1.0 (aopalliance:aopalliance)
-  Public Domain
---------------------------------------------
-"Aether API" 1.0.0.v20140518 (org.eclipse.aether:aether-api)
-  Copyright (c) 2010,2014 Sonatype, Inc.
---------------------------------------------
-"Aether Implementation" 1.0.0.v20140518 (org.eclipse.aether:aether-impl)
-  Copyright (c) 2010,2014 Sonatype, Inc.
---------------------------------------------
-"Aether SPI" 1.0.0.v20140518 (org.eclipse.aether:aether-spi)
-  Copyright (c) 2010,2014 Sonatype, Inc.
---------------------------------------------
-"Aether Utilities" 1.0.0.v20140518 (org.eclipse.aether:aether-util)
-  Copyright (c) 2010,2014 Sonatype, Inc.
---------------------------------------------
-"Aether Connector Basic" 1.0.0.v20140518 (org.eclipse.aether:aether-connector-basic)
-  Copyright (c) 2013,2014 Sonatype, Inc.
---------------------------------------------
-"Aether Transport Wagon" 1.0.0.v20140518 (org.eclipse.aether:aether-transport-wagon)
-  Copyright (c) 2010,2014 Sonatype, Inc.
---------------------------------------------
-"org.eclipse.sisu.plexus" 0.3.0.M1 (org.eclipse.sisu:org.eclipse.sisu.plexus)
-  Copyright (c) 2010,2013 Sonatype, Inc.
---------------------------------------------
-"org.eclipse.sisu.inject" 0.3.0.M1 (org.eclipse.sisu:org.eclipse.sisu.inject)
-  Copyright (c) 2010,2013 Sonatype, Inc.
-  Copyright (c) 2000-2013 INRIA, France Telecom
---------------------------------------------
-"Aether API" 1.0.0.v20140518 (org.eclipse.aether:aether-api)
-"Aether Implementation" 1.0.0.v20140518 (org.eclipse.aether:aether-impl)
-"Aether SPI" 1.0.0.v20140518 (org.eclipse.aether:aether-spi)
-"Aether Utilities" 1.0.0.v20140518 (org.eclipse.aether:aether-util)
-"Aether Connector Basic" 1.0.0.v20140518 (org.eclipse.aether:aether-connector-basic)
-"Aether Transport Wagon" 1.0.0.v20140518 (org.eclipse.aether:aether-transport-wagon)
-"org.eclipse.sisu.plexus" 0.3.0.M1 (org.eclipse.sisu:org.eclipse.sisu.plexus)
-"org.eclipse.sisu.inject" 0.3.0.M1 (org.eclipse.sisu:org.eclipse.sisu.inject)
-
-Eclipse Public License - v 1.0 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE
-TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR
-DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
-AGREEMENT.
-
-1. DEFINITIONS
-
-"Contribution" means:
-
-a) in the case of the initial Contributor, the initial code and documentation
-distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are
-distributed by that particular Contributor. A Contribution 'originates' from a
-Contributor if it was added to the Program by such Contributor itself or anyone
-acting on such Contributor's behalf. Contributions do not include additions to
-the Program which: (i) are separate modules of software distributed in
-conjunction with the Program under their own license agreement, and (ii) are not
-derivative works of the Program.
-
-"Contributor" means any person or entity that distributes the Program.
-
-"Licensed Patents" mean patent claims licensable by a Contributor which are
-necessarily infringed by the use or sale of its Contribution alone or when
-combined with the Program.
-
-"Program" means the Contributions distributed in accordance with this Agreement.
-
-"Recipient" means anyone who receives the Program under this Agreement,
-including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants
-Recipient a non-exclusive, worldwide, royalty-free copyright license to
-reproduce, prepare derivative works of, publicly display, publicly perform,
-distribute and sublicense the Contribution of such Contributor, if any, and such
-derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants
-Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed
-Patents to make, use, sell, offer to sell, import and otherwise transfer the
-Contribution of such Contributor, if any, in source code and object code form.
-This patent license shall apply to the combination of the Contribution and the
-Program if, at the time the Contribution is added by the Contributor, such
-addition of the Contribution causes such combination to be covered by the
-Licensed Patents. The patent license shall not apply to any other combinations
-which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to
-its Contributions set forth herein, no assurances are provided by any
-Contributor that the Program does not infringe the patent or other intellectual
-property rights of any other entity. Each Contributor disclaims any liability to
-Recipient for claims brought by any other entity based on infringement of
-intellectual property rights or otherwise. As a condition to exercising the
-rights and licenses granted hereunder, each Recipient hereby assumes sole
-responsibility to secure any other intellectual property rights needed, if any.
-For example, if a third party patent license is required to allow Recipient to
-distribute the Program, it is Recipient's responsibility to acquire that license
-before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright
-rights in its Contribution, if any, to grant the copyright license set forth in
-this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its
-own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and
-conditions, express and implied, including warranties or conditions of title and
-non-infringement, and implied warranties or conditions of merchantability and
-fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for
-damages, including direct, indirect, special, incidental and consequential
-damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by
-that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor,
-and informs licensees how to obtain it in a reasonable manner on or through a
-medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the
-Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if
-any, in a manner that reasonably allows subsequent Recipients to identify the
-originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with
-respect to end users, business partners and the like. While this license is
-intended to facilitate the commercial use of the Program, the Contributor who
-includes the Program in a commercial product offering should do so in a manner
-which does not create potential liability for other Contributors. Therefore, if
-a Contributor includes the Program in a commercial product offering, such
-Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
-every other Contributor ("Indemnified Contributor") against any losses, damages
-and costs (collectively "Losses") arising from claims, lawsuits and other legal
-actions brought by a third party against the Indemnified Contributor to the
-extent caused by the acts or omissions of such Commercial Contributor in
-connection with its distribution of the Program in a commercial product
-offering. The obligations in this section do not apply to any claims or Losses
-relating to any actual or alleged intellectual property infringement. In order
-to qualify, an Indemnified Contributor must: a) promptly notify the Commercial
-Contributor in writing of such claim, and b) allow the Commercial Contributor to
-control, and cooperate with the Commercial Contributor in, the defense and any
-related settlement negotiations. The Indemnified Contributor may participate in
-any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product
-offering, Product X. That Contributor is then a Commercial Contributor. If that
-Commercial Contributor then makes performance claims, or offers warranties
-related to Product X, those performance claims and warranties are such
-Commercial Contributor's responsibility alone. Under this section, the
-Commercial Contributor would have to defend claims against the other
-Contributors related to those performance claims and warranties, and if a court
-requires any other Contributor to pay any damages as a result, the Commercial
-Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
-Recipient is solely responsible for determining the appropriateness of using and
-distributing the Program and assumes all risks associated with its exercise of
-rights under this Agreement , including but not limited to the risks and costs
-of program errors, compliance with applicable laws, damage to or loss of data,
-programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
-CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
-PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
-GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable
-law, it shall not affect the validity or enforceability of the remainder of the
-terms of this Agreement, and without further action by the parties hereto, such
-provision shall be reformed to the minimum extent necessary to make such
-provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Program itself
-(excluding combinations of the Program with other software or hardware)
-infringes such Recipient's patent(s), then such Recipient's rights granted under
-Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient's rights under this Agreement shall terminate if it fails to
-comply with any of the material terms or conditions of this Agreement and does
-not cure such failure in a reasonable period of time after becoming aware of
-such noncompliance. If all Recipient's rights under this Agreement terminate,
-Recipient agrees to cease use and distribution of the Program as soon as
-reasonably practicable. However, Recipient's obligations under this Agreement
-and any licenses granted by Recipient relating to the Program shall continue and
-survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in
-order to avoid inconsistency the Agreement is copyrighted and may only be
-modified in the following manner. The Agreement Steward reserves the right to
-publish new versions (including revisions) of this Agreement from time to time.
-No one other than the Agreement Steward has the right to modify this Agreement.
-The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation
-may assign the responsibility to serve as the Agreement Steward to a suitable
-separate entity. Each new version of the Agreement will be given a
-distinguishing version number. The Program (including Contributions) may always
-be distributed subject to the version of the Agreement under which it was
-received. In addition, after a new version of the Agreement is published,
-Contributor may elect to distribute the Program (including its Contributions)
-under the new version. Except as expressly stated in Sections 2(a) and 2(b)
-above, Recipient receives no rights or licenses to the intellectual property of
-any Contributor under this Agreement, whether expressly, by implication,
-estoppel or otherwise. All rights in the Program not expressly granted under
-this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the
-intellectual property laws of the United States of America. No party to this
-Agreement will bring a legal action under this Agreement more than one year
-after the cause of action arose. Each party waives its rights to a jury trial in
-any resulting litigation.
-
---------------------------------------------
-"Hamcrest Core" 1.3 (org.hamcrest:hamcrest-core)
-  Copyright (c) www.hamcrest.org
-  Apache License Version 2.0
---------------------------------------------
-"JUnit" 4.11 (junit:junit)
-  Copyright 2010 Google Inc. All Rights Reserved.
-  Apache License Version 2.0
---------------------------------------------
-"SLF4J API Module" 1.7.10 (org.slf4j:slf4j-api)
-  Copyright (c) 2004-2011 QOS.ch
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core API" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-api)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core SPI" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-spi)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core Implementation Base" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-impl-base)
-  Copyright 2009,2014 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config API" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-api)
-  Copyright 2010,2013 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config SPI" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-spi)
-  Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config Implementation Base" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-impl-base)
-  Copyright 2010,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2005, JBoss Inc., and individual contributors as indicated
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test API" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-api)
-  Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test SPI" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-spi)
-  Copyright 2009,2016 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2010, Red Hat Middleware LLC, and individual contributors
-  Copyright 2014,2015 Red Hat, Inc. and/or its affiliates, and individual
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test Implementation Base" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-impl-base)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container SPI" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-spi)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Implementation Base" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-impl-base)
-  Copyright 2009,2013 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test API" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-api)
-  Copyright 2009,2010 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test SPI" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-spi)
-  Copyright 2008,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test Implementation Base" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-impl-base)
-  Copyright 2009,2015 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner JUnit Core" 1.4.0.Final (org.jboss.arquillian.junit:arquillian-junit-core)
-  Copyright 2009,2015 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner JUnit Container" 1.4.0.Final (org.jboss.arquillian.junit:arquillian-junit-container)
-  Copyright 2009,2016 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner JUnit Standalone" 1.4.0.Final (org.jboss.arquillian.junit:arquillian-junit-standalone)
-  Copyright 2011,2015 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner TestNG Core" 1.4.0.Final (org.jboss.arquillian.testng:arquillian-testng-core)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner TestNG Container" 1.4.0.Final (org.jboss.arquillian.testng:arquillian-testng-container)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestRunner TestNG Standalone" 1.4.0.Final (org.jboss.arquillian.testng:arquillian-testng-standalone)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Protocol Servlet 2.5/3.x" 1.4.0.Final (org.jboss.arquillian.protocol:arquillian-protocol-servlet)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2010,2011 Red Hat, Inc., and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Protocol JMX" 1.4.0.Final (org.jboss.arquillian.protocol:arquillian-protocol-jmx)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestEnricher CDI" 1.4.0.Final (org.jboss.arquillian.testenricher:arquillian-testenricher-cdi)
-  Copyright 2009,2014 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestEnricher EJB" 1.4.0.Final (org.jboss.arquillian.testenricher:arquillian-testenricher-ejb)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestEnricher Resource" 1.4.0.Final (org.jboss.arquillian.testenricher:arquillian-testenricher-resource)
-  Copyright 2009,2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestEnricher InitialContext" 1.4.0.Final (org.jboss.arquillian.testenricher:arquillian-testenricher-initialcontext)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap API" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-api)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap SPI" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-spi)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Implementation Base" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-impl-base)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap NIO.2 API" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-api-nio2)
-  Copyright 2012, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap NIO.2 Implementation" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-impl-nio2)
-  Copyright 2012, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver API" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api)
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver SPI" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven API" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api-maven)
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven SPI" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi-maven)
-  Copyright 2012, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven Implementation" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven)
-  Copyright (c) 2010 Sonatype, Inc. All rights reserved.
-  Copyright 2009,2015 Red Hat Middleware LLC, and individual contributors
-  Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Maven Aether Provider" 3.2.5 (org.apache.maven:maven-aether-provider)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Model" 3.2.5 (org.apache.maven:maven-model)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Model Builder" 3.2.5 (org.apache.maven:maven-model-builder)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Plexus :: Component Annotations" 1.5.5 (org.codehaus.plexus:plexus-component-annotations)
-  Copyright (C) 2007 the original author or authors.
-  Apache License Version 2.0
---------------------------------------------
-"Maven Repository Metadata Model" 3.2.5 (org.apache.maven:maven-repository-metadata)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Settings" 3.2.5 (org.apache.maven:maven-settings)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Settings Builder" 3.2.5 (org.apache.maven:maven-settings-builder)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Guava: Google Core Libraries for Java" 18.0 (com.google.guava:guava)
-  Copyright (C) 2005,2014 The Guava Authors
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Interpolation API" 1.21 (org.codehaus.plexus:plexus-interpolation)
-  Copyright 2001-2009 Codehaus Foundation.
-  Copyright (c) 2004, The Codehaus
-  Copyright 2001-2004 The Apache Software Foundation.
-  Copyright 2007 The Codehaus Foundation.
-  Copyright (c) 2001-2003 The Apache Software Foundation.  All rights
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Common Utilities" 3.0.20 (org.codehaus.plexus:plexus-utils)
-  Copyright (c) 2003 Extreme! Lab, Indiana University. All rights reserved.
-  Copyright (c) 2001- 2003, ThoughtWorks, Inc.
-  Copyright (C) 2003 The Trustees of Indiana University.
-  Copyright ,2011 The Codehaus Foundation.
-  Copyright (c) 2000-2003 The Apache Software Foundation.  All rights
-  Copyright 2003-2004 The Apache Software Foundation.
-  Copyright 2004 Sun Microsystems, Inc.
-  Copyright (c) 2003, ThoughtWorks, Inc.
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Security Dispatcher Component" 1.3 (org.sonatype.plexus:plexus-sec-dispatcher)
-  Copyright (c) 2008 Sonatype, Inc. All rights reserved.
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Cipher: encryption/decryption Component" 1.4 (org.sonatype.plexus:plexus-cipher)
-  Copyright (c) 2008 Sonatype, Inc. All rights reserved.
-  Apache License Version 2.0
---------------------------------------------
-"Apache Maven Wagon :: API" 2.6 (org.apache.maven.wagon:wagon-provider-api)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Apache Maven Wagon :: Providers :: File Provider" 2.6 (org.apache.maven.wagon:wagon-file)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Commons Lang" 2.6 (commons-lang:commons-lang)
-  Copyright 2001-2011 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Apache Maven Wagon :: Providers :: Lightweight HTTP Provider" 2.6 (org.apache.maven.wagon:wagon-http-lightweight)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Apache Maven Wagon :: Providers :: HTTP Shared Library" 2.6 (org.apache.maven.wagon:wagon-http-shared)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Commons IO" 2.2 (commons-io:commons-io)
-  Copyright 2002-2012 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven Archive API" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api-maven-archive)
-  Copyright 2012,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven Archive Implementation" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven-archive)
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven Archive SPI" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi-maven-archive)
-  Copyright 2012, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Javac Component" 2.3 (org.codehaus.plexus:plexus-compiler-javac)
-  Copyright (c) 2005, The Codehaus
-  Copyright 2004 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Compiler Api" 2.3 (org.codehaus.plexus:plexus-compiler-api)
-  Copyright (c) 2004,2005 The Codehaus
-  Copyright 2004 The Apache Software Foundation
-  Copyright 2001-2005 The Apache Software Foundation.
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Maven Plugin" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-maven-plugin)
-  Copyright 2012,2014 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Maven Plugin API" 3.2.5 (org.apache.maven:maven-plugin-api)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Artifact" 3.2.5 (org.apache.maven:maven-artifact)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Maven Core" 3.2.5 (org.apache.maven:maven-core)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License Version 2.0
---------------------------------------------
-"Sisu Guice - Core Library" 3.2.3 (org.sonatype.sisu:sisu-guice)
-  Copyright (C) 2006,2013 Google Inc.
-  Copyright 2006-2014 Google, Inc.
-  Apache License Version 2.0
---------------------------------------------
-"Plexus Classworlds" 2.5.2 (org.codehaus.plexus:plexus-classworlds)
-  Copyright 2002 (C) The Werken Company. All Rights Reserved.
-  Copyright 2001-2010 Codehaus Foundation.
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Embedded Gradle Archive API" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api-gradle-embedded-archive)
-  Copyright 2014, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Resolver Embedded Gradle Archive Implementation" 2.2.6 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-gradle-embedded-archive)
-  Copyright 2014, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors API Base" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Generated Java EE API" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-javaee)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Generated JBoss API" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-jboss)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Source Generator" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-gen)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Implementation" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-base)
-  Copyright 2010, Red Hat, Inc., and individual contributors
-  Copyright 2010, Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Generated Java EE Impl" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-javaee)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Generated JBoss Impl" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-jboss)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors SPI" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors Dependency Chain" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-depchain)
-  RedHat, Inc., JBoss community
-  Apache License Version 2.0
---------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Arquillian Container Weld 2.0.0.Final Red Hat, Inc.
-Other FOSS License
-Used by: [helidon-microprofile-grpc-core, helidon-microprofile-grpc-server, tck-config]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Arquillian Container Weld (org.jboss.arquillian.container:arquillian-weld-embedded)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Copyright Red Hat, Inc., and individual contributors
---------------------------------------------
-Creative Commons Legal Code
-
-CC0 1.0 Universal
-
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
-
-Statement of Purpose
-
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
-
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-"Arquillian Container SPI" 1.1.15.Final (org.jboss.arquillian.container:arquillian-container-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core SPI" 1.1.15.Final (org.jboss.arquillian.core:arquillian-core-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core API" 1.1.15.Final (org.jboss.arquillian.core:arquillian-core-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config API" 1.1.15.Final (org.jboss.arquillian.config:arquillian-config-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config Implementation Base" 1.1.15.Final (org.jboss.arquillian.config:arquillian-config-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright JBoss Inc., and individual contributors as indicated
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors SPI" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap API" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-api)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors API Base" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test SPI" 1.1.15.Final (org.jboss.arquillian.container:arquillian-container-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test SPI" 1.1.15.Final (org.jboss.arquillian.test:arquillian-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Copyright Red Hat, Inc. and/or its affiliates, and individual
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test API" 1.1.15.Final (org.jboss.arquillian.test:arquillian-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test API" 1.1.15.Final (org.jboss.arquillian.container:arquillian-container-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian TestEnricher CDI" 1.1.15.Final (org.jboss.arquillian.testenricher:arquillian-testenricher-cdi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Arquillian TestRunner TestNG 1.4.0.Final Red Hat, Inc.
-Apache 2.0
-Used by: [tck-config, tck-fault-tolerance, tck-health, tck-jwt-auth, tck-openapi]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Arquillian TestRunner TestNG Container (org.jboss.arquillian.testng:arquillian-testng-container)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-"Arquillian TestRunner TestNG Core" 1.4.0.Final (org.jboss.arquillian.testng:arquillian-testng-core)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test API" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core API" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test SPI" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Copyright Red Hat, Inc. and/or its affiliates, and individual
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core SPI" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test API" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap API" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-api)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors API Base" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test SPI" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container SPI" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Core Implementation Base" 1.4.0.Final (org.jboss.arquillian.core:arquillian-core-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Test Implementation Base" 1.4.0.Final (org.jboss.arquillian.test:arquillian-test-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat, Inc. and/or its affiliates, and individual
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Implementation Base" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config API" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config Implementation Base" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright JBoss Inc., and individual contributors as indicated
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Config SPI" 1.4.0.Final (org.jboss.arquillian.config:arquillian-config-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Descriptors SPI" 2.0.0 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"Arquillian Container Test Implementation Base" 1.4.0.Final (org.jboss.arquillian.container:arquillian-container-test-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap Implementation Base" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-impl-base)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-"ShrinkWrap SPI" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-spi)
-Copyright Red Hat Middleware LLC, and individual contributors
-  Apache License Version 2.0
---------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-JUnit 4.12 JUnit
-Eclipse Public License 1.0
-Used by: [helidon-arquillian]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright © 2002-2014 JUnit. All Rights Reserved.
-Copyright © 2002-2017 JUnit. All Rights Reserved.
-EPL-1.0
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-org.hamcrest: hamcrest-core</artifactId  - BSD3
-org.hamcrest: hamcrest-library</artifactId> - BSD 3
-
-BSD License
-
-Copyright (c) 2000-2015 www.hamcrest.org
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of
-conditions and the following disclaimer. Redistributions in binary form must reproduce
-the above copyright notice, this list of conditions and the following disclaimer in
-the documentation and/or other materials provided with the distribution.
-
-Neither the name of Hamcrest nor the names of its contributors may be used to endorse
-or promote products derived from this software without specific prior written
-permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-JUnit 5.6.2 JUnit Team
-Eclipse Public License 2.0
-Used by: Many
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-License Identifier: EPL-2.0
-1.  The follow files are available in source code form under the Eclipse Public License at:
-    https://github.com/junit-team/junit5
-2.  All past Contributors to JUnit5 disclaim all warranties and conditions, express and
-    implied, including warranties or conditions of title and non-infringement, and implied
-    warranties or conditions of merchantability and fitness for a particular purpose.
-    In addition, such Contributors are not liable for any damages, including direct,
-    indirect, special, incidental and consequential damages, such as lost profits.  
-3.  Any provisions of the Oracle license agreement that differ from the Eclipse Public License
-    are offered by Oracle alone and not by any other party.
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-junit-jupiter-params & junit-platform-console directories include an Apache license file
-Apache License 2
---------------------
-https://github.com/apiguardian-team/apiguardian/archive/r1.1.0.zip
- * Copyright 2002-2017 the original author or authors.
-Apache 2.0 License
---------------------
-https://github.com/ota4j-team/opentest4j/archive/r1.2.0.zip
- * Copyright 2015-2018 the original author or authors.
-Apache 2.0 License
---------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Config TCK 1.4 Eclipse Foundation
-Apache 2.0
-Used by: [tck-config]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Config TCK (org.eclipse.microprofile.config:microprofile-config-tck)
-Copyright (c) Contributors to the Eclipse Foundation  
-License Identifier: Apache-2.0
---------------------------------------------
-"BeanShell" 2.0b4 (org.beanshell:bsh)
-Copyright Patrick Niemeyer
-
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
-
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
-
---------------------------------------------
-"Hamcrest Core" 1.1 (org.hamcrest:hamcrest-core)
-Copyright (c) www.hamcrest.org
---------------------------------------------
-"Hamcrest All" 1.3 (org.hamcrest:hamcrest-all)
-Copyright (c) www.hamcrest.org
---------------------------------------------
-"Hamcrest Core" 1.1 (org.hamcrest:hamcrest-core)
-"Hamcrest All" 1.3 (org.hamcrest:hamcrest-all)
-
-The 2-Clause BSD License
-SPDX short identifier: BSD-2-Clause
-
-Further resources on the 2-clause BSD license
-Note: This license has also been called the "Simplified BSD License" and the
-"FreeBSD License". See also the 3-clause BSD License.
-
-Copyright <YEAR> <COPYRIGHT HOLDER>
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------
-"JUnit" 4.10 (junit:junit)
-Copyright (c) JUnit. All Rights Reserved.
-
-Common Public License Version 1.0 (CPL)
-(NOTE: This license has been superseded by the Eclipse Public License)
-
-(text)
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS COMMON PUBLIC
-LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
-CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-"Contribution" means:
-
-a) in the case of the initial Contributor, the initial code and documentation
-distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are
-distributed by that particular Contributor. A Contribution 'originates' from
-a Contributor if it was added to the Program by such Contributor itself or
-anyone acting on such Contributor's behalf. Contributions do not include
-additions to the Program which: (i) are separate modules of software
-distributed in conjunction with the Program under their own license agreement,
-and (ii) are not derivative works of the Program.
-
-"Contributor" means any person or entity that distributes the Program.
-
-"Licensed Patents " mean patent claims licensable by a Contributor which are
-necessarily infringed by the use or sale of its Contribution alone or when
-combined with the Program.
-
-"Program" means the Contributions distributed in accordance with this
-Agreement.
-
-"Recipient" means anyone who receives the Program under this Agreement,
-including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants
-Recipient a non-exclusive, worldwide, royalty-free copyright license to
-reproduce, prepare derivative works of, publicly display, publicly perform,
-distribute and sublicense the Contribution of such Contributor, if any, and
-such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants
-Recipient a non-exclusive, worldwide, royalty-free patent license under
-Licensed Patents to make, use, sell, offer to sell, import and otherwise
-transfer the Contribution of such Contributor, if any, in source code and
-object code form. This patent license shall apply to the combination of the
-Contribution and the Program if, at the time the Contribution is added by the
-Contributor, such addition of the Contribution causes such combination to be
-covered by the Licensed Patents. The patent license shall not apply to any
-other combinations which include the Contribution. No hardware per se is
-licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to
-its Contributions set forth herein, no assurances are provided by any
-Contributor that the Program does not infringe the patent or other intellectual
-property rights of any other entity. Each Contributor disclaims any liability
-to Recipient for claims brought by any other entity based on infringement of
-intellectual property rights or otherwise. As a condition to exercising the
-rights and licenses granted hereunder, each Recipient hereby assumes sole
-responsibility to secure any other intellectual property rights needed, if any.
-For example, if a third party patent license is required to allow Recipient to
-distribute the Program, it is Recipient's responsibility to acquire that
-license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient
-copyright rights in its Contribution, if any, to grant the copyright license
-set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under
-its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and
-conditions, express and implied, including warranties or conditions of title
-and non-infringement, and implied warranties or conditions of merchantability
-and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for
-damages, including direct, indirect, special, incidental and consequential
-damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by
-that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor,
-and informs licensees how to obtain it in a reasonable manner on or through a
-medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the
-Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if
-any, in a manner that reasonably allows subsequent Recipients to identify the
-originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with
-respect to end users, business partners and the like. While this license is
-intended to facilitate the commercial use of the Program, the Contributor who
-includes the Program in a commercial product offering should do so in a manner
-which does not create potential liability for other Contributors. Therefore, if
-a Contributor includes the Program in a commercial product offering, such
-Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
-every other Contributor ("Indemnified Contributor") against any losses, damages
-and costs (collectively "Losses") arising from claims, lawsuits and other legal
-actions brought by a third party against the Indemnified Contributor to the
-extent caused by the acts or omissions of such Commercial Contributor in
-connection with its distribution of the Program in a commercial product
-offering. The obligations in this section do not apply to any claims or Losses
-relating to any actual or alleged intellectual property infringement. In order
-to qualify, an Indemnified Contributor must: a) promptly notify the Commercial
-Contributor in writing of such claim, and b) allow the Commercial Contributor
-to control, and cooperate with the Commercial Contributor in, the defense and
-any related settlement negotiations. The Indemnified Contributor may
-participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product
-offering, Product X. That Contributor is then a Commercial Contributor. If that
-Commercial Contributor then makes performance claims, or offers warranties
-related to Product X, those performance claims and warranties are such
-Commercial Contributor's responsibility alone. Under this section, the
-Commercial Contributor would have to defend claims against the other
-Contributors related to those performance claims and warranties, and if a court
-requires any other Contributor to pay any damages as a result, the Commercial
-Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
-Recipient is solely responsible for determining the appropriateness of using
-and distributing the Program and assumes all risks associated with its
-exercise of rights under this Agreement, including but not limited to the
-risks and costs of program errors, compliance with applicable laws, damage to
-or loss of data, programs or equipment, and unavailability or interruption of
-operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
-CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
-LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY
-RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable
-law, it shall not affect the validity or enforceability of the remainder of the
-terms of this Agreement, and without further action by the parties hereto, such
-provision shall be reformed to the minimum extent necessary to make such
-provision valid and enforceable.
-
-If Recipient institutes patent litigation against a Contributor with respect to
-a patent applicable to software (including a cross-claim or counterclaim in a
-lawsuit), then any patent licenses granted by that Contributor to such
-Recipient under this Agreement shall terminate as of the date such litigation
-is filed. In addition, if Recipient institutes patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging that the
-Program itself (excluding combinations of the Program with other software or
-hardware) infringes such Recipient's patent(s), then such Recipient's rights
-granted under Section 2(b) shall terminate as of the date such litigation is
-filed.
-
-All Recipient's rights under this Agreement shall terminate if it fails to
-comply with any of the material terms or conditions of this Agreement and does
-not cure such failure in a reasonable period of time after becoming aware of
-such noncompliance. If all Recipient's rights under this Agreement terminate,
-Recipient agrees to cease use and distribution of the Program as soon as
-reasonably practicable. However, Recipient's obligations under this Agreement
-and any licenses granted by Recipient relating to the Program shall continue
-and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in
-order to avoid inconsistency the Agreement is copyrighted and may only be
-modified in the following manner. The Agreement Steward reserves the right to
-publish new versions (including revisions) of this Agreement from time to time.
-No one other than the Agreement Steward has the right to modify this Agreement.
-IBM is the initial Agreement Steward. IBM may assign the responsibility to
-serve as the Agreement Steward to a suitable separate entity. Each new version
-of the Agreement will be given a distinguishing version number. The Program
-(including Contributions) may always be distributed subject to the version of
-the Agreement under which it was received. In addition, after a new version of
-the Agreement is published, Contributor may elect to distribute the Program
-(including its Contributions) under the new version. Except as expressly stated
-in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to
-the intellectual property of any Contributor under this Agreement, whether
-expressly, by implication, estoppel or otherwise. All rights in the Program not
-expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the
-intellectual property laws of the United States of America. No party to this
-Agreement will bring a legal action under this Agreement more than one year
-after the cause of action arose. Each party waives its rights to a jury trial
-in any resulting litigation.
-
---------------------------------------------
-"JCommander" 1.48 (com.beust:jcommander)
-Copyright (C) the original author or authors.
-Apache License 2
---------------------------------------------
-"org.apache.tools.ant" 1.7.0 (org.apache.ant:ant)
-Copyright The Apache Software Foundation
-Apache License 2
---------------------------------------------
-"ant-launcher" 1.7.0 (org.apache.ant:ant-launcher)
-Copyright The Apache Software Foundation
-Apache License 2
---------------------------------------------
-"Arquillian TestRunner TestNG Container" 1.1.13.Final (org.jboss.arquillian.testng:arquillian-testng-container)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian TestRunner TestNG Core" 1.1.13.Final (org.jboss.arquillian.testng:arquillian-testng-core)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"Arquillian Test API" 1.1.13.Final (org.jboss.arquillian.test:arquillian-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Core API" 1.1.13.Final (org.jboss.arquillian.core:arquillian-core-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Test SPI" 1.1.13.Final (org.jboss.arquillian.test:arquillian-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-  Copyright Red Hat, Inc. and/or its affiliates, and individual
-Apache License 2
---------------------------------------------
-"Arquillian Core SPI" 1.1.13.Final (org.jboss.arquillian.core:arquillian-core-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Container Test API" 1.1.13.Final (org.jboss.arquillian.container:arquillian-container-test-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Container Test SPI" 1.1.13.Final (org.jboss.arquillian.container:arquillian-container-test-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Container SPI" 1.1.13.Final (org.jboss.arquillian.container:arquillian-container-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"ShrinkWrap Descriptors API Base" 2.0.0-alpha-10 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base)
-Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"Arquillian Core Implementation Base" 1.1.13.Final (org.jboss.arquillian.core:arquillian-core-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Test Implementation Base" 1.1.13.Final (org.jboss.arquillian.test:arquillian-test-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat, Inc. and/or its affiliates, and individual
-Apache License 2
---------------------------------------------
-"Arquillian Container Implementation Base" 1.1.13.Final (org.jboss.arquillian.container:arquillian-container-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Config API" 1.1.13.Final (org.jboss.arquillian.config:arquillian-config-api)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"Arquillian Config Implementation Base" 1.1.13.Final (org.jboss.arquillian.config:arquillian-config-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright JBoss Inc., and individual contributors as indicated
-Apache License 2
---------------------------------------------
-"ShrinkWrap Descriptors SPI" 2.0.0-alpha-10 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-  Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"Arquillian Container Test Implementation Base" 1.1.13.Final (org.jboss.arquillian.container:arquillian-container-test-impl-base)
-Copyright Red Hat Inc. and/or its affiliates and other contributors
-Apache License 2
---------------------------------------------
-"ShrinkWrap Implementation Base" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-impl-base)
-Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"ShrinkWrap SPI" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-spi)
-Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"ShrinkWrap API" 1.2.6 (org.jboss.shrinkwrap:shrinkwrap-api)
-Copyright Red Hat Middleware LLC, and individual contributors
-Apache License 2
---------------------------------------------
-"testng" 6.9.9 (org.testng:testng)
-Copyright (c) 2004 IBM Corporation and others.
-  Copyright GigaSpaces Technologies Inc.
-Apache License 2
---------------------------------------------
-"SnakeYAML" 1.15 (org.yaml:snakeyaml)
-Copyright (c) http://www.snakeyaml.org
-Apache License 2
---------------------------------------------
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Metrics TCK 2.2 Eclipse Foundation
-Apache 2.0
-Used by: [tck-metrics]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-MicroProfile Metrics TCK
-  Copyright (c) 2017 Contributors to the Eclipse Foundation
-Apache License 2
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-"jsoup" 1.7.2 (org.jsoup:jsoup)
-  Copyright © 2009 - 2017 Jonathan Hedley (jonathan@hedley.net)
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"Aether API" 0.9.0.M2 (org.eclipse.aether:aether-api)
-  Copyright (c) 2010,2013 Sonatype, Inc.
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"Aether Implementation" 0.9.0.M2 (org.eclipse.aether:aether-impl)
-  Copyright (c) 2010,2013 Sonatype, Inc.
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"Aether SPI" 0.9.0.M2 (org.eclipse.aether:aether-spi)
-  Copyright (c) 2010,2013 Sonatype, Inc.
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"Aether Utilities" 0.9.0.M2 (org.eclipse.aether:aether-util)
-  Copyright (c) 2010,2013 Sonatype, Inc.
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"Aether Connector Wagon" 0.9.0.M2 (org.eclipse.aether:aether-connector-wagon)
-  Copyright (c) 2010,2012 Sonatype, Inc.
-  Eclipse Public License - v 1.0 
---------------------------------------------
-"JUnit" 4.12 (junit:junit)
-  Copyright (c) JUnit. All Rights Reserved.
-  BSD 2-Clause
---------------------------------------------
-"Hamcrest integration" 1.2.1 (org.hamcrest:hamcrest-integration)
-  Copyright (c) www.hamcrest.org
-  BSD 2-Clause
---------------------------------------------
-"Hamcrest library" 1.2.1 (org.hamcrest:hamcrest-library)
-  Copyright (c) www.hamcrest.org
-  BSD 2-Clause
---------------------------------------------
-"Hamcrest Core" 1.3 (org.hamcrest:hamcrest-core)
-  Copyright (c) www.hamcrest.org
-  BSD 2-Clause
---------------------------------------------
-The 2-Clause BSD License
-SPDX short identifier: BSD-2-Clause
-
-Further resources on the 2-clause BSD license
-Note: This license has also been called the "Simplified BSD License" and the
-"FreeBSD License". See also the 3-clause BSD License.
-
-Copyright <YEAR> <COPYRIGHT HOLDER>
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------
-"MicroProfile Metrics API-TCK" 1.1 (org.eclipse.microprofile.metrics:microprofile-metrics-api-tck)
-"MicroProfile Metrics REST-TCK" 1.1 (org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck)
-  Copyright (c) 2017 Contributors to the Eclipse Foundation
-  Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
-  Apache License 2
---------------------------------------------
-"REST Assured" 2.4.0 (com.jayway.restassured:rest-assured)
-  Copyright 2011,2014 the original author or authors.
-  Apache License 2
---------------------------------------------
-"Groovy" 2.3.7 (org.codehaus.groovy:groovy)
-  Copyright 2003-2014 the original author or authors.
-  Copyright (c) 2004 IBM Corporation and others.
-  Apache License 2
---------------------------------------------
-"Groovy" 2.3.7 (org.codehaus.groovy:groovy-xml)
-  Copyright 2003-2014 the original author or authors.
-  Apache License 2
---------------------------------------------
-"Commons Logging" 1.1.3 (commons-logging:commons-logging)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Commons Codec" 1.6 (commons-codec:commons-codec)
-  Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org). Verbatim copying
-  Copyright 2002-2011 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"TagSoup" 1.2.1 (org.ccil.cowan.tagsoup:tagsoup)
-  Copyright 2002-2008 by John Cowan
-  Apache License 2
---------------------------------------------
-"json-path" 2.4.0 (com.jayway.restassured:json-path)
-  Copyright 2013 the original author or authors.
-  Apache License 2
---------------------------------------------
-"Groovy" 2.3.7 (org.codehaus.groovy:groovy-json)
-  Copyright 2003-2014 the original author or authors.
-  Apache License 2
---------------------------------------------
-"rest-assured-common" 2.4.0 (com.jayway.restassured:rest-assured-common)
-  Copyright 2013 the original author or authors.
-  Apache License 2
---------------------------------------------
-"xml-path" 2.4.0 (com.jayway.restassured:xml-path)
-  Copyright 2013 the original author or authors.
-  Apache License 2
---------------------------------------------
-"Apache Commons Lang" 3.3.2 (org.apache.commons:commons-lang3)
-  Copyright 2001-2014 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"jackson-databind" 2.8.6 (com.fasterxml.jackson.core:jackson-databind)
-  Copyright (c) Tatu Saloranta, tatu.saloranta@iki.f
-  Apache License 2
---------------------------------------------
-"Jackson-annotations" 2.8.0 (com.fasterxml.jackson.core:jackson-annotations)
-  No copyright in source code or on pages, part of FasterXML LLC code (https://github.com/FasterXML)
-  Apache License 2
---------------------------------------------
-"Jackson-core" 2.8.6 (com.fasterxml.jackson.core:jackson-core)
-  Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Resolver Maven Implementation" 2.1.1 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven)
-  Copyright 2009,2014 Red Hat Middleware LLC, and individual contributors
-  Copyright (c) 2010 Sonatype, Inc. All rights reserved.
-  Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Resolver Maven API" 2.1.1 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api-maven)
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Resolver API" 2.1.1 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api)
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Resolver Maven SPI" 2.1.1 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi-maven)
-  Copyright 2012, Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Resolver SPI" 2.1.1 (org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Maven Aether Provider" 3.1.1 (org.apache.maven:maven-aether-provider)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Maven Model" 3.1.1 (org.apache.maven:maven-model)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Maven Model Builder" 3.1.1 (org.apache.maven:maven-model-builder)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Plexus :: Component Annotations" 1.5.5 (org.codehaus.plexus:plexus-component-annotations)
-  Copyright (C) 2007 the original author or authors.
-  Apache License 2
---------------------------------------------
-"Maven Repository Metadata Model" 3.1.1 (org.apache.maven:maven-repository-metadata)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Maven Settings" 3.1.1 (org.apache.maven:maven-settings)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Maven Settings Builder" 3.1.1 (org.apache.maven:maven-settings-builder)
-  Copyright 2001-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Plexus Interpolation API" 1.19 (org.codehaus.plexus:plexus-interpolation)
-  Copyright 2001-2009 Codehaus Foundation.
-  Copyright (c) 2004, The Codehaus
-  Copyright 2001-2004 The Apache Software Foundation.
-  Copyright 2007 The Codehaus Foundation.
-  Copyright (c) 2001-2003 The Apache Software Foundation.  All rights
-  Apache License 2
---------------------------------------------
-"Plexus Common Utilities" 3.0.15 (org.codehaus.plexus:plexus-utils)
-  Copyright (c) 2003 Extreme! Lab, Indiana University. All rights reserved.
-  Copyright (c) 2000,2003 The Apache Software Foundation.  All rights
-  Copyright (c) 2001- 2003, ThoughtWorks, Inc.
-  Copyright (C) 2003 The Trustees of Indiana University.
-  Copyright ,2011 The Codehaus Foundation.
-  Copyright 2003-2004 The Apache Software Foundation.
-  Copyright 2004 Sun Microsystems, Inc.
-  Copyright (c) 2003, ThoughtWorks, Inc.
-  Apache License 2
---------------------------------------------
-"Plexus Security Dispatcher Component" 1.3 (org.sonatype.plexus:plexus-sec-dispatcher)
-  Copyright (c) 2008 Sonatype, Inc. All rights reserved.
-  Apache License 2
---------------------------------------------
-"Plexus Cipher: encryption/decryption Component" 1.4 (org.sonatype.plexus:plexus-cipher)
-  Copyright (c) 2008 Sonatype, Inc. All rights reserved.
-  Apache License 2
---------------------------------------------
-"Apache Maven Wagon :: API" 2.6 (org.apache.maven.wagon:wagon-provider-api)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Apache Maven Wagon :: Providers :: File Provider" 2.6 (org.apache.maven.wagon:wagon-file)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Commons Lang" 2.6 (commons-lang:commons-lang)
-  Copyright 2001-2011 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Apache Maven Wagon :: Providers :: Lightweight HTTP Provider" 2.6 (org.apache.maven.wagon:wagon-http-lightweight)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Apache Maven Wagon :: Providers :: HTTP Shared Library" 2.6 (org.apache.maven.wagon:wagon-http-shared)
-  Copyright 2003-2013 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Commons IO" 2.2 (commons-io:commons-io)
-  Copyright 2002-2012 The Apache Software Foundation
-  Apache License 2
---------------------------------------------
-"Arquillian TestRunner JUnit Container" 1.1.8.Final (org.jboss.arquillian.junit:arquillian-junit-container)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009, Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian TestRunner JUnit Core" 1.1.8.Final (org.jboss.arquillian.junit:arquillian-junit-core)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009, Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Test API" 1.1.8.Final (org.jboss.arquillian.test:arquillian-test-api)
-  Copyright 2010, Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Core API" 1.1.8.Final (org.jboss.arquillian.core:arquillian-core-api)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Test SPI" 1.1.8.Final (org.jboss.arquillian.test:arquillian-test-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Copyright 2014,2015 Red Hat, Inc. and/or its affiliates, and individual
-  Apache License 2
---------------------------------------------
-"Arquillian Core SPI" 1.1.8.Final (org.jboss.arquillian.core:arquillian-core-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Container Test API" 1.1.8.Final (org.jboss.arquillian.container:arquillian-container-test-api)
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap API" 1.2.2 (org.jboss.shrinkwrap:shrinkwrap-api)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Container Test SPI" 1.1.8.Final (org.jboss.arquillian.container:arquillian-container-test-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2008,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Container SPI" 1.1.8.Final (org.jboss.arquillian.container:arquillian-container-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Descriptors API Base" 2.0.0-alpha-7 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Core Implementation Base" 1.1.8.Final (org.jboss.arquillian.core:arquillian-core-impl-base)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Test Implementation Base" 1.1.8.Final (org.jboss.arquillian.test:arquillian-test-impl-base)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
-  Copyright 2009,2010 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Container Implementation Base" 1.1.8.Final (org.jboss.arquillian.container:arquillian-container-impl-base)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Config API" 1.1.8.Final (org.jboss.arquillian.config:arquillian-config-api)
-  Copyright 2011,2013 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2010, Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Config Implementation Base" 1.1.8.Final (org.jboss.arquillian.config:arquillian-config-impl-base)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2010,2011 Red Hat Middleware LLC, and individual contributors
-  Copyright 2005, JBoss Inc., and individual contributors as indicated
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Descriptors SPI" 2.0.0-alpha-7 (org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"Arquillian Container Test Implementation Base" 1.1.8.Final (org.jboss.arquillian.container:arquillian-container-test-impl-base)
-  Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-  Copyright 2009,2013 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap Implementation Base" 1.2.2 (org.jboss.shrinkwrap:shrinkwrap-impl-base)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"ShrinkWrap SPI" 1.2.2 (org.jboss.shrinkwrap:shrinkwrap-spi)
-  Copyright 2009,2012 Red Hat Middleware LLC, and individual contributors
-  Apache License 2
---------------------------------------------
-"MicroProfile Config API" 1.1 (org.eclipse.microprofile.config:microprofile-config-api)
-  Copyright (c) 2009-2017 Contributors to the Eclipse Foundation
-  Apache License 2
---------------------------------------------
-"org.osgi:org.osgi.annotation.versioning" 1.0.0 (org.osgi:org.osgi.annotation.versioning)
-  Copyright (c) OSGi Alliance (2013, 2014). All Rights Reserved.
-  Copyright (c) OSGi Alliance (2013). All Rights Reserved.
-  Apache License 2
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-OkHttp 3.14.1 Square, Inc.
-Apache 2.0
-Used by: [bookstore-se]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-OkHttp (com.squareup.okhttp3:okhttp)
-  Copyright (C) 2012,2019 Square, Inc.
-  Copyright 2013 Twitter, Inc.
-  Copyright (C) 2010,2012 The Android Open Source Project
-  Apache License 2
--------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-"Okio" 1.17.2 (com.squareup.okio:okio)
-  Copyright 2014 Square Inc.
-  Copyright (C) 2014,2019 Square, Inc.
-Apache License 2.0
-  
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Restito 0.9.1 Mark Kotsur
-MIT
-Used by: [helidon-config, helidon-config-tests-integration-tests]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-
-Copyright (C) 2015 Restito contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
---------------------------------------------
-Fourth Party Dependencies
---------------------------------------------
-"ASM Core" 5.0.3 (org.ow2.asm:asm)
-Copyright (c) INRIA, France Telecom
-  Copyright (c) Eugene Kuleshov
-
-Copyright (c) 2000-2011 INRIA, France Telecom
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holders nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------
-"JUnit" 4.12 (junit:junit)
-Copyright (c) JUnit. All Rights Reserved.
-Eclipse Public License - v 1.0 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE
-TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR
-DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
-AGREEMENT.
---------------------------------------------
-"Hamcrest Core" 1.3 (org.hamcrest:hamcrest-core)
-Copyright (c) www.hamcrest.org
-The 2-Clause BSD License
-SPDX short identifier: BSD-2-Clause
-
-Further resources on the 2-clause BSD license
-Note: This license has also been called the "Simplified BSD License" and the
-"FreeBSD License". See also the 3-clause BSD License.
-
-Copyright <YEAR> <COPYRIGHT HOLDER>
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------
-"SLF4J API Module" 1.7.21 (org.slf4j:slf4j-api)
-Copyright (c) QOS.ch
-
-The MIT License SPDX short identifier: MIT
-
-Further resources on the MIT License Copyright <YEAR> <COPYRIGHT HOLDER>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
---------------------------------------------
-"Json Path" 2.1.0 (com.jayway.jsonpath:json-path)
-Copyright the original author or authors.
-Apache License 2.0
---------------------------------------------
-"JSON Small and Fast Parser" 2.2 (net.minidev:json-smart)
-Copyright JSON-SMART authors
-Apache License 2.0
---------------------------------------------
-"ASM based accessors helper used by json-smart" 1.1 (net.minidev:accessors-smart)
-Copyright JSON-SMART authors
-Apache License 2.0
---------------------------------------------
-"Apache MINA Core" 2.0.13 (org.apache.mina:mina-core)
-Copyright (c) Eric Glass Permission to use, copy, modify, and distribute
-Apache License 2.0
---------------------------------------------
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-mockito-core 2.23.4 Mockito
-MIT
-Used by: Many
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-mockito-core (org.mockito:mockito-core:2.23.0)
-The MIT License
-
-Copyright (c) 2007 Mockito contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-======================================================================
-FOURTH PARTY LIBRARIES
-Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.9.0 - http://bytebuddy.net/byte-buddy)
-Byte Buddy Java agent (net.bytebuddy:byte-buddy-agent:1.9.0 - http://bytebuddy.net/byte-buddy-agent)
-Objenesis (org.objenesis:objenesis:2.6 - http://objenesis.org)
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-com.datastax.cassandra:cassandra-driver-core 3.4.0
-Used by: [helidon-examples-todo-backend]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright DataStax, Inc
-Apache License Version 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-com.github.akarnokd:rxjava2-jdk9-interop 0.1.0
-Used by: [helidon-config-tests-integration-tests]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2016-2020 David Karnok
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-io.netty:netty-tcnative-boringssl-static 2.0.26.Final
-Used by: [helidon-grpc-client, helidon-grpc-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2016 The Netty Project
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-io.reactivex.rxjava2:rxjava 2.0.8
-Used by: [helidon-grpc-client, helidon-microprofile-grpc-server, helidon-config-tests-integration-tests, helidon-grpc-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright (c) 2016-present, RxJava Contributors.
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-io.zipkin.zipkin2:zipkin-junit 2.12.5
-Used by: [helidon-grpc-server]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2015-2020 The OpenZipkin Authors
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.awaitility:awaitility 3.1.6
-Used by: [helidon-common-configurable]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2010 the original author or authors.
-Copyright 2011 the original author or authors.
-Copyright 2015 the original author or authors.
-Copyright 2016 the original author or authors.
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.eclipse.microprofile.health:microprofile-health-tck 2.1
-Used by: [tck-health]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright (c) 2017,2019 Contributors to the Eclipse Foundation
-Apache License 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.hamcrest:hamcrest-all 1.3
-Used by: Many
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-BSD License
-
-Copyright (c) 2000-2015 www.hamcrest.org
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of
-conditions and the following disclaimer. Redistributions in binary form must reproduce
-the above copyright notice, this list of conditions and the following disclaimer in
-the documentation and/or other materials provided with the distribution.
-
-Neither the name of Hamcrest nor the names of its contributors may be used to endorse
-or promote products derived from this software without specific prior written
-permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.junit.jupiter:junit-jupiter-api 5.6.2
-Used by: [helidon-quickstart-se]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2015-2020 the original author or authors.
-Eclipse Public License - v 2.0
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.reactivestreams:reactive-streams-tck 1.0.2
-Used by: [helidon-common-reactive]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Licensed under Public Domain (CC0)
-
-To the extent possible under law, the person who associated CC0 with
-this code has waived all copyright and related or neighboring
-rights to this code.
-
-You should have received a copy of the CC0 legalcode along with this
-work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-org.testng:testng 6.13.1
-Used by: [tck-config, tck-rest-client, tck-openapi, tck-health, tck-fault-tolerance, tck-metrics2, tck-jwt-auth, tck-opentracing, tck-metrics, tck-project]
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-Copyright 2015 the original author or authors.
-Copyright 2011 Wolfgang Baltes
-Apache License 2.0
+</attribution>
+        </dependency>
+    </dependencies>
+</attribution-document>

--- a/etc/copyright-exclude.txt
+++ b/etc/copyright-exclude.txt
@@ -44,3 +44,4 @@ node_modules
 archetype-resources/pom.xml
 # excluded as it contains both Oracle and original copyright notice
 src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+etc/THIRD_PARTY_LICENSES.xml


### PR DESCRIPTION
This PR creates a new version of our third party license file: `etc/THIRD_PARTY_LICENSES.xml`. This is a structured version of our third party runtime dependencies to support generated reports from.

This PR also updates the human readable version of our THIRD_PARTY_LICENSES.txt file to reflect latest dependencies (generated from the xml file).