### PR TITLE
1.x: Upgrade Jackson to 2.11.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -54,7 +54,7 @@
         <version.lib.hibernate>5.4.4.Final</version.lib.hibernate>
         <version.lib.hikaricp>3.4.1</version.lib.hikaricp>
         <version.lib.inject>1</version.lib.inject>
-        <version.lib.jackson>2.10.0</version.lib.jackson>
+        <version.lib.jackson>2.11.1</version.lib.jackson>
         <version.lib.jaegertracing>0.34.0</version.lib.jaegertracing>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>


### PR DESCRIPTION
Upgrades Jackson in Helidon 1.4.x to match the version in Helidon 2.x.