### PR TITLE
Update gRPC Version

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -52,7 +52,7 @@
         <version.lib.google-api-client>1.30.5</version.lib.google-api-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.graalvm>20.1.0</version.lib.graalvm>
-        <version.lib.grpc>1.27.1</version.lib.grpc>
+        <version.lib.grpc>1.32.1</version.lib.grpc>
         <version.lib.guava>28.1-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/grpc/io.grpc/src/main/java/module-info.java
+++ b/grpc/io.grpc/src/main/java/module-info.java
@@ -26,8 +26,6 @@ module io.grpc {
     requires java.logging;
     requires java.naming;
 
-    requires static com.google.common;
-
     uses io.grpc.ManagedChannelProvider;
     uses io.grpc.NameResolverProvider;
     uses io.grpc.ServerProvider;


### PR DESCRIPTION
 The gRPC Java libraries have a dependency on Netty. This PR is to update to the latest gRPC Java version to match with the version of Netty being used by the rest of Helidon.