### PR TITLE
Name support for all those operations that implement FtHandler

### DIFF
--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -98,9 +98,9 @@ public interface Bulkhead extends FtHandler {
         }
 
         /**
-         * Name is useful for debugging and in exception handling.
+         * A name assigned for debugging, error reporting or configuration purposes.
          *
-         * @param name name of this bulkhead
+         * @param name the name
          * @return updated builder instance
          */
         public Builder name(String name) {

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
@@ -56,6 +56,11 @@ class BulkheadImpl implements Bulkhead {
     }
 
     @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
     public <T> Single<T> invoke(Supplier<? extends CompletionStage<T>> supplier) {
         return invokeTask(DelayedTask.createSingle(supplier));
     }
@@ -91,6 +96,7 @@ class BulkheadImpl implements Bulkhead {
     }
 
     // this method must be called while NOT holding a permit
+    @SuppressWarnings("unchecked")
     private <R> R invokeTask(DelayedTask<R> task) {
         if (inProgress.tryAcquire()) {
             LOGGER.finest(() -> name + " invoke immediate: " + task);

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
@@ -97,6 +97,7 @@ public interface CircuitBreaker extends FtHandler {
         // rolling window size to
         private int volume = 10;
         private LazyValue<? extends ScheduledExecutorService> executor = FaultTolerance.scheduledExecutor();
+        private String name = "CircuitBreaker-" + System.identityHashCode(this);
 
         private Builder() {
         }
@@ -163,7 +164,8 @@ public interface CircuitBreaker extends FtHandler {
          * @param classes to consider failures to calculate failure ratio
          * @return updated builder instance
          */
-        public Builder applyOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder applyOn(Class<? extends Throwable>... classes) {
             applyOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addApplyOn);
@@ -191,7 +193,8 @@ public interface CircuitBreaker extends FtHandler {
          * @param classes to consider successful
          * @return updated builder instance
          */
-        public Builder skipOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder skipOn(Class<? extends Throwable>... classes) {
             skipOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addSkipOn);
@@ -224,6 +227,17 @@ public interface CircuitBreaker extends FtHandler {
             return this;
         }
 
+        /**
+         * A name assigned for debugging, error reporting or configuration purposes.
+         *
+         * @param name the name
+         * @return updated builder instance
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
         LazyValue<? extends ScheduledExecutorService> executor() {
             return executor;
         }
@@ -250,6 +264,10 @@ public interface CircuitBreaker extends FtHandler {
 
         int volume() {
             return volume;
+        }
+
+        String name() {
+            return name;
         }
     }
 }

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -54,6 +54,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
     private final AtomicBoolean halfOpenInProgress = new AtomicBoolean();
     private final AtomicReference<ScheduledFuture<Boolean>> schedule = new AtomicReference<>();
     private final ErrorChecker errorChecker;
+    private final String name;
 
     CircuitBreakerImpl(CircuitBreaker.Builder builder) {
         this.delayMillis = builder.delay().toMillis();
@@ -61,6 +62,12 @@ class CircuitBreakerImpl implements CircuitBreaker {
         this.results = new ResultWindow(builder.volume(), builder.errorRatio());
         this.executor = builder.executor();
         this.errorChecker = ErrorChecker.create(builder.skipOn(), builder.applyOn());
+        this.name = builder.name();
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Fallback.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Fallback.java
@@ -122,7 +122,8 @@ public interface Fallback<T> extends FtHandlerTyped<T> {
          * @param classes classes to fallback on
          * @return updated builder instance
          */
-        public Builder<T> applyOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder<T> applyOn(Class<? extends Throwable>... classes) {
             applyOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addApplyOn);
@@ -148,7 +149,8 @@ public interface Fallback<T> extends FtHandlerTyped<T> {
          * @param classes classes not to fallback on
          * @return updated builder instance
          */
-        public Builder<T> skipOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder<T> skipOn(Class<? extends Throwable>... classes) {
             skipOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addSkipOn);

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -349,9 +349,15 @@ public final class FaultTolerance {
 
         private static class FtHandlerImpl implements FtHandler {
             private final List<FtHandler> validFts;
+            private final String name = "FtHandler-" + System.identityHashCode(this);
 
             private FtHandlerImpl(List<FtHandler> validFts) {
                 this.validFts = new LinkedList<>(validFts);
+            }
+
+            @Override
+            public String name() {
+                return name;
             }
 
             @Override

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtHandler.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/FtHandler.java
@@ -33,6 +33,14 @@ import io.helidon.common.reactive.Single;
  * </ul>
  */
 public interface FtHandler {
+
+    /**
+     * A name assigned to a handler for debugging, error reporting or configuration purposes.
+     *
+     * @return a non-null name for this handler
+     */
+    String name();
+
     /**
      * Invoke this fault tolerance handler on a supplier of a {@link java.util.concurrent.CompletionStage}, such as a
      * {@link io.helidon.common.reactive.Single}.

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -60,6 +60,7 @@ public interface Retry extends FtHandler {
 
         private Duration overallTimeout = Duration.ofSeconds(1);
         private LazyValue<? extends ScheduledExecutorService> scheduledExecutor = FaultTolerance.scheduledExecutor();
+        private String name = "Retry-" + System.identityHashCode(this);
 
         private Builder() {
         }
@@ -90,7 +91,8 @@ public interface Retry extends FtHandler {
          * @param classes to consider failures and trigger a retry
          * @return updated builder instance
          */
-        public Builder applyOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder applyOn(Class<? extends Throwable>... classes) {
             applyOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addApplyOn);
@@ -118,7 +120,8 @@ public interface Retry extends FtHandler {
          * @param classes to skip retries
          * @return updated builder instance
          */
-        public Builder skipOn(Class<? extends Throwable>... classes) {
+        @SafeVarargs
+        public final Builder skipOn(Class<? extends Throwable>... classes) {
             skipOn.clear();
             Arrays.stream(classes)
                     .forEach(this::addSkipOn);
@@ -164,6 +167,17 @@ public interface Retry extends FtHandler {
             return this;
         }
 
+        /**
+         * A name assigned for debugging, error reporting or configuration purposes.
+         *
+         * @param name the name
+         * @return updated builder instance
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
         Set<Class<? extends Throwable>> applyOn() {
             return applyOn;
         }
@@ -182,6 +196,10 @@ public interface Retry extends FtHandler {
 
         LazyValue<? extends ScheduledExecutorService> scheduledExecutor() {
             return scheduledExecutor;
+        }
+
+        String name() {
+            return name;
         }
     }
 

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -38,12 +38,19 @@ class RetryImpl implements Retry {
     private final long maxTimeNanos;
     private final Retry.RetryPolicy retryPolicy;
     private final AtomicLong retryCounter = new AtomicLong(0L);
+    private final String name;
 
     RetryImpl(Retry.Builder builder) {
         this.scheduledExecutor = builder.scheduledExecutor();
         this.errorChecker = ErrorChecker.create(builder.skipOn(), builder.applyOn());
         this.maxTimeNanos = builder.overallTimeout().toNanos();
         this.retryPolicy = builder.retryPolicy();
+        this.name = builder.name();
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
@@ -53,6 +53,7 @@ public interface Timeout extends FtHandler {
         private Duration timeout = Duration.ofSeconds(10);
         private LazyValue<? extends ScheduledExecutorService> executor = FaultTolerance.scheduledExecutor();
         private boolean currentThread = false;
+        private String name = "Timeout-" + System.identityHashCode(this);
 
         private Builder() {
         }
@@ -96,6 +97,17 @@ public interface Timeout extends FtHandler {
             return this;
         }
 
+        /**
+         * A name assigned for debugging, error reporting or configuration purposes.
+         *
+         * @param name the name
+         * @return updated builder instance
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
         Duration timeout() {
             return timeout;
         }
@@ -106,6 +118,10 @@ public interface Timeout extends FtHandler {
 
         boolean currentThread() {
             return currentThread;
+        }
+
+        String name() {
+            return name;
         }
     }
 }

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
@@ -36,11 +36,18 @@ class TimeoutImpl implements Timeout {
     private final long timeoutMillis;
     private final LazyValue<? extends ScheduledExecutorService> executor;
     private final boolean currentThread;
+    private final String name;
 
     TimeoutImpl(Timeout.Builder builder) {
         this.timeoutMillis = builder.timeout().toMillis();
         this.executor = builder.executor();
         this.currentThread = builder.currentThread();
+        this.name = builder.name();
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override


### PR DESCRIPTION
Name support for all those operations that implement FtHandler. These names can be used for debugging, error reporting and future config support. Fixed some warnings too.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>