### PR TITLE
Update release of Prometheus Java client (in 2.x)

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -103,7 +103,7 @@
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.persistence-api>2.2.3</version.lib.persistence-api>
-        <version.lib.prometheus>0.6.0</version.lib.prometheus>
+        <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
         <version.lib.slf4j>1.7.26</version.lib.slf4j>
         <version.lib.smallrye-openapi>1.2.0</version.lib.smallrye-openapi>


### PR DESCRIPTION
Resolves #2402 

Update from 0.6.0 to current 0.9.0.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>