### PR TITLE
CDI.current().getBeanManager() now available during shutdown

### DIFF
--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -402,9 +402,12 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
             if (!isRunning.get()) {
                 LOGGER.warning("BeanManager requested during container shutdown. This may be caused by observer methods "
                                        + "that use CDI.current(). Switch to finest logging to see stack trace.");
-                LOGGER.log(Level.FINEST,
-                           "Invocation of container method during shutdown",
-                           new IllegalStateException("Container not running"));
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    // this should not be common, but guarding, so we do not fill stack trace unless necessary
+                    LOGGER.log(Level.FINEST,
+                               "Invocation of container method during shutdown",
+                               new IllegalStateException("Container not running"));
+                }
             }
 
             return new BeanManagerProxy(beanManager());

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -399,10 +399,15 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
 
         @Override
         public BeanManager getBeanManager() {
-            if (isRunning.get()) {
-                return new BeanManagerProxy(beanManager());
+            if (!isRunning.get()) {
+                LOGGER.warning("BeanManager requested during container shutdown. This may be caused by observer methods "
+                                       + "that use CDI.current(). Switch to finest logging to see stack trace.");
+                LOGGER.log(Level.FINEST,
+                           "Invocation of container method during shutdown",
+                           new IllegalStateException("Container not running"));
             }
-            throw new IllegalStateException("Container not running");
+
+            return new BeanManagerProxy(beanManager());
         }
 
         private BeanManagerImpl beanManager() {

--- a/tests/integration/mp-gh-2421/pom.xml
+++ b/tests/integration/mp-gh-2421/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-tests-integration</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>2.0.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-2421</artifactId>
+    <name>Helidon Tests Integration MP GH 2421</name>
+    <description>Reproducer for Github issue #2421 - CDI container not
+        available during shutdown</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.cdi</groupId>
+            <artifactId>helidon-microprofile-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-2421/src/test/java/io/helidon/tests/integration/gh2421/Gh2421Test.java
+++ b/tests/integration/mp-gh-2421/src/test/java/io/helidon/tests/integration/gh2421/Gh2421Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh2421;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.CDI;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test that an application scoped destroyed observer can use {@link javax.enterprise.inject.spi.CDI#current()}.
+ */
+public class Gh2421Test {
+    @Test
+    void testShutdownWorks() {
+        SeContainer container = SeContainerInitializer.newInstance()
+                .addBeanClasses(ListenerBean.class)
+                .initialize();
+
+        container.close();
+
+        assertThat(ListenerBean.called.get(), is(true));
+    }
+
+    @ApplicationScoped
+    public static class ListenerBean {
+        static AtomicBoolean called = new AtomicBoolean();
+
+        public void method(@Observes @BeforeDestroyed(ApplicationScoped.class) Object event) {
+            // need to call CDI.current() as that is not working
+            CDI.current().getBeanManager();
+            called.set(true);
+        }
+    }
+}

--- a/tests/integration/mp-gh-2421/src/test/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-gh-2421/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mp.initializer.allow=true
+mp.initializer.no-warn=true

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -41,6 +41,7 @@
         <module>webclient</module>
         <module>security</module>
         <module>mp-gh-1538</module>
+        <module>mp-gh-2421</module>
         <module>kafka</module>
     </modules>
 


### PR DESCRIPTION
Resolves #2421 

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>