### PR TITLE
helidon-cli-maven-plugin as extension

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -181,8 +181,7 @@
                 <plugins>
                     <plugin>
                         <groupId>io.helidon.build-tools</groupId>
-                        <artifactId>helidon-maven-plugin</artifactId>
-                        <version>${version.plugin.helidon}</version>
+                        <artifactId>helidon-cli-maven-plugin</artifactId>
                         <extensions>true</extensions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Update the helidon-cli profile to declare the helidon-cli-maven-plugin as an extension instead of the helidon-maven-plugin.

Also remove the version since the plugin is already managed.

Fixes #2398