### PR TITLE
Add third-party-license-report execution to archetype project poms

### DIFF
--- a/archetypes/bare-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-mp/src/main/resources/pom.xml.mustache
@@ -57,6 +57,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/bare-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/bare-se/src/main/resources/pom.xml.mustache
@@ -66,6 +66,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/database-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-mp/src/main/resources/pom.xml.mustache
@@ -176,6 +176,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/database-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/database-se/src/main/resources/pom.xml.mustache
@@ -132,6 +132,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/pom.xml.mustache
@@ -75,6 +75,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
+++ b/archetypes/quickstart-se/src/main/resources/pom.xml.mustache
@@ -66,6 +66,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Adds the third-party-license-report execution to projects generated from the archetypes.
