### PR TITLE
Fix uses of jlink-image directories to use new "-jri" suffix.

### DIFF
--- a/archetypes/quickstart-mp/src/main/resources/README.md.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/README.md.mustache
@@ -128,12 +128,12 @@ docker run --rm -p 8080:8080 {{artifactId}}-native:latest
 
 ## Build a Java Runtime Image using jlink
 
-You can build a custom Java Runtime Image (JRI) containing the application jars and the JDK modules 
+You can build a custom Java Runtime Image (JRI) containing the application jars and the JDK modules
 on which they depend. This image also:
 
-* Enables Class Data Sharing by default to reduce startup time. 
-* Contains a customized `start` script to simplify CDS usage and support debug and test modes. 
- 
+* Enables Class Data Sharing by default to reduce startup time.
+* Contains a customized `start` script to simplify CDS usage and support debug and test modes.
+
 You can build a custom JRI in two different ways:
 * Local
 * Using Docker
@@ -152,25 +152,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/{{artifactId}}/bin/start
+./target/{{artifactId}}-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t {{artifactId}}-jlink -f Dockerfile.jlink .
+docker build -t {{artifactId}}-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 {{artifactId}}-jlink:latest
+docker run --rm -p 8080:8080 {{artifactId}}-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm {{artifactId}}-jlink:latest --help
+docker run --rm {{artifactId}}-jri:latest --help
 ```

--- a/archetypes/quickstart-se/src/main/resources/README.md.mustache
+++ b/archetypes/quickstart-se/src/main/resources/README.md.mustache
@@ -127,12 +127,12 @@ docker run --rm -p 8080:8080 {{artifactId}}-native:latest
 
 ## Build a Java Runtime Image using jlink
 
-You can build a custom Java Runtime Image (JRI) containing the application jars and the JDK modules 
+You can build a custom Java Runtime Image (JRI) containing the application jars and the JDK modules
 on which they depend. This image also:
 
-* Enables Class Data Sharing by default to reduce startup time. 
-* Contains a customized `start` script to simplify CDS usage and support debug and test modes. 
- 
+* Enables Class Data Sharing by default to reduce startup time.
+* Contains a customized `start` script to simplify CDS usage and support debug and test modes.
+
 You can build a custom JRI in two different ways:
 * Local
 * Using Docker
@@ -151,25 +151,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/{{artifactId}}/bin/start
+./target/{{artifactId}}-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t {{artifactId}}-jlink -f Dockerfile.jlink .
+docker build -t {{artifactId}}-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 {{artifactId}}-jlink:latest
+docker run --rm -p 8080:8080 {{artifactId}}-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm {{artifactId}}-jlink:latest --help
+docker run --rm {{artifactId}}-jri:latest --help
 ```

--- a/docs/common/guides/jlink_image.adoc
+++ b/docs/common/guides/jlink_image.adoc
@@ -107,7 +107,7 @@ This uses the `helidon-maven-plugin` to perform the custom image generation.
 After the build completes it will report some statistics about the build including
 the reduction in image size.
 
-The `target/helidon-quickstart-{helidon-lc-flavor}` directory is a self contained
+The `target/helidon-quickstart-{helidon-lc-flavor}-jri` directory is a self contained
 custom image of your application. It contains your application, its runtime
 dependencies and the JDK modules it depends on. You can start your application
 using the provide
@@ -115,7 +115,7 @@ using the provide
 
 [source,bash,subs="attributes+"]
 ----
-./target/helidon-quickstart-{helidon-lc-flavor}/bin/start
+./target/helidon-quickstart-{helidon-lc-flavor}-jri/bin/start
 ----
 
 === Class Data Sharing (CDS) Archive
@@ -147,7 +147,7 @@ Dockerfile included with the quickstart.
 
 [source,bash,subs="attributes+"]
 ----
-docker build -t helidon-quickstart-{helidon-lc-flavor}-jlink -f Dockerfile.jlink .
+docker build -t helidon-quickstart-{helidon-lc-flavor}-jri -f Dockerfile.jlink .
 ----
 
 [TIP]
@@ -162,7 +162,7 @@ Start the application:
 
 [source,bash,subs="attributes+"]
 ----
-docker run --rm -p 8080:8080 helidon-quickstart-{helidon-lc-flavor}-jlink:latest
+docker run --rm -p 8080:8080 helidon-quickstart-{helidon-lc-flavor}-jri:latest
 ----
 
 You can exercise the application's endpoints as before.

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -35,6 +35,6 @@ RUN echo "done!"
 
 FROM debian:stretch-slim
 WORKDIR /helidon
-COPY --from=build /helidon/target/helidon-quickstart-mp ./
+COPY --from=build /helidon/target/helidon-quickstart-mp-jri ./
 ENTRYPOINT ["/bin/bash", "/helidon/bin/start"]
 EXPOSE 8080

--- a/examples/quickstarts/helidon-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-quickstart-mp/README.md
@@ -142,25 +142,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/helidon-quickstart-mp/bin/start
+./target/helidon-quickstart-mp-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t helidon-quickstart-mp-jlink -f Dockerfile.jlink .
+docker build -t helidon-quickstart-mp-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 helidon-quickstart-mp-jlink:latest
+docker run --rm -p 8080:8080 helidon-quickstart-mp-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm helidon-quickstart-mp-jlink:latest --help
+docker run --rm helidon-quickstart-mp-jri:latest --help
 ```

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -35,6 +35,6 @@ RUN echo "done!"
 
 FROM debian:stretch-slim
 WORKDIR /helidon
-COPY --from=build /helidon/target/helidon-quickstart-se ./
+COPY --from=build /helidon/target/helidon-quickstart-se-jri ./
 ENTRYPOINT ["/bin/bash", "/helidon/bin/start"]
 EXPOSE 8080

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -141,25 +141,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/helidon-quickstart-se/bin/start
+./target/helidon-quickstart-se-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t helidon-quickstart-se-jlink -f Dockerfile.jlink .
+docker build -t helidon-quickstart-se-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 helidon-quickstart-se-jlink:latest
+docker run --rm -p 8080:8080 helidon-quickstart-se-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm helidon-quickstart-se-jlink:latest --help
+docker run --rm helidon-quickstart-se-jri:latest --help
 ```

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -35,6 +35,6 @@ RUN echo "done!"
 
 FROM debian:stretch-slim
 WORKDIR /helidon
-COPY --from=build /helidon/target/helidon-quickstart-mp ./
+COPY --from=build /helidon/target/helidon-quickstart-mp-jri ./
 ENTRYPOINT ["/bin/bash", "/helidon/bin/start"]
 EXPOSE 8080

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/README.md
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/README.md
@@ -142,25 +142,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/helidon-quickstart-se/bin/start
+./target/helidon-quickstart-se-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t helidon-quickstart-mp-jlink -f Dockerfile.jlink .
+docker build -t helidon-quickstart-mp-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 helidon-quickstart-mp-jlink:latest
+docker run --rm -p 8080:8080 helidon-quickstart-mp-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm helidon-quickstart-mp-jlink:latest --help
+docker run --rm helidon-quickstart-mp-jri:latest --help
 ```

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -35,6 +35,6 @@ RUN echo "done!"
 
 FROM debian:stretch-slim
 WORKDIR /helidon
-COPY --from=build /helidon/target/helidon-quickstart-se ./
+COPY --from=build /helidon/target/helidon-quickstart-se-jri ./
 ENTRYPOINT ["/bin/bash", "/helidon/bin/start"]
 EXPOSE 8080

--- a/examples/quickstarts/helidon-standalone-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/README.md
@@ -142,25 +142,25 @@ See https://github.com/oracle/helidon-build-tools/tree/master/helidon-maven-plug
 Start the application:
 
 ```
-./target/helidon-quickstart-se/bin/start
+./target/helidon-quickstart-se-jri/bin/start
 ```
 
 ### Multi-stage Docker build
 
-Build the "jlink" Docker Image
+Build the JRI as a Docker Image
 
 ```
-docker build -t helidon-quickstart-se-jlink -f Dockerfile.jlink .
+docker build -t helidon-quickstart-se-jri -f Dockerfile.jlink .
 ```
 
 Start the application:
 
 ```
-docker run --rm -p 8080:8080 helidon-quickstart-se-jlink:latest
+docker run --rm -p 8080:8080 helidon-quickstart-se-jri:latest
 ```
 
 See the start script help:
 
 ```
-docker run --rm helidon-quickstart-se-jlink:latest --help
+docker run --rm helidon-quickstart-se-jri:latest --help
 ```


### PR DESCRIPTION
Fixes #2460 and the `Dockerfile.jlink` uses.