### PR TITLE
Override parent pom properties to include artifact in release

### DIFF
--- a/microprofile/tests/junit5/pom.xml
+++ b/microprofile/tests/junit5/pom.xml
@@ -32,6 +32,14 @@
         Integration with Junit5 to support tests with CDI injection
     </description>
 
+    <!-- Override properties from parent pom to include in release -->
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+        <maven.sources.skip>false</maven.sources.skip>
+        <maven.javadoc.skip>false</maven.javadoc.skip>
+        <spotbugs.skip>false</spotbugs.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.cdi</groupId>

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
@@ -453,7 +453,7 @@ class HelidonJunitExtension implements BeforeAllCallback,
                             int port = (int) m.invoke(extension);
                             String uri = "http://localhost:" + port;
                             return client.target(uri);
-                        } catch (Exception e) {
+                        } catch (ReflectiveOperationException e) {
                             return client.target("http://localhost:7001");
                         }
                     });

--- a/microprofile/tests/junit5/src/main/java/module-info.java
+++ b/microprofile/tests/junit5/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JUnit5 extension module to run CDI tests.
+ */
+module io.helidon.microprofile.tests.junit5 {
+
+    requires io.helidon.microprofile.cdi;
+    requires io.helidon.config.mp;
+    requires org.junit.jupiter.api;
+    requires transitive jakarta.enterprise.cdi.api;
+    requires transitive java.ws.rs;
+
+    exports io.helidon.microprofile.tests.junit5;
+}


### PR DESCRIPTION
Override parent pom properties to include artifact in release. Fixed spotbugs issue.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>