### PR TITLE
Add vetoed-bean support to metrics CDI extension

### DIFF
--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricUtil.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricUtil.java
@@ -107,7 +107,7 @@ public final class MetricUtil {
         return result;
     }
 
-    private static <A extends Annotation>  List<LookupResult<A>> lookupAnnotations(Annotated annotated,
+    static <A extends Annotation>  List<LookupResult<A>> lookupAnnotations(Annotated annotated,
             Class<A> annotClass) {
         // We have to filter by annotation class ourselves, because annotatedMethod.getAnnotations(Class) delegates
         // to the Java method. That would bypass any annotations that had been added dynamically to the configurator.

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -70,8 +70,6 @@ import io.helidon.common.Errors;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
 import io.helidon.metrics.MetricsSupport;
-import io.helidon.metrics.Registry;
-import io.helidon.metrics.RegistryFactory;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.webserver.Routing;
 
@@ -92,7 +90,6 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;
-import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -70,6 +70,8 @@ import io.helidon.common.Errors;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
 import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.Registry;
+import io.helidon.metrics.RegistryFactory;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.webserver.Routing;
 
@@ -90,6 +92,7 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
@@ -27,6 +27,9 @@ import javax.ws.rs.core.MediaType;
 import io.helidon.metrics.RegistryFactory;
 import io.helidon.microprofile.tests.junit5.AddConfig;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricFilter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.Tag;
@@ -97,6 +100,12 @@ public class HelloWorldTest extends MetricsMpServiceTest {
     SimpleTimer getSyntheticSimpleTimer() {
         Tag[] tags = new Tag[] {new Tag("class", HelloWorldResource.class.getName()),
                 new Tag("method", "messageWithArg_java.lang.String")};
+        assertThat("Synthetic simple timer "
+                        + MetricsCdiExtension.SYNTHETIC_SIMPLE_TIMER_METRIC_NAME
+                        + " should appear in registry but does not",
+                syntheticSimpleTimerRegistry().getSimpleTimers((metricID, metric) ->
+                        metricID.getName().equals(MetricsCdiExtension.SYNTHETIC_SIMPLE_TIMER_METRIC_NAME)).isEmpty(),
+                is(false));
         SimpleTimer syntheticSimpleTimer = syntheticSimpleTimerRegistry().simpleTimer(
                 MetricsCdiExtension.SYNTHETIC_SIMPLE_TIMER_METADATA, tags);
         return syntheticSimpleTimer;

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/MetricsMpServiceTest.java
@@ -46,6 +46,10 @@ public class MetricsMpServiceTest {
         return baseRegistry;
     }
 
+    MetricRegistry registry() {
+        return registry;
+    }
+
     boolean isSyntheticSimpleTimerPresent() {
         return !syntheticSimpleTimerRegistry().getSimpleTimers((metricID, metric) ->
                         metricID.equals(MetricsCdiExtension.SYNTHETIC_SIMPLE_TIMER_METRIC_NAME))

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestVetoedResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestVetoedResource.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.lang.reflect.Method;
+
+@HelidonTest
+@AddExtension(VetoCdiExtension.class)
+public class TestVetoedResource extends MetricsMpServiceTest {
+
+    @Test
+    void testNoAnnotatedMetricForVetoedResource() throws NoSuchMethodException {
+        // The metrics CDI extension should ignore the vetoed resource's explicitly-annotated metrics.
+        MetricID vetoedID = new MetricID(VetoedResource.COUNTER_NAME);
+        assertThat("Metrics CDI extension incorrectly registered a metric on a vetoed resource",
+                registry().getCounters()
+                        .containsKey(vetoedID), is(false));
+    }
+
+    @Test
+    void testNoSyntheticSimplyTimedMetricForVetoedResource() throws NoSuchMethodException {
+        // Makes sure that a vetoed JAX-RS resource with an explicit metric annotation was not registered with a synthetic
+        // SimplyTimed metric.
+        Method method = VetoedResource.class.getMethod("get");
+        assertThat(
+                "Metrics CDI extension incorrectly registered a synthetic simple timer on a vetoed resource JAX-RS endpoint "
+                        + "method with an explicit metrics annotation",
+                syntheticSimpleTimerRegistry()
+                        .getSimpleTimers()
+                        .containsKey(MetricsCdiExtension.syntheticSimpleTimerMetricID(method)),
+                is(false));
+    }
+
+    @Test
+    void testNoSyntheticSimplyTimedMetricForVetoedResourceWithJaxRsEndpointButOtherwiseUnmeasured() throws NoSuchMethodException {
+        // Makes sure that a vetoed JAX-RS resource with no explicit metric annotation was not registered with a synthetic
+        // SimpleTimed metric.
+        Method method = VetoedJaxRsButOtherwiseUnmeasuredResource.class.getMethod("get");
+        assertThat(
+                "Metrics CDI extension incorrectly registered a synthetic simple timer on JAX-RS endpoint method with no "
+                        + "explicit metrics annotation: "
+                        + VetoedJaxRsButOtherwiseUnmeasuredResource.class.getName() + "#" + method.getName(),
+                MetricsCdiExtension.getRegistryForSyntheticSimpleTimers()
+                        .getSimpleTimers()
+                        .containsKey(MetricsCdiExtension.syntheticSimpleTimerMetricID(method)),
+                is(false));
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoCdiExtension.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoCdiExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.Path;
+import java.util.Set;
+
+/**
+ * Vetoes selected resources which should suppress the registration of their annotation-defined metrics and
+ * implicitly-created synthetic simply timed metrics.
+ */
+public class VetoCdiExtension implements Extension {
+
+    private static final Set<Class<?>> VETOED_RESOURCE_CLASSES = Set.of(VetoedResource.class,
+            VetoedJaxRsButOtherwiseUnmeasuredResource.class);
+
+    private void vetoResourceClass(@Observes @WithAnnotations(Path.class) ProcessAnnotatedType<?> resourceType) {
+        Class<?> resourceClass = resourceType.getAnnotatedType().getJavaClass();
+        if (VETOED_RESOURCE_CLASSES.contains(resourceClass)) {
+            resourceType.veto();
+        }
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoedJaxRsButOtherwiseUnmeasuredResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoedJaxRsButOtherwiseUnmeasuredResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * JAX-RS resource, vetoed by a test CDI extension, with no explicit metrics annotation.
+ */
+@Path("/vetoedOtherwiseUnmeasured")
+@RequestScoped
+public class VetoedJaxRsButOtherwiseUnmeasuredResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response get() {
+        return Response.ok().build();
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoedResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/VetoedResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * JAX-RS resource, vetoed by a test CDI extension, with an explicit metrics annotation.
+ */
+@Path("/vetoed")
+@RequestScoped
+public class VetoedResource {
+
+    static final String COUNTER_NAME = "vetoedCounter";
+
+    @Counted(name = COUNTER_NAME, absolute = true)
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response get() {
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
Resolves #2492 

There are two overall changes so that we honor other CDI extensions' vetoes of beans.

1. Previously, we defined metrics for annotated elements in the `ProcessAnnotatedType` observer. This incorrectly included beans which other extension might have vetoed.

    Instead,  now the `ProcessAnnotatedType` observer records the Java class for each annotated type identified by CDI as being annotated with a metrics annotation.
 
    Later, CDI invokes a new `ProcessManagedBean` observer only for beans which were not vetoed. This by itself takes care of honoring bean vetoes by other extensions.

    But this new observer runs for _every_ bean, whether decorated with a metrics annotation or not. We have to check each constructor and method in every bean we process to look for metrics annotations.

    This new observer will do that processing only if the type in the `ProcessManagedBean` appears in the collection of metrics-annotated classes prepared by the `ProcessAnnotatedType` observer. This observer also maintains a collection of types that _have_ been processes. An `AfterDeploymentValidation` observer method uses the collections to log (FINE) any vetoed beans that the extension decided to _not_ process.

1. A relatively recent change to MP metrics includes automatically adding (if configured) a `SimpleTimer` metric to every JAX-RS endpoint method. Previously, we did this by:

    1. Using a `ProcessAnnotatedType` observer on the HTTP operation annotations (`@GET`, `@PUT`, etc.) which would store each `Method` that had one of the HTTP method annotations and add a synthetic annotation `@SyntheticSimplyTimed` to the CDI `AnnotatedMethod` for the method.

    1. Using an `AfterBeanValidation` observer to go through each such saved `Method` and create the corresponding `SimpleTimer` metric.

    But that would create metrics for methods on vetoed beans.

    With this PR, the `ProcessAnnotatedType` observer:

    1. Adds the synthetic annotation to the relevant methods in the `AnnotatedType`, and
    1. Records a map entry with key = the Java class and value = collection of `Method`s with a JAX-RS operation annotation. 

    A new `ProcessManagedBean` observer checks the Java class of the bean against the map, and if found registers the synthetic `SimpleTimer` metrics for each method stored as the map entry's value.

The net result of these pairs of observers is that the extension _efficiently_ creates the metrics for metrics-annotated and JAX-RS-annotated methods but only for non-vetoed beans.