### PR TITLE
Made JUL aware of HelidonConsoleHandler when used with native-image

### DIFF
--- a/logging/jul/src/main/java/io/helidon/logging/jul/HelidonConsoleHandler.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/HelidonConsoleHandler.java
@@ -16,6 +16,8 @@
 
 package io.helidon.logging.jul;
 
+import io.helidon.common.Reflected;
+
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.StreamHandler;
@@ -24,6 +26,7 @@ import java.util.logging.StreamHandler;
  * A {@link StreamHandler} that writes to {@link System#out standard out} and uses a {@link HelidonFormatter} for formatting.
  * Sets the level to {@link Level#ALL} so that level filtering is performed solely by the loggers.
  */
+@Reflected
 public class HelidonConsoleHandler extends StreamHandler {
 
     /**


### PR DESCRIPTION
The HelidonConsoleHandler needs to be announced to native-image.

My test works now:
`[helidon-mdc-test]2020.11.17 13:51:46 INFO com.oracle.cx.verticals.wolpertinger.openapi.repository.Main Thread[main,5,main]: Started Helidon Webserver on port 8080
`