### PR TITLE
Examples of logging with Helidon

### DIFF
--- a/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
+++ b/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
@@ -480,6 +480,12 @@ final class FeatureCatalog {
             "Tracing",
             "Reactive web client support for tracing",
             "WebClient", "Tracing");
+        add("io.helidon.logging.log4j",
+            FeatureDescriptor.builder()
+                    .name("Log4j")
+                    .path("Logging", "Log4j")
+                    .description("Log4j MDC support")
+                    .nativeDescription("Only programmatic configuration supported, does not work with Helidon loggers"));
 
         /*
          * Packages that are not a feature
@@ -515,6 +521,8 @@ final class FeatureCatalog {
         exclude("io.helidon.integrations.graal.mp.nativeimage.extension");
         exclude("io.helidon.integrations.jta.weld");
         exclude("io.helidon.jersey.common");
+        exclude("io.helidon.logging.common");
+        exclude("io.helidon.logging.jul");
         exclude("io.helidon.media.common");
         exclude("io.helidon.media.common.spi");
         exclude("io.helidon.openapi.internal");

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -116,7 +116,7 @@
         <version.lib.reactive-streams-tck>1.0.3</version.lib.reactive-streams-tck>
         <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
         <version.lib.scala>2.12.10</version.lib.scala>
-        <version.lib.slf4j>1.7.26</version.lib.slf4j>
+        <version.lib.slf4j>1.7.30</version.lib.slf4j>
         <version.lib.smallrye-openapi>1.2.0</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.27</version.lib.snakeyaml>
         <version.lib.transaction-api>1.3.3</version.lib.transaction-api>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -766,6 +766,16 @@
                 <version>${version.lib.log4j}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${version.lib.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jul</artifactId>
+                <version>${version.lib.log4j}</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.lib.logback}</version>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -84,6 +84,7 @@
         <version.lib.kafka-junit5>3.2.1</version.lib.kafka-junit5>
         <version.lib.kafka>2.5.0</version.lib.kafka>
         <version.lib.log4j>2.13.3</version.lib.log4j>
+        <version.lib.logback>1.2.3</version.lib.logback>
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.microprofile-config>1.4</version.lib.microprofile-config>
@@ -739,7 +740,6 @@
                 <artifactId>jandex</artifactId>
                 <version>${version.lib.jandex}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -756,11 +756,20 @@
                 <version>${version.lib.slf4j}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${version.lib.slf4j}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${version.lib.log4j}</version>
             </dependency>
-
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${version.lib.logback}</version>
+            </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api</artifactId>

--- a/examples/logging/jul/README.md
+++ b/examples/logging/jul/README.md
@@ -1,0 +1,7 @@
+JUL Example
+---
+
+This example shows how to use Java Util Logging with MDC
+ using Helidon API.
+ 
+The example can be built using GraalVM native image as well.

--- a/examples/logging/jul/README.md
+++ b/examples/logging/jul/README.md
@@ -5,3 +5,48 @@ This example shows how to use Java Util Logging with MDC
  using Helidon API.
  
 The example can be built using GraalVM native image as well.
+
+# Running as jar
+
+Build this application:
+```shell script
+mvn clean package
+```
+
+Run from command line:
+```shell script
+java -jar target/helidon-examples-logging-jul.jar
+```
+
+Expected output should be similar to the following:
+```text
+2020.11.19 15:37:28 INFO io.helidon.common.LogConfig Thread[main,5,main]: Logging at initialization configured using classpath: /logging.properties ""
+2020.11.19 15:37:28 INFO io.helidon.examples.logging.jul.Main Thread[main,5,main]: Starting up "startup"
+2020.11.19 15:37:28 INFO io.helidon.examples.logging.jul.Main Thread[pool-1-thread-1,5,main]: Running on another thread "propagated"
+2020.11.19 15:37:28 INFO io.helidon.common.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
+2020.11.19 15:37:28 INFO io.helidon.webserver.NettyWebServer Thread[nioEventLoopGroup-2-1,10,main]: Channel '@default' started: [id: 0x8a5f5634, L:/0:0:0:0:0:0:0:0:8080] ""
+```
+
+# Running as native image
+You must use GraalVM with native image installed as your JDK,
+or you can specify an environment variable `GRAALVM_HOME` that points
+to such an installation.
+
+Build this application:
+```shell script
+mvn clean package -Pnative-image
+```
+
+Run from command line:
+```shell script
+./target/helidon-examples-logging-jul
+```
+
+Expected output should be similar to the following:
+```text
+2020.11.19 15:38:14 INFO io.helidon.common.LogConfig Thread[main,5,main]: Logging at runtime configured using classpath: /logging.properties ""
+2020.11.19 15:38:14 INFO io.helidon.examples.logging.jul.Main Thread[main,5,main]: Starting up "startup"
+2020.11.19 15:38:14 INFO io.helidon.examples.logging.jul.Main Thread[pool-1-thread-1,5,main]: Running on another thread "propagated"
+2020.11.19 15:38:14 INFO io.helidon.common.HelidonFeatures Thread[features-thread,5,main]: Helidon SE 2.2.0 features: [Config, WebServer] ""
+2020.11.19 15:38:14 INFO io.helidon.webserver.NettyWebServer Thread[nioEventLoopGroup-2-1,10,main]: Channel '@default' started: [id: 0x2b929906, L:/0:0:0:0:0:0:0:0:8080] ""
+```

--- a/examples/logging/jul/pom.xml
+++ b/examples/logging/jul/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+        <relativePath>../../../applications/se/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.logging</groupId>
+    <artifactId>helidon-examples-logging-jul</artifactId>
+    <name>Helidon Examples Logging Java Util Logging</name>
+
+    <description>
+        Example of logging and MDC using JUL
+    </description>
+
+    <properties>
+        <mainClass>io.helidon.examples.logging.jul.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/Main.java
+++ b/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/Main.java
@@ -32,8 +32,11 @@ import io.helidon.webserver.WebServer;
 /**
  * Main class of the example, runnable from command line.
  */
-public class Main {
+public final class Main {
     private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
+
+    private Main() {
+    }
 
     /**
      * Starts the example.

--- a/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/Main.java
+++ b/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/Main.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.logging.jul;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.logging.common.HelidonMdc;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+/**
+ * Main class of the example, runnable from command line.
+ */
+public class Main {
+    private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
+
+    /**
+     * Starts the example.
+     *
+     * @param args not used
+     */
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+
+        // the Helidon context is used to propagate MDC across threads
+        // if running within Helidon WebServer, you do not need to runInContext, as that is already
+        // done by the webserver
+        Contexts.runInContext(Context.create(), Main::logging);
+
+        WebServer.builder()
+                .routing(Routing.builder()
+                                 .get("/", (req, res) -> {
+                                     HelidonMdc.set("name", String.valueOf(req.requestId()));
+                                     LOGGER.info("Running in webserver, id:");
+                                     res.send("Hello");
+                                 })
+                                 .build())
+                .port(8080)
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+    }
+
+    private static void logging() {
+        HelidonMdc.set("name", "startup");
+        LOGGER.info("Starting up");
+
+        // now let's see propagation across executor service boundary
+        HelidonMdc.set("name", "propagated");
+        // wrap executor so it supports Helidon context, this is done for all built-in executors in Helidon
+        ExecutorService es = Contexts.wrap(Executors.newSingleThreadExecutor());
+
+        Future<?> submit = es.submit(() -> {
+            LOGGER.info("Running on another thread");
+        });
+        try {
+            submit.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        es.shutdown();
+    }
+}

--- a/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/package-info.java
+++ b/examples/logging/jul/src/main/java/io/helidon/examples/logging/jul/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Java util logging example with Mapped diagnostics context in Helidon.
+ */
+package io.helidon.examples.logging.jul;

--- a/examples/logging/jul/src/main/resources/logging.properties
+++ b/examples/logging/jul/src/main/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Send messages to the console
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+
+# !thread! is replaced by Helidon with the thread name
+# any %X{...} is replaced by a value from MDC
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s "%X{name}"%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO

--- a/examples/logging/log4j/README.md
+++ b/examples/logging/log4j/README.md
@@ -1,0 +1,9 @@
+Log4j Example
+---
+
+This example shows how to use log4j with MDC (`ThreadContext`)
+ using Helidon API.
+ 
+The example moves all Java Util Logging to log4j.
+
+The example can be built using GraalVM native image as well.

--- a/examples/logging/log4j/README.md
+++ b/examples/logging/log4j/README.md
@@ -7,3 +7,50 @@ This example shows how to use log4j with MDC (`ThreadContext`)
 The example moves all Java Util Logging to log4j.
 
 The example can be built using GraalVM native image as well.
+
+# Running as jar
+
+Build this application:
+```shell script
+mvn clean package
+```
+
+Run from command line:
+```shell script
+java -jar target/helidon-examples-logging-log4j.jar
+```
+
+Expected output should be similar to the following:
+```text
+2020-11-19 15:44:48,561 main INFO Registered Log4j as the java.util.logging.LogManager.
+15:44:48.596 INFO  [main] io.helidon.examples.logging.log4j.Main - Starting up "startup"
+15:44:48.598 INFO  [main] io.helidon.examples.logging.log4j.Main - Using JUL logger "startup"
+15:44:48.600 INFO  [pool-2-thread-1] io.helidon.examples.logging.log4j.Main - Running on another thread "propagated"
+15:44:48.704 INFO  [features-thread] io.helidon.common.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer] ""
+15:44:48.801 INFO  [nioEventLoopGroup-2-1] io.helidon.webserver.NettyWebServer - Channel '@default' started: [id: 0xa215c23d, L:/0:0:0:0:0:0:0:0:8080] ""
+```
+
+# Running as native image
+You must use GraalVM with native image installed as your JDK,
+or you can specify an environment variable `GRAALVM_HOME` that points
+to such an installation.
+
+Build this application:
+```shell script
+mvn clean package -Pnative-image
+```
+
+Run from command line:
+```shell script
+./target/helidon-examples-logging-log4j
+```
+
+*In native image, we can only replace loggers initialized after reconfiguration of logging system
+This unfortunately means that Helidon logging would not be available*
+
+Expected output should be similar to the following:
+```text
+15:47:53.033 INFO  [main] io.helidon.examples.logging.log4j.Main - Starting up "startup"
+15:47:53.033 INFO  [main] io.helidon.examples.logging.log4j.Main - Using JUL logger "startup"
+15:47:53.033 INFO  [pool-2-thread-1] io.helidon.examples.logging.log4j.Main - Running on another thread "propagated"
+```

--- a/examples/logging/log4j/pom.xml
+++ b/examples/logging/log4j/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+        <relativePath>../../../applications/se/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.logging</groupId>
+    <artifactId>helidon-examples-logging-log4j</artifactId>
+    <name>Helidon Examples Logging Log4j</name>
+
+    <description>
+        Example of logging and MDC using Log4j
+    </description>
+
+    <properties>
+        <mainClass>io.helidon.examples.logging.log4j.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/logging/log4j/pom.xml
+++ b/examples/logging/log4j/pom.xml
@@ -55,12 +55,10 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
-            <version>2.14.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
+++ b/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.logging.log4j;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.logging.common.HelidonMdc;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+
+/**
+ * Main class of the example, runnable from command line.
+ * There is a limitation of log4j in native image - we only have loggers that are
+ * initialized after we configure logging, which unfortunately excludes Helidon loggers.
+ * You would need to use JUL or slf4j to have Helidon logs combined with application logs.
+ */
+public class Main {
+    static {
+        // replace JUL log manager with Log4j log manager, so we log all to it
+        System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    }
+
+    private static java.util.logging.Logger julLogger;
+    private static Logger logger;
+
+    /**
+     * Starts the example.
+     *
+     * @param args not used
+     */
+    public static void main(String[] args) {
+        // file based logging configuration does not work
+        // with native image!
+        configureLogging();
+        // get logger after configuration
+        logger = LogManager.getLogger(Main.class.getName());
+        julLogger = java.util.logging.Logger.getLogger(Main.class.getName());
+
+        // the Helidon context is used to propagate MDC across threads
+        // if running within Helidon WebServer, you do not need to runInContext, as that is already
+        // done by the webserver
+        Contexts.runInContext(Context.create(), Main::logging);
+
+        WebServer.builder()
+                .routing(Routing.builder()
+                                 .get("/", (req, res) -> {
+                                     HelidonMdc.set("name", String.valueOf(req.requestId()));
+                                     logger.info("Running in webserver, id:");
+                                     res.send("Hello");
+                                 })
+                                 .build())
+                .port(8080)
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+    }
+
+    private static void logging() {
+        HelidonMdc.set("name", "startup");
+        logger.info("Starting up");
+        julLogger.info("Using JUL logger");
+
+        // now let's see propagation across executor service boundary, we can also use Log4j's ThreadContext
+        ThreadContext.put("name", "propagated");
+        // wrap executor so it supports Helidon context, this is done for all built-in executors in Helidon
+        ExecutorService es = Contexts.wrap(Executors.newSingleThreadExecutor());
+
+        Future<?> submit = es.submit(Main::log);
+        try {
+            submit.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        es.shutdown();
+    }
+
+    private static void log() {
+        logger.info("Running on another thread");
+    }
+
+    private static void configureLogging() {
+        // configure log4j
+        final var builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        builder.setConfigurationName("root");
+        builder.setStatusLevel(Level.INFO);
+        final var appenderComponentBuilder = builder.newAppender("Stdout", "CONSOLE")
+                .addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+        appenderComponentBuilder.add(builder.newLayout("PatternLayout")
+                                             .addAttribute("pattern", "%d{HH:mm:ss.SSS} %-5level [%t] %logger{36} - %msg "
+                                                     + "\"%X{name}\"%n"));
+        builder.add(appenderComponentBuilder);
+        builder.add(builder.newRootLogger(Level.INFO)
+                            .add(builder.newAppenderRef("Stdout")));
+        Configurator.reconfigure(builder.build());
+
+        java.util.logging.LogManager logManager = java.util.logging.LogManager.getLogManager();
+        System.out.println("Log manager: " + logManager.getClass().getName());
+        logManager.reset();
+    }
+}

--- a/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
+++ b/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFact
  * initialized after we configure logging, which unfortunately excludes Helidon loggers.
  * You would need to use JUL or slf4j to have Helidon logs combined with application logs.
  */
-public class Main {
+public final class Main {
     static {
         // replace JUL log manager with Log4j log manager, so we log all to it
         System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
@@ -49,6 +49,9 @@ public class Main {
 
     private static java.util.logging.Logger julLogger;
     private static Logger logger;
+
+    private Main() {
+    }
 
     /**
      * Starts the example.

--- a/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
+++ b/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/Main.java
@@ -121,10 +121,6 @@ public final class Main {
         builder.add(appenderComponentBuilder);
         builder.add(builder.newRootLogger(Level.INFO)
                             .add(builder.newAppenderRef("Stdout")));
-        Configurator.reconfigure(builder.build());
-
-        java.util.logging.LogManager logManager = java.util.logging.LogManager.getLogManager();
-        System.out.println("Log manager: " + logManager.getClass().getName());
-        logManager.reset();
+        Configurator.initialize(builder.build());
     }
 }

--- a/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/package-info.java
+++ b/examples/logging/log4j/src/main/java/io/helidon/examples/logging/log4j/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Log4j example with Mapped diagnostics context (ThreadContext) in Helidon.
+ */
+package io.helidon.examples.logging.log4j;

--- a/examples/logging/pom.xml
+++ b/examples/logging/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.examples</groupId>
+        <artifactId>helidon-examples-project</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.examples.logging</groupId>
+    <artifactId>helidon-examples-logging-project</artifactId>
+    <name>Helidon Examples Logging</name>
+    <packaging>pom</packaging>
+
+    <description>
+        Examples of Helidon Logging
+    </description>
+
+    <modules>
+        <module>jul</module>
+        <module>log4j</module>
+        <module>slf4j</module>
+    </modules>
+</project>

--- a/examples/logging/slf4j/README.md
+++ b/examples/logging/slf4j/README.md
@@ -1,0 +1,45 @@
+Slf4j Example
+---
+
+This example shows how to use slf4j with MDC
+ using Helidon API.
+
+The example moves all Java Util Logging to slf4j
+ 
+The example can be built using GraalVM native image as well.
+
+Expected output should be similar to the following (for both hotspot and native):
+```text
+15:40:44.240 INFO  [main] i.h.examples.logging.slf4j.Main - Starting up startup
+15:40:44.241 INFO  [main] i.h.examples.logging.slf4j.Main - Using JUL logger startup
+15:40:44.245 INFO  [pool-1-thread-1] i.h.examples.logging.slf4j.Main - Running on another thread propagated
+15:40:44.395 INFO  [features-thread] io.helidon.common.HelidonFeatures - Helidon SE 2.2.0 features: [Config, WebServer]
+15:40:44.538 INFO  [nioEventLoopGroup-2-1] io.helidon.webserver.NettyWebServer - Channel '@default' started: [id: 0x8e516487, L:/0:0:0:0:0:0:0:0:8080]
+```
+
+# Running as jar
+
+Build this application:
+```shell script
+mvn clean package
+```
+
+Run from command line:
+```shell script
+java -jar target/helidon-examples-logging-sfl4j.jar
+```
+
+# Running as native image
+You must use GraalVM with native image installed as your JDK,
+or you can specify an environment variable `GRAALVM_HOME` that points
+to such an installation.
+
+Build this application:
+```shell script
+mvn clean package -Pnative-image
+```
+
+Run from command line:
+```shell script
+./target/helidon-examples-logging-sfl4j
+```

--- a/examples/logging/slf4j/pom.xml
+++ b/examples/logging/slf4j/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>2.1.1-SNAPSHOT</version>
+        <relativePath>../../../applications/se/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.logging</groupId>
+    <artifactId>helidon-examples-logging-slf4j</artifactId>
+    <name>Helidon Examples Logging Slf4j</name>
+
+    <description>
+        Example of logging and MDC using Slf4j
+    </description>
+
+    <properties>
+        <mainClass>io.helidon.examples.logging.slf4j.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/Main.java
+++ b/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/Main.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.logging.slf4j;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.logging.common.HelidonMdc;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+public class Main {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
+    private static final java.util.logging.Logger JUL_LOGGER = java.util.logging.Logger.getLogger(Main.class.getName());
+
+    public static void main(String[] args) {
+        // use slf4j for JUL as well
+        setupLogging();
+
+        // the Helidon context is used to propagate MDC across threads
+        // if running within Helidon WebServer, you do not need to runInContext, as that is already
+        // done by the webserver
+        Contexts.runInContext(Context.create(), Main::logging);
+
+        WebServer.builder()
+                .routing(Routing.builder()
+                                 .get("/", (req, res) -> {
+                                     HelidonMdc.set("name", String.valueOf(req.requestId()));
+                                     LOGGER.info("Running in webserver, id:");
+                                     res.send("Hello");
+                                 })
+                                 .build())
+                .port(8080)
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+    }
+
+    private static void setupLogging() {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+    }
+
+    private static void logging() {
+        HelidonMdc.set("name", "startup");
+        LOGGER.info("Starting up");
+        JUL_LOGGER.info("Using JUL logger");
+
+        // now let's see propagation across executor service boundary, we can also use Log4j's ThreadContext
+        MDC.put("name", "propagated");
+        // wrap executor so it supports Helidon context, this is done for all built-in executors in Helidon
+        ExecutorService es = Contexts.wrap(Executors.newSingleThreadExecutor());
+
+        Future<?> submit = es.submit(Main::log);
+        try {
+            submit.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        es.shutdown();
+    }
+
+    private static void log() {
+        LOGGER.info("Running on another thread");
+    }
+}

--- a/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/Main.java
+++ b/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/Main.java
@@ -32,10 +32,21 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-public class Main {
+/**
+ * Main class of the example, runnable from command line.
+ */
+public final class Main {
     private static final Logger LOGGER = LoggerFactory.getLogger(Main.class);
     private static final java.util.logging.Logger JUL_LOGGER = java.util.logging.Logger.getLogger(Main.class.getName());
 
+    private Main() {
+    }
+
+    /**
+     * Starts the example.
+     *
+     * @param args not used
+     */
     public static void main(String[] args) {
         // use slf4j for JUL as well
         setupLogging();

--- a/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/package-info.java
+++ b/examples/logging/slf4j/src/main/java/io/helidon/examples/logging/slf4j/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Slf4j example with Mapped diagnostics context (MDC) in Helidon.
+ */
+package io.helidon.examples.logging.slf4j;

--- a/examples/logging/slf4j/src/main/resources/logback.xml
+++ b/examples/logging/slf4j/src/main/resources/logback.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (c) 2020 Oracle and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT"
+            class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg %X{name}%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -56,6 +56,7 @@
         <module>webclient</module>
         <module>cors</module>
         <module>messaging</module>
+        <module>logging</module>
     </modules>
 
     <build>

--- a/logging/jul/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-jul/reflect-config.json
+++ b/logging/jul/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-jul/reflect-config.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "io.helidon.logging.jul.HelidonConsoleHandler",
+        "allDeclaredConstructors": true,
+        "allPublicMethods": true
+    }
+]

--- a/logging/log4j/src/main/resources/META-INF/helidon/native-image/reflection-config.json
+++ b/logging/log4j/src/main/resources/META-INF/helidon/native-image/reflection-config.json
@@ -1,0 +1,31 @@
+{
+    "annotated":[
+    ],
+    "class-hierarchy": [
+        "org.apache.logging.log4j.core.lookup.StrLookup",
+        "org.apache.logging.log4j.core.config.LoggerConfig",
+        "org.apache.logging.log4j.core.config.plugins.visitors.PluginVisitor",
+        "org.apache.logging.log4j.core.config.plugins.convert.TypeConverter",
+        "org.apache.logging.log4j.core.layout.Encoder",
+        "org.apache.logging.log4j.core.Appender",
+        "org.apache.logging.log4j.core.pattern.PatternConverter",
+        "org.apache.logging.log4j.core.util.Builder",
+        "org.apache.logging.log4j.message.MessageFactory",
+        "org.apache.logging.log4j.core.config.plugins.validation.ConstraintValidator",
+        "org.apache.logging.log4j.message.FlowMessageFactory"
+    ],
+    "classes": [
+    ],
+    "exclude": [
+        "org.apache.logging.log4j.core.layout.AbstractCsvLayout",
+        "org.apache.logging.log4j.core.layout.CsvParameterLayout",
+        "org.apache.logging.log4j.core.layout.JsonLayout",
+        "org.apache.logging.log4j.core.layout.XmlLayout",
+        "org.apache.logging.log4j.core.layout.YamlLayout",
+        "org.apache.logging.log4j.core.layout.CsvLogEventLayout",
+        "org.apache.logging.log4j.core.appender.mom.JmsAppender",
+        "org.apache.logging.log4j.core.layout.AbstractJacksonLayout",
+        "org.apache.logging.log4j.core.appender.mom.JmsAppender$Builder",
+        "org.apache.logging.log4j.core.net.MimeMessageBuilder"
+    ]
+}

--- a/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/native-image.properties
+++ b/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/native-image.properties
@@ -1,0 +1,132 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=-Dlog4j2.disable.jmx=true \
+  -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
+  --allow-incomplete-classpath \
+  --report-unsupported-elements-at-runtime \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.status.StatusConfiguration \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.AppenderRef \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.convert.TypeConverters \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.util.PluginBuilder \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.ResourceBundleLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.visitors.PluginVisitors \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.convert.TypeConverterRegistry \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.visitors.AbstractPluginVisitor \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.visitors.PluginBuilderAttributeVisitor \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.validation.validators.RequiredValidator \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.visitors.PluginConfigurationVisitor \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.Configurator \
+  --initialize-at-build-time=org.apache.logging.log4j.Level \
+  --initialize-at-build-time=org.apache.logging.log4j.LogManager \
+  --initialize-at-build-time=org.apache.logging.log4j.ThreadContext \
+  --initialize-at-build-time=org.apache.logging.log4j.core.AbstractLifeCycle \
+  --initialize-at-build-time=org.apache.logging.log4j.core.LoggerContext \
+  --initialize-at-build-time=org.apache.logging.log4j.core.appender.AbstractManager \
+  --initialize-at-build-time=org.apache.logging.log4j.core.appender.ConsoleAppender \
+  --initialize-at-build-time=org.apache.logging.log4j.core.appender.DefaultErrorHandler \
+  --initialize-at-build-time=org.apache.logging.log4j.core.appender.OutputStreamManager \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.AbstractConfiguration \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.ConfigurationFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.ConfigurationScheduler \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.ConfigurationSource \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.DefaultConfiguration \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.LoggerConfig \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.Property \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.json.JsonConfigurationFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.util.PluginManager \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.plugins.util.PluginRegistry \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.xml.XmlConfigurationFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.config.yaml.YamlConfigurationFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.filter.AbstractFilterable \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.Log4jContextFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.Log4jLogEvent \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ReusableLogEventFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ThreadContextDataInjector \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ThrowableFormatOptions \
+  --initialize-at-build-time=org.apache.logging.log4j.core.jmx.LoggerContextAdmin \
+  --initialize-at-build-time=org.apache.logging.log4j.core.jmx.Server \
+  --initialize-at-build-time=org.apache.logging.log4j.core.layout.AbstractLayout \
+  --initialize-at-build-time=org.apache.logging.log4j.core.layout.AbstractStringLayout \
+  --initialize-at-build-time=org.apache.logging.log4j.core.layout.PatternLayout \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.DateLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.Interpolator \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.JndiLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.Log4jLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.StrMatcher \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.StrMatcher$StringMatcher \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.StrSubstitutor \
+  --initialize-at-build-time=org.apache.logging.log4j.core.lookup.SystemPropertiesLookup \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.AbstractPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.DatePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.ExtendedThrowablePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.LevelPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.LiteralPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.LogEventPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.LoggerPatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.MessagePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.NamePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.PatternParser \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.PatternParser$1 \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.pattern.ThrowablePatternConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.script.ScriptManager \
+  --initialize-at-build-time=org.apache.logging.log4j.core.selector.ClassLoaderContextSelector \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.BasicAuthorizationProvider \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.Constants \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.DefaultShutdownCallbackRegistry \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.Loader \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.NetUtils \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.OptionConverter \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.ShutdownCallbackRegistry \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.WatchManager \
+  --initialize-at-build-time=org.apache.logging.log4j.message.ReusableMessageFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.AbstractLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.CopyOnWriteSortedArrayThreadContextMap \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.DefaultThreadContextMap \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.DefaultThreadContextStack \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.LoggerRegistry \
+  --initialize-at-build-time=org.apache.logging.log4j.status.StatusLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.util.Constants \
+  --initialize-at-build-time=org.apache.logging.log4j.util.LoaderUtil \
+  --initialize-at-build-time=org.apache.logging.log4j.util.PropertiesUtil \
+  --initialize-at-build-time=org.apache.logging.log4j.util.PropertySource$Util \
+  --initialize-at-build-time=org.apache.logging.log4j.util.SortedArrayStringMap \
+  --initialize-at-build-time=org.apache.logging.log4j.util.StackLocator \
+  --initialize-at-build-time=org.apache.logging.log4j.util.StackLocatorUtil \
+  --initialize-at-build-time=org.apache.logging.log4j.util.Strings \
+  --initialize-at-build-time=org.apache.logging.slf4j.Log4jLogger \
+  --initialize-at-build-time=org.apache.logging.slf4j.Log4jMarkerFactory \
+  --initialize-at-build-time=org.slf4j.LoggerFactory \
+  --initialize-at-build-time=org.slf4j.impl.StaticLoggerBinder \
+  --initialize-at-build-time=org.apache.logging.slf4j.Log4jLoggerFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.ThreadContextMapFactory \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.GarbageFreeSortedArrayThreadContextMap \
+  --initialize-at-build-time=io.helidon.common.serviceloader.HelidonServiceLoader \
+  --initialize-at-build-time=org.apache.logging.log4j.core.util.ClockFactory \
+  --initialize-at-build-time=io.helidon.common.serviceloader.HelidonServiceLoader$Builder$ServiceWithPriority \
+  --initialize-at-build-time=org.apache.logging.log4j.spi.Provider \
+  --initialize-at-build-time=org.apache.logging.log4j.jul.ApiLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.jul.CoreLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.jul.LogManager \
+  --initialize-at-build-time=org.apache.logging.log4j.jul.WrappedLogger \
+  --initialize-at-build-time=org.apache.logging.log4j.jul.LevelTranslator \
+  --initialize-at-build-time=org.apache.logging.log4j.core.impl.ContextDataFactory

--- a/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/reflect-config.json
+++ b/logging/log4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-log4j/reflect-config.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration",
+        "allDeclaredConstructors": true,
+        "allDeclaredMethods": true
+    },
+    {
+        "name": "org.apache.logging.log4j.core.config.AppenderRef",
+        "allDeclaredConstructors": true,
+        "allDeclaredMethods": true
+    },
+    {
+        "name": "org.apache.logging.log4j.core.config.LoggersPlugin",
+        "allDeclaredConstructors": true,
+        "allDeclaredMethods": true
+    },
+    {
+        "name": "org.apache.logging.log4j.core.config.AppendersPlugin",
+        "allDeclaredConstructors": true,
+        "allDeclaredMethods": true
+    }
+]

--- a/logging/slf4j/src/main/java/module-info.java
+++ b/logging/slf4j/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.logging.slf4j {
     requires io.helidon.common.context;
     requires io.helidon.logging.common;
 
-    requires slf4j.api;
+    requires org.slf4j;
 
     exports io.helidon.logging.slf4j;
 

--- a/logging/slf4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-slf4j/native-image.properties
+++ b/logging/slf4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-slf4j/native-image.properties
@@ -18,4 +18,7 @@ Args=--initialize-at-build-time=ch.qos.logback \
   --initialize-at-build-time=org.slf4j \
   --initialize-at-build-time=jdk.xml.internal.SecuritySupport \
   --initialize-at-build-time=javax.xml.parsers.FactoryFinder \
-  --initialize-at-build-time=com.sun.org.apache.xerces
+  --initialize-at-build-time=com.sun.org.apache.xerces \
+  --initialize-at-build-time=javax.xml.datatype.DatatypeFactory \
+  --initialize-at-build-time=jdk.xml.internal.JdkXmlUtils \
+  --initialize-at-build-time=com.sun.xml.internal.stream.util.ThreadLocalBufferAllocator

--- a/logging/slf4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-slf4j/native-image.properties
+++ b/logging/slf4j/src/main/resources/META-INF/native-image/io.helidon.logging/helidon-logging-slf4j/native-image.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=--initialize-at-build-time=ch.qos.logback \
+  --initialize-at-build-time=org.slf4j \
+  --initialize-at-build-time=jdk.xml.internal.SecuritySupport \
+  --initialize-at-build-time=javax.xml.parsers.FactoryFinder \
+  --initialize-at-build-time=com.sun.org.apache.xerces


### PR DESCRIPTION
Also added support for native image to log4j, slf4j and JUL modules of the new logging implementation.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>