### PR TITLE
Revised logic for handling request scopes and contexts in Jersey/HK2

### DIFF
--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/MultiTenantService2.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/MultiTenantService2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.requestscope;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@RequestScoped
+@Path("/test2")
+public class MultiTenantService2 {
+
+    @Inject
+    SomeService2 someService2;
+
+    @GET
+    public String getTenantResource() {
+        try {
+            String s = someService2.test();
+            return s == null ? "" : s;
+        } catch (Exception e) {
+            // This path implies a CDI exception related to request scope
+            // See https://github.com/oracle/helidon/issues/2532
+            throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/SomeService2.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/SomeService2.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.requestscope;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class SomeService2 {
+
+    private AtomicLong counter = new AtomicLong(0);
+
+    @Inject
+    TenantContext tenantContext;
+
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4)
+    @Fallback(fallbackMethod = "testFallback")
+    public String test() {
+        maybeFail();
+        return tenantContext.getTenantId();
+    }
+
+    public String testFallback() {
+        return tenantContext.getTenantId();
+    }
+
+    private void maybeFail() {
+        final long invocationNumber = counter.getAndIncrement();
+        if (invocationNumber % 4 > 1) {     // alternate 2 successful and 2 failing invocations
+            throw new RuntimeException("Service failed.");
+        }
+    }
+}

--- a/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
+++ b/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
@@ -40,4 +40,15 @@ class TenantTest {
                 .get();
         assertThat(r.getStatus(), is(HttpResponseStatus.OK.code()));
     }
+
+    @Test
+    public void test2() {
+        Response r;
+        for (int i = 0; i < 3; i++) {
+            r = baseTarget.path("test2")
+                    .request()
+                    .get();
+            assertThat(r.getStatus(), is(HttpResponseStatus.OK.code()));
+        }
+    }
 }


### PR DESCRIPTION
Revised logic for handling request scopes and contexts in Jersey/HK2. Some additional logic for fallback calls. Relates to fix for issue 2480. Request scope test has been updated to cover these use cases of request scope.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>