### PR TITLE
Global context and its use in Security

### DIFF
--- a/common/context/src/main/java/io/helidon/common/context/Context.java
+++ b/common/context/src/main/java/io/helidon/common/context/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,13 +171,25 @@ public interface Context {
         private static final AtomicLong CHILD_CONTEXT_COUNTER = new AtomicLong(1);
         private Context parent;
         private String id;
+        private boolean notGlobal = true;
 
         @Override
         public Context build() {
-            if (null == id) {
+            if (id == null) {
                 id = generateId();
             }
+
+            if (notGlobal && (parent == null)) {
+                // only configure a parent for non-global context. Global context is the only one that has a null parent
+                parent = Contexts.globalContext();
+            }
+
             return new ListContext(this);
+        }
+
+        Builder global() {
+            notGlobal = false;
+            return this;
         }
 
         private String generateId() {

--- a/common/context/src/main/java/io/helidon/common/context/Contexts.java
+++ b/common/context/src/main/java/io/helidon/common/context/Contexts.java
@@ -69,6 +69,8 @@ public final class Contexts {
      * Global context is also used as a parent for newly created contexts, unless you specify a parent using
      * {@link Context.Builder#parent(Context)}.
      * Registering any instance in this context will make it available to any component in this JVM.
+     *
+     * @return global context instance, never null
      */
     public static Context globalContext() {
         return GLOBAL_CONTEXT.get();

--- a/common/context/src/main/java/io/helidon/common/context/Contexts.java
+++ b/common/context/src/main/java/io/helidon/common/context/Contexts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,17 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
+import io.helidon.common.LazyValue;
+
 /**
  * Support for handling {@link io.helidon.common.context.Context} across thread boundaries.
  */
 public final class Contexts {
     private static final ThreadLocal<Stack<Context>> REGISTRY = ThreadLocal.withInitial(Stack::new);
+    private static final LazyValue<Context> GLOBAL_CONTEXT = LazyValue.create(() -> Context.builder()
+            .id("helidon")
+            .global()
+            .build());
 
     private Contexts() {
     }
@@ -55,6 +61,17 @@ public final class Contexts {
         }
 
         return Optional.ofNullable(contextStack.peek());
+    }
+
+    /**
+     * Global context is always present and statically shared in this JVM.
+     * This is similar to Singleton scope when using an injection engine.
+     * Global context is also used as a parent for newly created contexts, unless you specify a parent using
+     * {@link Context.Builder#parent(Context)}.
+     * Registering any instance in this context will make it available to any component in this JVM.
+     */
+    public static Context globalContext() {
+        return GLOBAL_CONTEXT.get();
     }
 
     /**

--- a/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
+++ b/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
@@ -179,6 +179,9 @@ class ContextsTest {
 
     @Test
     void testMultipleContexts() {
+        Context global = Contexts.globalContext();
+        global.register("global", TEST_STRING);
+
         Context topLevel = Context.create();
         topLevel.register("topLevel", TEST_STRING);
         topLevel.register("first", TEST_STRING);
@@ -189,16 +192,19 @@ class ContextsTest {
 
         Contexts.runInContext(topLevel, () -> {
             Context myContext = Contexts.context().get();
+            assertThat(myContext.get("global", String.class), is(TEST_STRING_OPTIONAL));
             assertThat(myContext.get("topLevel", String.class), is(TEST_STRING_OPTIONAL));
             assertThat(myContext.get("first", String.class), is(TEST_STRING_OPTIONAL));
 
             Contexts.runInContext(firstLevel, () -> {
                 Context firstLevelContext = Contexts.context().get();
+                assertThat(myContext.get("global", String.class), is(TEST_STRING_OPTIONAL));
                 assertThat(firstLevelContext.get("topLevel", String.class), is(TEST_STRING_OPTIONAL));
                 assertThat(firstLevelContext.get("first", String.class), is(Optional.of(TEST_STRING + "_1")));
                 assertThat(firstLevelContext.get("second", String.class), is(TEST_STRING_OPTIONAL));
             });
 
+            assertThat(myContext.get("global", String.class), is(TEST_STRING_OPTIONAL));
             assertThat(myContext.get("topLevel", String.class), is(TEST_STRING_OPTIONAL));
             assertThat(myContext.get("first", String.class), is(TEST_STRING_OPTIONAL));
         });

--- a/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
+++ b/common/context/src/test/java/io/helidon/common/context/ContextsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -70,9 +70,11 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 
 import io.helidon.common.Errors;
+import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
 import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.RegistryFactory;
 import io.helidon.microprofile.cdi.RuntimeStart;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.webserver.Routing;
@@ -719,6 +721,9 @@ public class MetricsCdiExtension implements Extension {
                         vendorMetricsAdded.add(routeName);
                     }
                 });
+
+        // registry factory is available in global
+        Contexts.globalContext().register(RegistryFactory.getInstance());
     }
 
     private static boolean chooseRestEndpointsSetting(Config metricsConfig) {

--- a/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
+++ b/microprofile/security/src/main/java/io/helidon/microprofile/security/SecurityCdiExtension.java
@@ -106,6 +106,9 @@ public class SecurityCdiExtension implements Extension {
         // we need an effectively final instance to use in lambda
         Security security = tmpSecurity;
 
+        // security is available in global
+        Contexts.globalContext().register(security);
+
         JaxRsCdiExtension jaxrs = bm.getExtension(JaxRsCdiExtension.class);
         ServerCdiExtension server = bm.getExtension(ServerCdiExtension.class);
 

--- a/microprofile/tests/tck/tck-opentracing/pom.xml
+++ b/microprofile/tests/tck/tck-opentracing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2019, 2020 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@
                     <!-- TCK requires Jackson, not JSON-B -->
                     <groupId>org.glassfish.jersey.media</groupId>
                     <artifactId>jersey-media-json-binding</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- we must remove security tracing -->
+                    <groupId>io.helidon.security.integration</groupId>
+                    <artifactId>helidon-security-integration-jersey-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/TracingCdiExtension.java
+++ b/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/TracingCdiExtension.java
@@ -70,6 +70,9 @@ public class TracingCdiExtension implements Extension {
                 .config(config)
                 .build();
 
+        // tracer is available in global
+        Contexts.globalContext().register(tracer);
+
         server.serverBuilder()
                 .tracer(tracer);
 


### PR DESCRIPTION
Resolves #2548 

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

The `Contexts.globalContext()` can be used to register components that are application wide (e.g. `Singleton`) - such as `Security`, metrics `RegistryFactory` and `Tracer` in Helidon MP (in Helidon SE, this is at the discretion of developer, what get registered, if anything).

Updated JAX-RS Client and REST client support for security to use this global registry for cases when we invoke an outbound call without `SecurityContext` or `Context`. This is the case for example in messaging flows.