### PR TITLE
SE blocking API for WebServer

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -78,6 +78,11 @@
                 <artifactId>helidon-webserver-cors</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.webserver</groupId>
+                <artifactId>helidon-webserver-blocking</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
             <!-- Helidon Jersey -->
             <dependency>
                 <groupId>io.helidon.jersey</groupId>

--- a/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
+++ b/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
@@ -163,6 +163,13 @@ final class FeatureCatalog {
                     .flavor(HelidonFlavor.SE)
                     .experimental(true));
 
+        add("io.helidon.webserver.blocking",
+            FeatureDescriptor.builder()
+                    .flavor(HelidonFlavor.SE)
+                    .name("Blocking API")
+                    .description("WebServer blocking API")
+                    .path("WebServer", "Blocking")
+                    .experimental(true));
         /*
          * MP Modules
          */

--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
     private final int growthRate;
     private final ThreadPool.RejectionHandler rejectionHandler;
     private final LazyValue<ExecutorService> lazyValue = LazyValue.create(() -> Contexts.wrap(getThreadPool()));
+    private final boolean useVirtualThreads;
 
     private ThreadPoolSupplier(Builder builder) {
         this.corePoolSize = builder.corePoolSize;
@@ -71,6 +72,7 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
         this.growthThreshold = builder.growthThreshold;
         this.growthRate = builder.growthRate;
         this.rejectionHandler = builder.rejectionHandler == null ? DEFAULT_REJECTION_POLICY : builder.rejectionHandler;
+        this.useVirtualThreads = builder.useVirtualThreads || builder.virtualThreadsEnforced;
     }
 
     /**
@@ -102,7 +104,14 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
         return builder().build();
     }
 
-    ThreadPool getThreadPool() {
+    ExecutorService getThreadPool() {
+        if (useVirtualThreads) {
+            if (VirtualExecutorUtil.isVirtualSupported()) {
+                LOGGER.fine("Using unbounded virtual executor service for pool " + name);
+                return VirtualExecutorUtil.executorService();
+            }
+        }
+
         ThreadPool result = ThreadPool.create(name,
                                               corePoolSize,
                                               maxPoolSize,
@@ -149,6 +158,8 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
         private int growthRate = DEFAULT_GROWTH_RATE;
         private ThreadPool.RejectionHandler rejectionHandler = DEFAULT_REJECTION_POLICY;
         private String name;
+        private boolean useVirtualThreads;
+        private boolean virtualThreadsEnforced;
 
         private Builder() {
         }
@@ -160,6 +171,11 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
             }
             if (rejectionHandler == null) {
                 rejectionHandler = DEFAULT_REJECTION_POLICY;
+            }
+            if (virtualThreadsEnforced) {
+                if (!VirtualExecutorUtil.isVirtualSupported()) {
+                    throw new IllegalStateException("Virtual threads are required, yet not available on this JVM");
+                }
             }
 
             return new ThreadPoolSupplier(this);
@@ -390,8 +406,43 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
             config.get("growth-rate").asInt().ifPresent(value -> {
                 warnExperimental("growth-rate");
                 growthRate(value);
-
             });
+            config.get("virtual-threads").asBoolean().ifPresent(value -> {
+                warnExperimental("virtual-threads");
+                virtualIfAvailable(value);
+            });
+            config.get("virtual-enforced").asBoolean().ifPresent(value -> {
+                warnExperimental("virtual-enforced");
+                virtualEnforced(value);
+            });
+            return this;
+        }
+
+        /**
+         * When configured to {@code true}, virtual thread executor service must be available, otherwise the built
+         * executor would fail to start.
+         *
+         * @param enforceVirtualThreads whether to enforce virtual threads, defaults to {@code false}
+         * @return updated builder instance
+         * @see #virtualIfAvailable(boolean)
+         */
+        public Builder virtualEnforced(boolean enforceVirtualThreads) {
+            this.virtualThreadsEnforced = enforceVirtualThreads;
+            return this;
+        }
+
+        /**
+         * When configured to {@code true}, an unbounded virtual executor service (project Loom) will be used
+         * if available.
+         * This is an experimental feature.
+         * <p>
+         * If enabled and available, all other configuration options of this executor service are ignored!
+         *
+         * @param useVirtualThreads whether to use virtual threads or not, defaults to {@code false}
+         * @return updated builder instance
+         */
+        public Builder virtualIfAvailable(boolean useVirtualThreads) {
+            this.useVirtualThreads = useVirtualThreads;
             return this;
         }
 

--- a/common/configurable/src/main/java/io/helidon/common/configurable/VirtualExecutorUtil.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/VirtualExecutorUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common.configurable;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.helidon.common.LazyValue;
+
+final class VirtualExecutorUtil {
+    private static final Logger LOGGER = Logger.getLogger(VirtualExecutorUtil.class.getName());
+    private static final LazyValue<Boolean> SUPPORTED = LazyValue.create(VirtualExecutorUtil::findSupported);
+    private static final LazyValue<ExecutorService> EXECUTOR_SERVICE = LazyValue.create(VirtualExecutorUtil::findExecutor);
+
+    private VirtualExecutorUtil() {
+    }
+
+    static boolean isVirtualSupported() {
+        return SUPPORTED.get();
+    }
+
+    static ExecutorService executorService() {
+        ExecutorService result = EXECUTOR_SERVICE.get();
+        if (result == null) {
+            throw new IllegalStateException("Virtual executor service is not supported on this JVM");
+        }
+        return result;
+    }
+
+    private static boolean findSupported() {
+        try {
+            // the method is intentionally NOT CACHED in static context, to support differences between build
+            // and runtime environments (support for GraalVM native image)
+            findMethod();
+            return true;
+        } catch (final ReflectiveOperationException e) {
+            LOGGER.log(Level.FINEST, "Loom virtual executor service not available", e);
+        }
+
+        return false;
+    }
+
+    private static ExecutorService findExecutor() {
+        try {
+            // the method is intentionally NOT CACHED in static context, to support differences between build
+            // and runtime environments (support for GraalVM native image)
+            return (ExecutorService) findMethod().invoke(null);
+        } catch (final ReflectiveOperationException e) {
+            LOGGER.log(Level.FINEST, "Loom virtual executor service not available", e);
+        }
+
+        return null;
+    }
+
+    private static Method findMethod() throws ReflectiveOperationException{
+        return Executors.class.getDeclaredMethod("newVirtualThreadExecutor");
+    }
+}

--- a/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolSupplierTest.java
+++ b/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,9 @@ class ThreadPoolSupplierTest {
 
     @BeforeAll
     static void initClass() {
-        defaultInstance = ThreadPoolSupplier.create().getThreadPool();
+        defaultInstance = (ThreadPoolExecutor) ThreadPoolSupplier.create().getThreadPool();
 
-        builtInstance = ThreadPoolSupplier.builder()
+        builtInstance = (ThreadPoolExecutor) ThreadPoolSupplier.builder()
                                           .threadNamePrefix("thread-pool-unit-test-")
                                           .corePoolSize(2)
                                           .daemon(true)
@@ -61,7 +61,7 @@ class ThreadPoolSupplierTest {
                                           .build()
                                           .getThreadPool();
 
-        configuredInstance = ThreadPoolSupplier.create(Config.create().get("unit.thread-pool"))
+        configuredInstance = (ThreadPoolExecutor) ThreadPoolSupplier.create(Config.create().get("unit.thread-pool"))
                                                .getThreadPool();
     }
 

--- a/docs/se/aot/01_introduction.adoc
+++ b/docs/se/aot/01_introduction.adoc
@@ -103,6 +103,7 @@ for native image.
 |✅ |{nbsp} |Multi-part |{nbsp}
 |❓ |{nbsp} |Prometheus |Not yet tested.
 |✅ |{nbsp} |Websocket |Server only.
+|✅ |{nbsp} |Blocking |{nbsp}
 |✅ |gRPC Server |gRPC Server |Since GraalVM 21.0.0
 |✅ |{nbsp} |Metrics |{nbsp}
 |✅ |gRPC Client |gRPC Client |Since GraalVM 21.0.0

--- a/examples/webserver/blocking/README.md
+++ b/examples/webserver/blocking/README.md
@@ -1,0 +1,47 @@
+# WebServer Blocking API Example
+
+This example demonstrates how to use the Helidon SE WebServer blocking
+APIs, with support for project Loom (https://jdk.java.net/loom/) and
+its virtual threads.
+
+There are three servers in this example:
+
+1. `SleepingServer` that has an endpoint that sleeps for 50ms
+2. `BlockingServer` using blocking APIs and invoking the sleeping service
+3. `ReactiveServer` using reactive APIs and invoking the sleeping service
+
+## Build
+
+```
+mvn package
+```
+
+## Run
+
+First, start the server (on explicit ports, by default uses random ports):
+
+```
+java -Dservers.blocking.port=8081 -Dservers.reactive.port=8082 -jar target/helidon-examples-webserver-blocking.jar
+```
+
+Invoke the blocking endpoint
+
+```
+curl -i http://localhost:8081/call
+```
+
+Invoke the reactive endpoint
+
+```
+curl -i http://localhost:8082/call
+```
+
+## JMeter
+There is a JMeter script for unix based system `run-tests.sh` that can be invoked with either `reactive` or `blocking` parameter to run appropriate tests. 
+Ports expected are as in the run command above - port `8081` for blocking service, `8082` for reactive.
+
+Invoke blocking tests:
+
+```
+./run-tests.sh blocking
+```

--- a/examples/webserver/blocking/pom.xml
+++ b/examples/webserver/blocking/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+        <relativePath>../../../applications/se/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.webserver</groupId>
+    <artifactId>helidon-examples-webserver-blocking</artifactId>
+    <name>Helidon WebServer Examples Blockin API</name>
+
+    <description>
+        Examples of blocking API use of the Web Server
+    </description>
+
+    <properties>
+        <mainClass>io.helidon.webserver.examples.blocking.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-blocking</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/webserver/blocking/run-tests.sh
+++ b/examples/webserver/blocking/run-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Parameters:
+#    type (blocking|reactive)
+
+JMETER_HOME=~/bin/apache-jmeter-5.3
+JMETER=$JMETER_HOME/bin
+
+type=$1
+time=$(date +"%Y-%m-%d_%H-%M")
+directory=test/"${type}-load.test."${time}
+
+$JMETER/jmeter.sh -n -t test/$1-test-plan.jmx -l "${directory}"/log.jtl -e -o "${directory}"

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/BlockingServer.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/BlockingServer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.config.Config;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+class BlockingServer {
+    private volatile WebServer webServer;
+
+    // returns port
+    int start(Config config, HttpClient httpClient, int port) {
+        webServer = WebServer.builder()
+                .routing(Routing.builder()
+                                 .register(new BlockingService(httpClient, port)))
+                .config(config.get("servers.blocking"))
+                .addMediaSupport(JsonpSupport.create())
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+
+        return webServer.port();
+    }
+
+    void stop() {
+        webServer.shutdown()
+                .await(10, TimeUnit.SECONDS);
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/BlockingService.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/BlockingService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.HttpException;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.blocking.BlockingHandler;
+
+/**
+ * An example of a WebServer service using blocking APIs.
+ */
+class BlockingService implements Service {
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+    private final HttpClient httpClient;
+    private final int port;
+
+    BlockingService(HttpClient httpClient, int port) {
+        this.httpClient = httpClient;
+        this.port = port;
+    }
+
+    /**
+     * A service registers itself by updating the routing rules.
+     * @param rules the routing rules.
+     */
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/call", BlockingHandler.create(this::call));
+    }
+
+    /**
+     * OK or FAILED depending on response from backend service.
+     * @return proper hello world message
+     */
+    private JsonObject call() {
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/sleep"))
+                .GET()
+                .build();
+
+        try {
+            int responseCode = httpClient.send(request, HttpResponse.BodyHandlers.discarding())
+                    .statusCode();
+            if (responseCode == Http.Status.OK_200.code()) {
+                return JSON.createObjectBuilder().add("status", "OK").build();
+            }
+
+            throw new HttpException("FAILED", Http.Status.find(responseCode).orElse(Http.Status.INTERNAL_SERVER_ERROR_500));
+        } catch (Exception e) {
+            throw new HttpException("FAILED", e);
+        }
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/Main.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/Main.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.net.http.HttpClient;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.configurable.ThreadPoolSupplier;
+import io.helidon.config.Config;
+import io.helidon.webclient.WebClient;
+import io.helidon.webserver.blocking.BlockingHandler;
+
+/**
+ * Main class of the example, starts the server.
+ */
+public final class Main {
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     * @param args command line arguments.
+     */
+    public static void main(final String[] args) {
+        // load logging configuration
+        LogConfig.configureRuntime();
+
+        // By default this will pick up application.yaml from the classpath
+        Config config = Config.create();
+
+        // explicitly configure an executor service
+        // the default uses virtual threads if available, but not enforced
+        ThreadPoolSupplier executor = ThreadPoolSupplier.create(config.get("executor"));
+        BlockingHandler.executorService(executor);
+
+        // let's start our three server, we must start with the "sleeping server", as it is used
+        // by the other two
+        SleepingServer sleepingServer = new SleepingServer();
+        int sleepingPort = sleepingServer.start(config);
+
+        // now we can create a client to be used by other server
+        WebClient webClient = WebClient.builder()
+                .baseUri("http://localhost:" + sleepingPort + "/sleep")
+                .keepAlive(true)
+                .build();
+
+        // client for blocking calls
+        HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .executor(executor.get())
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+
+        BlockingServer blockingServer = new BlockingServer();
+        int blockingPort = blockingServer.start(config, client, sleepingPort);
+
+        ReactiveServer reactiveServer = new ReactiveServer();
+        int reactivePort = reactiveServer.start(config, webClient);
+
+        System.out.println("Servers started");
+        System.out.println("  Sleeping service:");
+        System.out.println("    http://localhost:" + sleepingPort + "/sleep");
+        System.out.println("  Blocking service:");
+        System.out.println("    http://localhost:" + blockingPort + "/call");
+        System.out.println("  Reactive service:");
+        System.out.println("    http://localhost:" + reactivePort + "/call");
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/ReactiveServer.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/ReactiveServer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.config.Config;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+class ReactiveServer {
+    private volatile WebServer webServer;
+
+    // returns port
+    int start(Config config, WebClient webClient) {
+        webServer = WebServer.builder()
+                .routing(Routing.builder()
+                                 .register(new ReactiveService(webClient)))
+                .config(config.get("servers.reactive"))
+                .addMediaSupport(JsonpSupport.create())
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+
+        return webServer.port();
+    }
+
+    void stop() {
+        webServer.shutdown()
+                .await(10, TimeUnit.SECONDS);
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/ReactiveService.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/ReactiveService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.util.Map;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+
+import io.helidon.webclient.WebClient;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+/**
+ * The usual reactive Helidon Greet service.
+ */
+class ReactiveService implements Service {
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+
+    private final WebClient webClient;
+
+    ReactiveService(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    /**
+     * A service registers itself by updating the routing rules.
+     * @param rules the routing rules.
+     */
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/call", this::call);
+    }
+
+    /**
+     * OK or FAILED depending on response from backend service.
+     * @param req the server request
+     * @param res the server response
+     */
+    private void call(ServerRequest req, ServerResponse res) {
+        webClient.get()
+                .request(String.class)
+                .thenAccept(it -> {
+                    res.send(JSON.createObjectBuilder().add("status", it).build());
+                })
+                .exceptionally(res::send);
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/SleepingServer.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/SleepingServer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+class SleepingServer {
+    private volatile WebServer webServer;
+
+    // returns port
+    int start(Config config) {
+        webServer = WebServer.builder()
+                .routing(Routing.builder()
+                                 .register(new SleepingService()))
+                .config(config.get("servers.sleeping"))
+                .build()
+                .start()
+                .await(10, TimeUnit.SECONDS);
+
+        return webServer.port();
+    }
+
+    void stop() {
+        webServer.shutdown()
+                .await(10, TimeUnit.SECONDS);
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/SleepingService.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/SleepingService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.blocking.BlockingHandler;
+
+/**
+ * A service that sleeps for {@value #SLEEP_MILLIS} ms to emulate some blocking operation.
+ */
+class SleepingService implements Service {
+    private static final int SLEEP_MILLIS = 10;
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/sleep", BlockingHandler.create(this::sleep));
+    }
+
+    private String sleep() {
+        try {
+            Thread.sleep(SLEEP_MILLIS);
+            return "OK";
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Should have slept, but got interrupted", e);
+        }
+    }
+}

--- a/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/package-info.java
+++ b/examples/webserver/blocking/src/main/java/io/helidon/webserver/examples/blocking/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Example of reactive and blocking APIs for WebServer.
+ */
+package io.helidon.webserver.examples.blocking;

--- a/examples/webserver/blocking/src/main/resources/application.yaml
+++ b/examples/webserver/blocking/src/main/resources/application.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Use current server
+backend-port: -1
+
+executor:
+  # This is ignored when using virtual executor service
+  thread-name-prefix: "custom-blocking-"
+  # Use virtual threads if running in a Loom enabled JVM
+  virtual-threads: true
+  # If set to true - enforce use of virtual threads (will fail to start on JVMs that do not support Loom)
+  virtual-enforced: false
+  # Used when virtual threads are not available
+  max-pool-size: 250
+  # we need more than 100, as the test uses 100 threads and we need 2 threads per request (server and client)
+  core-pool-size: 250
+
+servers:
+  blocking:
+    port: 0
+  reactive:
+    port: 0
+  sleeping:
+    port: 0

--- a/examples/webserver/blocking/src/main/resources/logging.properties
+++ b/examples/webserver/blocking/src/main/resources/logging.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO

--- a/examples/webserver/blocking/src/test/java/io/helidon/webserver/examples/blocking/MainTest.java
+++ b/examples/webserver/blocking/src/test/java/io/helidon/webserver/examples/blocking/MainTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.examples.blocking;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.json.JsonObject;
+
+import io.helidon.config.Config;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MainTest {
+    private static SleepingServer sleepingServer;
+    private static WebClient sleepingClient;
+    private static BlockingServer blockingServer;
+    private static WebClient blockingClient;
+    private static ReactiveServer reactiveServer;
+    private static WebClient reactiveClient;
+
+    @BeforeAll
+    static void initTest() {
+        Config config = Config.create();
+        sleepingServer = new SleepingServer();
+        int sleepingPort = sleepingServer.start(config);
+        // now we can create a client to be used by other server
+        WebClient webClient = WebClient.builder()
+                .baseUri("http://localhost:" + sleepingPort + "/sleep")
+                .keepAlive(true)
+                .build();
+
+        // client for blocking calls
+        HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .executor(Executors.newFixedThreadPool(5))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+
+        blockingServer = new BlockingServer();
+        int blockingPort = blockingServer.start(config, client, sleepingPort);
+        reactiveServer = new ReactiveServer();
+        int reactivePort = reactiveServer.start(config, webClient);
+
+        sleepingClient = WebClient.builder()
+                .baseUri("http://localhost:" + sleepingPort)
+                .build();
+        blockingClient = WebClient.builder()
+                .baseUri("http://localhost:" + blockingPort)
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+        reactiveClient = WebClient.builder()
+                .baseUri("http://localhost:" + reactivePort)
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+    }
+
+    @AfterAll
+    static void destroyTest() {
+        if (sleepingServer != null) {
+            sleepingServer.stop();
+        }
+        if (blockingServer != null) {
+            blockingServer.stop();
+        }
+        if (reactiveServer != null) {
+            reactiveServer.stop();
+        }
+    }
+
+    @Test
+    void testReactiveEndpoint() {
+        JsonObject response = reactiveClient.get()
+                .path("/call")
+                .request(JsonObject.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertEquals("OK", response.getString("status"));
+    }
+
+    @Test
+    void testBlockingEndpoint() {
+        JsonObject response = blockingClient.get()
+                .path("/call")
+                .request(JsonObject.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertEquals("OK", response.getString("status"));
+    }
+
+    @Test
+    void testSleepService() {
+        String response = sleepingClient.get()
+                .path("/sleep")
+                .request(String.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertEquals("OK", response);
+    }
+}

--- a/examples/webserver/blocking/src/test/resources/application.yaml
+++ b/examples/webserver/blocking/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  # Run on a random port for tests
+  port: -1

--- a/examples/webserver/blocking/test/blocking-test-plan.jmx
+++ b/examples/webserver/blocking/test/blocking-test-plan.jmx
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan for Go Implmenetation" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">10000</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">10</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8081</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/call</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">test_results</stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">test_results</stringProp>
+          <stringProp name="RespTimeGraph.interval">100</stringProp>
+          <stringProp name="RespTimeGraph.graphtitle">Response Time Graph</stringProp>
+          <intProp name="RespTimeGraph.lineshapepoint">4</intProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/examples/webserver/blocking/test/reactive-test-plan.jmx
+++ b/examples/webserver/blocking/test/reactive-test-plan.jmx
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan for Go Implmenetation" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">10000</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">100</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">10</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8082</stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/call</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">test_results</stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">test_results</stringProp>
+          <stringProp name="RespTimeGraph.interval">100</stringProp>
+          <stringProp name="RespTimeGraph.graphtitle">Response Time Graph</stringProp>
+          <intProp name="RespTimeGraph.lineshapepoint">4</intProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/examples/webserver/pom.xml
+++ b/examples/webserver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/webserver/pom.xml
+++ b/examples/webserver/pom.xml
@@ -33,6 +33,7 @@
 
     <modules>
         <module>basics</module>
+        <module>blocking</module>
         <module>tutorial</module>
         <module>comment-aas</module>
         <module>static-content</module>

--- a/webserver/blocking/README.md
+++ b/webserver/blocking/README.md
@@ -1,0 +1,26 @@
+Synchronous API for Helidon SE
+---
+
+These APIs reap benefits of project Loom (https://jdk.java.net/loom/).
+
+If you run these on the loom build of the JDK, the application
+will be synchronous in code, yet non-blocking.
+
+
+Results of a Jmeter test:
+Sample: 10 000 000 requests
+
+Reactive
+- using reactive service implementation on Java 16 (with loom)
+
+Throughput: 120 310 transactions/second 
+
+Loom
+- using unbounded virtual executor service on Java 16 (with loom)
+Throughput: 112 146 transaction/second
+Throughput: 117 307 transaction/second when not renaming threads
+
+Blocking
+- using Helidon executor service on Java 15
+
+Throughput: 104289 transactions/second 

--- a/webserver/blocking/pom.xml
+++ b/webserver/blocking/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.webserver</groupId>
+        <artifactId>helidon-webserver-project</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-webserver-blocking</artifactId>
+    <name>Helidon WebServer Blocking APIs</name>
+    <description>Blocking APIs support in Helidon SE</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingContent.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingContent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import io.helidon.common.GenericType;
+
+/**
+ * Access to request entity using blocking API.
+ */
+public interface BlockingContent {
+    /**
+     * Consumes and converts the request content into the requested type.
+     * <p>
+     * The conversion requires an appropriate reader to be registered with webserver
+     * {@link io.helidon.webserver.WebServer.Builder#addMediaSupport(io.helidon.media.common.MediaSupport)} or
+     * {@link io.helidon.webserver.WebServer.Builder#addReader(io.helidon.media.common.MessageBodyReader)}.
+     *
+     * @param <T>  the requested type
+     * @param type the requested type class
+     * @return entity as the expected type
+     * @throws java.lang.RuntimeException when the entity cannot be read
+     */
+    <T> T as(Class<T> type);
+
+    /**
+     * Consumes and converts the request content into the requested type.
+     * <p>
+     * The conversion requires an appropriate reader to be registered with webserver
+     * {@link io.helidon.webserver.WebServer.Builder#addMediaSupport(io.helidon.media.common.MediaSupport)} or
+     * {@link io.helidon.webserver.WebServer.Builder#addReader(io.helidon.media.common.MessageBodyReader)}.
+     *
+     * @param <T>  the requested type
+     * @param type the requested type, can be a generic type
+     * @return entity as the expected type
+     * @throws java.lang.RuntimeException when the entity cannot be read
+     */
+    <T> T as(GenericType<T> type);
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingContentImpl.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingContentImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import io.helidon.common.GenericType;
+import io.helidon.media.common.MessageBodyReadableContent;
+
+class BlockingContentImpl implements BlockingContent {
+    private final MessageBodyReadableContent content;
+
+    BlockingContentImpl(MessageBodyReadableContent content) {
+        this.content = content;
+    }
+
+    static BlockingContent create(MessageBodyReadableContent content) {
+        return new BlockingContentImpl(content);
+    }
+
+    @Override
+    public <T> T as(Class<T> type) {
+        return content.as(type).await();
+    }
+
+    @Override
+    public <T> T as(GenericType<T> type) {
+        return content.as(type).await();
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingHandler.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingHandler.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.Handler;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+
+/**
+ * A handler for blocking APIs.
+ * Use one of the {@link #create(java.util.function.Supplier)} methods to create a blocking handler.
+ * Use the {@link #executorService(java.util.concurrent.ExecutorService)} to configure a custom executor service
+ * to process incoming requests (must be configured before the first request).
+ * Default executor service will use virtual threads if available (project Loom).
+ * <p>
+ * Handlers that return entity can control exception cases using {@link io.helidon.webserver.HttpException} to
+ *  return a specific HTTP status code.
+ */
+@FunctionalInterface
+public interface BlockingHandler extends Handler {
+    /**
+     * A method handling a blocking request.
+     *
+     * @param req HTTP request abstraction with blocking methods
+     * @param res HTTP response abstraction with blocking methods
+     */
+    void handle(BlockingRequest req, BlockingResponse res);
+
+    @Override
+    default void accept(ServerRequest req, ServerResponse res) {
+        ExecutorServiceSupport.executorService()
+                .submit(() -> {
+                    String originalName = Thread.currentThread().getName();
+                    if ("<unnamed>".equals(originalName)) {
+                        // virtual thread
+                        Thread.currentThread().setName("Virtual: " + req.method().name() + " " + req.path());
+                    } else {
+                        Thread.currentThread().setName(originalName + ": " + req.method().name() + " " + req.path());
+                    }
+                    try {
+                        handle(BlockingRequestImpl.create(req), BlockingResponseImpl.create(res));
+                    } catch (Throwable e) {
+                        req.next(e);
+                    } finally {
+                        Thread.currentThread().setName(originalName);
+                    }
+                });
+    }
+
+    /**
+     * Configure executor service to use for processing blocking requests.
+     *
+     * @param executor executor service to use
+     */
+    static void executorService(ExecutorService executor) {
+        ExecutorServiceSupport.defaultExecutor(executor);
+    }
+
+    /**
+     * Configure executor service to use for processing blocking requests.
+     *
+     * @param executor executor service to use
+     */
+    static void executorService(Supplier<ExecutorService> executor) {
+        ExecutorServiceSupport.defaultExecutor(executor);
+    }
+
+    /**
+     * Create a blocking handler that uses both request and response for processing.
+     *
+     * @param handler handler to use
+     * @return a new blocking handler to register with web server
+     */
+    static BlockingHandler create(BiConsumer<BlockingRequest, BlockingResponse> handler) {
+        return handler::accept;
+    }
+
+    /**
+     * Create a blocking handler that consumes entity.
+     * This handler will use HTTP status code {@link Http.Status#NO_CONTENT_204}.
+     *
+     * @param requestEntityType type of entity to read (must be supported by one of the readers registered with web server)
+     * @param handler consumer of the entity
+     * @param <T> type of request entity
+     * @return a new blocking handler to register with web server
+     */
+    static <T> BlockingHandler create(Class<T> requestEntityType, Consumer<T> handler) {
+        return (req, res) -> {
+            T requestObject = req.content().as(requestEntityType);
+            handler.accept(requestObject);
+            res.status(Http.Status.NO_CONTENT_204);
+            res.send();
+        };
+    }
+
+    /**
+     * Create a blocking handler that consumes entity and returns an entity.
+     *
+     * @param requestEntityType type of entity to read (must be supported by one of the readers registered with web server)
+     * @param handler handler that consumes entity and returns an entity to respond with
+     * @param <T> type of request entity
+     * @return a new blocking handler to register with web server
+     */
+    static <T> BlockingHandler create(Class<T> requestEntityType, Function<T, ?> handler) {
+        return (req, res) -> {
+            T requestObject = req.content().as(requestEntityType);
+            Object response = handler.apply(requestObject);
+            res.send(response);
+        };
+    }
+
+    /**
+     * Create a blocking handler that consumes full request and returns an entity.
+     * @param handler handler that consumes request and returns an entity
+     * @return a new blocking handler to register with web server
+     */
+    static BlockingHandler create(Function<BlockingRequest, ?> handler) {
+        return (req, res) -> {
+            Object response = handler.apply(req);
+            res.send(response);
+        };
+    }
+
+    /**
+     * Create a blocking handler that provides an entity.
+     *
+     * @param handler handler that supplies response entity
+     * @return a new blocking handler to register with web server
+     */
+    static BlockingHandler create(Supplier<?> handler) {
+        return (req, res) -> {
+            Object response = handler.get();
+            res.send(response);
+        };
+    }
+
+    /**
+     * Create a blocking handler that runs code that does not require any information from request
+     * and does not return an entity.
+     *
+     * @param handler handler that runs on request
+     * @return new blocking handler to register with web server
+     */
+    static BlockingHandler create(Runnable handler) {
+        return (req, res) -> {
+            handler.run();
+            res.send();
+        };
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingRequest.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingRequest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpRequest;
+import io.helidon.webserver.HttpException;
+import io.helidon.webserver.RequestHeaders;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+/**
+ * HTTP request abstraction that uses fully blocking methods.
+ */
+public interface BlockingRequest extends HttpRequest {
+    /**
+     * Returns a blocking representation of the request content (entity).
+     *
+     * @return request content
+     */
+    BlockingContent content();
+
+    /**
+     * Returns a request context as a child of {@link io.helidon.webserver.WebServer} context.
+     *
+     * @return a request context
+     */
+    Context context();
+
+    /**
+     * Returns the Internet Protocol (IP) address of the interface on which the request was received.
+     *
+     * @return an address
+     */
+    String localAddress();
+
+    /**
+     * Returns the Internet Protocol (IP) port number of the interface on which the request was received.
+     *
+     * @return the port number
+     */
+    int localPort();
+
+    /**
+     * Returns the Internet Protocol (IP) address of the client or last proxy that sent the request.
+     *
+     * @return the address of the client that sent the request
+     */
+    String remoteAddress();
+
+    /**
+     * Returns the Internet Protocol (IP) source port of the client or last proxy that sent the request.
+     *
+     * @return the port number.
+     */
+    int remotePort();
+
+    /**
+     * Returns an indicating whether this request was made using a secure channel, such as HTTPS.
+     *
+     * @return {@code true} if the request was made using a secure channel
+     */
+    boolean isSecure();
+
+    /**
+     * Returns http request headers.
+     *
+     * @return an http headers
+     */
+    RequestHeaders headers();
+
+    /**
+     * A unique correlation ID that is associated with this request and its associated response.
+     *
+     * @return a unique correlation ID associated with this request and its response
+     */
+    long requestId();
+
+    /**
+     * Returns a span context related to the current request.
+     * <p>
+     * {@code SpanContext} is a tracing component from <a href="http://opentracing.io">opentracing.io</a> standard.
+     *
+     * @return the related span context, empty if not enabled
+     */
+    Optional<SpanContext> spanContext();
+
+    /**
+     * Returns the {@link io.opentracing.Tracer} associated with {@link io.helidon.webserver.WebServer}.
+     *
+     * @return the tracer associated, or {@link io.opentracing.util.GlobalTracer#get()}
+     */
+    Tracer tracer();
+
+    /**
+     * Absolute URI of the incoming request, including query parameters and fragment.
+     * The host and port are obtained from the interface this server listens on ({@code host} header is not used).
+     *
+     * @return the URI of incoming request
+     */
+    default URI absoluteUri() {
+        try {
+            // Use raw string representation and URL to avoid re-encoding chars like '%'
+            URI partialUri = new URL(isSecure() ? "https" : "http", localAddress(),
+                                     localPort(), path().absolute().toRawString()).toURI();
+            StringBuilder sb = new StringBuilder(partialUri.toString());
+            if (uri().toString().endsWith("/") && sb.charAt(sb.length() - 1) != '/') {
+                sb.append('/');
+            }
+
+            // unfortunately, the URI constructor encodes the 'query' and 'fragment' which is totally silly
+            if (query() != null && !query().isEmpty()) {
+                sb.append("?")
+                        .append(query());
+            }
+            if (fragment() != null && !fragment().isEmpty()) {
+                sb.append("#")
+                        .append(fragment());
+            }
+            return new URI(sb.toString());
+        } catch (URISyntaxException | MalformedURLException e) {
+            throw new HttpException("Unable to parse request URL", Http.Status.BAD_REQUEST_400, e);
+        }
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingRequestImpl.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingRequestImpl.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.net.URI;
+import java.util.Optional;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.http.Http;
+import io.helidon.common.http.HttpRequest;
+import io.helidon.common.http.Parameters;
+import io.helidon.webserver.RequestHeaders;
+import io.helidon.webserver.ServerRequest;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+
+/**
+ * Blocking request implementation.
+ */
+class BlockingRequestImpl implements BlockingRequest {
+    private final ServerRequest req;
+
+    BlockingRequestImpl(ServerRequest req) {
+        this.req = req;
+    }
+
+    static BlockingRequest create(ServerRequest req) {
+        return new BlockingRequestImpl(req);
+    }
+
+    @Override
+    public BlockingContent content() {
+        return BlockingContentImpl.create(req.content());
+    }
+
+    @Override
+    public HttpRequest.Path path() {
+        return req.path();
+    }
+
+    @Override
+    public Context context() {
+        return req.context();
+    }
+
+    @Override
+    public String localAddress() {
+        return req.localAddress();
+    }
+
+    @Override
+    public int localPort() {
+        return req.localPort();
+    }
+
+    @Override
+    public String remoteAddress() {
+        return req.remoteAddress();
+    }
+
+    @Override
+    public int remotePort() {
+        return req.remotePort();
+    }
+
+    @Override
+    public boolean isSecure() {
+        return req.isSecure();
+    }
+
+    @Override
+    public RequestHeaders headers() {
+        return req.headers();
+    }
+
+    @Override
+    public long requestId() {
+        return req.requestId();
+    }
+
+    @Override
+    public Optional<SpanContext> spanContext() {
+        return req.spanContext();
+    }
+
+    @Override
+    public Tracer tracer() {
+        return req.tracer();
+    }
+
+    @Override
+    public Http.RequestMethod method() {
+        return req.method();
+    }
+
+    @Override
+    public Http.Version version() {
+        return req.version();
+    }
+
+    @Override
+    public URI uri() {
+        return req.uri();
+    }
+
+    @Override
+    public String query() {
+        return req.query();
+    }
+
+    @Override
+    public Parameters queryParams() {
+        return req.queryParams();
+    }
+
+    @Override
+    public String fragment() {
+        return req.fragment();
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingResponse.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingResponse.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.util.function.Consumer;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.ResponseHeaders;
+
+/**
+ * Abstraction of HTTP response that uses fully blocking methods.
+ */
+public interface BlockingResponse {
+    /**
+     * Send a message and close the response.
+     *
+     * Type must be supported by one of the registered writers using
+     * {@link io.helidon.webserver.WebServer.Builder#addWriter(io.helidon.media.common.MessageBodyWriter)}
+     * or
+     * {@link io.helidon.webserver.WebServer.Builder#addMediaSupport(io.helidon.media.common.MediaSupport)}.
+     *
+     * @param content response content to send
+     * @param <T>     type of the content
+     *
+     * @throws IllegalArgumentException if there is no registered writer for a given type
+     * @throws IllegalStateException if any {@code send(...)} method was already called
+     */
+    <T> void send(T content);
+
+    /**
+     * Sends an empty response. Does nothing if response was already send.
+     */
+    void send();
+
+    /**
+     * Sets new HTTP status code. Can be done before headers are completed - see {@link ResponseHeaders} documentation.
+     *
+     * @param status new status code, such as {@link Http.Status#ACCEPTED_202}
+     * @throws io.helidon.common.http.AlreadyCompletedException if headers were completed (sent to the client)
+     * @return this instance
+     */
+    BlockingResponse status(Http.ResponseStatus status);
+
+    /**
+     * Returns actual response status code.
+     * <p>
+     * Default value for handlers is {@code 200} and for failure handlers {@code 500}. Value can be redefined using
+     * {@link #status(io.helidon.common.http.Http.ResponseStatus)} method before headers are send.
+     *
+     * @return an HTTP status code
+     */
+    Http.ResponseStatus status();
+
+    /**
+     * Returns response headers. Headers can be modified before they are sent to the client.
+     *
+     * @return response headers
+     */
+    ResponseHeaders headers();
+
+    /**
+     * Support for fluent API way of updating response headers.
+     *
+     * @param updater code that uses response headers to update them
+     * @return this instance
+     */
+    default BlockingResponse updateHeaders(Consumer<ResponseHeaders> updater) {
+        updater.accept(headers());
+        return this;
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingResponseImpl.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/BlockingResponseImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.ResponseHeaders;
+import io.helidon.webserver.ServerResponse;
+
+class BlockingResponseImpl implements BlockingResponse {
+    private final ServerResponse res;
+
+    BlockingResponseImpl(ServerResponse res) {
+        this.res = res;
+    }
+
+    static BlockingResponse create(ServerResponse res) {
+        return new BlockingResponseImpl(res);
+    }
+
+    @Override
+    public void send(Object content) {
+        res.send(content).await();
+    }
+
+    @Override
+    public BlockingResponse status(Http.ResponseStatus status) {
+        res.status(status);
+        return this;
+    }
+
+    @Override
+    public Http.ResponseStatus status() {
+        return res.status();
+    }
+
+    @Override
+    public void send() {
+        res.send().await();
+    }
+
+    @Override
+    public ResponseHeaders headers() {
+        return res.headers();
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/ExecutorServiceSupport.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/ExecutorServiceSupport.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import io.helidon.common.LazyValue;
+import io.helidon.common.configurable.ThreadPoolSupplier;
+
+/**
+ * Handling of configured (or default) executor service.
+ */
+final class ExecutorServiceSupport {
+    private ExecutorServiceSupport() {
+    }
+
+    static void defaultExecutor(ExecutorService executor) {
+        ExecutorServiceHolder.EXECUTOR_SUPPLIER.set(() -> executor);
+    }
+
+    static void defaultExecutor(Supplier<ExecutorService> executor) {
+        ExecutorServiceHolder.EXECUTOR_SUPPLIER.set(executor);
+    }
+
+    static ExecutorService executorService() {
+        return ExecutorServiceHolder.EXECUTOR.get();
+    }
+
+    private static ExecutorService defaultExecutor() {
+        return ThreadPoolSupplier.builder()
+                .virtualIfAvailable(true)
+                .name("server-blocking")
+                .threadNamePrefix("blocking-")
+                .build()
+                .get();
+    }
+
+    private static final class ExecutorServiceHolder {
+        private static final AtomicReference<Supplier<ExecutorService>> EXECUTOR_SUPPLIER =
+                new AtomicReference<>(ExecutorServiceSupport::defaultExecutor);
+
+        private static final LazyValue<ExecutorService> EXECUTOR = LazyValue.create(() -> EXECUTOR_SUPPLIER.get().get());
+    }
+}

--- a/webserver/blocking/src/main/java/io/helidon/webserver/blocking/package-info.java
+++ b/webserver/blocking/src/main/java/io/helidon/webserver/blocking/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon {@link io.helidon.webserver.WebServer} blocking API support.
+ *
+ * @see io.helidon.webserver.blocking.BlockingHandler
+ */
+package io.helidon.webserver.blocking;

--- a/webserver/blocking/src/main/java/module-info.java
+++ b/webserver/blocking/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Blocking API for {@link io.helidon.webserver.WebServer}.
+ */
+module io.helidon.webserver.blocking {
+    requires io.helidon.common;
+    requires io.helidon.media.common;
+    requires io.helidon.common.http;
+    requires io.helidon.webserver;
+    requires io.opentracing.api;
+}

--- a/webserver/blocking/src/test/java/io/helidon/webserver/blocking/BlockingTest.java
+++ b/webserver/blocking/src/test/java/io/helidon/webserver/blocking/BlockingTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.blocking;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.http.Http;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+import io.helidon.webserver.HttpException;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class BlockingTest {
+    private static WebServer webServer;
+    private static WebClient client;
+
+    @BeforeAll
+    static void initClass() {
+        webServer = WebServer.create(routing())
+            .start()
+            .await(10, TimeUnit.SECONDS);
+
+        client = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port())
+                .build();
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        if (webServer != null) {
+            webServer.shutdown().await(10, TimeUnit.SECONDS);
+        }
+        client = null;
+    }
+
+    @Test
+    void testFullEcho() {
+        String entity = "Hello world!";
+
+        String response = client.post()
+                .path("/echo/full")
+                .submit(entity, String.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertThat(response, is(entity));
+    }
+
+    @Test
+    void testSimpleEcho() {
+        String entity = "Hello world!";
+
+        String response = client.post()
+                .path("/echo/simple")
+                .submit(entity, String.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertThat(response, is(entity));
+    }
+
+    @Test
+    void testUpper() {
+        String text = "VeryText";
+
+        String response = client.get()
+                .path("/upper/" + text)
+                .request(String.class)
+                .await(10, TimeUnit.SECONDS);
+
+        assertThat(response, is(text.toUpperCase()));
+    }
+
+    @Test
+    void testFailureStatusCode() {
+        WebClientResponse response = client.post()
+                .path("/fail")
+                .submit("message")
+                .await(10, TimeUnit.SECONDS);
+
+        assertThat(response.status(), is(Http.Status.BAD_GATEWAY_502));
+        assertThat(response.content().as(String.class).await(10, TimeUnit.SECONDS), is("Failure"));
+    }
+
+    private static Routing routing() {
+        return Routing.builder()
+                .post("/echo/full", (BlockingHandler) BlockingTest::fullEcho)
+                .post("/echo/simple", BlockingHandler.create(String.class, BlockingTest::simpleEcho))
+                .get("/upper/{text}", BlockingHandler.create(BlockingTest::upperCase))
+                .post("/fail", BlockingHandler.create(BlockingTest::fail))
+                .build();
+    }
+
+    private static String fail() {
+        throw new HttpException("Failure", Http.Status.BAD_GATEWAY_502);
+    }
+
+    private static void fullEcho(BlockingRequest request, BlockingResponse response) {
+        response.send(request.content().as(String.class));
+    }
+
+    private static String upperCase(BlockingRequest request) {
+        return request.path().param("text").toUpperCase();
+    }
+
+    private static String simpleEcho(String entity) {
+        return entity;
+    }
+}

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/AsyncExecutorProvider.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/AsyncExecutorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package io.helidon.webserver.jersey;
 
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import io.helidon.common.configurable.ThreadPoolSupplier;
@@ -37,36 +36,14 @@ class AsyncExecutorProvider implements ExecutorServiceProvider {
 
     static ExecutorServiceProvider create(Config config) {
         Config asyncExecutorServiceConfig = config.get("async-executor-service");
-        final java.lang.reflect.Method m;
-        if (asyncExecutorServiceConfig.get("virtual-threads").asBoolean().orElse(false)) {
-            java.lang.reflect.Method temp = null;
-            try {
-                temp = Executors.class.getDeclaredMethod("newVirtualThreadExecutor");
-            } catch (final ReflectiveOperationException notLoom) {
-                temp = null;
-            } finally {
-                m = temp;
-            }
-        } else {
-            m = null;
-        }
-        if (m != null) {
-            return new AsyncExecutorProvider(() -> {
-                try {
-                    return (ExecutorService) m.invoke(null);
-                } catch (final ReflectiveOperationException reflectiveOperationException) {
-                    throw new IllegalStateException(reflectiveOperationException.getMessage(), reflectiveOperationException);
-                }
-            });
-        } else {
-            return new AsyncExecutorProvider(ThreadPoolSupplier.builder()
+
+        return new AsyncExecutorProvider(ThreadPoolSupplier.builder()
                                                  .corePoolSize(1)
                                                  .maxPoolSize(10)
                                                  .prestart(false)
                                                  .threadNamePrefix("helidon-jersey-async")
                                                  .config(asyncExecutorServiceConfig)
                                                  .build());
-        }
     }
 
     static ExecutorServiceProvider create(ExecutorService executor) {

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -38,6 +38,7 @@
         <module>access-log</module>
         <module>tyrus</module>
         <module>cors</module>
+        <module>blocking</module>
         <module>static-content</module>
     </modules>
 </project>


### PR DESCRIPTION
Related to #2341 

This is a brand new feature to support blocking APIs that work nicely with project Loom.
Support for virtual threads is incorporated into the `ThreadPoolSupplier`, so it can be used in any part of Helidon simply by configuring `virtual-threads: true` for that executor.

This PR contains the API, implementation, and example. It is tested with native image.

This is first (experimental) approach, for discussion. Main features:

1. Blocking APIs do not introduce new routing abstraction
2. Main access point is `BlockingHandler` that allows you to create blocking routing methods and register them as usual with WebServer routing
3. All blocking calls are invoked in a custom executor service, that is by default using virtual threads when running on Loom enabled JVM
4. I have moved Loom support into `ThreadPoolSupplier`, so we can use it anywhere in Helidon (also refactored existing usage)
