### PR TITLE
Using config reference instead of ${ALIAS=

### DIFF
--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
@@ -40,7 +40,7 @@ import io.helidon.config.spi.ConfigFilter;
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
- * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}</li>
+ * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}}</li>
  * <li>${CLEAR=text} - clear-text password. Intentionally denoting this value as a protectable one, so we can enforce encryption
  * (e.g. in prod)</li>
  * </ul>

--- a/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/EncryptionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import io.helidon.config.spi.ConfigFilter;
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
- * <li>${ALIAS=alias_name} - reference to another property, that is encrypted</li>
+ * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}</li>
  * <li>${CLEAR=text} - clear-text password. Intentionally denoting this value as a protectable one, so we can enforce encryption
  * (e.g. in prod)</li>
  * </ul>
@@ -48,7 +48,7 @@ import io.helidon.config.spi.ConfigFilter;
  * <pre>
  * google_client_secret=${AES=mYRkg+4Q4hua1kvpCCI2hg==}
  * service_password=${RSA=mYRkg+4Q4hua1kvpCCI2hg==}
- * another_password=${ALIAS=service_password}
+ * another_password=${service_password}
  * cleartext_password=${CLEAR=known_password}
  * </pre>
  *

--- a/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
@@ -38,7 +38,7 @@ import org.eclipse.microprofile.config.Config;
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
- * <li>${ALIAS=alias_name} - reference to another property, that is encrypted</li>
+ * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}</li>
  * <li>${CLEAR=text} - clear-text password. Intentionally denoting this value as a protectable one, so we can enforce encryption
  * (e.g. in prod)</li>
  * </ul>
@@ -46,7 +46,7 @@ import org.eclipse.microprofile.config.Config;
  * <pre>
  * google_client_secret=${AES=mYRkg+4Q4hua1kvpCCI2hg==}
  * service_password=${RSA=mYRkg+4Q4hua1kvpCCI2hg==}
- * another_password=${ALIAS=service_password}
+ * another_password=${service_password}
  * cleartext_password=${CLEAR=known_password}
  * </pre>
  *

--- a/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/MpEncryptionFilter.java
@@ -38,7 +38,7 @@ import org.eclipse.microprofile.config.Config;
  * property or environment variable)</li>
  * <li>${RSA=base64} - encrypted password using a public key (private key must be available to Prime instance,
  * its location must be provided to prime through configuration, system property or environment variable)</li>
- * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}</li>
+ * <li>${ALIAS=alias_name} - no longer needed, please use {@code ${alias_name}}</li>
  * <li>${CLEAR=text} - clear-text password. Intentionally denoting this value as a protectable one, so we can enforce encryption
  * (e.g. in prod)</li>
  * </ul>

--- a/docs/mp/security/03_configuration-secrets.adoc
+++ b/docs/mp/security/03_configuration-secrets.adoc
@@ -67,9 +67,6 @@ The supported templates are:
 |Shared secret ecryption, base64 value
 |${GCM=D/UgMzsNb265HU1NDvdzm7tACHdsW6u1PjYEcRkV/OLiWcI+ET6Q4MKCz0zHyEh9}
 
-|${ALIAS=...}
-|Reference to another key
-|${ALIAS=someOtherKey}
 |===
 
 === Requiring encryption 

--- a/examples/microprofile/idcs/src/main/resources/application.yaml
+++ b/examples/microprofile/idcs/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,22 +37,22 @@ security:
     - abac:
       # Adds ABAC Provider - it does not require any configuration
     - oidc:
-        client-id: "${ALIAS=security.properties.idcs-client-id}"
-        client-secret: "${ALIAS=security.properties.idcs-client-secret}"
-        identity-uri: "${ALIAS=security.properties.idcs-uri}"
+        client-id: "${security.properties.idcs-client-id}"
+        client-secret: "${security.properties.idcs-client-secret}"
+        identity-uri: "${security.properties.idcs-uri}"
         # A prefix used for custom scopes
         scope-audience: "http://localhost:7987/test-application"
-        proxy-host: "${ALIAS=security.properties.proxy-host}"
-        frontend-uri: "${ALIAS=security.properties.frontend-uri}"
+        proxy-host: "${security.properties.proxy-host}"
+        frontend-uri: "${security.properties.frontend-uri}"
     - idcs-role-mapper:
         multitenant: false
         oidc-config:
           # we must repeat IDCS configuration, as in this case
           # IDCS serves both as open ID connect authenticator and
           # as a role mapper. Using minimal configuration here
-          client-id: "${ALIAS=security.properties.idcs-client-id}"
-          client-secret: "${ALIAS=security.properties.idcs-client-secret}"
-          identity-uri: "${ALIAS=security.properties.idcs-uri}"
+          client-id: "${security.properties.idcs-client-id}"
+          client-secret: "${security.properties.idcs-client-secret}"
+          identity-uri: "${security.properties.idcs-uri}"
   web-server:
     paths:
       - path: "/web[/{*}]"

--- a/examples/security/google-login/src/main/resources/application.yaml
+++ b/examples/security/google-login/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2020 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,11 +27,11 @@ security:
         # Also update the client id configured in header of index.html
         # Detailed how-to for login button (including links how to create an application):
         # https://developers.google.com/identity/sign-in/web/sign-in
-        client-id: "${ALIAS=security.properties.google-client-id}"
+        client-id: "${security.properties.google-client-id}"
         # Defaults for Helidon
         # realm: "helidon"
         # Configure proxy host if needed
-        proxy-host: "${ALIAS=security.properties.proxy-host}"
+        proxy-host: "${security.properties.proxy-host}"
         # proxy-port: 80
 
         # This is the default for GoogleTokenProvider

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -31,13 +31,13 @@ security:
   - abac:
     # Adds ABAC Provider - it does not require any configuration
   - oidc:
-      client-id: "${ALIAS=security.properties.idcs-client-id}"
-      client-secret: "${ALIAS=security.properties.idcs-client-secret}"
-      identity-uri: "${ALIAS=security.properties.idcs-uri}"
+      client-id: "${security.properties.idcs-client-id}"
+      client-secret: "${security.properties.idcs-client-secret}"
+      identity-uri: "${security.properties.idcs-uri}"
       # A prefix used for custom scopes
       scope-audience: "http://localhost:7987/test-application"
-      proxy-host: "${ALIAS=security.properties.proxy-host}"
-      frontend-uri: "${ALIAS=security.properties.frontend-uri}"
+      proxy-host: "${security.properties.proxy-host}"
+      frontend-uri: "${security.properties.frontend-uri}"
       # support for non-public signature JWK (and maybe other IDCS specific handling)
       server-type: "idcs"
   - idcs-role-mapper:
@@ -46,9 +46,9 @@ security:
         # we must repeat IDCS configuration, as in this case
         # IDCS serves both as open ID connect authenticator and
         # as a role mapper. Using minimal configuration here
-        client-id: "${ALIAS=security.properties.idcs-client-id}"
-        client-secret: "${ALIAS=security.properties.idcs-client-secret}"
-        identity-uri: "${ALIAS=security.properties.idcs-uri}"
+        client-id: "${security.properties.idcs-client-id}"
+        client-secret: "${security.properties.idcs-client-secret}"
+        identity-uri: "${security.properties.idcs-uri}"
   web-server:
     # protected paths on the web server - do not include paths served by Jersey, as those are protected directly
     paths:


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Since version 2.0.0, we support direct configuration references using `${key}` in both SE and MP. The obsolete `${ALIAS=key}` is no longer needed.

This PR removes all uses (except for unit tests), while keeping backward compatibility.