### PR TITLE
Logging setup in examples and templates

### DIFF
--- a/archetypes/bare-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
+++ b/archetypes/bare-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
@@ -1,10 +1,7 @@
 
 package {{package}};
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -27,20 +24,18 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
         // load logging configuration
-        setupLogging();
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
@@ -89,14 +84,5 @@ public final class Main {
                 .register(metrics)                  // Metrics at "/metrics"
                 .register("/greet", greetService)
                 .build();
-    }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
     }
 }

--- a/archetypes/database-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
+++ b/archetypes/database-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
@@ -1,9 +1,7 @@
 
 package {{package}};
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.health.DbClientHealthCheck;
@@ -31,9 +29,8 @@ public final class Main {
      * Application main entry point.
      *
      * @param args command line arguments
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
@@ -41,11 +38,10 @@ public final class Main {
      * Start the server.
      *
      * @return the created {@link io.helidon.webserver.WebServer} instance
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
         // Load logging configuration
-        LogManager.getLogManager().readConfiguration(Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/archetypes/quickstart-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
+++ b/archetypes/quickstart-se/src/main/resources/src/main/java/__pkg__/Main.java.mustache
@@ -1,17 +1,13 @@
 
 package {{package}};
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
 import io.helidon.metrics.MetricsSupport;
 import io.helidon.webserver.Routing;
-import io.helidon.webserver.ServerConfiguration;
 import io.helidon.webserver.WebServer;
 
 /**
@@ -28,20 +24,18 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
         // load logging configuration
-        setupLogging();
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
@@ -90,14 +84,5 @@ public final class Main {
                 .register(metrics)                  // Metrics at "/metrics"
                 .register("/greet", greetService)
                 .build();
-    }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
     }
 }

--- a/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
@@ -17,10 +17,9 @@
 package io.helidon.examples.cors;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -59,10 +58,7 @@ public final class Main {
     static WebServer startServer() throws IOException {
 
         // load logging configuration
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager()
-                    .readConfiguration(is);
-        }
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/examples/dbclient/jdbc/src/main/java/io/helidon/examples/dbclient/jdbc/JdbcExampleMain.java
+++ b/examples/dbclient/jdbc/src/main/java/io/helidon/examples/dbclient/jdbc/JdbcExampleMain.java
@@ -16,9 +16,7 @@
 
 package io.helidon.examples.dbclient.jdbc;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.health.DbClientHealthCheck;
@@ -45,9 +43,8 @@ public final class JdbcExampleMain {
      * Application main entry point.
      *
      * @param args command line arguments.
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
@@ -55,13 +52,11 @@ public final class JdbcExampleMain {
      * Start the server.
      *
      * @return the created {@link io.helidon.webserver.WebServer} instance
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                JdbcExampleMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/examples/dbclient/mongodb/src/main/java/io/helidon/examples/dbclient/mongo/MongoDbExampleMain.java
+++ b/examples/dbclient/mongodb/src/main/java/io/helidon/examples/dbclient/mongo/MongoDbExampleMain.java
@@ -16,9 +16,7 @@
 
 package io.helidon.examples.dbclient.mongo;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.dbclient.DbClient;
 import io.helidon.dbclient.DbStatementType;
@@ -48,9 +46,8 @@ public final class MongoDbExampleMain {
      * Application main entry point.
      *
      * @param args command line arguments.
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
@@ -58,13 +55,11 @@ public final class MongoDbExampleMain {
      * Start the server.
      *
      * @return the created {@link io.helidon.webserver.WebServer} instance
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                MongoDbExampleMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMain.java
+++ b/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMain.java
@@ -16,9 +16,7 @@
 
 package io.helidon.examples.dbclient.pokemons;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.dbclient.DbClient;
@@ -56,9 +54,8 @@ public final class PokemonMain {
      * Application main entry point.
      *
      * @param args Command line arguments. Run with MongoDB support when 1st argument is mongo, run with JDBC support otherwise.
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         if (args != null && args.length > 0 && args[0] != null && "mongo".equals(args[0].toLowerCase())) {
             System.out.println("MongoDB database selected");
             mongo = true;
@@ -73,12 +70,11 @@ public final class PokemonMain {
      * Start the server.
      *
      * @return the created {@link io.helidon.webserver.WebServer} instance
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(PokemonMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = isMongo() ? Config.create(ConfigSources.classpath(MONGO_CFG)) : Config.create();

--- a/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
+++ b/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
@@ -16,10 +16,7 @@
 
 package io.helidon.service.employee;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -43,23 +40,19 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        try (InputStream logFile = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(logFile);
-        }
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/examples/grpc/basics/src/main/java/io/helidon/grpc/examples/basics/Server.java
+++ b/examples/grpc/basics/src/main/java/io/helidon/grpc/examples/basics/Server.java
@@ -16,8 +16,7 @@
 
 package io.helidon.grpc.examples.basics;
 
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.GreetService;
 import io.helidon.grpc.examples.common.GreetServiceJava;
@@ -42,16 +41,13 @@ public class Server {
      * The main program entry point.
      *
      * @param args  the program arguments
-     *
-     * @throws Exception  if an error occurs
      */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Server.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // Get gRPC server config from the "grpc" section of application.yaml
         GrpcServerConfiguration serverConfig =

--- a/examples/grpc/metrics/src/main/java/io/helidon/grpc/examples/metrics/Server.java
+++ b/examples/grpc/metrics/src/main/java/io/helidon/grpc/examples/metrics/Server.java
@@ -16,8 +16,7 @@
 
 package io.helidon.grpc.examples.metrics;
 
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.GreetService;
 import io.helidon.grpc.examples.common.StringService;
@@ -49,8 +48,7 @@ public class Server {
         Config config = Config.create();
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Server.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // Get gRPC server config from the "grpc" section of application.yaml
         GrpcServerConfiguration serverConfig =

--- a/examples/grpc/opentracing/src/main/java/io/helidon/grpc/examples/opentracing/ZipkinExampleMain.java
+++ b/examples/grpc/opentracing/src/main/java/io/helidon/grpc/examples/opentracing/ZipkinExampleMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package io.helidon.grpc.examples.opentracing;
 
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.GreetService;
 import io.helidon.grpc.examples.common.StringService;
@@ -49,8 +48,7 @@ public class ZipkinExampleMain {
         Config config = Config.create();
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                ZipkinExampleMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Tracer tracer = TracerBuilder.create(config.get("tracing")).build();
 

--- a/examples/grpc/security-abac/src/main/java/io/helidon/grpc/examples/security/abac/AbacServer.java
+++ b/examples/grpc/security-abac/src/main/java/io/helidon/grpc/examples/security/abac/AbacServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.helidon.grpc.examples.security.abac;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.examples.common.StringService;
 import io.helidon.grpc.server.GrpcRouting;
 import io.helidon.grpc.server.GrpcServer;
@@ -50,12 +50,9 @@ public class AbacServer {
      * Main entry point.
      *
      * @param args  the program arguments
-     *
-     * @throws Exception if an error occurs
      */
-    public static void main(String[] args) throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                AbacServer.class.getResourceAsStream("/logging.properties"));
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
 
         Security security = Security.builder()
                 .addProvider(AtnProvider.builder().build())   // add out custom provider

--- a/examples/grpc/security-abac/src/main/java/io/helidon/grpc/examples/security/abac/AbacServerFromConfig.java
+++ b/examples/grpc/security-abac/src/main/java/io/helidon/grpc/examples/security/abac/AbacServerFromConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package io.helidon.grpc.examples.security.abac;
 
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.StringService;
 import io.helidon.grpc.server.GrpcRouting;
@@ -44,12 +43,9 @@ public class AbacServerFromConfig {
      * Main entry point.
      *
      * @param args  the program arguments
-     *
-     * @throws Exception if an error occurs
      */
-    public static void main(String[] args) throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                AbacServerFromConfig.class.getResourceAsStream("/logging.properties"));
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
 
         Config config = Config.create();
 

--- a/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
+++ b/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
@@ -17,8 +17,8 @@
 package io.helidon.grpc.examples.security.outbound;
 
 import java.util.Optional;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.context.Context;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
@@ -71,11 +71,9 @@ public class SecureServer {
      * Program entry point.
      *
      * @param args the program command line arguments
-     * @throws Exception if there is a program error
      */
-    public static void main(String[] args) throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                SecureServer.class.getResourceAsStream("/logging.properties"));
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
 
         Config config = Config.create();
 

--- a/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureServer.java
+++ b/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package io.helidon.grpc.examples.security;
 
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.examples.common.GreetService;
 import io.helidon.grpc.examples.common.StringService;
@@ -41,12 +40,9 @@ public class SecureServer {
      * Main entry point.
      *
      * @param args  the program arguments
-     *
-     * @throws Exception if an error occurs
      */
-    public static void main(String[] args) throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                SecureServer.class.getResourceAsStream("/logging.properties"));
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
 
         Config config = Config.create();
 

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/Main.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/Main.java
@@ -19,7 +19,6 @@ import io.helidon.common.http.Http;
 import io.helidon.media.jsonp.JsonpSupport;
 import io.helidon.media.multipart.MultiPartSupport;
 import io.helidon.webserver.Routing;
-import io.helidon.webserver.ServerConfiguration;
 import io.helidon.webserver.StaticContentSupport;
 import io.helidon.webserver.WebServer;
 
@@ -56,12 +55,9 @@ public final class Main {
      * @param args command line arguments.
      */
     public static void main(String[] args) {
-        ServerConfiguration config = ServerConfiguration.builder()
-                .port(8080)
-                .build();
 
         WebServer server = WebServer.builder(createRouting())
-                .config(config)
+                .port(8080)
                 .addMediaSupport(MultiPartSupport.create())
                 .addMediaSupport(JsonpSupport.create())
                 .build();

--- a/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/Main.java
+++ b/examples/messaging/kafka-websocket-se/src/main/java/io/helidon/examples/messaging/se/Main.java
@@ -18,12 +18,9 @@
 
 package io.helidon.examples.messaging.se;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
 import javax.websocket.server.ServerEndpointConfig;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.StaticContentSupport;
@@ -45,9 +42,8 @@ public final class Main {
      * Application main entry point.
      *
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
@@ -55,11 +51,10 @@ public final class Main {
      * Start the server.
      *
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
         // load logging configuration
-        setupLogging();
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
@@ -94,7 +89,7 @@ public final class Main {
     /**
      * Creates new {@link Routing}.
      *
-     * @param config configuration of this server
+     * @param sendingService service to configure
      * @return routing configured with JSON support, a health check, and a service
      */
     private static Routing createRouting(SendingService sendingService) {
@@ -112,14 +107,5 @@ public final class Main {
                                         .build())
                                 .build())
                 .build();
-    }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
     }
 }

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -16,9 +16,7 @@
 
 package io.helidon.examples.openapi;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -42,22 +40,19 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -16,10 +16,7 @@
 
 package io.helidon.examples.quickstart.se;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -42,21 +39,19 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
 
         // load logging configuration
-        setupLogging();
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
@@ -106,14 +101,4 @@ public final class Main {
                 .register("/greet", greetService)
                 .build();
     }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
-    }
-
 }

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -16,10 +16,7 @@
 
 package io.helidon.examples.quickstart.se;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -42,21 +39,18 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
-
+    static WebServer startServer() {
         // load logging configuration
-        setupLogging();
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();
@@ -107,14 +101,4 @@ public final class Main {
                 .register("/greet", greetService)
                 .build();
     }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
-    }
-
 }

--- a/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsBuilderMain.java
+++ b/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsBuilderMain.java
@@ -19,8 +19,8 @@ package io.helidon.security.examples.idcs;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.security.Security;
@@ -58,7 +58,7 @@ public final class IdcsBuilderMain {
      */
     public static void main(String[] args) throws IOException {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(IdcsBuilderMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = buildConfig();
 

--- a/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
+++ b/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
@@ -16,10 +16,9 @@
 
 package io.helidon.security.examples.idcs;
 
-import java.io.IOException;
 import java.util.Optional;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.security.Security;
@@ -50,11 +49,10 @@ public final class IdcsMain {
      * Start the example.
      *
      * @param args ignored
-     * @throws IOException if logging configuration fails
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(IdcsMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = buildConfig();
 

--- a/examples/security/webserver-digest-auth/src/main/java/io/helidon/security/examples/webserver/digest/DigestExampleBuilderMain.java
+++ b/examples/security/webserver-digest-auth/src/main/java/io/helidon/security/examples/webserver/digest/DigestExampleBuilderMain.java
@@ -16,7 +16,6 @@
 
 package io.helidon.security.examples.webserver.digest;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -25,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.MediaType;
 import io.helidon.security.Security;
 import io.helidon.security.SecurityContext;
@@ -61,11 +60,10 @@ public final class DigestExampleBuilderMain {
      * Starts this example. Programmatical configuration. See standard output for instructions.
      *
      * @param args ignored
-     * @throws IOException in case of logging configuration failure
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(DigestExampleConfigMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // build routing (same as done in application.conf)
         Routing routing = Routing.builder()

--- a/examples/security/webserver-digest-auth/src/main/java/io/helidon/security/examples/webserver/digest/DigestExampleConfigMain.java
+++ b/examples/security/webserver-digest-auth/src/main/java/io/helidon/security/examples/webserver/digest/DigestExampleConfigMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 
 package io.helidon.security.examples.webserver.digest;
 
-import java.io.IOException;
 import java.util.Optional;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.security.SecurityContext;
@@ -41,11 +40,10 @@ public final class DigestExampleConfigMain {
      * Starts this example. Loads configuration from src/main/resources/application.conf. See standard output for instructions.
      *
      * @param args ignored
-     * @throws IOException in case of logging configuration failure
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(DigestExampleConfigMain.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // load configuration
         Config config = Config.create();

--- a/examples/todo-app/backend/src/main/java/io/helidon/demo/todos/backend/Main.java
+++ b/examples/todo-app/backend/src/main/java/io/helidon/demo/todos/backend/Main.java
@@ -16,10 +16,9 @@
 
 package io.helidon.demo.todos.backend;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.microprofile.server.Server;
 
@@ -42,14 +41,11 @@ public final class Main {
      * Application main entry point.
      *
      * @param args command line arguments
-     * @throws IOException if an error occurred while reading logging
-     * configuration
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = buildConfig();
 

--- a/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/Main.java
+++ b/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/Main.java
@@ -16,15 +16,14 @@
 
 package io.helidon.demo.todos.frontend;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.FileSystemWatcher;
 import io.helidon.media.jsonp.JsonpSupport;
@@ -66,14 +65,11 @@ public final class Main {
      * Application main entry point.
      *
      * @param args command line arguments
-     * @throws IOException if an error occurred while reading logging
-     * configuration
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
 
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // needed for default connection of Jersey client
         // to allow our headers to be set

--- a/examples/translator-app/backend/src/main/java/io/helidon/examples/translator/backend/Main.java
+++ b/examples/translator-app/backend/src/main/java/io/helidon/examples/translator/backend/Main.java
@@ -16,10 +16,9 @@
 
 package io.helidon.examples.translator.backend;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionStage;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.tracing.TracerBuilder;
@@ -37,11 +36,10 @@ public class Main {
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    public static CompletionStage<WebServer> startBackendServer() throws IOException {
+    public static CompletionStage<WebServer> startBackendServer() {
         // configure logging in order to not have the standard JVM defaults
-        LogManager.getLogManager().readConfiguration(Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = Config.builder()
                 .sources(ConfigSources.environmentVariables())

--- a/examples/translator-app/frontend/src/main/java/io/helidon/examples/translator/frontend/Main.java
+++ b/examples/translator-app/frontend/src/main/java/io/helidon/examples/translator/frontend/Main.java
@@ -16,10 +16,9 @@
 
 package io.helidon.examples.translator.frontend;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionStage;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.tracing.TracerBuilder;
@@ -37,11 +36,10 @@ public class Main {
     /**
      * Start the server.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    public static CompletionStage<WebServer> startFrontendServer() throws IOException {
+    public static CompletionStage<WebServer> startFrontendServer() {
         // configure logging in order to not have the standard JVM defaults
-        LogManager.getLogManager().readConfiguration(Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = Config.builder()
                 .sources(ConfigSources.environmentVariables())

--- a/examples/webserver/jersey/src/main/java/io/helidon/webserver/examples/jersey/Main.java
+++ b/examples/webserver/jersey/src/main/java/io/helidon/webserver/examples/jersey/Main.java
@@ -16,10 +16,9 @@
 
 package io.helidon.webserver.examples.jersey;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionStage;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.jersey.JerseySupport;
@@ -41,11 +40,10 @@ public final class Main {
      * Run the Jersey WebServer Example.
      *
      * @param args arguments are not used
-     * @throws IOException in case of an IO error
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         // configure logging in order to not have the standard JVM defaults
-        LogManager.getLogManager().readConfiguration(Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // start the server on port 8080
         startServer(8080);

--- a/examples/webserver/opentracing/src/main/java/io/helidon/webserver/examples/opentracing/Main.java
+++ b/examples/webserver/opentracing/src/main/java/io/helidon/webserver/examples/opentracing/Main.java
@@ -16,9 +16,7 @@
 
 package io.helidon.webserver.examples.opentracing;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.tracing.TracerBuilder;
@@ -41,12 +39,11 @@ public final class Main {
      * Run the OpenTracing application.
      *
      * @param args not used
-     * @throws IOException in case of an error
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
 
         // configure logging in order to not have the standard JVM defaults
-        LogManager.getLogManager().readConfiguration(Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = Config.builder()
                 .sources(ConfigSources.environmentVariables())

--- a/examples/webserver/tls/src/main/java/io/helidon/webserver/examples/tls/Main.java
+++ b/examples/webserver/tls/src/main/java/io/helidon/webserver/examples/tls/Main.java
@@ -16,11 +16,9 @@
 
 package io.helidon.webserver.examples.tls;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.CompletionStage;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.KeyConfig;
 import io.helidon.config.Config;
@@ -43,8 +41,9 @@ public final class Main {
      *
      * @param args start arguments are ignored
      */
-    public static void main(String[] args) throws IOException {
-        setupLogging();
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+
         Config config = Config.create();
         startConfigBasedServer(config.get("config-based"))
                 .thenAccept(ws -> {
@@ -81,14 +80,5 @@ public final class Main {
         return Routing.builder()
                 .get("/", (req, res) -> res.send("Hello!"))
                 .build();
-    }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        try (InputStream is = Main.class.getResourceAsStream("/logging.properties")) {
-            LogManager.getLogManager().readConfiguration(is);
-        }
     }
 }

--- a/grpc/client/src/test/java/io/helidon/grpc/client/PojoServiceClientIT.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/PojoServiceClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.server.GrpcRouting;
 import io.helidon.grpc.server.GrpcServer;
 import io.helidon.grpc.server.GrpcServerConfiguration;
@@ -52,7 +52,7 @@ public class PojoServiceClientIT {
     @BeforeAll
     public static void startServer() throws Exception {
 
-        LogManager.getLogManager().readConfiguration();
+        LogConfig.configureRuntime();
 
         GrpcRouting routing = GrpcRouting.builder()
                 .register(new TreeMapService())

--- a/grpc/client/src/test/java/io/helidon/grpc/client/ProtoGrpcServiceClientIT.java
+++ b/grpc/client/src/test/java/io/helidon/grpc/client/ProtoGrpcServiceClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.client.test.StringServiceGrpc;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.server.GrpcRouting;
@@ -90,7 +90,7 @@ public class ProtoGrpcServiceClientIT {
     @BeforeAll
     public static void startServer() throws Exception {
 
-        LogManager.getLogManager().readConfiguration();
+        LogConfig.configureRuntime();
 
         GrpcRouting routing = GrpcRouting.builder()
                 .intercept(headerCheckingInterceptor)

--- a/grpc/metrics/src/test/java/io/helidon/grpc/metrics/MetricsIT.java
+++ b/grpc/metrics/src/test/java/io/helidon/grpc/metrics/MetricsIT.java
@@ -18,12 +18,12 @@ package io.helidon.grpc.metrics;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import javax.json.JsonStructure;
 import javax.json.JsonValue;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.MediaType;
 import io.helidon.grpc.server.GrpcRouting;
 import io.helidon.grpc.server.GrpcServer;
@@ -83,7 +83,7 @@ public class MetricsIT {
 
     @BeforeAll
     public static void setup() throws Exception {
-        LogManager.getLogManager().readConfiguration(MetricsIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // start the server at a free port
         startWebServer();

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ContextIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ContextIT.java
@@ -18,9 +18,9 @@ package io.helidon.grpc.server;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
 import io.helidon.grpc.core.ContextKeys;
@@ -58,7 +58,7 @@ public class ContextIT {
 
     @BeforeAll
     public static void setup() throws Exception {
-        LogManager.getLogManager().readConfiguration(TracingIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         startGrpcServer();
 

--- a/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/SslIT.java
@@ -18,12 +18,12 @@ package io.helidon.grpc.server;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import javax.net.ssl.SSLException;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.configurable.Resource;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -87,7 +87,7 @@ public class SslIT {
 
     @BeforeAll
     public static void setup() throws Exception {
-        LogManager.getLogManager().readConfiguration(SslIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         AvailablePortIterator ports = LocalPlatform.get().getAvailablePorts();
 

--- a/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/TracingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package io.helidon.grpc.server;
 
-import com.oracle.bedrock.testsupport.deferred.Eventually;
-
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import javax.annotation.Priority;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.server.test.Echo;
 import io.helidon.grpc.server.test.EchoServiceGrpc;
 import io.helidon.tracing.TracerBuilder;
 
+import com.oracle.bedrock.testsupport.deferred.Eventually;
 import io.grpc.Channel;
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -41,7 +40,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -49,12 +47,12 @@ import services.EchoService;
 import zipkin2.Span;
 import zipkin2.junit.ZipkinRule;
 
+import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static com.oracle.bedrock.deferred.DeferredHelper.invoking;
 
 /**
  * Tests for gRPC server with tracing.
@@ -89,7 +87,7 @@ public class TracingIT {
 
     @BeforeAll
     public static void setup() throws Exception {
-        LogManager.getLogManager().readConfiguration(TracingIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         //start zipkin server on an ephemeral port
         zipkin.start(0);

--- a/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/OutboundSecurityIT.java
+++ b/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/OutboundSecurityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@
 package io.helidon.security.integration.grpc;
 
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Response;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.grpc.core.GrpcHelper;
@@ -73,8 +73,7 @@ public class OutboundSecurityIT {
 
     @BeforeAll
     public static void startServers() throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                ServiceAndMethodLevelSecurityIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = Config.create();
 

--- a/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/SecurityFromConfigIT.java
+++ b/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/SecurityFromConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.helidon.security.integration.grpc;
 
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
 import io.helidon.grpc.server.GrpcRouting;
@@ -64,8 +64,7 @@ public class SecurityFromConfigIT {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                ServiceAndMethodLevelSecurityIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // load the config containing the gRPC service security settings
         Config config = Config.builder().sources(ConfigSources.classpath("secure-services.conf")).build();

--- a/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/ServiceAndMethodLevelSecurityIT.java
+++ b/security/integration/grpc/src/test/java/io/helidon/security/integration/grpc/ServiceAndMethodLevelSecurityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package io.helidon.security.integration.grpc;
 
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.grpc.server.GrpcRouting;
 import io.helidon.grpc.server.GrpcServer;
@@ -67,8 +67,7 @@ public class ServiceAndMethodLevelSecurityIT {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                ServiceAndMethodLevelSecurityIT.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         Config config = Config.create();
 

--- a/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/Main.java
+++ b/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,7 @@
 
 package io.helidon.tests.apps.bookstore.mp;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.microprofile.server.Server;
 
 /**
@@ -34,10 +32,9 @@ public final class Main {
     /**
      * Application main entry point.
      * @param args command line arguments
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
-        setupLogging();
+    public static void main(final String[] args) {
+        LogConfig.configureRuntime();
 
         Server server = startServer();
 
@@ -53,14 +50,5 @@ public final class Main {
         // microprofile-config.properties
         // and Application classes annotated as @ApplicationScoped
         return Server.create().start();
-    }
-
-    /**
-     * Configure logging from logging.properties file.
-     */
-    private static void setupLogging() throws IOException {
-        // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Main.class.getResourceAsStream("/logging.properties"));
     }
 }

--- a/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
+++ b/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
@@ -16,9 +16,7 @@
 
 package io.helidon.tests.apps.bookstore.se;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
+import io.helidon.common.LogConfig;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.pki.KeyConfig;
 import io.helidon.config.Config;
@@ -31,8 +29,8 @@ import io.helidon.metrics.MetricsSupport;
 import io.helidon.webserver.ExperimentalConfiguration;
 import io.helidon.webserver.Http2Configuration;
 import io.helidon.webserver.Routing;
-import io.helidon.webserver.WebServerTls;
 import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerTls;
 
 /**
  * Simple Hello World rest application.
@@ -57,9 +55,8 @@ public final class Main {
      * Application main entry point.
      *
      * @param args command line arguments.
-     * @throws IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
@@ -67,9 +64,8 @@ public final class Main {
      * Start the server.
      *
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
+    static WebServer startServer() {
         return startServer(false, false);
     }
 
@@ -79,12 +75,10 @@ public final class Main {
      * @param ssl Enable ssl support.
      * @param http2 Enable http2 support.
      * @return the created {@link WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer(boolean ssl, boolean http2) throws IOException {
+    static WebServer startServer(boolean ssl, boolean http2) {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = Config.create();

--- a/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
+++ b/tests/functional/context-propagation/src/test/java/io/helidon/tests/functional/context/hello/HelloTest.java
@@ -16,14 +16,12 @@
 
 package io.helidon.tests.functional.context.hello;
 
-import java.io.IOException;
-import java.util.logging.LogManager;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import io.helidon.common.LogConfig;
 import io.helidon.microprofile.server.Server;
 
 import org.junit.jupiter.api.AfterAll;
@@ -41,8 +39,8 @@ class HelloTest {
     private static WebTarget baseTarget;
 
     @BeforeAll
-    static void initClass() throws IOException {
-        LogManager.getLogManager().readConfiguration(HelloTest.class.getResourceAsStream("/logging.properties"));
+    static void initClass() {
+        LogConfig.configureRuntime();
         Main.main(new String[0]);
         server = Main.server();
         Client client = ClientBuilder.newClient();

--- a/tests/functional/jax-rs-subresource/src/test/java/io/helidon/tests/functional/jaxrs/subresource/MpSubResourceTest.java
+++ b/tests/functional/jax-rs-subresource/src/test/java/io/helidon/tests/functional/jaxrs/subresource/MpSubResourceTest.java
@@ -16,29 +16,25 @@
 
 package io.helidon.tests.functional.jaxrs.subresource;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.logging.LogManager;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import io.helidon.microprofile.server.Server;
+import io.helidon.common.LogConfig;
 import io.helidon.jersey.connector.HelidonConnectorProvider;
+import io.helidon.microprofile.server.Server;
 
 import org.glassfish.jersey.client.JerseyClient;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -51,8 +47,9 @@ class MpSubResourceTest {
     private static WebTarget baseTarget;
 
     @BeforeAll
-    static void initClass() throws IOException {
-        LogManager.getLogManager().readConfiguration(MpSubResourceTest.class.getResourceAsStream("/logging.properties"));
+    static void initClass() {
+        LogConfig.configureRuntime();
+
         Main.main(new String[0]);
         server = Main.server();
         client = ClientBuilder.newClient();

--- a/tests/integration/mp-grpc/src/test/java/io/helidon/microprofile/grpc/metrics/MetricsTest.java
+++ b/tests/integration/mp-grpc/src/test/java/io/helidon/microprofile/grpc/metrics/MetricsTest.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.grpc.metrics;
 import java.io.StringReader;
 import java.util.Iterator;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import javax.enterprise.inject.Instance;
@@ -32,6 +31,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.examples.common.StringServiceGrpc;
 import io.helidon.grpc.examples.common.Strings.StringMessage;
 import io.helidon.grpc.server.GrpcServer;
@@ -79,7 +79,7 @@ public class MetricsTest {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        LogManager.getLogManager().readConfiguration(MetricsTest.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         server = Server.create().start();
         beanManager = CDI.current().getBeanManager();

--- a/tests/integration/mp-grpc/src/test/java/io/helidon/microprofile/grpc/server/AnnotatedServiceTest.java
+++ b/tests/integration/mp-grpc/src/test/java/io/helidon/microprofile/grpc/server/AnnotatedServiceTest.java
@@ -21,13 +21,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.BeanManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.grpc.core.ResponseHelper;
 import io.helidon.grpc.server.CollectingObserver;
 import io.helidon.grpc.server.GrpcRouting;
@@ -50,7 +50,6 @@ import io.helidon.microprofile.grpc.server.test.UnaryServiceGrpc;
 import io.grpc.Channel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.stub.StreamObserver;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -59,8 +58,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Functional tests to verify the various server side call handlers.
@@ -73,8 +72,7 @@ public class AnnotatedServiceTest {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        LogManager.getLogManager().readConfiguration(
-                AnnotatedServiceTest.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         GrpcRouting routing = GrpcRouting.builder()
                                          // register the service class

--- a/tests/integration/native-image/se-1/src/main/java/io/helidon/tests/integration/nativeimage/se1/Se1Main.java
+++ b/tests/integration/native-image/se-1/src/main/java/io/helidon/tests/integration/nativeimage/se1/Se1Main.java
@@ -15,11 +15,12 @@
  */
 package io.helidon.tests.integration.nativeimage.se1;
 
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Set;
-import java.util.logging.LogManager;
 
+import javax.websocket.server.ServerEndpointConfig;
+
+import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.FileSystemWatcher;
 import io.helidon.health.HealthSupport;
@@ -35,8 +36,6 @@ import io.helidon.webserver.WebServer;
 import io.helidon.webserver.tyrus.TyrusSupport;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
-
-import javax.websocket.server.ServerEndpointConfig;
 
 import static io.helidon.config.ConfigSources.classpath;
 import static io.helidon.config.ConfigSources.file;
@@ -54,22 +53,18 @@ public final class Se1Main {
     /**
      * Application main entry point.
      * @param args command line arguments.
-     * @throws java.io.IOException if there are problems reading logging properties
      */
-    public static void main(final String[] args) throws IOException {
+    public static void main(final String[] args) {
         startServer();
     }
 
     /**
      * Start the server.
      * @return the created {@link io.helidon.webserver.WebServer} instance
-     * @throws IOException if there are problems reading logging properties
      */
-    static WebServer startServer() throws IOException {
-
+    static WebServer startServer() {
         // load logging configuration
-        LogManager.getLogManager().readConfiguration(
-                Se1Main.class.getResourceAsStream("/logging.properties"));
+        LogConfig.configureRuntime();
 
         // By default this will pick up application.yaml from the classpath
         Config config = buildConfig();

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleMain.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseyExampleMain.java
@@ -25,9 +25,9 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
+import io.helidon.common.LogConfig;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
-import io.helidon.webserver.testsupport.LoggingTestUtils;
 
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
@@ -56,7 +56,7 @@ public final class JerseyExampleMain {
 
     public static void main(String... args) throws InterruptedException, ExecutionException, TimeoutException {
 
-        LoggingTestUtils.initializeLogging();
+        LogConfig.configureRuntime();
 
         INSTANCE.webServer(false);
     }

--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/LoggingTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package io.helidon.webserver.testsupport;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.logging.LogManager;
+import io.helidon.common.LogConfig;
 
 /**
  * The LoggingTestUtils.
+ *
+ * @deprecated This class is no longer needed, please use {@link io.helidon.common.LogConfig#configureRuntime()} instead.
  */
+@Deprecated(since = "2.2.0", forRemoval = true)
 public final class LoggingTestUtils {
 
     // checkstyle compliance
@@ -35,14 +36,11 @@ public final class LoggingTestUtils {
      * <p>
      * The purpose of this method is to add a conventional way of an easy override of the standard JUL
      * defaults.
+     *
+     * @deprecated please use {@link io.helidon.common.LogConfig#configureRuntime()} instead
      */
+    @Deprecated
     public static void initializeLogging() {
-        if (System.getProperty("java.util.logging.config.file") == null) {
-            try (InputStream stream = LoggingTestUtils.class.getResourceAsStream("/logging-test.properties")) {
-                LogManager.getLogManager().readConfiguration(stream);
-            } catch (IOException e) {
-                // ignored for now
-            }
-        }
+        LogConfig.configureRuntime();
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/TestHttpParsingDefaults.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/TestHttpParsingDefaults.java
@@ -16,12 +16,11 @@
 
 package io.helidon.webserver;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.LogManager;
 
+import io.helidon.common.LogConfig;
 import io.helidon.common.http.Http;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientResponse;
@@ -42,6 +41,8 @@ class TestHttpParsingDefaults {
 
     @BeforeAll
     static void initClass() throws InterruptedException, ExecutionException, TimeoutException {
+        LogConfig.configureRuntime();
+
         webServer = WebServer.builder(Routing.builder()
                                               .any(TestHttpParsingDefaults::handleRequest)
                                               .build())
@@ -55,13 +56,6 @@ class TestHttpParsingDefaults {
                 .validateHeaders(false)
                 .keepAlive(true)
                 .build();
-
-        try {
-            LogManager.getLogManager()
-                    .readConfiguration(TestHttpParsingDefaults.class.getResourceAsStream("/logging-test.properties"));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 
     @AfterAll


### PR DESCRIPTION
Removed use of `LogManager`, now using `io.helidon.common.LogConfig` instead.
Updated all examples and templates.

Related to #1419 