### PR TITLE
Exclude jakarta.ejb-api

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -257,6 +257,13 @@
                 <groupId>jakarta.interceptor</groupId>
                 <artifactId>jakarta.interceptor-api</artifactId>
                 <version>${version.lib.interceptor-api}</version>
+                <exclusions>
+                  <!-- Exclude EJB. See https://github.com/eclipse-ee4j/interceptor-api/issues/31 -->
+                  <exclusion>
+                      <groupId>jakarta.ejb</groupId>
+                      <artifactId>jakarta.ejb-api</artifactId>
+                  </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>jakarta.inject</groupId>


### PR DESCRIPTION
While reviewing the dependencies in the MP quickstart I noticed jakarta.ejb-api (and jakarta.transaction-api). Those are not needed for the quickstart and are being dragged in by jakarta.interceptor-api 1.2.5 that has a dependency on jakarta.ejb-api. That is a bug. See https://github.com/eclipse-ee4j/interceptor-api/issues/31

So we exclude jakarta.ejb-api. Not sure why we didn't do this earlier.


