### PR TITLE
Added support for @Singleton as a bean defining annotation.

### DIFF
--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -38,6 +38,7 @@ import javax.enterprise.inject.se.SeContainer;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.inject.spi.Extension;
+import javax.inject.Singleton;
 
 import io.helidon.common.HelidonFeatures;
 import io.helidon.common.HelidonFlavor;
@@ -143,7 +144,8 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
     private HelidonContainerImpl init() {
         LOGGER.fine(() -> "Initializing CDI container " + id);
 
-        addHelidonBeanDefiningAnnotations("javax.ws.rs.Path",
+        addHelidonBeanDefiningAnnotations(Singleton.class.getName(),
+                                          "javax.ws.rs.Path",
                                           "javax.ws.rs.ext.Provider",
                                           "javax.websocket.server.ServerEndpoint",
                                           "org.eclipse.microprofile.graphql.GraphQLApi",

--- a/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/SingletonBean.java
+++ b/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/SingletonBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cdi;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class SingletonBean {
+    private final long created;
+
+    public SingletonBean() {
+        created = System.nanoTime();
+    }
+
+    public long getTime() {
+        return created;
+    }
+}

--- a/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/SingletonTest.java
+++ b/microprofile/cdi/src/test/java/io/helidon/microprofile/cdi/SingletonTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.cdi;
+
+import java.util.Map;
+
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import io.helidon.config.mp.MpConfigSources;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SingletonTest {
+    private static Config originalConfig;
+    private static ConfigProviderResolver configResolver;
+    private static ClassLoader cl;
+    private static SeContainer container;
+
+    @BeforeAll
+    static void initClass() {
+        originalConfig = ConfigProvider.getConfig();
+        configResolver = ConfigProviderResolver.instance();
+        cl = Thread.currentThread().getContextClassLoader();
+
+        Config config = configResolver.getBuilder()
+                .withSources(MpConfigSources.create(Map.of("mp.initializer.allow", "true",
+                                                           "mp.initializer.no-warn", "true")))
+                .build();
+
+        configResolver.registerConfig(config, cl);
+
+        container = SeContainerInitializer.newInstance()
+                .disableDiscovery()
+                .addBeanClasses(SingletonBean.class)
+                .initialize();
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        configResolver.registerConfig(originalConfig, cl);
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    @Test
+    void testSingleton() throws InterruptedException {
+        SingletonBean first = container.select(SingletonBean.class).get();
+        Thread.sleep(1);
+        SingletonBean second = container.select(SingletonBean.class).get();
+
+        assertThat(first.getTime(), is(second.getTime()));
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

By default beans with `@Singleton` are ignored by Weld. I have added this annotation as a bean defining annotation, so it is picked when discovery mode is `annotated` (it works now with `all` mode).
