### PR TITLE
Removed HTTP/2 pipeline test 

### DIFF
--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -161,10 +161,5 @@
             <artifactId>helidon-config-testing</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
@@ -16,32 +16,14 @@
 
 package io.helidon.webserver;
 
-import javax.net.ssl.X509TrustManager;
-import java.io.IOException;
-import java.net.URL;
-import java.security.cert.X509Certificate;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.webserver.utils.SocketHttpClient;
-
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.Interceptor;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,26 +42,6 @@ public class HttpPipelineTest {
     private static WebServer webServer;
     private static AtomicInteger counter = new AtomicInteger(0);
     private static ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
-    private static OkHttpClient client;
-
-    private static class LoggingInterceptor implements Interceptor {
-        @Override
-        public okhttp3.Response intercept(Interceptor.Chain chain) throws IOException {
-            Request request = chain.request();
-
-            long t1 = System.nanoTime();
-            System.out.println(String.format("Sending request %s on %s%n%s",
-                    request.url(), chain.connection(), request.headers()));
-
-            Response response = chain.proceed(request);
-
-            long t2 = System.nanoTime();
-            System.out.println(String.format("Received response for %s in %.1fms%nProtocol is %s%n%s",
-                    response.request().url(), (t2 - t1) / 1e6d, response.protocol(), response.headers()));
-
-            return response;
-        }
-    }
 
     @BeforeAll
     public static void startServer() throws Exception {
@@ -117,11 +79,6 @@ public class HttpPipelineTest {
                 .toCompletableFuture()
                 .get(10, TimeUnit.SECONDS);
 
-        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
-                .addNetworkInterceptor(new LoggingInterceptor())
-                .protocols(Collections.singletonList(Protocol.H2_PRIOR_KNOWLEDGE));
-        client = clientBuilder.build();
-
         LOGGER.info("Started server at: https://localhost:" + webServer.port());
     }
 
@@ -145,64 +102,5 @@ public class HttpPipelineTest {
             String get1 = s.receive();
             assertThat(get1, containsString("Response 1"));
         }
-    }
-
-    /**
-     * Same as previous test but using HTTP/2 and OkHttp as async client.
-     */
-    @Test
-    public void testPipeliningHttp2() throws Exception {
-        MediaType mt = MediaType.get("text/plain");
-        URL url = new URL("http://localhost:" + webServer.port() + "/");
-        Request put = new Request.Builder().url(url).put(RequestBody.create(mt, "")).build();
-        client.newCall(put).execute();
-
-        Request get = new Request.Builder().url(url).build();
-        CompletableFuture<?> cf0 = new CompletableFuture<>();
-        CompletableFuture<?> cf1 = new CompletableFuture<>();
-
-        client.newCall(get).enqueue(new Callback() {
-            @Override
-            public void onFailure(Call call, IOException e) {
-                cf0.completeExceptionally(e);
-            }
-
-            @Override
-            public void onResponse(Call call, Response r0) throws IOException {
-                LOGGER.info("Received r0");
-                if (cf1.isDone()) {
-                    LOGGER.info("Expected r0 before r1");
-                    cf0.completeExceptionally(new RuntimeException("Expected r0 before r1"));
-                } else {
-                    try {
-                        assertThat(r0.body().string(), containsString("Response 0"));
-                        cf0.complete(null);
-                    } catch (AssertionError e) {
-                        cf0.completeExceptionally(e);
-                    }
-                }
-            }
-        });
-
-        client.newCall(get).enqueue(new Callback() {
-            @Override
-            public void onFailure(Call call, IOException e) {
-                cf1.completeExceptionally(e);
-            }
-
-            @Override
-            public void onResponse(Call call, Response r1) throws IOException {
-                LOGGER.info("Received r1");
-                try {
-                    cf0.get(100L, TimeUnit.MILLISECONDS);   // give r0 callback a chance
-                    assertThat(r1.body().string(), containsString("Response 1"));
-                    cf1.complete(null);
-                } catch (InterruptedException | ExecutionException | TimeoutException | AssertionError e) {
-                    LOGGER.info("Expected r0 before r1");
-                    cf1.completeExceptionally(e);
-                }
-            }
-        });
-        CompletableFuture.allOf(cf0, cf1).get(2000L, TimeUnit.MILLISECONDS);
     }
 }


### PR DESCRIPTION
Removed HTTP/2 pipeline test because client cannot guarantee proper pipelining and can fail intermittently.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>