### PR TITLE
Re-organize dependencyManagement 

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -137,7 +137,25 @@
     </properties>
 
     <dependencyManagement>
+        <!--
+         IMPORTANT! These dependencies are organized into four sections. When adding
+         or updating a dependency please place it in the correction section:
+
+         Section 1: Direct third party dependencies of the Helidon toolkit. These are
+                    dependencies used directly by the Helidon implementation (not
+                     examples, not tests) and can be runtime dependencies of a Helidon
+                     application.
+         Section 2: Direct third party dependencies that are used by examples (beyond those
+                    in Section 1). Might also be used in tests.
+         Section 3: Transitive dependencies (or fourth party dependencies) that we
+                    need to manage the version of for convergence or forced upgrade.
+                    Nothing in Helidon depends on these APIs directly.
+         Section 4: Dependencies used for testing only. It's preferable that these are
+                    in the Helidon root project pom, but sometimes they need to be here.
+        -->
+
         <dependencies>
+            <!-- Section 1: direct third party dependencies -->
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
@@ -174,12 +192,6 @@
                         <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <!-- Explicitly force jackson-annotations to use proper version; bom doesn't -->
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${version.lib.jackson}</version>
             </dependency>
             <dependency>
                 <groupId>io.jaegertracing</groupId>
@@ -296,12 +308,6 @@
                 <version>${version.lib.jsonp-impl}</version>
             </dependency>
             <dependency>
-                <!-- contains the API as well -->
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
-                <version>${version.lib.el-impl}</version>
-            </dependency>
-            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${version.lib.netty}</version>
@@ -309,16 +315,6 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
                 <version>${version.lib.netty}</version>
             </dependency>
             <dependency>
@@ -334,34 +330,6 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>linux-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>linux-aarch64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>${version.lib.netty}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
                 <version>${version.lib.netty}</version>
             </dependency>
             <dependency>
@@ -463,12 +431,6 @@
                 <version>${version.lib.grpc}</version>
             </dependency>
             <dependency>
-                <!-- required for dependency convergence, used from guava and perfmark-api -->
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>${version.lib.google-error-prone}</version>
-            </dependency>
-            <dependency>
               <groupId>io.opentracing.contrib</groupId>
               <artifactId>opentracing-grpc</artifactId>
               <version>${version.lib.opentracing.grpc}</version>
@@ -514,11 +476,6 @@
                         <artifactId>zipkin</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.reactivestreams</groupId>
-                <artifactId>reactive-streams</artifactId>
-                <version>${version.lib.reactivestreams}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.websocket</groupId>
@@ -628,11 +585,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.microprofile.graphql</groupId>
-                <artifactId>microprofile-graphql-tck</artifactId>
-                <version>${version.lib.microprofile-graphql}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.microprofile.jwt</groupId>
                 <artifactId>microprofile-jwt-auth-api</artifactId>
                 <version>${version.lib.microprofile-jwt}</version>
@@ -703,39 +655,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.microprofile.metrics</groupId>
-                <artifactId>microprofile-metrics-rest-tck</artifactId>
-                <version>${version.lib.microprofile-metrics-api}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.arquillian.junit</groupId>
-                        <artifactId>arquillian-junit-container</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.metrics</groupId>
-                <artifactId>microprofile-metrics-optional-tck</artifactId>
-                <version>${version.lib.microprofile-metrics-api}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.arquillian.junit</groupId>
-                        <artifactId>arquillian-junit-container</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.metrics</groupId>
-                <artifactId>microprofile-metrics-api-tck</artifactId>
-                <version>${version.lib.microprofile-metrics-api}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.arquillian.junit</groupId>
-                        <artifactId>arquillian-junit-container</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
                 <artifactId>microprofile-reactive-streams-operators-api</artifactId>
                 <version>${version.lib.microprofile-reactive-streams-operators-api}</version>
@@ -765,16 +684,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.netflix.hystrix</groupId>
-                <artifactId>hystrix-core</artifactId>
-                <version>${version.lib.hystrix}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.jodah</groupId>
-                <artifactId>failsafe</artifactId>
-                <version>${version.lib.failsafe}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>
                 <version>${version.lib.jandex}</version>
@@ -790,34 +699,9 @@
                 <version>${version.lib.slf4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${version.lib.slf4j}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-jul</artifactId>
-                <version>${version.lib.log4j}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${version.lib.logback}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
@@ -852,19 +736,9 @@
                 <version>${version.lib.mysql-connector-java}</version>
             </dependency>
             <dependency>
-                <groupId>org.mariadb.jdbc</groupId>
-                <artifactId>mariadb-java-client</artifactId>
-                <version>${version.lib.mariadb-java-client}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${version.lib.postgresql}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.microsoft.sqlserver</groupId>
-                <artifactId>mssql-jdbc</artifactId>
-                <version>${version.lib.mssql-jdbc}</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.oci.sdk</groupId>
@@ -975,11 +849,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                <version>${version.lib.jboss.transaction-api}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.weld.environment</groupId>
                 <artifactId>weld-environment-common</artifactId>
                 <version>${version.lib.weld}</version>
@@ -988,21 +857,6 @@
                 <groupId>org.jboss.classfilewriter</groupId>
                 <artifactId>jboss-classfilewriter</artifactId>
                 <version>${version.lib.jboss.classfilewriter}</version>
-            </dependency>
-            <dependency>
-                <!-- if needed (as excluded from weld) -->
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-all</artifactId>
-                <version>${version.lib.groovy-all}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence, transitive dependency of both
-                commons-configuration (through hystrix-core)
-                org.apache.httpcomponents:httpclient (through health-tck)
-                -->
-                <groupId>commons-logging</groupId>
-                <artifactId>commons-logging</artifactId>
-                <version>${version.lib.commons-logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -1044,37 +898,6 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${version.lib.kafka}</version>
-            </dependency>
-            <!-- Testing libraries -->
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${version.lib.mockito}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${version.lib.junit}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>${version.lib.hamcrest}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-                <version>${version.lib.hamcrest}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.media</groupId>
@@ -1147,21 +970,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.reactivestreams</groupId>
-                <artifactId>reactive-streams-tck</artifactId>
-                <version>${version.lib.reactive-streams-tck}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-client</artifactId>
-                <version>${version.lib.activemq}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-kahadb-store</artifactId>
-                <version>${version.lib.activemq}</version>
-            </dependency>
             <!-- Micronaut integrations -->
             <dependency>
                 <groupId>io.micronaut</groupId>
@@ -1200,12 +1008,68 @@
             </dependency>
             <dependency>
                 <groupId>io.micronaut</groupId>
-                <artifactId>micronaut-validation</artifactId>
+                <artifactId>micronaut-aop</artifactId>
                 <version>${version.lib.micronaut}</version>
+            </dependency>
+            <!-- imported boms -->
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc-bom</artifactId>
+                <version>${version.lib.ojdbc8}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${version.lib.jersey}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${version.lib.jackson}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- END OF Section 1: direct third party dependencies -->
+
+            <!-- Section 2: third party dependencies used by examples -->
+            <dependency>
+                <!-- contains the API as well -->
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.lib.el-impl}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${version.lib.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${version.lib.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jul</artifactId>
+                <version>${version.lib.log4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${version.lib.logback}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${version.lib.activemq}</version>
             </dependency>
             <dependency>
                 <groupId>io.micronaut</groupId>
-                <artifactId>micronaut-http</artifactId>
+                <artifactId>micronaut-validation</artifactId>
                 <version>${version.lib.micronaut}</version>
             </dependency>
             <dependency>
@@ -1218,11 +1082,6 @@
                         <artifactId>validation-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.micronaut</groupId>
-                <artifactId>micronaut-aop</artifactId>
-                <version>${version.lib.micronaut}</version>
             </dependency>
             <dependency>
                 <groupId>io.micronaut.sql</groupId>
@@ -1263,6 +1122,94 @@
             </dependency>
             <dependency>
                 <groupId>io.micronaut.data</groupId>
+                <artifactId>micronaut-data-processor</artifactId>
+                <version>${version.lib.micronaut.data}</version>
+            </dependency>
+            <!-- END OF Section 2: third party dependencies used by examples -->
+
+            <!-- Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
+            <dependency>
+                <!-- Explicitly force jackson-annotations to use proper version; bom doesn't -->
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.lib.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${version.lib.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${version.lib.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${version.lib.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${version.lib.netty}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${version.lib.netty}</version>
+                <classifier>linux-aarch64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-kqueue</artifactId>
+                <version>${version.lib.netty}</version>
+                <classifier>osx-x86_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${version.lib.netty}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence, used from guava and perfmark-api -->
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${version.lib.google-error-prone}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams</artifactId>
+                <version>${version.lib.reactivestreams}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                <version>${version.lib.jboss.transaction-api}</version>
+            </dependency>
+            <dependency>
+                <!-- if needed (as excluded from weld) -->
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${version.lib.groovy-all}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence, transitive dependency of both
+                commons-configuration (through hystrix-core)
+                org.apache.httpcomponents:httpclient (through health-tck)
+                -->
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${version.lib.commons-logging}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micronaut</groupId>
+                <artifactId>micronaut-http</artifactId>
+                <version>${version.lib.micronaut}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micronaut.data</groupId>
                 <artifactId>micronaut-data-model</artifactId>
                 <version>${version.lib.micronaut.data}</version>
                 <exclusions>
@@ -1287,33 +1234,104 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
+
+            <!-- Section 4: Testing -->
             <dependency>
-                <groupId>io.micronaut.data</groupId>
-                <artifactId>micronaut-data-processor</artifactId>
-                <version>${version.lib.micronaut.data}</version>
-            </dependency>
-            <!-- imported boms -->
-            <dependency>
-                <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc-bom</artifactId>
-                <version>${version.lib.ojdbc8}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.lib.mockito}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${version.lib.jersey}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${version.lib.junit}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${version.lib.jackson}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${version.lib.junit}</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${version.lib.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>${version.lib.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${version.lib.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams-tck</artifactId>
+                <version>${version.lib.reactive-streams-tck}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-kahadb-store</artifactId>
+                <version>${version.lib.activemq}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.graphql</groupId>
+                <artifactId>microprofile-graphql-tck</artifactId>
+                <version>${version.lib.microprofile-graphql}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-rest-tck</artifactId>
+                <version>${version.lib.microprofile-metrics-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.junit</groupId>
+                        <artifactId>arquillian-junit-container</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-optional-tck</artifactId>
+                <version>${version.lib.microprofile-metrics-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.junit</groupId>
+                        <artifactId>arquillian-junit-container</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api-tck</artifactId>
+                <version>${version.lib.microprofile-metrics-api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.arquillian.junit</groupId>
+                        <artifactId>arquillian-junit-container</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${version.lib.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mariadb.jdbc</groupId>
+                <artifactId>mariadb-java-client</artifactId>
+                <version>${version.lib.mariadb-java-client}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${version.lib.mssql-jdbc}</version>
+            </dependency>
+            <!-- END OF Section 4: Testing -->
+
         </dependencies>
     </dependencyManagement>
 </project>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -152,6 +152,9 @@
                     Nothing in Helidon depends on these APIs directly.
          Section 4: Dependencies used for testing only. It's preferable that these are
                     in the Helidon root project pom, but sometimes they need to be here.
+
+         Importing of BOMs should always be at the end since we want more specific
+         dependencies to override them.
         -->
 
         <dependencies>
@@ -1011,28 +1014,6 @@
                 <artifactId>micronaut-aop</artifactId>
                 <version>${version.lib.micronaut}</version>
             </dependency>
-            <!-- imported boms -->
-            <dependency>
-                <groupId>com.oracle.database.jdbc</groupId>
-                <artifactId>ojdbc-bom</artifactId>
-                <version>${version.lib.ojdbc8}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${version.lib.jersey}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${version.lib.jackson}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- END OF Section 1: direct third party dependencies -->
 
             <!-- Section 2: third party dependencies used by examples -->
@@ -1331,6 +1312,29 @@
                 <version>${version.lib.mssql-jdbc}</version>
             </dependency>
             <!-- END OF Section 4: Testing -->
+
+            <!-- imported boms -->
+            <dependency>
+                <groupId>com.oracle.database.jdbc</groupId>
+                <artifactId>ojdbc-bom</artifactId>
+                <version>${version.lib.ojdbc8}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${version.lib.jersey}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${version.lib.jackson}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This organizes dependencyManagement into four sections:

```
         Section 1: Direct third party dependencies of the Helidon toolkit. These are
                    dependencies used directly by the Helidon implementation (not
                     examples, not tests) and can be runtime dependencies of a Helidon
                     application.
         Section 2: Direct third party dependencies that are used by examples (beyond those
                    in Section 1). Might also be used in tests.
         Section 3: Transitive dependencies (or fourth party dependencies) that we
                    need to manage the version of for convergence or forced upgrade.
                    Nothing in Helidon depends on these APIs directly.
         Section 4: Dependencies used for testing only. It's preferable that these are
                    in the Helidon root project pom, but sometimes they need to be here
```

Also removes hystrix-core and failsafe.