### PR TITLE
1.4: Keep Jackson on 2.10.x: 2.10.5 with 2.10.5.1 databind

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -55,7 +55,9 @@
         <version.lib.hibernate>5.4.25.Final</version.lib.hibernate>
         <version.lib.hikaricp>3.4.1</version.lib.hikaricp>
         <version.lib.inject>1</version.lib.inject>
-        <version.lib.jackson>2.11.1</version.lib.jackson>
+        <!-- This gives us Jackson 2.10.5 with 2.10.5.1 databind -->
+        <version.lib.jackson>2.10.5</version.lib.jackson>
+        <version.lib.jackson-bom>2.10.5.20201202</version.lib.jackson-bom>
         <version.lib.jaegertracing>0.35.5</version.lib.jaegertracing>
         <version.lib.jakarta-persistence-api>2.2.2</version.lib.jakarta-persistence-api>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>
@@ -706,7 +708,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${version.lib.jackson}</version>
+                <version>${version.lib.jackson-bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
In 1.4.7 we had Jackson 2.10. This PR keeps us on 2.10 (instead of going to 2.11) for compatibility concerns.

This uses the latest version of Jackson 2.10 to address https://nvd.nist.gov/vuln/detail/CVE-2020-25649. To address this CVE Jackson released a new version of databind  along with a new BOM. But left the rest of Jackson alone. So we end up with:

jackson-bom: 2.10.5.20201202
jackson-databind: 2.10.5.1
jackson-core, annotation and others: 2.10.5

Also see issue #2672 and #2566