### PR TITLE
Add fallbackPath to StaticContentSupport, fixes #2631

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ClassPathContentHandler.java
@@ -52,11 +52,12 @@ class ClassPathContentHandler extends StaticContentHandler {
     private final Path tempDir;
 
     ClassPathContentHandler(String welcomeFilename,
+                            String fallbackPath,
                             ContentTypeSelector contentTypeSelector,
                             String root,
                             Path tempDir,
                             ClassLoader classLoader) {
-        super(welcomeFilename, contentTypeSelector);
+        super(welcomeFilename, fallbackPath, contentTypeSelector);
 
         this.classLoader = (classLoader == null) ? this.getClass().getClassLoader() : classLoader;
         this.tempDir = tempDir;
@@ -65,6 +66,7 @@ class ClassPathContentHandler extends StaticContentHandler {
     }
 
     public static StaticContentHandler create(String welcomeFileName,
+                                              String fallbackPath,
                                               ContentTypeSelector selector,
                                               String clRoot,
                                               Path tempDir,
@@ -83,7 +85,7 @@ class ClassPathContentHandler extends StaticContentHandler {
             throw new IllegalArgumentException("Cannot serve full classpath, please configure a classpath prefix");
         }
 
-        return new ClassPathContentHandler(welcomeFileName, selector, clRoot, tempDir, contentClassloader);
+        return new ClassPathContentHandler(welcomeFileName, fallbackPath, selector, clRoot, tempDir, contentClassloader);
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
@@ -36,15 +36,15 @@ class FileSystemContentHandler extends StaticContentHandler {
 
     private final Path root;
 
-    FileSystemContentHandler(String welcomeFilename, ContentTypeSelector contentTypeSelector, Path root) {
-        super(welcomeFilename, contentTypeSelector);
+    FileSystemContentHandler(String welcomeFilename, String fallbackPath, ContentTypeSelector contentTypeSelector, Path root) {
+        super(welcomeFilename, fallbackPath, contentTypeSelector);
 
         this.root = root.toAbsolutePath().normalize();
     }
 
-    public static StaticContentHandler create(String welcomeFileName, ContentTypeSelector selector, Path fsRoot) {
+    public static StaticContentHandler create(String welcomeFileName, String fallbackPath, ContentTypeSelector selector, Path fsRoot) {
         if (Files.exists(fsRoot) && Files.isDirectory(fsRoot)) {
-            return new FileSystemContentHandler(welcomeFileName, selector, fsRoot);
+            return new FileSystemContentHandler(welcomeFileName, fallbackPath, selector, fsRoot);
         } else {
             throw new IllegalArgumentException("Cannot create file system static content, path "
                                                        + fsRoot.toAbsolutePath()

--- a/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/FileSystemContentHandler.java
@@ -42,7 +42,10 @@ class FileSystemContentHandler extends StaticContentHandler {
         this.root = root.toAbsolutePath().normalize();
     }
 
-    public static StaticContentHandler create(String welcomeFileName, String fallbackPath, ContentTypeSelector selector, Path fsRoot) {
+    public static StaticContentHandler create(String welcomeFileName,
+                                              String fallbackPath,
+                                              ContentTypeSelector selector,
+                                              Path fsRoot) {
         if (Files.exists(fsRoot) && Files.isDirectory(fsRoot)) {
             return new FileSystemContentHandler(welcomeFileName, fallbackPath, selector, fsRoot);
         } else {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/StaticContentSupport.java
@@ -57,7 +57,7 @@ public class StaticContentSupport implements Service {
         routing.get((req, res) -> handler.handle(Http.Method.GET, req, res));
         routing.head((req, res) -> handler.handle(Http.Method.HEAD, req, res));
     }
-    
+
     private void onNewWebServer(WebServer ws) {
         webServerStarted();
         ws.whenShutdown().thenRun(this::webServerStopped);
@@ -194,7 +194,7 @@ public class StaticContentSupport implements Service {
             this.welcomeFileName = welcomeFileName;
             return this;
         }
-        
+
         /**
          * Sets a fallback request path which will be resolved if the requested file does not exist.
          * The given fallback may be a directory, in which case the {@link #welcomeFileName(java.lang.String) welcome file}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/StaticContentHandlerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/StaticContentHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/UnstableTempTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/UnstableTempTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/test/java/io/helidon/webserver/UnstableTempTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/UnstableTempTest.java
@@ -77,6 +77,7 @@ public class UnstableTempTest {
         LOGGER.fine(() -> "Generated test jar url: " + jarUrl.toString());
         ClassPathContentHandler classPathContentHandler =
                 new ClassPathContentHandler(null,
+                        null,
                         new ContentTypeSelector(null),
                         "/",
                         tmpDir,


### PR DESCRIPTION
This implements a variation of the feature proposed in #2631:

```java
var staticContent = StaticContentSupport.builder("META-INF/frontend", ClassLoader.getSystemClassLoader())
    .welcomeFileName("index.html")
    // If the requested file wasn't found, try this path instead of nexting the request.
    // Since the fallback path identifies a directory, the welcome file will be tried against it,
    // resulting in META-INF/frontend/index.html being served.
    .fallbackPath("/")
    .build();
```

I signed the OCA.