### PR TITLE
Performance improvements to queue(s) management in Webserver

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
@@ -99,9 +99,9 @@ class ByteBufRequestChunk implements DataChunk {
 
     /**
      * An implementation of {@link ReferenceHoldingQueue} that logs a warning
-     * message once and only once.
+     * message once and only once when releasing a reference in the queue.
      */
-    static class RefHoldingQueue extends ReferenceHoldingQueue<DataChunk> {
+    static class DataChunkHoldingQueue extends ReferenceHoldingQueue<DataChunk> {
 
         @Override
         protected void hookOnAutoRelease() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
@@ -40,7 +40,6 @@ class ByteBufRequestChunk implements DataChunk {
     private final ReferenceHoldingQueue.ReleasableReference<DataChunk> ref;
 
     ByteBufRequestChunk(ByteBuf byteBuf, ReferenceHoldingQueue<DataChunk> referenceHoldingQueue) {
-
         Objects.requireNonNull(byteBuf, "The ByteBuf must not be null!");
         byteBuffers = new ByteBuffer[] {byteBuf.nioBuffer().asReadOnlyBuffer()};
         ref = new ReferenceHoldingQueue.ReleasableReference<>(this, referenceHoldingQueue, byteBuf::release);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ByteBufRequestChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -27,8 +27,8 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLEngine;
 
-import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
+import io.helidon.webserver.ByteBufRequestChunk.DataChunkHoldingQueue;
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
 
 import io.netty.buffer.ByteBuf;
@@ -161,7 +161,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                     .ifPresent(name -> request.headers().set(Http.Header.X_HELIDON_CN, name));
 
             // Context, publisher and DataChunk queue for this request/response
-            ReferenceHoldingQueue<DataChunk> queue = new ReferenceHoldingQueue<>();
+            DataChunkHoldingQueue queue = new DataChunkHoldingQueue();
             requestContext = new RequestContext(new HttpRequestScopedPublisher(queue), request);
 
             // Closure local variables that cache mutable instance variables
@@ -172,7 +172,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // publisher is ready for collection, we have access to queue by calling its
             // acquire method. We shall also attempt to release queue on completion of
             // bareResponse below.
-            IndirectReference<HttpRequestScopedPublisher, ReferenceHoldingQueue<DataChunk>> publisherPh =
+            IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherPh =
                     new IndirectReference<>(publisherRef, queues, queue);
 
             // Set up read strategy for channel based on consumer demand

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver;
 
-import javax.net.ssl.SSLEngine;
 import java.lang.ref.ReferenceQueue;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
@@ -26,9 +25,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
+import javax.net.ssl.SSLEngine;
+
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -181,7 +181,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // point.
             //
             // when publisherRef is lost, make sure non-empty queue is enqueued with queues
-            final IndirectReference<ReferenceHoldingQueue<DataChunk>> publisherPh =
+            final IndirectReference<HttpRequestScopedPublisher, ReferenceHoldingQueue<DataChunk>> publisherPh =
                     new IndirectReference<>(publisherRef, queues, queue);
 
             publisherRef.onRequest((n, demand) -> {
@@ -200,6 +200,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                     LOGGER.finest("No hook action required.");
                 }
             });
+
             long requestId = REQUEST_ID_GENERATOR.incrementAndGet();
 
             // If a problem with the request URI, return 400 response

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -16,20 +16,18 @@
 
 package io.helidon.webserver;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Logger;
-import java.lang.ref.Reference;
-import java.lang.ref.ReferenceQueue;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLPeerUnverifiedException;
 
 import io.helidon.webserver.HelidonConnectionHandler.HelidonHttp2ConnectionHandlerBuilder;
-
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -62,8 +60,20 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
     private final NettyWebServer webServer;
     private final SocketConfiguration soConfig;
     private final Routing routing;
-    private final ReferenceQueue<Object> refQ = new ReferenceQueue<>();
-    private final Queue<ReferenceHoldingQueue<?>> queues = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Reference queue that collects ReferenceHoldingQueue's when they become
+     * ready for garbage collection. ReferenceHoldingQueue's extracted from
+     * this collection that cannot be fully released (some buffers still in
+     * use) will be added to {@code unreleasedQueues} for later retries.
+     */
+    private final ReferenceQueue<Object> queues = new ReferenceQueue<>();
+
+    /**
+     * Concurrent queue to track all ReferenceHoldingQueue's not fully released
+     * (some buffers still in use) after becoming ready for garbage collection.
+     */
+    private final Queue<ReferenceHoldingQueue<?>> unreleasedQueues = new ConcurrentLinkedQueue<>();
 
     HttpInitializer(SocketConfiguration soConfig,
                     SslContext sslContext,
@@ -75,30 +85,45 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         this.webServer = webServer;
     }
 
+    /**
+     * Calls release on every ReferenceHoldingQueue that has been deemed ready for
+     * garbage collection and added to {@code queues}.
+     * Those ReferenceHoldingQueue's not fully released are added to {@code unreleasedQueues}
+     * for later retries.
+     */
     private void clearQueues() {
-        for(Reference<?> r = refQ.poll(); r != null; r = refQ.poll()) {
-           if (!(r instanceof IndirectReference<?>)) {
-              continue;
-           }
-           ReferenceHoldingQueue<?> q = ((IndirectReference<ReferenceHoldingQueue<?>>) r).acquire();
-           if (q == null) {
-              continue;
-           }
-           if (!q.release()) {
-              queues.add(q);
-           }
+        for (Reference<?> r = queues.poll(); r != null; r = queues.poll()) {
+            if (!(r instanceof IndirectReference<?, ?>)) {
+                LOGGER.finest("Unexpected reference in queues");
+                continue;
+            }
+            ReferenceHoldingQueue<?> q = ((IndirectReference<?, ReferenceHoldingQueue<?>>) r).acquire();
+            if (q == null) {
+                continue;       // no longer referenced
+            }
+            if (!q.release()) {
+                unreleasedQueues.add(q);
+            }
         }
-        queues.removeIf(ReferenceHoldingQueue::release);
+        unreleasedQueues.removeIf(ReferenceHoldingQueue::release);
     }
 
+    /**
+     * Clears and shuts down all remaining ReferenceHoldingQueue's still being tracked.
+     */
     void queuesShutdown() {
         clearQueues();
-        queues.removeIf(queue -> {
+        unreleasedQueues.removeIf(queue -> {
             queue.shutdown();
             return true;
         });
     }
 
+    /**
+     * Initializes pipeline for new socket channel.
+     *
+     * @param ch the socket channel.
+     */
     @Override
     public void initChannel(SocketChannel ch) {
         final ChannelPipeline p = ch.pipeline();
@@ -148,13 +173,20 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         // Helidon's forwarding handler
-        p.addLast(new ForwardingHandler(routing, webServer, sslEngine, refQ,
+        p.addLast(new ForwardingHandler(routing, webServer, sslEngine, queues,
                                         requestDecoder, soConfig.maxPayloadSize()));
 
         // Cleanup queues as part of event loop
         ch.eventLoop().execute(this::clearQueues);
     }
 
+    /**
+     * Sets {@code CERTIFICATE_NAME} in socket channel.
+     *
+     * @param future future passed to listener
+     * @param ch the socket channel
+     * @param sslHandler the SSL handler
+     */
     private void obtainClientCN(Future<? super Channel> future, SocketChannel ch, SslHandler sslHandler) {
         if (future.cause() == null) {
             try {
@@ -182,6 +214,9 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
         }
     }
 
+    /**
+     * Event logger for HTTP/2 events.
+     */
     private static final class HelidonEventLogger extends ChannelInboundHandlerAdapter {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -16,8 +16,6 @@
 
 package io.helidon.webserver;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLPeerUnverifiedException;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.security.Principal;
@@ -28,8 +26,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
 import io.helidon.webserver.HelidonConnectionHandler.HelidonHttp2ConnectionHandlerBuilder;
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -91,6 +91,7 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
      * Those ReferenceHoldingQueue's not fully released are added to {@code unreleasedQueues}
      * for later retries.
      */
+    @SuppressWarnings("unchecked")
     private void clearQueues() {
         for (Reference<?> r = queues.poll(); r != null; r = queues.poll()) {
             if (!(r instanceof IndirectReference<?, ?>)) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpRequestScopedPublisher.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpRequestScopedPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,53 +15,24 @@
  */
 package io.helidon.webserver;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Logger;
-
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.reactive.BufferedEmittingPublisher;
 import io.helidon.common.reactive.Multi;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
 
 /**
- * This publisher is always associated with a single http request. Additionally,
- * it is associated with the connection context handler and it maintains a fine
- * control of the associated context handler to perform Netty push-backing.
+ * This publisher is always associated with a single http request. All data
+ * chunks emitted by this publisher are linked to a reference queue for
+ * proper cleanup.
  */
 class HttpRequestScopedPublisher extends BufferedEmittingPublisher<DataChunk> {
 
-    private static final Logger LOGGER = Logger.getLogger(HttpRequestScopedPublisher.class.getName());
-
-    private final ReentrantReadWriteLock.WriteLock lock = new ReentrantReadWriteLock().writeLock();
     private final ReferenceHoldingQueue<DataChunk> referenceQueue;
 
-    HttpRequestScopedPublisher(ChannelHandlerContext ctx, ReferenceHoldingQueue<DataChunk> referenceQueue) {
+    HttpRequestScopedPublisher(ReferenceHoldingQueue<DataChunk> referenceQueue) {
         super();
         this.referenceQueue = referenceQueue;
-        super.onRequest((n, demand) -> {
-            if (super.isUnbounded()) {
-                LOGGER.finest("Netty autoread: true");
-                ctx.channel().config().setAutoRead(true);
-            } else {
-                LOGGER.finest("Netty autoread: false");
-                ctx.channel().config().setAutoRead(false);
-            }
-
-            try {
-                lock.lock();
-
-                if (super.hasRequests()) {
-                    LOGGER.finest("Requesting next chunks from Netty.");
-                    ctx.channel().read();
-                } else {
-                    LOGGER.finest("No hook action required.");
-                }
-            } finally {
-                lock.unlock();
-            }
-        });
     }
 
     public int emit(ByteBuf data) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ReferenceHoldingQueue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ReferenceHoldingQueue.java
@@ -131,11 +131,15 @@ class ReferenceHoldingQueue<T> extends ReferenceQueue<T> {
      * @param <R> type of the other object
      */
     static class IndirectReference<T, R> extends PhantomReference<T> {
-        protected final AtomicReference<R> otherRef = new AtomicReference<>();
+        private final AtomicReference<R> otherRef = new AtomicReference<>();
 
-        public IndirectReference(T referent, ReferenceQueue<? super T> q, R otherRef) {
+        IndirectReference(T referent, ReferenceQueue<? super T> q, R otherRef) {
             super(referent, q);
             this.otherRef.lazySet(otherRef);
+        }
+
+        public AtomicReference<R> otherRef() {
+            return otherRef;
         }
 
         /**
@@ -181,7 +185,7 @@ class ReferenceHoldingQueue<T> extends ReferenceQueue<T> {
          * @return {@code true} if released was invoked, {@code false} otherwise
          */
         boolean isReleased() {
-            return otherRef.get() == null;
+            return otherRef().get() == null;
         }
 
         /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ReferenceHoldingQueue.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ReferenceHoldingQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Webserver keeps track of a queue of queues to release buffers back to Netty. Every new request that comes in creates a queue to track the Netty buffers. The cost of removing one of these queues when no longer needed is O(N) where N is the number of active connections. When N is large (e.g. 16K) this housekeeping operation can be costly. 

This PR uses a different approach that avoids the O(N) removal operation. It uses phantom references and lets the GC gather the queues when the associated publisher becomes ready for collection. A `clearQueues` method is called periodically to clean up the queue of queues. Thanks to @olotenko.