### PR TITLE
Graalvm upgrade (Merge do not squash)

### DIFF
--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -52,7 +52,7 @@
         <version.lib.failsafe>2.3.1</version.lib.failsafe>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
-        <version.lib.graalvm>20.2.0</version.lib.graalvm>
+        <version.lib.graalvm>21.0.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>
         <version.lib.grpc>1.35.0</version.lib.grpc>

--- a/docs/common/guides/graalnative.adoc
+++ b/docs/common/guides/graalnative.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ In this guide you will learn how to build a native image locally on your machine
 |===
 |About 10 minutes
 | <<about/03_prerequisites.adoc,Helidon Prerequisites>>
-| GraalVM CE https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-20.2.0[20.2.0]
+| GraalVM CE https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.0[21.0.0]
 |===
 
 == Install GraalVM and the Native Image Command
@@ -41,7 +41,7 @@ set the `GRAALVM_HOME` environment variable to point at your GraalVM installatio
 [source,bash]
 ----
 # Your path might be different
-export GRAALVM_HOME=/usr/local/graalvm-ce-20.2.0/Contents/Home/
+export GRAALVM_HOME=/usr/local/graalvm-ce-21.0.0/Contents/Home/
 ----
 
 Then install the optional `native-image` command:

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -53,59 +53,25 @@
    <cpe>cpe:/a:java-websocket_project:java-websocket</cpe>
 </suppress>
 
-
-<!-- GraalVM -->
-<!-- JDK CVE for remote code execution in Java Web Start and applets running untrusted code.
-     Does not apply to our use of GraalVM -->
-<suppress>
-   <notes><![CDATA[
-   file name: graal-sdk-20.2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.graalvm\.sdk/graal\-sdk@.*$</packageUrl>
-   <cve>CVE-2020-14803</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: objectfile-20.2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.graalvm\.nativeimage/objectfile@.*$</packageUrl>
-   <cve>CVE-2020-14803</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: pointsto-20.2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.graalvm\.nativeimage/pointsto@.*$</packageUrl>
-   <cve>CVE-2020-14803</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: svm-20.2.0.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.graalvm\.nativeimage/svm@.*$</packageUrl>
-   <cve>CVE-2020-14803</cve>
-</suppress>
-
-
 <!-- GraalVM -->
 <!-- This suppresses multiple CVEs related to old versions of the JDK -->
 <suppress>
    <notes><![CDATA[
-   file name: truffle-nfi-20.2.0.jar
+   file name: truffle-nfi-21.0.0.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
    <cpe>cpe:/a:oracle:graalvm</cpe>
 </suppress>
 <suppress>
    <notes><![CDATA[
-   file name: truffle-nfi-20.2.0.jar
+   file name: truffle-nfi-21.0.0.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
    <cpe>cpe:/a:oracle:openjdk</cpe>
 </suppress>
 <suppress>
    <notes><![CDATA[
-   file name: truffle-nfi-20.2.0.jar
+   file name: truffle-nfi-21.0.0.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
    <cpe>cpe:/a:sun:openjdk</cpe>

--- a/etc/dockerfiles/Dockerfile.jdk11-graalvm
+++ b/etc/dockerfiles/Dockerfile.jdk11-graalvm
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ RUN set -x \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
 
-# BEGIN PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
+# BEGIN PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL
 # SEE: https://www.graalvm.org/reference-manual/native-image/StaticImages/
 ARG RESULT_LIB="/staticlibs"
 
@@ -85,7 +85,7 @@ RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
     cd / && \
     rm -rf /zlib && \
     rm -f /zlib.tar.gz
-#END PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
+#END PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL
 
 WORKDIR /graal
 COPY --from=build /build/graalvm /graal/graalvm

--- a/etc/dockerfiles/Dockerfile.jdk11-graalvm
+++ b/etc/dockerfiles/Dockerfile.jdk11-graalvm
@@ -23,7 +23,7 @@ RUN set -x \
     && apt-get -y install curl
 
 RUN curl -O -L \
-    https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz && \
+    https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java11-linux-amd64-21.0.0.tar.gz && \
     tar -xvzf graalvm-*.tar.gz && \
     rm graalvm-*.tar.gz && \
     mv graalvm-* graalvm && \
@@ -50,10 +50,42 @@ FROM debian:stretch-slim as final
 
 RUN set -x \
     && apt-get -y update \
-    && apt-get -y install gcc zlib1g-dev libstdc++-6-dev \
+    && apt-get -y install gcc zlib1g-dev libstdc++-6-dev curl unzip make \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+
+# BEGIN PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
+# SEE: https://www.graalvm.org/reference-manual/native-image/StaticImages/
+ARG RESULT_LIB="/staticlibs"
+
+RUN mkdir ${RESULT_LIB} && \
+    curl -L -o musl.tar.gz https://musl.libc.org/releases/musl-1.2.2.tar.gz && \
+    mkdir musl && \
+    tar -xvzf musl.tar.gz -C musl --strip-components 1 && \
+    cd musl && \
+    ./configure --disable-shared --prefix=${RESULT_LIB} && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /muscl && \
+    rm -f /musl.tar.gz && \
+    cp /usr/lib/gcc/x86_64-linux-gnu/6.3.0/libstdc++.a ${RESULT_LIB}/lib/
+
+ENV PATH="$PATH:${RESULT_LIB}/bin"
+ENV CC="musl-gcc"
+
+RUN curl -L -o zlib.tar.gz https://zlib.net/zlib-1.2.11.tar.gz && \
+   mkdir zlib && \
+   tar -xvzf zlib.tar.gz -C zlib --strip-components 1 && \
+   cd zlib && \
+   ./configure --static --prefix=${RESULT_LIB} && \
+    make && \
+    make install && \
+    cd / && \
+    rm -rf /zlib && \
+    rm -f /zlib.tar.gz
+#END PRE-REQUISITES FOR STATIC NATIVE IMAGES FOR GRAAL 20.2.0
 
 WORKDIR /graal
 COPY --from=build /build/graalvm /graal/graalvm

--- a/etc/dockerfiles/Dockerfile.jdk11-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk11-graalvm-maven
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/dockerfiles/Dockerfile.jdk11-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk11-graalvm-maven
@@ -30,7 +30,7 @@ RUN set -x && \
 
 RUN echo "done!"
 
-FROM helidon/jdk11-graalvm:20.2.0
+FROM helidon/jdk11-graalvm:21.0.0
 
 COPY --from=build /build/maven /usr/share/maven
 RUN ln -s /usr/share/maven/bin/mvn /bin/

--- a/etc/dockerfiles/README.md
+++ b/etc/dockerfiles/README.md
@@ -1,0 +1,30 @@
+# Upgrading GraalVM version
+
+## Maven dependency
+Go to `dependencies/pom.xml` and update the property `version.lib.graalvm` to the desired version.
+
+This defines the dependencies used by Helidon native image feature used during native image build.
+
+## Docker images
+In `etc/dockerfiles`, update the version:
+
+1. `build.sh` - update the `GRAALVM_VERSION` variable to the desired version
+2. `Dockerfile.jdk11-graalvm` update the curl command to point to the correct tar
+3. `Dockerfile.jdk11-graalvm-maven` update the `FROM` command to use the latest image
+4. Run `build.sh` to create the docker images and push them to docker hub
+
+## Examples
+Fix `Dockerfile.native` and `README.md` in all examples that have them.
+
+Update `FROM helidon/jdk11-graalvm-maven:version as build` to the desired version in Dockerfile.
+
+## Examples
+Fix `Dockerfile.native.mustache` and `README.md` in all archetypes that have them.
+
+Update `FROM helidon/jdk11-graalvm-maven:version as build` to the desired version in Dockerfile.
+
+## Documentation
+Update `docs/common/guides/graalnative.adoc` - fix link and file name
+
+## Tests
+Update `etc/scripts/test-integ-mysql.sh` and `etc/scripts/test-integ-pgsql.sh` to use the desired version

--- a/etc/dockerfiles/build.sh
+++ b/etc/dockerfiles/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/dockerfiles/build.sh
+++ b/etc/dockerfiles/build.sh
@@ -58,7 +58,7 @@ else
 fi
 readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
 
-readonly GRAALVM_VERSION=20.2.0
+readonly GRAALVM_VERSION=21.0.0
 
 docker build -f ${MY_DIR}/Dockerfile.jdk11-graalvm -t helidon/jdk11-graalvm:${GRAALVM_VERSION} ${MY_DIR}
 docker build -f ${MY_DIR}/Dockerfile.jdk11-graalvm-maven -t helidon/jdk11-graalvm-maven:${GRAALVM_VERSION} ${MY_DIR}

--- a/etc/scripts/test-integ-mysql.sh
+++ b/etc/scripts/test-integ-mysql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ readonly WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 
 source ${WS_DIR}/etc/scripts/pipeline-env.sh
 
-JAVA_HOME='/tools/graalvm-ce-java11-20.2.0'
+JAVA_HOME='/tools/graalvm-ce-java11-21.0.0'
 PATH="${PATH}:${JAVA_HOME}/bin"
 
 mvn ${MAVEN_ARGS} --version

--- a/etc/scripts/test-integ-pgsql.sh
+++ b/etc/scripts/test-integ-pgsql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ readonly WS_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; cd ../.. ; pwd -P)
 
 source ${WS_DIR}/etc/scripts/pipeline-env.sh
 
-JAVA_HOME='/tools/graalvm-ce-java11-20.2.0'
+JAVA_HOME='/tools/graalvm-ce-java11-21.0.0'
 PATH="${PATH}:${JAVA_HOME}/bin"
 
 mvn ${MAVEN_ARGS} --version

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates. 
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
+import org.dom4j.DocumentFactory;
 import org.hibernate.engine.jndi.spi.JndiService;
 import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
 
@@ -36,6 +37,12 @@ import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatfor
  */
 @ApplicationScoped
 public class CDISEJtaPlatform extends AbstractJtaPlatform {
+  static {
+    // this is needed for native image, since 21.0.0
+    // as the document factory gets initialized lazily and that causes
+    // native image to fail. This way we force eager initialization
+    DocumentFactory.getInstance();
+  }
 
   private final TransactionManager transactionManager;
 

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ module io.helidon.integrations.cdi.hibernate {
     requires jakarta.inject.api;
     requires jakarta.enterprise.cdi.api;
     requires org.hibernate.orm.core;
+    // needed only for native image, transitive dependency of hibernate-core
+    requires dom4j;
 
     exports io.helidon.integrations.cdi.hibernate;
 }

--- a/integrations/db/ojdbc/src/main/resources/META-INF/native-image/io.helidon.integrations.db/ojdbc/native-image.properties
+++ b/integrations/db/ojdbc/src/main/resources/META-INF/native-image/io.helidon.integrations.db/ojdbc/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,4 +35,5 @@ Args= --allow-incomplete-classpath \
   --initialize-at-run-time=oracle.net.nt.TcpMultiplexer \
   --initialize-at-run-time=oracle.net.nt.TcpMultiplexer$LazyHolder \
   --initialize-at-run-time=oracle.jdbc.driver.SQLUtil$XMLFactory \
-  --initialize-at-run-time=oracle.jdbc.driver.NamedTypeAccessor$XMLFactory
+  --initialize-at-run-time=oracle.jdbc.driver.NamedTypeAccessor$XMLFactory \
+  --initialize-at-run-time=oracle.xml.util.UnicodeUtil


### PR DESCRIPTION
Upgrades GraalVm to 21.0.0
Docker images are pushed to docker hub

Resolves #2683 
Replaces #2685 

Contains contribution by @dansiviter (Thanks!)