### PR TITLE
Upgrade grpc to v1.35.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -55,7 +55,7 @@
         <version.lib.graalvm>20.2.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>
-        <version.lib.grpc>1.32.1</version.lib.grpc>
+        <version.lib.grpc>1.35.0</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
         <version.lib.kafka-junit5>3.2.1</version.lib.kafka-junit5>
-        <version.lib.netty.tcnative>2.0.26.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.36.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.2.10</version.lib.rxjava>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2016, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
As Netty has been upgraded recently the Java gRPC libraries can also be upgraded.