### PR TITLE
Properly release underlying buffer before passing it to WebSocket handler

### DIFF
--- a/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
+++ b/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
@@ -34,7 +34,6 @@ import static javax.websocket.CloseReason.CloseCodes.UNEXPECTED_CONDITION;
  * Class TyrusReaderSubscriber.
  */
 public class TyrusReaderSubscriber implements Flow.Subscriber<DataChunk> {
-    private static final Logger LOGGER = Logger.getLogger(TyrusSupport.class.getName());
 
     private static final int MAX_RETRIES = 5;
     private static final CloseReason CONNECTION_CLOSED = new CloseReason(NORMAL_CLOSURE, "Connection closed");

--- a/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
+++ b/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
@@ -19,7 +19,6 @@ package io.helidon.webserver.tyrus;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
-import java.util.logging.Logger;
 
 import javax.websocket.CloseReason;
 

--- a/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
+++ b/webserver/tyrus/src/main/java/io/helidon/webserver/tyrus/TyrusReaderSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,16 +63,15 @@ public class TyrusReaderSubscriber implements Flow.Subscriber<DataChunk> {
 
     @Override
     public void onNext(DataChunk item) {
+        // Copy underlying buffer into a ByteBuffer and release DataChunk
+        ByteBuffer byteBuffer = ByteBuffer.wrap(item.bytes());
+        item.release();
+
+        // Submit buffer to Tyrus
         if (executorService == null) {
-            for (ByteBuffer byteBuffer : item.data()) {
-                submitBuffer(byteBuffer);
-            }
+            submitBuffer(byteBuffer);
         } else {
-            executorService.submit(() -> {
-                for (ByteBuffer byteBuffer : item.data()) {
-                    submitBuffer(byteBuffer);
-                }
-            });
+            executorService.submit(() -> submitBuffer(byteBuffer));
         }
     }
 


### PR DESCRIPTION
Underlying buffers are reference counted and need to be manually released back to the pool