### PR TITLE
Support for custom default config file suffixes

### DIFF
--- a/config/config/src/main/java/io/helidon/config/BuilderImpl.java
+++ b/config/config/src/main/java/io/helidon/config/BuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -414,7 +414,7 @@ class BuilderImpl implements Config.Builder {
 
         if (nothingConfigured) {
             // use meta configuration to load all sources
-            MetaConfig.configSources(mediaType -> context.findParser(mediaType).isPresent())
+            MetaConfig.configSources(mediaType -> context.findParser(mediaType).isPresent(), context.supportedSuffixes())
                     .stream()
                     .map(context::sourceRuntimeBase)
                     .forEach(targetSources::add);
@@ -564,6 +564,16 @@ class BuilderImpl implements Config.Builder {
 
         Executor changesExecutor() {
             return changesExecutor;
+        }
+
+        List<String> supportedSuffixes() {
+            List<String> result = new LinkedList<>();
+
+            configParsers.stream()
+                    .map(ConfigParser::supportedSuffixes)
+                    .forEach(result::addAll);
+
+            return result;
         }
     }
 

--- a/config/config/src/main/java/io/helidon/config/spi/ConfigParser.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package io.helidon.config.spi;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -78,6 +79,22 @@ public interface ConfigParser {
      * @throws ConfigParserException in case of problem to parse configuration from the source
      */
     ObjectNode parse(Content content) throws ConfigParserException;
+
+    /**
+     * Config parser can define supported file suffixes. If such are defined, Helidon will
+     * use these to discover default configuration sources.
+     * For example if there is a {@code ConfigParser} that returns {@code xml}, config would look for
+     * {@code meta-config.xml} to discover meta configuration, and for {@code application.xml} on file
+     * system and on classpath to discover configuration files.
+     * <p>
+     * Note that the suffixes must resolve into a media type supported by a config parser
+     * (see {@link io.helidon.common.media.type.MediaTypes#detectExtensionType(String)}).
+     *
+     * @return a set of file suffixes supported by this config parser.
+     */
+    default List<String> supportedSuffixes() {
+        return List.of();
+    }
 
     /**
      * Config content to be parsed by a {@link ConfigParser}.

--- a/config/config/src/test/java/io/helidon/config/TestCustomDefaultFile.java
+++ b/config/config/src/test/java/io/helidon/config/TestCustomDefaultFile.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.helidon.config.spi.ConfigNode;
+import io.helidon.config.spi.ConfigParser;
+import io.helidon.config.spi.ConfigParserException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TestCustomDefaultFile {
+    @Test
+    void testFileLoaded() {
+        Config config = Config.builder()
+                .addParser(new YmlParser())
+                .build();
+
+        ConfigValue<Boolean> configValue = config.get("it-works").asBoolean();
+
+        assertThat(configValue.asOptional(), not(Optional.empty()));
+        assertThat(configValue.get(), is(true));
+    }
+
+    private static class YmlParser implements ConfigParser {
+        private static final Pattern PROPERTY_PATTERN = Pattern.compile("(.*?): (.*)");
+
+        @Override
+        public Set<String> supportedMediaTypes() {
+            return Set.of("application/x-yaml");
+        }
+
+        @Override
+        public ConfigNode.ObjectNode parse(Content content) throws ConfigParserException {
+            List<String> lines = new LinkedList<>();
+
+            try(BufferedReader br = new BufferedReader(new InputStreamReader(content.data()))) {
+                String line;
+
+                while ((line = br.readLine()) != null) {
+                    if (line.startsWith("#")) {
+                        continue;
+                    }
+                    if (line.trim().isEmpty()) {
+                        continue;
+                    }
+                    lines.add(line);
+                }
+            } catch (IOException e) {
+                throw new ConfigParserException("Failed to read content", e);
+            }
+
+            //it-works: true
+            // a very stupid way to do this, but this is just a test
+
+            ConfigNode.ObjectNode.Builder rootNodeBuilder = ConfigNode.ObjectNode.builder();
+            for (String line : lines) {
+                Matcher matcher = PROPERTY_PATTERN.matcher(line);
+                if (matcher.matches()) {
+                    rootNodeBuilder.addValue(matcher.group(1), matcher.group(2));
+                }
+            }
+            return rootNodeBuilder.build();
+        }
+
+        @Override
+        public List<String> supportedSuffixes() {
+            return List.of("yml", "yaml");
+        }
+    }
+}

--- a/config/config/src/test/resources/application.yml
+++ b/config/config/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+it-works: true

--- a/config/yaml/src/main/java/io/helidon/config/yaml/YamlConfigParser.java
+++ b/config/yaml/src/main/java/io/helidon/config/yaml/YamlConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ public class YamlConfigParser implements ConfigParser {
     public static final int PRIORITY = ConfigParser.PRIORITY + 100;
 
     private static final Set<String> SUPPORTED_MEDIA_TYPES = Set.of(MEDIA_TYPE_APPLICATION_YAML);
+    private static final List<String> SUPPORTED_SUFFIXES = List.of("yml", "yaml");
 
     /**
      * Default constructor needed by Java Service loader.
@@ -87,6 +88,11 @@ public class YamlConfigParser implements ConfigParser {
     @Override
     public Set<String> supportedMediaTypes() {
         return SUPPORTED_MEDIA_TYPES;
+    }
+
+    @Override
+    public List<String> supportedSuffixes() {
+        return SUPPORTED_SUFFIXES;
     }
 
     @Override

--- a/docs/se/config/01_introduction.adoc
+++ b/docs/se/config/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -194,7 +194,7 @@ For example the default configuration when you use `Config.create()` uses the fo
 2. Environment variables config source
 3. A classpath config source called `application.?` where the `?` depends on supported media types
     currently on the classpath. By default it is `properties`, if you have YAML support on classpath,
-    it would be `application.yaml`
+    it would be `application.yaml` (a `ConfigParser` may add additional supported suffixes for default file)
 
 Let's consider the following keys:
 

--- a/docs/se/config/07_extensions.adoc
+++ b/docs/se/config/07_extensions.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -276,6 +276,7 @@ hide empty members
 interface ConfigParser {
     + Set<String> getSupportedMediaTypes()
     + ObjectNode parse(Content content)
+    + Set<String> supportedSuffixes()
 }
 
 interface ConfigParser.Content {

--- a/tests/integration/config/gh-2171-yml/pom.xml
+++ b/tests/integration/config/gh-2171-yml/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 Oracle and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-config</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-gh-2171-yml</artifactId>
+    <name>Helidon Tests Integration GH 2171 YML</name>
+    <description>Validation for Github issue #2171 - read application.yml as default config source</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/config/gh-2171-yml/src/main/java/io/helidon/tests/integration/gh2171/yml/Configuration.java
+++ b/tests/integration/config/gh-2171-yml/src/main/java/io/helidon/tests/integration/gh2171/yml/Configuration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh2171.yml;
+
+import java.util.Optional;
+
+import io.helidon.config.Config;
+
+/**
+ * Test that yaml is loaded and not yml when both on classpath.
+ */
+public class Configuration {
+    private final Config config;
+
+    private Configuration(Config config) {
+        this.config = config;
+    }
+
+    static Configuration create() {
+        Config config = Config.create();
+        return new Configuration(config);
+    }
+
+    Optional<String> value(String key) {
+        return config.get(key).asString().asOptional();
+    }
+}

--- a/tests/integration/config/gh-2171-yml/src/main/java/io/helidon/tests/integration/gh2171/yml/package-info.java
+++ b/tests/integration/config/gh-2171-yml/src/main/java/io/helidon/tests/integration/gh2171/yml/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for loading YML.
+ */
+package io.helidon.tests.integration.gh2171.yml;

--- a/tests/integration/config/gh-2171-yml/src/main/resources/application.yml
+++ b/tests/integration/config/gh-2171-yml/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value: "yml"

--- a/tests/integration/config/gh-2171-yml/src/test/java/io/helidon/tests/integration/gh2171/yml/ConfigurationTest.java
+++ b/tests/integration/config/gh-2171-yml/src/test/java/io/helidon/tests/integration/gh2171/yml/ConfigurationTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh2171.yml;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.OptionalMatcher.value;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ConfigurationTest {
+    private static Configuration configuration;
+
+    @BeforeAll
+    static void createInstance() {
+        configuration = Configuration.create();
+    }
+
+    @Test
+    void testValue() {
+        assertThat(configuration.value("value"), value(is("yml")));
+    }
+
+}

--- a/tests/integration/config/gh-2171/pom.xml
+++ b/tests/integration/config/gh-2171/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 Oracle and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-config</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-gh-2171</artifactId>
+    <name>Helidon Tests Integration GH 2171</name>
+    <description>Validation for Github issue #2171 - ignore application.yaml when application.yml on classpath</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/config/gh-2171/src/main/java/io/helidon/tests/integration/gh2171/Configuration.java
+++ b/tests/integration/config/gh-2171/src/main/java/io/helidon/tests/integration/gh2171/Configuration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh2171;
+
+import java.util.Optional;
+
+import io.helidon.config.Config;
+
+/**
+ * Test that yaml is loaded and not yml when both on classpath.
+ */
+public class Configuration {
+    private final Config config;
+
+    private Configuration(Config config) {
+        this.config = config;
+    }
+
+    static Configuration create() {
+        Config config = Config.create();
+        return new Configuration(config);
+    }
+
+    Optional<String> value(String key) {
+        return config.get(key).asString().asOptional();
+    }
+}

--- a/tests/integration/config/gh-2171/src/main/java/io/helidon/tests/integration/gh2171/package-info.java
+++ b/tests/integration/config/gh-2171/src/main/java/io/helidon/tests/integration/gh2171/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test for loading YAML over YML.
+ */
+package io.helidon.tests.integration.gh2171;

--- a/tests/integration/config/gh-2171/src/main/resources/application.yaml
+++ b/tests/integration/config/gh-2171/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value: "yaml"
+yaml: "yaml"

--- a/tests/integration/config/gh-2171/src/main/resources/application.yml
+++ b/tests/integration/config/gh-2171/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value: "yml"
+yml: "yml"

--- a/tests/integration/config/gh-2171/src/test/java/io/helidon/tests/integration/gh2171/ConfigurationTest.java
+++ b/tests/integration/config/gh-2171/src/test/java/io/helidon/tests/integration/gh2171/ConfigurationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh2171;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.config.testing.OptionalMatcher.empty;
+import static io.helidon.config.testing.OptionalMatcher.value;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ConfigurationTest {
+    private static Configuration configuration;
+
+    @BeforeAll
+    static void createInstance() {
+        configuration = Configuration.create();
+    }
+
+    @Test
+    void testSameKey() {
+        assertThat(configuration.value("value"), value(is("yaml")));
+    }
+
+    @Test
+    void testYamlPresent() {
+        assertThat(configuration.value("yaml"), value(is("yaml")));
+    }
+
+    @Test
+    void testYmlNotPresent() {
+        assertThat(configuration.value("yml"), empty());
+    }
+
+}

--- a/tests/integration/config/pom.xml
+++ b/tests/integration/config/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 Oracle and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+
+    <packaging>pom</packaging>
+    <artifactId>helidon-tests-integration-config</artifactId>
+    <name>Helidon Integration Tests Config</name>
+
+    <description>
+        Config integration tests
+    </description>
+
+    <modules>
+        <module>gh-2171</module>
+        <module>gh-2171-yml</module>
+    </modules>
+</project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -46,6 +46,7 @@
         <module>mp-gh-2461</module>
         <module>kafka</module>
         <module>jms</module>
+        <module>config</module>
     </modules>
 
     <profiles>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+  Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #2171 

Config now allows `ConfigParser`s to configure a new suffix to use when searching for default config source.
YAML parser now added `yml` suffix.
The search is ordered - so if there is `application.yaml` and `application.yml`, we still use `application.yaml`.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>