### PR TITLE
Upgrade grpc to v1.35.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -48,7 +48,7 @@
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
         <version.lib.graalvm>19.2.0</version.lib.graalvm>
-        <version.lib.grpc>1.27.1</version.lib.grpc>
+        <version.lib.grpc>1.35.0</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/grpc/io.grpc/src/main/java9/module-info.java
+++ b/grpc/io.grpc/src/main/java9/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ module io.grpc {
 
     requires java.logging;
     requires java.naming;
-
-    requires static com.google.common;
 
     uses io.grpc.ManagedChannelProvider;
     uses io.grpc.NameResolverProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
         <version.lib.jsch>0.1.55</version.lib.jsch>
-        <version.lib.netty.tcnative>2.0.26.Final</version.lib.netty.tcnative>
+        <version.lib.netty.tcnative>2.0.36.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
         <version.lib.rxjava2-jdk9-interop>0.1.0</version.lib.rxjava2-jdk9-interop>
         <version.lib.rxjava>2.0.8</version.lib.rxjava>


### PR DESCRIPTION
As Netty has been upgraded recently the Java gRPC libraries can also be upgraded.