### PR TITLE
Upgrade to Jersey 2.33 and set of client property

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -76,7 +76,7 @@
         <version.lib.jboss.transaction-api>1.0.0.Final</version.lib.jboss.transaction-api>
         <version.lib.jboss.transaction-spi>7.6.0.Final</version.lib.jboss.transaction-spi>
         <version.lib.jedis>3.1.0</version.lib.jedis>
-        <version.lib.jersey>2.32</version.lib.jersey>
+        <version.lib.jersey>2.33</version.lib.jersey>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>

--- a/security/integration/jersey/pom.xml
+++ b/security/integration/jersey/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -129,11 +129,6 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-jersey</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
-import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.server.ApplicationHandler;
@@ -98,7 +98,6 @@ public class JerseySupport implements Service {
 
     private static final Type REQUEST_TYPE = (new GenericType<Ref<ServerRequest>>() { }).getType();
     private static final Type RESPONSE_TYPE = (new GenericType<Ref<ServerResponse>>() { }).getType();
-    private static final Type SPAN_TYPE = (new GenericType<Ref<Span>>() { }).getType();
     private static final Type SPAN_CONTEXT_TYPE = (new GenericType<Ref<SpanContext>>() { }).getType();
     private static final AtomicReference<ExecutorService> DEFAULT_THREAD_POOL = new AtomicReference<>();
 
@@ -107,6 +106,18 @@ public class JerseySupport implements Service {
     private final JerseyHandler handler = new JerseyHandler();
     private final HelidonJerseyContainer container;
     private final Thread serviceShutdownHook;
+
+    /**
+     * This configuration via system properties is for the Jersey Client API. Any
+     * response in an exception will be mapped to an empty one to prevent data leaks.
+     * See https://github.com/eclipse-ee4j/jersey/pull/4641.
+     */
+    static final String IGNORE_EXCEPTION_RESPONSE = "jersey.config.client.ignoreExceptionResponse";
+
+    static {
+         System.setProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, "true");
+         System.setProperty(IGNORE_EXCEPTION_RESPONSE, "true");
+    }
 
     /**
      * Creates a Jersey Support based on the provided JAX-RS application.

--- a/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
+++ b/webserver/jersey/src/test/java/io/helidon/webserver/jersey/JerseySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,11 @@ import javax.ws.rs.core.Response;
 
 import io.helidon.common.http.HttpRequest;
 
+import org.glassfish.jersey.CommonProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static io.helidon.webserver.jersey.JerseySupport.IGNORE_EXCEPTION_RESPONSE;
 import static io.helidon.webserver.jersey.JerseySupport.basePath;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -330,6 +332,12 @@ public class JerseySupportTest {
                 is("/my/"));
         assertThat(basePath(new PathMockup("/my/application/path", "/my/application/path")),
                 is("/"));
+    }
+
+    @Test
+    public void testJerseyProperties() {
+        assertThat(System.getProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER), is("true"));
+        assertThat(System.getProperty(IGNORE_EXCEPTION_RESPONSE), is("true"));
     }
 
     static class PathMockup implements HttpRequest.Path {


### PR DESCRIPTION
Changes in this commit:
1. Upgrade to Jersey 2.33
2. Configuration via system properties for the Jersey Client API. Any response in an exception will be mapped to an empty one to prevent data leaks. See https://github.com/eclipse-ee4j/jersey/pull/4641.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>