### PR TITLE
Support async invocations using optional synthetic SimplyTimed behavior

### DIFF
--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorSyntheticSimplyTimed.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/InterceptorSyntheticSimplyTimed.java
@@ -18,6 +18,7 @@ package io.helidon.microprofile.metrics;
 
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.Priority;
@@ -79,7 +80,7 @@ final class InterceptorSyntheticSimplyTimed {
             }
             return simpleTimer.time(context::proceed);
         } catch (Throwable t) {
-            LOGGER.fine("Throwable caught by interceptor '" + t.getMessage() + "'");
+            LOGGER.log(Level.FINE, "Throwable caught by interceptor", t);
             throw t;
         }
     }
@@ -101,6 +102,9 @@ final class InterceptorSyntheticSimplyTimed {
         public void onComplete(Throwable throwable) {
             long nowNanos = System.nanoTime();
             simpleTimer.update(Duration.ofNanos(nowNanos - startTimeNanos));
+            if (throwable != null) {
+                LOGGER.log(Level.FINE, "Throwable detected by interceptor callback", throwable);
+            }
         }
     }
 }

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldAsyncResponseTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.metrics;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import javax.ws.rs.client.AsyncInvoker;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.MediaType;
+
+import io.helidon.microprofile.metrics.InterceptorSyntheticSimplyTimed.FinishCallback;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.SimpleTimer;
+import org.eclipse.microprofile.metrics.Tag;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@HelidonTest
+public class HelloWorldAsyncResponseTest extends HelloWorldTest {
+
+    @Test
+    public void test() {
+        String result = webTarget
+                .path("helloworld/slow")
+                .request()
+                .accept(MediaType.TEXT_PLAIN)
+                .get(String.class);
+
+        assertThat("Mismatched string result", result, is(HelloWorldResource.SLOW_RESPONSE));
+
+        Tag[] tags = {
+                new Tag("class", HelloWorldResource.class.getName()),
+                new Tag("method", "slowMessage_" + AsyncResponse.class.getName())
+        };
+
+        SimpleTimer simpleTimer = syntheticSimpleTimerRegistry().simpleTimer("REST.request", tags);
+        assertThat(simpleTimer, is(notNullValue()));
+        Duration minDuration = Duration.ofSeconds(HelloWorldResource.SLOW_DELAY_SECS);
+        assertThat(simpleTimer.getElapsedTime().compareTo(minDuration), is(greaterThan(0)));
+    }
+}

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldResource.java
@@ -41,7 +41,9 @@ import java.util.concurrent.TimeUnit;
 public class HelloWorldResource {
 
     static final String SLOW_RESPONSE = "At last";
-    static final int SLOW_DELAY_SECS = 5;
+
+    // In case pipeline runs need a different time
+    static final int SLOW_DELAY_SECS = Integer.getInteger("helidon.asyncSimplyTimedDelaySeconds", 2);
 
     private static ExecutorService executorService = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
Resolves #2742 

If the JAX-RS method has a `@Suspended AsyncResponse` then the synthetic `SimplyTimed` behavior now measures the actual length of the operation, not the time taken to _begin_ the operation.

Also added a test for this.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>