### PR TITLE
Do not attempt to access the request context in Fallback callback

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -587,21 +587,9 @@ class MethodInvoker implements FtSupplier<Object> {
         if (introspector.hasFallback()) {
             Fallback<Object> fallback = Fallback.builder()
                     .fallback(throwable -> {
-                        try {
-                            // Reference request context if request scope is active
-                            if (requestScope != null) {
-                                requestContext = requestScope.referenceCurrent();
-                            }
-
-                            // Execute callback logic
-                            CommandFallback cfb = new CommandFallback(context, introspector, throwable);
-                            return toCompletionStageSupplier(cfb::execute).get();
-                        } finally {
-                            // Release request context if referenced
-                            if (requestContext != null) {
-                                requestContext.release();
-                            }
-                        }
+                        // Execute callback logic
+                        CommandFallback cfb = new CommandFallback(context, introspector, throwable);
+                        return toCompletionStageSupplier(cfb::execute).get();
                     })
                     .applyOn(mapTypes(introspector.getFallback().applyOn()))
                     .skipOn(mapTypes(introspector.getFallback().skipOn()))

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean1.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 @ApplicationScoped
-public class SomeService {
+public class Bean1 {
 
     @Inject
     @TestQualifier
-    RequestTestQualifier requestTestQualifier;
+    private RequestTestQualifier requestTestQualifier;
 
     @Retry
     public String test() throws Exception {

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean2.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,36 @@
  */
 package io.helidon.tests.functional.requestscope;
 
-import javax.enterprise.context.ApplicationScoped;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
 @ApplicationScoped
-public class SomeService3 {
+public class Bean2 {
 
     private AtomicLong counter = new AtomicLong(0);
 
+    @Inject
+    private TenantContext tenantContext;
+
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4)
     @Fallback(fallbackMethod = "testFallback")
-    public String test(String testParam) throws Exception {
+    public String test() {
         maybeFail();
-        return testParam;
+        return tenantContext.getTenantId();
     }
 
-    public String testFallback(String testParam) throws Exception {
-        return testParam;
+    public String testFallback() {
+        return tenantContext.getTenantId();
     }
 
     private void maybeFail() {
-        final Long invocationNumber = counter.getAndIncrement();
-        if (invocationNumber % 4 > 1) { // alternate 2 successful and 2 failing invocations
+        final long invocationNumber = counter.getAndIncrement();
+        if (invocationNumber % 4 > 1) {     // alternate 2 successful and 2 failing invocations
             throw new RuntimeException("Service failed.");
         }
     }

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean3.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean3.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.requestscope;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class Bean3 {
+
+    private AtomicLong counter = new AtomicLong(0);
+
+    @Fallback(fallbackMethod = "testFallback")
+    public String test(String testParam) throws Exception {
+        maybeFail();
+        return testParam;
+    }
+
+    public String testFallback(String testParam) throws Exception {
+        return testParam;
+    }
+
+    private void maybeFail() {
+        final Long invocationNumber = counter.getAndIncrement();
+        if (invocationNumber % 4 > 1) { // alternate 2 successful and 2 failing invocations
+            throw new RuntimeException("Service failed.");
+        }
+    }
+}

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean4.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Bean4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,36 +15,25 @@
  */
 package io.helidon.tests.functional.requestscope;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
 
 @ApplicationScoped
-public class SomeService2 {
+public class Bean4 {
 
     private AtomicLong counter = new AtomicLong(0);
 
-    @Inject
-    TenantContext tenantContext;
-
-    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4)
+    @Retry(jitter = 1000L, delay = 3)
     @Fallback(fallbackMethod = "testFallback")
-    public String test() {
-        maybeFail();
-        return tenantContext.getTenantId();
+    public String test(String testParam) throws Exception {
+        throw new RuntimeException("called failed");
     }
 
-    public String testFallback() {
-        return tenantContext.getTenantId();
-    }
-
-    private void maybeFail() {
-        final long invocationNumber = counter.getAndIncrement();
-        if (invocationNumber % 4 > 1) {     // alternate 2 successful and 2 failing invocations
-            throw new RuntimeException("Service failed.");
-        }
+    public String testFallback(String testParam) throws Exception {
+        return testParam;
     }
 }

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service1.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service1.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.requestscope;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@RequestScoped
+@Path("/test")
+public class Service1 {
+
+    @Inject
+    private Bean1 bean1;
+
+    @GET
+    public String getTenantResource() {
+        try {
+            return bean1.test();
+        } catch (IllegalTenantException e) {
+            return "Expected";
+        } catch (Exception e) {
+            // This path implies a CDI exception related to request scope
+            // See https://github.com/oracle/helidon/issues/2480
+            throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service2.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,15 @@ import javax.ws.rs.core.Response;
 
 @RequestScoped
 @Path("/test2")
-public class MultiTenantService2 {
+public class Service2 {
 
     @Inject
-    SomeService2 someService2;
+    private Bean2 bean2;
 
     @GET
     public String getTenantResource() {
         try {
-            String s = someService2.test();
+            String s = bean2.test();
             return s == null ? "" : s;
         } catch (Exception e) {
             // This path implies a CDI exception related to request scope

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service3.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,18 @@ import javax.ws.rs.core.Response;
 
 @RequestScoped
 @Path("/test3")
-public class MyResource {
+public class Service3 {
 
     @Inject
-    SomeService3 someService3;
+    private Bean3 bean3;
 
     @GET
     public String getTestResource(@QueryParam("param1") String param1) {
         try {
-            return someService3.test(param1);
+            return bean3.test(param1);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service4.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/Service4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,23 @@ import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @RequestScoped
-@Path("/test")
-public class MultiTenantService {
+@Path("/test4")
+public class Service4 {
 
     @Inject
-    SomeService someService;
+    private Bean4 bean4;
 
     @GET
-    public String getTenantResource() {
+    public String getTestResource(@QueryParam("param1") String param1) {
         try {
-            return someService.test();
-        } catch (IllegalTenantException e) {
-            return "Expected";
+            return bean4.test(param1);
         } catch (Exception e) {
-            // This path implies a CDI exception related to request scope
-            // See https://github.com/oracle/helidon/issues/2480
+            System.out.println(e.getMessage());
             throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
         }
     }

--- a/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
+++ b/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,5 +65,17 @@ class TenantTest {
             String entityValue = r.readEntity(String.class);
             assertThat(entityValue, is(paramValue));
         }
+    }
+
+    @Test
+    public void test4() {
+        Response r;
+        r = baseTarget.path("test4")
+                .queryParam("param1", "1")
+                .request()
+                .get();
+        assertThat(r.getStatus(), is(HttpResponseStatus.OK.code()));
+        String entityValue = r.readEntity(String.class);
+        assertThat(entityValue, is("1"));
     }
 }


### PR DESCRIPTION
Do not attempt to access the request context in Fallback callback. If used together with Retry, it is possible for the fallback to be called in a fresh thread for which there is no current request scope. Instead just use the original value obtained in this class' constructor. Updated functional test (with some class renaming) to cover this use case.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>