### PR TITLE
Remove standard output.

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -284,7 +284,6 @@ public class ServerCdiExtension implements Extension {
         } finally {
             long t = TimeUnit.MILLISECONDS.convert(System.nanoTime() - beforeT, TimeUnit.NANOSECONDS);
             LOGGER.info(() -> "Server stopped in " + t + " milliseconds.");
-            System.out.println("Server stopped in " + t + " milliseconds.");
         }
     }
 


### PR DESCRIPTION
This line should not be in Helidon. There is already a log statement doing the same.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>