### PR TITLE
1.x: Upgrade graalvm to 21.0.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.el-impl>3.0.0</version.lib.el-impl>
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
-        <version.lib.graalvm>19.2.0</version.lib.graalvm>
+        <version.lib.graalvm>20.2.0</version.lib.graalvm>
         <version.lib.grpc>1.35.0</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
@@ -656,7 +656,7 @@
                 <version>${version.lib.graalvm}</version>
             </dependency>
             <dependency>
-                <groupId>com.oracle.substratevm</groupId>
+                <groupId>org.graalvm.nativeimage</groupId>
                 <artifactId>svm</artifactId>
                 <version>${version.lib.graalvm}</version>
             </dependency>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.el-impl>3.0.0</version.lib.el-impl>
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
-        <version.lib.graalvm>20.2.0</version.lib.graalvm>
+        <version.lib.graalvm>21.0.0</version.lib.graalvm>
         <version.lib.grpc>1.35.0</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>

--- a/docs/src/main/docs/guides/36_graalnative.adoc
+++ b/docs/src/main/docs/guides/36_graalnative.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ In this guide you will learn how to build a native image locally on your machine
 |===
 |About 10 minutes
 | <<about/03_prerequisites.adoc,Helidon Prerequisites>>
-| GraalVM CE https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-20.2.0[20.2.0]
+| GraalVM CE https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.0[21.0.0]
 |===
 
 == Install GraalVM and the Native Image Command
@@ -50,7 +50,7 @@ set the `GRAALVM_HOME` environment variable to point at your GraalVM installatio
 [source,bash]
 ----
 # Your path might be different
-export GRAALVM_HOME=/usr/local/graalvm-ce-20.2.0/Contents/Home/
+export GRAALVM_HOME=/usr/local/graalvm-ce-21.0.0/Contents/Home/
 ----
 
 Then install the optional `native-image` command:

--- a/docs/src/main/docs/guides/36_graalnative.adoc
+++ b/docs/src/main/docs/guides/36_graalnative.adoc
@@ -39,18 +39,18 @@ In this guide you will learn how to build a native image locally on your machine
 |===
 |About 10 minutes
 | <<about/03_prerequisites.adoc,Helidon Prerequisites>>
-| GraalVM CE https://www.graalvm.org/downloads[19.2+ or 19.3+]
+| GraalVM CE https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-20.2.0[20.2.0]
 |===
 
 == Install GraalVM and the Native Image Command
 
-After https://github.com/oracle/graal/releases[downloading and installing] GraalVM,
+After https://github.com/graalvm/graalvm-ce-builds/releases[downloading and installing] GraalVM,
 set the `GRAALVM_HOME` environment variable to point at your GraalVM installation.
 
 [source,bash]
 ----
 # Your path might be different
-export GRAALVM_HOME=/usr/local/graalvm-ce-19.2.0/Contents/Home/
+export GRAALVM_HOME=/usr/local/graalvm-ce-20.2.0/Contents/Home/
 ----
 
 Then install the optional `native-image` command:

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -103,6 +103,30 @@
    <cve>CVE-2014-8122</cve>
 </suppress>
 
+<!-- GraalVM -->
+<!-- This suppresses multiple CVEs related to old versions of the JDK -->
+<suppress>
+   <notes><![CDATA[
+   file name: truffle-nfi-21.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
+   <cpe>cpe:/a:oracle:graalvm</cpe>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: truffle-nfi-21.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
+   <cpe>cpe:/a:oracle:openjdk</cpe>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: truffle-nfi-21.0.0.jar
+   ]]></notes>
+   <packageUrl regex="true">^pkg:maven/org\.graalvm\.truffle/truffle\-nfi@.*$</packageUrl>
+   <cpe>cpe:/a:sun:openjdk</cpe>
+</suppress>
+
 <!-- grpc -->
 <!-- This was applying the version of opentracing-grpc to grpc
      which triggered CVEs for older versions of grpc and grpc-js
@@ -114,6 +138,7 @@
    <packageUrl regex="true">^pkg:maven/io\.opentracing\.contrib/opentracing\-grpc@.*$</packageUrl>
    <cpe>cpe:/a:grpc:grpc</cpe>
 </suppress>
+
 
 </suppressions>
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk8-graalvm-maven:19.3.1 as build
+FROM helidon/jdk11-graalvm-maven:20.2.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -80,7 +80,7 @@ You can build a native executable in 2 different ways:
 ### Local build
 
 Download Graal VM at https://www.graalvm.org/downloads, the versions
- currently supported for Helidon are `19.2` and `19.3`.
+ currently supported for Helidon are `20.2.0`.
 
 ```
 # Setup the environment

--- a/examples/quickstarts/helidon-quickstart-se/README.md
+++ b/examples/quickstarts/helidon-quickstart-se/README.md
@@ -80,7 +80,7 @@ You can build a native executable in 2 different ways:
 ### Local build
 
 Download Graal VM at https://www.graalvm.org/downloads, the versions
- currently supported for Helidon are `20.2.0`.
+ currently supported for Helidon are `21.0.0`.
 
 ```
 # Setup the environment

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk11-graalvm-maven:21.0.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk8-graalvm-maven:19.3.1 as build
+FROM helidon/jdk11-graalvm-maven:20.2.0 as build
 
 WORKDIR /helidon
 

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -43,7 +43,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.substratevm</groupId>
+            <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/integrations/graal/native-image-extension/pom.xml
+++ b/integrations/graal/native-image-extension/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Upgrades Helidon 1.4.x to use GraalVM 21.0.0. Helidon 1.x only support native-image in SE.

I tested the SE quickstart, both locally and in Docker (using Dockerfile.native).

Part of 1.x dependency upgrade effort: #2566 

