### PR TITLE
OCI integration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -909,6 +909,17 @@
                 <artifactId>helidon-logging-log4j</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <!-- OCI -->
+            <dependency>
+                <groupId>io.helidon.integrations.oci</groupId>
+                <artifactId>helidon-integrations-oci</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.integrations.oci</groupId>
+                <artifactId>helidon-integrations-oci-objectstorage</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -110,6 +110,7 @@
         <version.lib.narayana>5.9.3.Final</version.lib.narayana>
         <version.lib.netty>4.1.58.Final</version.lib.netty>
         <version.lib.oci-java-sdk-objectstorage>1.31.0</version.lib.oci-java-sdk-objectstorage>
+        <version.lib.oci-java-sdk>1.31.0</version.lib.oci-java-sdk>
         <version.lib.ojdbc8>19.8.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
@@ -754,6 +755,31 @@
                         <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-core</artifactId>
+                <version>${version.lib.oci-java-sdk}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-objectstorage</artifactId>
+                <version>${version.lib.oci-java-sdk}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-identity</artifactId>
+                <version>${version.lib.oci-java-sdk}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
+                <version>${version.lib.oci-java-sdk}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
+                <version>${version.lib.oci-java-sdk}</version>
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>

--- a/examples/integrations/oci/base/identity-se/src/main/java/io/helidon/integrations/examples/oci/ListRegions/se/RegionsService.java
+++ b/examples/integrations/oci/base/identity-se/src/main/java/io/helidon/integrations/examples/oci/ListRegions/se/RegionsService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.examples.oci.ListRegions.se;
+
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.identity.IdentityClient;
+import com.oracle.bmc.identity.requests.ListRegionsRequest;
+import com.oracle.bmc.identity.responses.ListRegionsResponse;
+
+/**
+ * Region service class. Currently the easiest way to test connectivity and authentication to OCI.
+ */
+public class RegionsService implements Service {
+    private static final Logger LOGGER = Logger.getLogger(RegionsService.class.getName());
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    private final IdentityClient identityClient;
+
+    /**
+     * Constructor for RegionService.
+     * @param inProvider
+     */
+    public RegionsService(AuthenticationDetailsProvider inProvider) {
+        super();
+        this.identityClient = new IdentityClient(inProvider);
+        identityClient.setRegion(Region.US_PHOENIX_1);
+    }
+
+    /**
+     * A service registers itself by updating the routing rules.
+     *
+     * @param rules the routing rules.
+     */
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/all", this::getRegionsHandler);
+    }
+
+    /**
+     * Return all regions in OCI.
+     *
+     * @param request  the server request
+     * @param response the server response
+     */
+    private void getRegionsHandler(ServerRequest request, ServerResponse response) {
+        final ListRegionsResponse regionsResponse =
+                identityClient.listRegions(ListRegionsRequest.builder().build());
+        LOGGER.info("The regions are " + regionsResponse.getItems().toString());
+        JsonObject returnObject = JSON.createObjectBuilder()
+                .add("Regions", regionsResponse.getItems().toString())
+                .build();
+        response.send(returnObject);
+    }
+}

--- a/examples/integrations/oci/base/identity-se/src/main/resources/application.yaml
+++ b/examples/integrations/oci/base/identity-se/src/main/resources/application.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+oci:
+  auth:
+    user: "ocid1.user.oc1.."
+    fingerprint: "7c:6d:89:fc:05:32:5b:4c:b8:94::43:b5:0b:b0:e3"
+    tenancy: "ocid1.tenancy.oc1.."
+    keyFile: no/way
+    region: "eu-frankfurt-1"
+
+server:
+  port: 8080
+  host: 0.0.0.0

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/Dockerfile
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/Dockerfile
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# 1st stage, build the app
+FROM maven:3.6-jdk-11 as build
+
+WORKDIR /helidon
+
+# Create a first layer to cache the "Maven World" in the local repository.
+# Incremental docker builds will always resume after that, unless you update
+# the pom
+ADD pom.xml .
+RUN mvn package -Dmaven.test.skip
+
+# Do the Maven build!
+# Incremental docker builds will resume here when you change sources
+ADD src src
+RUN mvn package -DskipTests
+RUN echo "done!"
+
+# 2nd stage, build the runtime image
+FROM openjdk:11-jre-slim
+WORKDIR /helidon
+
+# Copy the binary built in the 1st stage
+COPY --from=build /helidon/target/helidon-examples-integrations-cdi-oci-objectstorage-mp.jar ./
+COPY --from=build /helidon/target/libs ./libs
+
+CMD [ "sh", "-c", "exec java \
+    -Doci.auth.fingerprint=\"${OCI_AUTH_FINGERPRINT}\" \
+    -Doci.auth.passphraseCharacters=\"${OCI_AUTH_PASSPHRASE}\" \
+    -Doci.auth.privateKey=\"${OCI_AUTH_PRIVATEKEY}\" \
+    -Doci.auth.tenancy=\"${OCI_AUTH_TENANCY}\" \
+    -Doci.auth.user=\"${OCI_AUTH_USER}\" \
+    -Doci.objectstorage.compartmentId=\"${OCI_OBJECTSTORAGE_COMPARTMENT}\" \
+    -Doci.objectstorage.region=\"${OCI_OBJECTSTORAGE_REGION}\" \
+    -jar helidon-examples-integrations-cdi-oci-objectstorage-mp.jar" ]
+
+EXPOSE 8080

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/README.md
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/README.md
@@ -1,0 +1,68 @@
+# OCI Object Storage CDI Integration Example
+
+## OCI setup
+
+Setup your OCI SDK [configuration](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm)
+ if you haven't done so already, and then run the following command:
+```bash
+./oci-setup.sh && source oci-env
+```
+
+This example requires an Object Storage, you can create one using the
+ [OCI console](https://console.us-phoenix-1.oraclecloud.com). Once created,
+ upload a file in order to exercise the example.
+
+## Build and run
+
+With Docker:
+```bash
+docker build -t helidon-examples-integrations-cdi-oci-objectstorage-mp .
+docker run --rm -d -p 8080:8080 \
+    -e OCI_AUTH_PRIVATEKEY \
+    -e OCI_AUTH_FINGERPRINT \
+    -e OCI_AUTH_PASSPHRASE \
+    -e OCI_AUTH_TENANCY \
+    -e OCI_AUTH_USER \
+    -e OCI_OBJECTSTORAGE_COMPARTMENT \
+    -e OCI_OBJECTSTORAGE_REGION \
+    --name helidon-examples-integrations-cdi-oci-objectstorage-mp \
+    helidon-examples-integrations-cdi-oci-objectstorage-mp:latest
+```
+
+With Java:
+```bash
+mvn package
+java -Doci.auth.fingerprint="${OCI_AUTH_FINGERPRINT}" \
+    -Doci.auth.passphraseCharacters="${OCI_AUTH_PASSPHRASE}" \
+    -Doci.auth.privateKey="${OCI_AUTH_PRIVATEKEY}" \
+    -Doci.auth.tenancy="${OCI_AUTH_TENANCY}" \
+    -Doci.auth.user="${OCI_AUTH_USER}" \
+    -Doci.objectstorage.compartmentId="${OCI_OBJECTSTORAGE_COMPARTMENT}" \
+    -Doci.objectstorage.region="${OCI_OBJECTSTORAGE_REGION}" \
+    -jar target/helidon-examples-integrations-cdi-oci-objectstorage-mp.jar
+```
+
+Try the endpoint:
+
+```bash
+curl http://localhost:8080/logo/{namespaceName}/{bucketName}/{objectName}
+```
+
+## Run With Kubernetes (docker for desktop)
+
+```bash
+docker build -t helidon-examples-integrations-cdi-oci-objectstorage-mp .
+./oci-setup.sh -k8s
+kubectl apply -f ../../../k8s/ingress.yaml -f app.yaml
+```
+
+Try the endpoint:
+
+```bash
+curl http://localhost/oci-objectstorage/logo/{namespaceName}/{bucketName}/{objectName}
+```
+
+Stop the docker containers:
+```bash
+docker stop helidon-examples-integrations-cdi-oci-objectstorage-mp
+```

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/app.yaml
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/app.yaml
@@ -1,0 +1,102 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: helidon-examples-integrations-cdi-oci-objectstorage-mp
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helidon-examples-integrations-cdi-oci-objectstorage-mp
+        version: v1
+    spec:
+      containers:
+      - name: helidon-examples-integrations-cdi-oci-objectstorage-mp
+        image: helidon-examples-integrations-cdi-oci-objectstorage-mp
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+        env:
+        - name: OCI_AUTH_FINGERPRINT
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_AUTH_FINGERPRINT
+        - name: OCI_AUTH_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_AUTH_PASSPHRASE
+        - name: OCI_AUTH_PRIVATEKEY
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_AUTH_PRIVATEKEY
+        - name: OCI_AUTH_TENANCY
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_AUTH_TENANCY
+        - name: OCI_AUTH_USER
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_AUTH_USER
+        - name: OCI_OBJECTSTORAGE_COMPARTMENT
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_OBJECTSTORAGE_COMPARTMENT
+        - name: OCI_OBJECTSTORAGE_REGION
+          valueFrom:
+            secretKeyRef:
+              name: oci-objectstorage-secret
+              key: OCI_OBJECTSTORAGE_REGION
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: helidon-examples-integrations-cdi-oci-objectstorage-mp
+  labels:
+    app: helidon-examples-integrations-cdi-oci-objectstorage-mp
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: helidon-examples-integrations-cdi-oci-objectstorage-mp
+  sessionAffinity: None
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: helidon-examples-integrations-cdi-oci-objectstorage-mp
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - path: /oci-objectstorage/(.*)
+        backend:
+          serviceName: helidon-examples-integrations-cdi-oci-objectstorage-mp
+          servicePort: 8080

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/oci-setup.sh
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/oci-setup.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly OCI_SECRET_FILE=$(dirname ${0})/oci-env
+
+if [ ! -f ${OCI_SECRET_FILE} ] ; then
+    if [ -f ${HOME}/.oci/config ] ; then
+        echo "Found ${HOME}/.oci/config"
+        eval $(cat ~/.oci/config | sed -n '/\[ADMIN_USER\]/q;p' | sed '1d' | sed -E s@'^(.*)=(.*)$'@'oci_\1=\2'@g)
+    fi
+
+    if [ -z "${oci_user}" ] ; then
+        read -p "User OCID: " oci_user
+    fi
+    if [ -z "${oci_user}" ] ; then
+        echo "ERROR: user OCID is empty"
+    fi
+
+    if [ -z "${oci_key_file}" ] ; then
+        read -p "Private key location: " oci_key_file
+    fi
+    if [ -z "${oci_key_file}" ] || [ ! -f ${oci_key_file} ] ; then
+        echo "ERROR: Private key is not a valid file"
+    fi
+
+    if [ -z "${oci_pass_phrase}" ] ; then
+        read -p "Private key passphrase: " oci_pass_phrase
+    fi
+
+    if [ -z "${oci_fingerprint}" ] ; then
+        read -p "Public key fingerprint: " oci_fingerprint
+    fi
+    if [ -z "${oci_fingerprint}" ] ; then
+        echo "ERROR: Public key is empty"
+    fi
+
+    if [ -z "${oci_tenancy}" ] ; then
+        read -p "Tenancy OCID: " oci_tenancy
+    fi
+    if [ -z "${oci_tenancy}" ] ; then
+        echo "ERROR: Tenancy OCID is empty"
+    fi
+
+    if [ -z "${oci_region}" ] ; then
+        read -p "Region: " oci_region
+    fi
+    if [ -z "${oci_region}" ] ; then
+        echo "ERROR: Region is empty"
+    fi
+
+    if [ -z "${oci_compartment}" ] ; then
+      read -p "Compartment OCID: " oci_compartment
+    fi
+    if [ -z "${oci_compartment}" ] ; then
+        echo "ERROR: Compartment OCID is empty"
+    fi
+
+    readonly OCI_AUTH_PRIVATEKEY="$(cat ~/.oci/oci_api_key.pem)"
+    readonly OCI_AUTH_FINGERPRINT="${oci_fingerprint}"
+    readonly OCI_AUTH_PASSPHRASE="${oci_passphrase}"
+    readonly OCI_AUTH_TENANCY="${oci_tenancy}"
+    readonly OCI_AUTH_USER="${oci_user}"
+    readonly OCI_OBJECTSTORAGE_COMPARTMENT="${oci_compartment}"
+    readonly OCI_OBJECTSTORAGE_REGION="${oci_region}"
+
+    echo "export OCI_AUTH_PRIVATEKEY=\"${OCI_AUTH_PRIVATEKEY}\"" > ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_FINGERPRINT=\"${OCI_AUTH_FINGERPRINT}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_PASSPHRASE=\"${OCI_AUTH_PASSPHRASE}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_TENANCY=\"${OCI_AUTH_TENANCY}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_USER=\"${OCI_AUTH_USER}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_OBJECTSTORAGE_COMPARTMENT=\"${OCI_OBJECTSTORAGE_COMPARTMENT}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_OBJECTSTORAGE_REGION=\"${OCI_OBJECTSTORAGE_REGION}\"" >> ${OCI_SECRET_FILE}
+fi
+
+if [ "${1}" = "-k8s" ] ; then
+    kubectl create secret generic oci-objectstorage-secret \
+    --from-literal=OCI_AUTH_FINGERPRINT="${OCI_AUTH_FINGERPRINT}" \
+    --from-literal=OCI_AUTH_PASSPHRASE="${OCI_AUTH_PASSPHRASE}" \
+    --from-literal=OCI_AUTH_PRIVATEKEY="${OCI_AUTH_PRIVATEKEY}" \
+    --from-literal=OCI_AUTH_TENANCY="${OCI_AUTH_TENANCY}" \
+    --from-literal=OCI_AUTH_USER="${OCI_AUTH_USER}" \
+    --from-literal=OCI_OBJECTSTORAGE_COMPARTMENT="${OCI_OBJECTSTORAGE_COMPARTMENT}" \
+    --from-literal=OCI_OBJECTSTORAGE_REGION="${OCI_OBJECTSTORAGE_REGION}"
+fi

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/pom.xml
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../../../../../applications/mp/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-objectstorage-mp</artifactId>
+    <name>Helidon CDI Extensions Examples OCI ObjectStorage</name>
+
+    <dependencies>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci-objectstorage</artifactId>
+        </dependency>
+        <!-- Runtime-scoped dependencies. -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/java/io/helidon/examples/integrations/oci/objectstorage/jaxrs/HelidonLogoResource.java
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/java/io/helidon/examples/integrations/oci/objectstorage/jaxrs/HelidonLogoResource.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.examples.integrations.oci.objectstorage.jaxrs;
+
+import java.util.Objects;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * A JAX-RS resource class rooted at {@code /logo}.
+ *
+ * @see #getLogo(String, String, String)
+ */
+@Path("/logo")
+@ApplicationScoped
+public class HelidonLogoResource {
+
+    private final ObjectStorage client;
+
+    private final String namespaceName;
+
+    /**
+     * Creates a new {@link HelidonLogoResource}.
+     *
+     * @param client an {@link ObjectStorage} client; must not be {@code
+     * null}
+     *
+     * @param namespaceName the name of an OCI object storage namespace that will be used; must not be {@code null}
+     *
+     * @exception NullPointerException if either parameter is {@code
+     * null}
+     */
+    @Inject
+    public HelidonLogoResource(final ObjectStorage client,
+            @ConfigProperty(name = "oci.objectstorage.namespace") final String namespaceName) {
+        super();
+        this.client = Objects.requireNonNull(client);
+        this.namespaceName = Objects.requireNonNull(namespaceName);
+    }
+
+    /**
+     * Returns a non-{@code null} {@link Response} which, if successful, will contain the object stored under the supplied {@code
+     * namespaceName}, {@code bucketName} and {@code objectName}.
+     *
+     * @param namespaceName the OCI object storage namespace to use; must not be {@code null}
+     *
+     * @param bucketName the OCI object storage bucket name to use; must not be {@code null}
+     *
+     * @param objectName the OCI object storage object name to use; must not be {@code null}
+     *
+     * @return a non-{@code null} {@link Response} describing the operation
+     *
+     * @exception NullPointerException if any of the parameters is {@code null}
+     */
+    @GET
+    @Path("/{namespaceName}/{bucketName}/{objectName}")
+    @Produces(MediaType.WILDCARD)
+    public Response getLogo(@PathParam("namespaceName") String namespaceName,
+            @PathParam("bucketName") final String bucketName,
+            @PathParam("objectName") final String objectName) {
+        final Response returnValue;
+        if (bucketName == null || bucketName.isEmpty() || objectName == null || objectName.isEmpty()) {
+            returnValue = Response.status(400)
+                    .build();
+        } else {
+            if (namespaceName == null || namespaceName.isEmpty()) {
+                namespaceName = this.namespaceName;
+            }
+            Response temp = null;
+            try {
+                final GetObjectRequest request = GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+                assert request != null;
+                final GetObjectResponse response = this.client.getObject(request);
+                assert response != null;
+                final Long contentLength = response.getContentLength();
+                assert contentLength != null;
+                if (contentLength <= 0L) {
+                    temp = Response.noContent()
+                            .build();
+                } else {
+                    temp = Response.ok()
+                            .type(response.getContentType())
+                            .entity(response.getInputStream())
+                            .build();
+                }
+            } catch (final BmcException bmcException) {
+                final int statusCode = bmcException.getStatusCode();
+                temp = Response.status(statusCode)
+                        .build();
+            } finally {
+                returnValue = temp;
+            }
+        }
+        return returnValue;
+    }
+
+}

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/java/io/helidon/examples/integrations/oci/objectstorage/jaxrs/package-info.java
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/java/io/helidon/examples/integrations/oci/objectstorage/jaxrs/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides JAX-RS-related classes and interfaces for this example
+ * project.
+ */
+package io.helidon.examples.integrations.oci.objectstorage.jaxrs;

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/resources/META-INF/beans.xml
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-mp/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+oci.config.profile=DEFAULT
+
+oci.objectstorage.namespace=${oci.objectstorage.namespaceName}
+
+
+# Microprofile server properties
+server.port=8080
+server.host=0.0.0.0

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/Dockerfile
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/Dockerfile
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# 1st stage, build the app
+FROM maven:3.6-jdk-11 as build
+
+WORKDIR /helidon
+
+# Create a first layer to cache the "Maven World" in the local repository.
+# Incremental docker builds will always resume after that, unless you update
+# the pom
+ADD ../../pom.xml .
+RUN mvn package -Dmaven.test.skip
+
+# Do the Maven build!
+# Incremental docker builds will resume here when you change sources
+ADD src src
+RUN mvn package -DskipTests
+RUN echo "done!"
+
+# 2nd stage, build the runtime image
+FROM openjdk:11-jre-slim
+WORKDIR /helidon
+
+# Copy the binary built in the 1st stage
+COPY --from=build /helidon/target/helidon-examples-integrations-oci-objectstorage-se.jar ./
+COPY --from=build /helidon/target/libs ./libs
+
+CMD [ "sh", "-c", "exec java \
+    -Doci.auth.fingerprint=\"${OCI_AUTH_FINGERPRINT}\" \
+    -Doci.auth.passphraseCharacters=\"${OCI_AUTH_PASSPHRASE}\" \
+    -Doci.auth.privateKey=\"${OCI_AUTH_PRIVATEKEY}\" \
+    -Doci.auth.tenancy=\"${OCI_AUTH_TENANCY}\" \
+    -Doci.auth.user=\"${OCI_AUTH_USER}\" \
+    -Doci.listregions.compartmentId=\"${OCI_LISTREGIONS_COMPARTMENT}\" \
+    -Doci.listregions.region=\"${OCI_LISTREGIONS_REGION}\" \
+    -jar helidon-examples-integrations-oci-objectstorage-se.jar" ]
+
+EXPOSE 8080

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/README.md
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/README.md
@@ -1,0 +1,75 @@
+# OCI List Regions Integration Example
+
+## OCI setup
+
+Setup your OCI SDK [configuration](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm)
+ if you haven't done so already, and then run the following command:
+```bash
+./oci-setup.sh && source oci-env
+```
+Setup your OCI login information:
+
+```yaml
+oci:
+  auth:
+    user: "ocid1.user.oc1.."
+    fingerprint: "7c:6d:89:fc:05:32:5b:"
+    tenancy: "ocid1.tenancy.oc1.."
+    keyFile: /path/to/file.pem
+    region: "eu-frankfurt-1"
+```
+
+## Build and run
+
+With Docker:
+```bash
+docker build -t helidon-examples-integrations-oci-objectstorage-se .
+docker run --rm -d -p 8080:8080 \
+    -e OCI_AUTH_PRIVATEKEY \
+    -e OCI_AUTH_FINGERPRINT \
+    -e OCI_AUTH_PASSPHRASE \
+    -e OCI_AUTH_TENANCY \
+    -e OCI_AUTH_USER \
+    -e OCI_OBJECTSTORAGE_COMPARTMENT \
+    -e OCI_OBJECTSTORAGE_REGION \
+    --name helidon-examples-integrations-cdi-oci-listregions \
+    helidon-examples-integrations-oci-objectstorage-se:latest
+```
+
+With Java:
+```bash
+mvn package
+java -Doci.auth.fingerprint="${OCI_AUTH_FINGERPRINT}" \
+    -Doci.auth.passphraseCharacters="${OCI_AUTH_PASSPHRASE}" \
+    -Doci.auth.privateKey="${OCI_AUTH_PRIVATEKEY}" \
+    -Doci.auth.tenancy="${OCI_AUTH_TENANCY}" \
+    -Doci.auth.user="${OCI_AUTH_USER}" \
+    -Doci.objectstorage.compartmentId="${OCI_OBJECTSTORAGE_COMPARTMENT}" \
+    -Doci.objectstorage.region="${OCI_OBJECTSTORAGE_REGION}" \
+    -jar target/helidon-examples-integrations-oci-objectstorage-se.jar
+```
+
+Try the endpoint:
+
+```bash
+curl http://localhost:8080/{namespaceName}/{bucketName}/{objectName}
+```
+
+## Run With Kubernetes (docker for desktop)
+
+```bash
+docker build -t helidon-examples-integrations-oci-objectstorage-se .
+./oci-setup.sh -k8s
+kubectl apply -f ../../../k8s/ingress.yaml -f app.yaml
+```
+
+Try the endpoint:
+
+```bash
+curl http://localhost:8080/{namespaceName}/{bucketName}/{objectName}
+```
+
+Stop the docker containers:
+```bash
+docker stop helidon-examples-integrations-oci-objectstorage-se
+```

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/oci-setup.sh
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/oci-setup.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly OCI_SECRET_FILE=$(dirname ${0})/oci-env
+
+if [ ! -f ${OCI_SECRET_FILE} ] ; then
+    if [ -f ${HOME}/.oci/config ] ; then
+        echo "Found ${HOME}/.oci/config"
+        eval $(cat ~/.oci/config | sed -n '/\[ADMIN_USER\]/q;p' | sed '1d' | sed -E s@'^(.*)=(.*)$'@'oci_\1=\2'@g)
+    fi
+
+    if [ -z "${oci_user}" ] ; then
+        read -p "User OCID: " oci_user
+    fi
+    if [ -z "${oci_user}" ] ; then
+        echo "ERROR: user OCID is empty"
+    fi
+
+    if [ -z "${oci_key_file}" ] ; then
+        read -p "Private key location: " oci_key_file
+    fi
+    if [ -z "${oci_key_file}" ] || [ ! -f ${oci_key_file} ] ; then
+        echo "ERROR: Private key is not a valid file"
+    fi
+
+    if [ -z "${oci_pass_phrase}" ] ; then
+        read -p "Private key passphrase: " oci_pass_phrase
+    fi
+
+    if [ -z "${oci_fingerprint}" ] ; then
+        read -p "Public key fingerprint: " oci_fingerprint
+    fi
+    if [ -z "${oci_fingerprint}" ] ; then
+        echo "ERROR: Public key is empty"
+    fi
+
+    if [ -z "${oci_tenancy}" ] ; then
+        read -p "Tenancy OCID: " oci_tenancy
+    fi
+    if [ -z "${oci_tenancy}" ] ; then
+        echo "ERROR: Tenancy OCID is empty"
+    fi
+
+    if [ -z "${oci_region}" ] ; then
+        read -p "Region: " oci_region
+    fi
+    if [ -z "${oci_region}" ] ; then
+        echo "ERROR: Region is empty"
+    fi
+
+    if [ -z "${oci_compartment}" ] ; then
+      read -p "Compartment OCID: " oci_compartment
+    fi
+    if [ -z "${oci_compartment}" ] ; then
+        echo "ERROR: Compartment OCID is empty"
+    fi
+
+    readonly OCI_AUTH_PRIVATEKEY="$(cat ~/.oci/oci_api_key.pem)"
+    readonly OCI_AUTH_FINGERPRINT="${oci_fingerprint}"
+    readonly OCI_AUTH_PASSPHRASE="${oci_passphrase}"
+    readonly OCI_AUTH_TENANCY="${oci_tenancy}"
+    readonly OCI_AUTH_USER="${oci_user}"
+    readonly OCI_LISTREGIONS_COMPARTMENT="${oci_compartment}"
+    readonly OCI_LISTREGIONS_COMPARTMENT_REGION="${oci_region}"
+
+    echo "export OCI_AUTH_PRIVATEKEY=\"${OCI_AUTH_PRIVATEKEY}\"" > ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_FINGERPRINT=\"${OCI_AUTH_FINGERPRINT}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_PASSPHRASE=\"${OCI_AUTH_PASSPHRASE}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_TENANCY=\"${OCI_AUTH_TENANCY}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_AUTH_USER=\"${OCI_AUTH_USER}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_LISTREGIONS_COMPARTMENT=\"${OCI_LISTREGIONS_COMPARTMENT}\"" >> ${OCI_SECRET_FILE}
+    echo "export OCI_LISTREGIONS_COMPARTMENT_REGION=\"${OCI_LISTREGIONS_COMPARTMENT_REGION}\"" >> ${OCI_SECRET_FILE}
+fi
+
+if [ "${1}" = "-k8s" ] ; then
+    kubectl create secret generic oci-objectstorage-secret \
+    --from-literal=OCI_AUTH_FINGERPRINT="${OCI_AUTH_FINGERPRINT}" \
+    --from-literal=OCI_AUTH_PASSPHRASE="${OCI_AUTH_PASSPHRASE}" \
+    --from-literal=OCI_AUTH_PRIVATEKEY="${OCI_AUTH_PRIVATEKEY}" \
+    --from-literal=OCI_AUTH_TENANCY="${OCI_AUTH_TENANCY}" \
+    --from-literal=OCI_AUTH_USER="${OCI_AUTH_USER}" \
+    --from-literal=OCI_LISTREGIONS_COMPARTMENT="${OCI_LISTREGIONS_COMPARTMENT}" \
+    --from-literal=OCI_LISTREGIONS_COMPARTMENT_REGION="${OCI_LISTREGIONS_COMPARTMENT_REGION}"
+fi

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/pom.xml
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../../../../../applications/mp/pom.xml</relativePath>
+    </parent>
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-objectstorage-se</artifactId>
+    <name>Examples OCI Object Storage with Helidon SE</name>
+
+    <properties>
+        <mainClass>io.helidon.examples.integrations.oci.objectstore.se.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <!-- Compile-scoped dependencies. -->
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci-objectstorage</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/src/main/resources/application.yaml
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/src/main/resources/application.yaml
@@ -1,0 +1,11 @@
+
+oci:
+  config:
+    profile: "DEFAULT"
+  objectstorage:
+    namespace: "${oci.objectstorage.namespaceName}"
+
+
+server:
+  port: 8080
+  host: 0.0.0.0

--- a/examples/integrations/oci/objectstorage/oci-objectstorage-se/src/main/resources/logging.properties
+++ b/examples/integrations/oci/objectstorage/oci-objectstorage-se/src/main/resources/logging.properties
@@ -1,0 +1,19 @@
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO

--- a/examples/integrations/oci/objectstorage/pom.xml
+++ b/examples/integrations/oci/objectstorage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020, 2021 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,24 +16,22 @@
     limitations under the License.
 
 -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.examples</groupId>
-        <artifactId>helidon-examples-project</artifactId>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
         <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../../../../applications/mp/pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.examples.integrations</groupId>
-    <artifactId>helidon-examples-integrations-project</artifactId>
-    <name>Helidon Integrations Examples</name>
+    <groupId>io.helidon.examples.integrations.oci.base</groupId>
+    <artifactId>helidon-examples-integrations-oci-objectstore-project</artifactId>
+    <name>Examples for OCI Object Storage integrations</name>
     <packaging>pom</packaging>
 
     <modules>
-        <module>cdi</module>
-        <module>micronaut</module>
-        <module>oci</module>
+        <module>oci-objectstorage-mp</module>
     </modules>
-
 </project>

--- a/examples/integrations/oci/oci/pom.xml
+++ b/examples/integrations/oci/oci/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.integrations-oci</groupId>
+        <artifactId>helidon-integrations-oci-project</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.integrations.oci</groupId>
+    <artifactId>helidon-integrations-oci</artifactId>
+    <name>Helidon OCI base integrations</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-identity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/Oci.java
+++ b/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/Oci.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package io.helidon.integrations.oci;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+
+import io.helidon.config.Config;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+
+
+
+/**
+ * OCI support for Helidon.
+ */
+public class Oci {
+
+    private AuthenticationDetailsProvider provider;
+    private ClientConfiguration clientConfig;
+
+    private Oci() {
+        //private constructor
+    }
+
+    private Oci(Builder builder) {
+        provider = builder.configureProvider();
+        clientConfig = builder.getClientConfig();
+    }
+
+    /**
+     * The OCI create method.
+     *
+     * @param config from SE.
+     * @return using builder pattern.
+     */
+    public static Oci create(Config config) {
+        return builder().config(config).build();
+    }
+
+    /**
+     * Get the registered provider.
+     *
+     * @return AuthenticationDetailsProvider.
+     */
+    public AuthenticationDetailsProvider provider() {
+        return provider;
+    }
+
+    /**
+     * Get the Configured client.
+     *
+     * @return ClientConfiguration.
+     */
+    public ClientConfiguration clientConfig() {
+        return clientConfig;
+    }
+
+    /**
+     * Access to Builder.
+     *
+     * @return The Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    /**
+     * Builder for {@link Oci}.
+     */
+    public static final class Builder implements io.helidon.common.Builder<Oci> {
+
+        private AuthenticationDetailsProvider provider;
+        private ClientConfiguration clientConfig;
+
+        private String ociAuthProfile;
+        private String ociConfigPath;
+
+        private String ociAuthFingerprint;
+        private String ociAuthPassphraseCharacters;
+        private String ociAuthTenancy;
+        private String ociAuthUser;
+        private String ociAuthPrivateKey;
+        private String ociAuthKeyFile;
+        private String ociAuthRegion;
+
+        private Profile configProfile;
+
+        private int clientConnectionTimeoutMillis = 3000;
+        private int clientReadTimeoutMillis = 60000;
+
+        /**
+         * Build the OCI support.
+         *
+         * @return
+         */
+        @Override
+        public Oci build() {
+            provider = configureProvider();
+            clientConfig = configureClient();
+            return new Oci(this);
+        }
+
+        /**
+         * Read the configuration.
+         *
+         * @param config
+         * @return Builder
+         */
+        public Builder config(Config config) {
+            config.get("config.profile").as(Profile.class).ifPresent(this::configProfile);
+            config.get("auth.profile").asString().ifPresent(this::ociAuthProfile);
+            config.get("config.path").asString().ifPresent(this::ociConfigPath);
+            config.get("auth.fingerprint").asString().ifPresent(this::ociAuthFingerprint);
+            config.get("auth.passphrase.characters").asString().ifPresent(this::ociAuthPassphraseCharacters);
+            config.get("auth.tenancy").asString().ifPresent(this::ociAuthTenancy);
+            config.get("auth.user").asString().ifPresent(this::ociAuthUser);
+            config.get("auth.private.key").asString().ifPresent(this::ociAuthPrivateKey);
+            config.get("auth.keyFile").asString().ifPresent(this::ociAuthKeyFile);
+            config.get("auth.region").asString().ifPresent(this::ociAuthRegion);
+
+            config.get("client.connectionTimeoutMillis").asInt().ifPresent(this::clientConnectionTimeoutMillis);
+            config.get("client.readTimeoutMillis").asInt().ifPresent(this::clientReadTimeoutMillis);
+
+            return this;
+        }
+
+        /**
+         * Configuration profile.
+         */
+        public enum Profile {
+            /**
+             * Should be used when external OCI config file provided.
+             */
+            DEFAULT,
+            /**
+             * Should be used when Helidon configuration is the source for parameters.
+             */
+            MANUAL
+        }
+
+        AuthenticationDetailsProvider configureProvider() {
+            if (configProfile == Profile.DEFAULT) {
+                ConfigFileAuthenticationDetailsProvider temp = null;
+                try {
+                    if (ociConfigPath == null) {
+                        temp = new ConfigFileAuthenticationDetailsProvider(ociAuthProfile);
+                    } else {
+                        temp = new ConfigFileAuthenticationDetailsProvider(ociConfigPath, ociAuthProfile);
+                    }
+                } catch (final IOException ioException) {
+                    temp = null;
+                } finally {
+                    return temp;
+                }
+            } else { //Should we use MANUAL here?
+                SimpleAuthenticationDetailsProvider simpleProvider =
+                        SimpleAuthenticationDetailsProvider.builder()
+                                .tenantId(ociAuthTenancy)
+                                .userId(ociAuthUser)
+                                .fingerprint(ociAuthFingerprint)
+                                .region(Region.valueOf(ociAuthRegion))
+                                .passphraseCharacters(ociAuthPassphraseCharacters.toCharArray())
+                                .privateKeySupplier(this::getPrivateKey)
+                                .build();
+                return simpleProvider;
+            }
+        }
+
+        ClientConfiguration configureClient() {
+            ClientConfiguration clientConfig
+                    = ClientConfiguration.builder()
+                    .connectionTimeoutMillis(clientConnectionTimeoutMillis)
+                    .readTimeoutMillis(clientReadTimeoutMillis)
+                    .build();
+            return clientConfig;
+        }
+
+        /**
+         * Access point to the provider.
+         *
+         * @return AuthenticationDetailsProvider as the main entry point.
+         */
+        public AuthenticationDetailsProvider getProvider() {
+            return provider;
+        }
+
+        /**
+         * Access point to the Client configuration.
+         *
+         * @return ClientConfiguration built and configured.
+         */
+        public ClientConfiguration getClientConfig() {
+            return clientConfig;
+        }
+
+        private InputStream getPrivateKey() {
+            if (ociAuthPrivateKey == null || ociAuthPrivateKey.trim().isEmpty()) {
+                final String pemFormattedPrivateKeyFilePath =
+                        Optional.ofNullable(ociAuthKeyFile)
+                                .orElse(Paths.get(System.getProperty("user.home"), ".oci/oci_api_key.pem").toString());
+                assert pemFormattedPrivateKeyFilePath != null;
+                try {
+                    return new BufferedInputStream(Files.newInputStream(Paths.get(pemFormattedPrivateKeyFilePath)));
+                } catch (final IOException ioException) {
+                    throw new RuntimeException(ioException.getMessage(), ioException);
+                }
+            } else {
+                return new BufferedInputStream(new ByteArrayInputStream(ociAuthPrivateKey.getBytes(StandardCharsets.UTF_8)));
+            }
+        }
+
+        /**
+         * OCI Auth profile.
+         *
+         * @param ociAuthProfile
+         * @return builder
+         */
+        public Builder ociAuthProfile(String ociAuthProfile) {
+            this.ociAuthProfile = ociAuthProfile;
+            return this;
+        }
+
+        /**
+         * OCI Config path.
+         *
+         * @param ociConfigPath
+         * @return builder
+         */
+        public Builder ociConfigPath(String ociConfigPath) {
+            this.ociConfigPath = ociConfigPath;
+            return this;
+        }
+
+        /**
+         * OCI Auth Fingerprint.
+         *
+         * @param ociAuthFingerprint
+         * @return builder
+         */
+        public Builder ociAuthFingerprint(String ociAuthFingerprint) {
+            this.ociAuthFingerprint = ociAuthFingerprint;
+            return this;
+        }
+
+        /**
+         * OCI Auth Passphrase Characters.
+         *
+         * @param ociAuthPassphraseCharacters
+         * @return builder
+         */
+        public Builder ociAuthPassphraseCharacters(String ociAuthPassphraseCharacters) {
+            this.ociAuthPassphraseCharacters = ociAuthPassphraseCharacters;
+            return this;
+        }
+
+        /**
+         * OCI Auth Tenancy.
+         *
+         * @param ociAuthTenancy
+         * @return builder
+         */
+        public Builder ociAuthTenancy(String ociAuthTenancy) {
+            this.ociAuthTenancy = ociAuthTenancy;
+            return this;
+        }
+
+        /**
+         *  OCI Auth User.
+         *
+         * @param ociAuthUser
+         * @return builder
+         */
+        public Builder ociAuthUser(String ociAuthUser) {
+            this.ociAuthUser = ociAuthUser;
+            return this;
+        }
+
+        /**
+         * OCI Auth Private Key.
+         *
+         * @param ociAuthPrivateKey
+         * @return builder
+         */
+        public Builder ociAuthPrivateKey(String ociAuthPrivateKey) {
+            this.ociAuthPrivateKey = ociAuthPrivateKey;
+            return this;
+        }
+
+        /**
+         * OCI Auth Key File.
+         *
+         * @param ociAuthKeyFile
+         * @return builder
+         */
+        public Builder ociAuthKeyFile(String ociAuthKeyFile) {
+            this.ociAuthKeyFile = ociAuthKeyFile;
+            return this;
+        }
+
+        /**
+         * OCI Auth Region.
+         *
+         * @param ociAuthRegion
+         * @return builder
+         */
+        public Builder ociAuthRegion(String ociAuthRegion) {
+            this.ociAuthRegion = ociAuthRegion;
+            return this;
+        }
+
+        /**
+         * Config Profile.
+         *
+         * @param configProfile
+         * @return builder
+         */
+        public Builder configProfile(Profile configProfile) {
+            this.configProfile = configProfile;
+            return this;
+        }
+
+        /**
+         * Client Connection Timeout Millis.
+         *
+         * @param clientConnectionTimeoutMillis
+         * @return builder
+         */
+        public Builder clientConnectionTimeoutMillis(int clientConnectionTimeoutMillis) {
+            this.clientConnectionTimeoutMillis = clientConnectionTimeoutMillis;
+            return this;
+        }
+
+        /**
+         * Client Read Timeout Millis.
+         *
+         * @param clientReadTimeoutMillis
+         * @return builder
+         */
+        public Builder clientReadTimeoutMillis(int clientReadTimeoutMillis) {
+            this.clientReadTimeoutMillis = clientReadTimeoutMillis;
+            return this;
+        }
+    }
+}

--- a/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciException.java
+++ b/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package io.helidon.integrations.oci;
+
+/**
+ * OCI Exception.
+ */
+public class OciException extends RuntimeException {
+    /**
+     * OCI Exception.
+     *
+     * @param s Message.
+     */
+    public OciException(String s) {
+    }
+
+    /**
+     * OCI Exception.
+     *
+     * @param message Message.
+     * @param cause The Cause.
+     */
+    public OciException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * OCI Exception.
+     * @param cause The cause.
+     */
+    public OciException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * OCI Exception.
+     * @param message Message.
+     * @param cause The Cause.
+     * @param enableSuppression if enabled.
+     * @param writableStackTrace if print stack trace.
+     */
+    protected OciException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciProducer.java
+++ b/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciProducer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import io.helidon.config.ConfigValue;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+
+/**
+ * Class OciProducer.
+ */
+@ApplicationScoped
+public class OciProducer {
+    private static final String OCI_NAME_PREFIX = "oci";
+
+    private AuthenticationDetailsProvider provider;
+    private ClientConfiguration clientConfig;
+
+    /**
+     * Creates and sets up the {@link AuthenticationDetailsProvider} and {@link ClientConfiguration}.
+     *
+     * @param config injected from the container.
+     */
+    @Inject
+    public OciProducer(io.helidon.config.Config config) {
+        ConfigValue<Oci> configValue = config.get(OCI_NAME_PREFIX).as(Oci::create);
+        if (configValue.isPresent()) {
+            provider = configValue.get().provider();
+            clientConfig = configValue.get().clientConfig();
+        } else {
+            throw new OciException("OCI cannot be properly configured!");
+        }
+    }
+
+    /**
+     * Produces {@link AuthenticationDetailsProvider}.
+     *
+     * @return provider.
+     */
+    @Produces
+    public AuthenticationDetailsProvider getProvider() {
+        return provider;
+    }
+
+    /**
+     * Produces {@link ClientConfiguration}.
+     *
+     * @return clientConfig.
+     */
+    @Produces
+    public ClientConfiguration getClientConfig() {
+        return clientConfig;
+    }
+}

--- a/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/package-info.java
+++ b/examples/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * OCI integrations for Helidon.
+ */
+package io.helidon.integrations.oci;

--- a/examples/integrations/oci/oci/src/main/java/module-info.java
+++ b/examples/integrations/oci/oci/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OCI support module.
+ */
+module io.helidon.integrations.oci {
+    requires java.logging;
+
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.interceptor.api;
+    requires io.helidon.config;
+    requires io.helidon.config.mp;
+
+    requires oci.java.sdk.common;
+    requires com.google.common;
+
+    exports io.helidon.integrations.oci;
+
+    opens io.helidon.integrations.oci to weld.core.impl, io.helidon.microprofile.cdi;
+
+}

--- a/examples/integrations/oci/oci/src/main/resources/META-INF/beans.xml
+++ b/examples/integrations/oci/oci/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/examples/integrations/oci/pom.xml
+++ b/examples/integrations/oci/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,24 +16,23 @@
     limitations under the License.
 
 -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.examples</groupId>
-        <artifactId>helidon-examples-project</artifactId>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-mp</artifactId>
         <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../../../applications/mp/pom.xml</relativePath>
     </parent>
-    <groupId>io.helidon.examples.integrations</groupId>
-    <artifactId>helidon-examples-integrations-project</artifactId>
-    <name>Helidon Integrations Examples</name>
+    <groupId>io.helidon.examples.integrations.oci</groupId>
+    <artifactId>helidon-examples-integrations-oci-project</artifactId>
+    <name>Examples for OCI integrations</name>
     <packaging>pom</packaging>
 
     <modules>
-        <module>cdi</module>
-        <module>micronaut</module>
         <module>oci</module>
+        <module>objectstorage</module>
     </modules>
-
 </project>

--- a/integrations/oci/oci-objectstorage/pom.xml
+++ b/integrations/oci/oci-objectstorage/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.integrations-oci</groupId>
+        <artifactId>helidon-integrations-oci-project</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.integrations.oci</groupId>
+    <artifactId>helidon-integrations-oci-objectstorage</artifactId>
+    <name>Helidon OCI object storage integrations</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.integrations.oci</groupId>
+            <artifactId>helidon-integrations-oci</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorage.java
+++ b/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorage.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.objectstorage;
+
+import java.util.Objects;
+
+import io.helidon.integrations.oci.OciException;
+
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+
+
+/**
+ * Class OciObjectStorage.
+ */
+public class OciObjectStorage {
+    private AuthenticationDetailsProvider authenticationDetailsProvider;
+    private ObjectStorage objectStorage;
+
+    /**
+     * Constructor for OciObjectStorage.
+     *
+     * @param builder following the builder pattern.
+     */
+    public OciObjectStorage(Builder builder) {
+        authenticationDetailsProvider = builder.authenticationDetailsProvider;
+        try {
+            objectStorage = ObjectStorageClient.builder().build(authenticationDetailsProvider);
+        } catch (BmcException e) {
+            throw new OciException("Wrong client setup", e);
+        }
+    }
+
+    /**
+     * Get the builder.
+     *
+     * @return the construction builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Get the used Authentication Details Provider.
+     *
+     * @return AuthenticationDetailsProvider.
+     */
+    public AuthenticationDetailsProvider getAuthenticationDetailsProvider() {
+        return authenticationDetailsProvider;
+    }
+
+    /**
+     * Get the set up Object Storage.
+     *
+     * @return ObjectStorage.
+     */
+    public ObjectStorage getObjectStorage() {
+        return objectStorage;
+    }
+
+    public static class Builder implements io.helidon.common.Builder<OciObjectStorage> {
+
+        private AuthenticationDetailsProvider authenticationDetailsProvider;
+
+        private Builder() {
+        }
+
+        /**
+         * Builder for the wrapper class.
+         *
+         * @return wrapper.
+         */
+        public OciObjectStorage build() {
+            Objects.requireNonNull(authenticationDetailsProvider,
+                    "Must set the Authentication Details Provider before building");
+            return new OciObjectStorage(this);
+        }
+
+        /**
+         * Submit the Authentication Details Provider.
+         *
+         * @param authenticationDetailsProvider
+         * @return Builder.
+         */
+        public Builder authenticationDetailsProvider(AuthenticationDetailsProvider authenticationDetailsProvider) {
+            this.authenticationDetailsProvider = authenticationDetailsProvider;
+            return this;
+        }
+    }
+}

--- a/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorageProducer.java
+++ b/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorageProducer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci.objectstorage;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+
+
+/**
+ * Class OciObjectStorageProduced.
+ */
+@ApplicationScoped
+public class OciObjectStorageProducer {
+
+    private ObjectStorage objectStorage;
+
+    /**
+     * Constructor for Object Storage.
+     *
+     * @param authenticationDetailsProvider from CDI environment
+     */
+    @Inject
+    public OciObjectStorageProducer(AuthenticationDetailsProvider authenticationDetailsProvider) {
+        this.objectStorage = OciObjectStorage.builder()
+                .authenticationDetailsProvider(authenticationDetailsProvider)
+                .build()
+                .getObjectStorage();
+    }
+
+    /**
+     * Produces Object storage in CDI environment.
+     *
+     * @return the ObjectStorage.
+     */
+    @Produces
+    public ObjectStorage getObjectStorage() {
+        return objectStorage;
+    }
+}

--- a/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/package-info.java
+++ b/integrations/oci/oci-objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * OCI integrations for Helidon.
+ */
+package io.helidon.integrations.oci.objectstorage;

--- a/integrations/oci/oci-objectstorage/src/main/java/module-info.java
+++ b/integrations/oci/oci-objectstorage/src/main/java/module-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OCI Objectstoragesupport module.
+ */
+module io.helidon.integrations.oci.objectstorage {
+    requires java.logging;
+
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.interceptor.api;
+    requires io.helidon.config;
+    requires io.helidon.config.mp;
+
+    requires oci.java.sdk.common;
+    requires com.google.common;
+    requires oci.java.sdk.objectstorage.generated;
+    requires io.helidon.integrations.oci;
+
+    exports io.helidon.integrations.oci.objectstorage;
+
+    opens io.helidon.integrations.oci.objectstorage to weld.core.impl, io.helidon.microprofile.cdi;
+}

--- a/integrations/oci/oci-objectstorage/src/main/resources/META-INF/beans.xml
+++ b/integrations/oci/oci-objectstorage/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/integrations/oci/oci/pom.xml
+++ b/integrations/oci/oci/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.integrations-oci</groupId>
+        <artifactId>helidon-integrations-oci-project</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.integrations.oci</groupId>
+    <artifactId>helidon-integrations-oci</artifactId>
+    <name>Helidon OCI base integrations</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-identity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/Oci.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/Oci.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package io.helidon.integrations.oci;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+
+import io.helidon.config.Config;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+
+
+/**
+ * OCI support for Helidon.
+ */
+public class Oci {
+
+    private AuthenticationDetailsProvider provider;
+    private ClientConfiguration clientConfig;
+
+    private Oci() {
+        //private constructor
+    }
+
+    private Oci(Builder builder) {
+        provider = builder.configureProvider();
+        clientConfig = builder.getClientConfig();
+    }
+
+    /**
+     * The OCI create method.
+     *
+     * @param config from SE.
+     * @return using builder pattern.
+     */
+    public static Oci create(Config config) {
+        return builder().config(config).build();
+    }
+
+    /**
+     * Get the registered provider.
+     *
+     * @return AuthenticationDetailsProvider.
+     */
+    public AuthenticationDetailsProvider provider() {
+        return provider;
+    }
+
+    /**
+     * Get the Configured client.
+     *
+     * @return ClientConfiguration.
+     */
+    public ClientConfiguration clientConfig() {
+        return clientConfig;
+    }
+
+    /**
+     * Access to Builder.
+     *
+     * @return The Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    /**
+     * Builder for {@link Oci}.
+     */
+    public static final class Builder implements io.helidon.common.Builder<Oci> {
+
+        private AuthenticationDetailsProvider provider;
+        private ClientConfiguration clientConfig;
+
+        private String ociAuthProfile;
+        private String ociConfigPath;
+
+        private String ociAuthFingerprint;
+        private String ociAuthPassphraseCharacters;
+        private String ociAuthTenancy;
+        private String ociAuthUser;
+        private String ociAuthPrivateKey;
+        private String ociAuthKeyFile;
+        private String ociAuthRegion;
+
+        private Profile configProfile;
+
+        private int clientConnectionTimeoutMillis = 3000;
+        private int clientReadTimeoutMillis = 60000;
+
+        /**
+         * Build the OCI support.
+         *
+         * @return
+         */
+        @Override
+        public Oci build() {
+            provider = configureProvider();
+            clientConfig = configureClient();
+            return new Oci(this);
+        }
+
+        /**
+         * Read the configuration.
+         *
+         * @param config
+         * @return builder
+         */
+        public Builder config(Config config) {
+            config.get("config.profile").as(Profile.class).ifPresent(this::configProfile);
+            config.get("auth.profile").asString().ifPresent(this::ociAuthProfile);
+            config.get("config.path").asString().ifPresent(this::ociConfigPath);
+            config.get("auth.fingerprint").asString().ifPresent(this::ociAuthFingerprint);
+            config.get("auth.passphrase.characters").asString().ifPresent(this::ociAuthPassphraseCharacters);
+            config.get("auth.tenancy").asString().ifPresent(this::ociAuthTenancy);
+            config.get("auth.user").asString().ifPresent(this::ociAuthUser);
+            config.get("auth.private.key").asString().ifPresent(this::ociAuthPrivateKey);
+            config.get("auth.keyFile").asString().ifPresent(this::ociAuthKeyFile);
+            config.get("auth.region").asString().ifPresent(this::ociAuthRegion);
+
+            config.get("client.connectionTimeoutMillis").asInt().ifPresent(this::clientConnectionTimeoutMillis);
+            config.get("client.readTimeoutMillis").asInt().ifPresent(this::clientReadTimeoutMillis);
+
+            return this;
+        }
+
+        /**
+         * Configuration profile.
+         */
+        public enum Profile {
+            /**
+             * Should be used when external OCI config file provided.
+             */
+            DEFAULT,
+            /**
+             * Should be used when Helidon configuration is the source for parameters.
+             */
+            MANUAL
+        }
+
+        AuthenticationDetailsProvider configureProvider() {
+            if (configProfile == Profile.DEFAULT) {
+                ConfigFileAuthenticationDetailsProvider temp = null;
+                try {
+                    if (ociConfigPath == null) {
+                        temp = new ConfigFileAuthenticationDetailsProvider(ociAuthProfile);
+                    } else {
+                        temp = new ConfigFileAuthenticationDetailsProvider(ociConfigPath, ociAuthProfile);
+                    }
+                } catch (final IOException ioException) {
+                    temp = null;
+                } finally {
+                    return temp;
+                }
+            } else { //Should we use MANUAL here?
+                SimpleAuthenticationDetailsProvider simpleProvider =
+                        SimpleAuthenticationDetailsProvider.builder()
+                                .tenantId(ociAuthTenancy)
+                                .userId(ociAuthUser)
+                                .fingerprint(ociAuthFingerprint)
+                                .region(Region.valueOf(ociAuthRegion))
+                                .passphraseCharacters(ociAuthPassphraseCharacters.toCharArray())
+                                .privateKeySupplier(this::getPrivateKey)
+                                .build();
+                return simpleProvider;
+            }
+        }
+
+        ClientConfiguration configureClient() {
+            ClientConfiguration clientConfig
+                    = ClientConfiguration.builder()
+                    .connectionTimeoutMillis(clientConnectionTimeoutMillis)
+                    .readTimeoutMillis(clientReadTimeoutMillis)
+                    .build();
+            return clientConfig;
+        }
+
+        /**
+         * Access point to the provider.
+         *
+         * @return AuthenticationDetailsProvider as the main entry point.
+         */
+        public AuthenticationDetailsProvider getProvider() {
+            return provider;
+        }
+
+        /**
+         * Access point to the Client configuration.
+         *
+         * @return ClientConfiguration built and configured.
+         */
+        public ClientConfiguration getClientConfig() {
+            return clientConfig;
+        }
+
+        private InputStream getPrivateKey() {
+            if (ociAuthPrivateKey == null || ociAuthPrivateKey.trim().isEmpty()) {
+                final String pemFormattedPrivateKeyFilePath =
+                        Optional.ofNullable(ociAuthKeyFile)
+                                .orElse(Paths.get(System.getProperty("user.home"), ".oci/oci_api_key.pem").toString());
+                assert pemFormattedPrivateKeyFilePath != null;
+                try {
+                    return new BufferedInputStream(Files.newInputStream(Paths.get(pemFormattedPrivateKeyFilePath)));
+                } catch (final IOException ioException) {
+                    throw new RuntimeException(ioException.getMessage(), ioException);
+                }
+            } else {
+                return new BufferedInputStream(new ByteArrayInputStream(ociAuthPrivateKey.getBytes(StandardCharsets.UTF_8)));
+            }
+        }
+
+        /**
+         * OCI Auth profile.
+         *
+         * @param ociAuthProfile
+         * @return builder
+         */
+        public Builder ociAuthProfile(String ociAuthProfile) {
+            this.ociAuthProfile = ociAuthProfile;
+            return this;
+        }
+
+        /**
+         * OCI Config path.
+         *
+         * @param ociConfigPath
+         * @return builder
+         */
+        public Builder ociConfigPath(String ociConfigPath) {
+            this.ociConfigPath = ociConfigPath;
+            return this;
+        }
+
+        /**
+         * OCI Auth Fingerprint.
+         *
+         * @param ociAuthFingerprint
+         * @return builder
+         */
+        public Builder ociAuthFingerprint(String ociAuthFingerprint) {
+            this.ociAuthFingerprint = ociAuthFingerprint;
+            return this;
+        }
+
+        /**
+         * OCI Auth Passphrase Characters.
+         *
+         * @param ociAuthPassphraseCharacters
+         * @return builder
+         */
+        public Builder ociAuthPassphraseCharacters(String ociAuthPassphraseCharacters) {
+            this.ociAuthPassphraseCharacters = ociAuthPassphraseCharacters;
+            return this;
+        }
+
+        /**
+         * OCI Auth Tenancy.
+         *
+         * @param ociAuthTenancy
+         * @return builder
+         */
+        public Builder ociAuthTenancy(String ociAuthTenancy) {
+            this.ociAuthTenancy = ociAuthTenancy;
+            return this;
+        }
+
+        /**
+         *  OCI Auth User.
+         *
+         * @param ociAuthUser
+         * @return builder
+         */
+        public Builder ociAuthUser(String ociAuthUser) {
+            this.ociAuthUser = ociAuthUser;
+            return this;
+        }
+
+        /**
+         * OCI Auth Private Key.
+         *
+         * @param ociAuthPrivateKey
+         * @return builder
+         */
+        public Builder ociAuthPrivateKey(String ociAuthPrivateKey) {
+            this.ociAuthPrivateKey = ociAuthPrivateKey;
+            return this;
+        }
+
+        /**
+         * OCI Auth Key File.
+         *
+         * @param ociAuthKeyFile
+         * @return builder
+         */
+        public Builder ociAuthKeyFile(String ociAuthKeyFile) {
+            this.ociAuthKeyFile = ociAuthKeyFile;
+            return this;
+        }
+
+        /**
+         * OCI Auth Region.
+         *
+         * @param ociAuthRegion
+         * @return builder
+         */
+        public Builder ociAuthRegion(String ociAuthRegion) {
+            this.ociAuthRegion = ociAuthRegion;
+            return this;
+        }
+
+        /**
+         * Config Profile.
+         *
+         * @param configProfile
+         * @return builder
+         */
+        public Builder configProfile(Profile configProfile) {
+            this.configProfile = configProfile;
+            return this;
+        }
+
+        /**
+         * Client Connection Timeout Millis.
+         *
+         * @param clientConnectionTimeoutMillis
+         * @return builder
+         */
+        public Builder clientConnectionTimeoutMillis(int clientConnectionTimeoutMillis) {
+            this.clientConnectionTimeoutMillis = clientConnectionTimeoutMillis;
+            return this;
+        }
+
+        /**
+         * Client Read Timeout Millis.
+         *
+         * @param clientReadTimeoutMillis
+         * @return builder
+         */
+        public Builder clientReadTimeoutMillis(int clientReadTimeoutMillis) {
+            this.clientReadTimeoutMillis = clientReadTimeoutMillis;
+            return this;
+        }
+    }
+}

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciException.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package io.helidon.integrations.oci;
+
+/**
+ * OCI Exception.
+ */
+public class OciException extends RuntimeException {
+    /**
+     * OCI Exception.
+     *
+     * @param s Message.
+     */
+    public OciException(String s) {
+    }
+
+    /**
+     * OCI Exception.
+     *
+     * @param message Message.
+     * @param cause The Cause.
+     */
+    public OciException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * OCI Exception.
+     * @param cause The cause.
+     */
+    public OciException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * OCI Exception.
+     * @param message Message.
+     * @param cause The Cause.
+     * @param enableSuppression if enabled.
+     * @param writableStackTrace if print stack trace.
+     */
+    protected OciException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciProducer.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/OciProducer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.integrations.oci;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import io.helidon.config.ConfigValue;
+
+import com.oracle.bmc.ClientConfiguration;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+
+/**
+ * Class OciProducer.
+ */
+@ApplicationScoped
+public class OciProducer {
+    private static final String OCI_NAME_PREFIX = "oci";
+
+    private AuthenticationDetailsProvider provider;
+    private ClientConfiguration clientConfig;
+
+    /**
+     * Creates and sets up the {@link AuthenticationDetailsProvider} and {@link ClientConfiguration}.
+     *
+     * @param config injected from the container.
+     */
+    @Inject
+    public OciProducer(io.helidon.config.Config config) {
+        ConfigValue<Oci> configValue = config.get(OCI_NAME_PREFIX).as(Oci::create);
+        if (configValue.isPresent()) {
+            provider = configValue.get().provider();
+            clientConfig = configValue.get().clientConfig();
+        } else {
+            throw new OciException("OCI cannot be properly configured!");
+        }
+    }
+
+    /**
+     * Produces {@link AuthenticationDetailsProvider}.
+     *
+     * @return provider.
+     */
+    @Produces
+    public AuthenticationDetailsProvider getProvider() {
+        return provider;
+    }
+
+    /**
+     * Produces {@link ClientConfiguration}.
+     *
+     * @return clientConfig.
+     */
+    @Produces
+    public ClientConfiguration getClientConfig() {
+        return clientConfig;
+    }
+}

--- a/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/package-info.java
+++ b/integrations/oci/oci/src/main/java/io/helidon/integrations/oci/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * OCI integrations for Helidon.
+ */
+package io.helidon.integrations.oci;

--- a/integrations/oci/oci/src/main/java/module-info.java
+++ b/integrations/oci/oci/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OCI support module.
+ */
+module io.helidon.integrations.oci {
+    requires java.logging;
+
+    requires static jakarta.enterprise.cdi.api;
+    requires static jakarta.inject.api;
+    requires static jakarta.interceptor.api;
+    requires io.helidon.config;
+    requires io.helidon.config.mp;
+
+    requires oci.java.sdk.common;
+    requires com.google.common;
+
+    exports io.helidon.integrations.oci;
+
+    opens io.helidon.integrations.oci to weld.core.impl, io.helidon.microprofile.cdi;
+
+}

--- a/integrations/oci/oci/src/main/resources/META-INF/beans.xml
+++ b/integrations/oci/oci/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/integrations/oci/pom.xml
+++ b/integrations/oci/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,24 +16,23 @@
     limitations under the License.
 
 -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>io.helidon.examples</groupId>
-        <artifactId>helidon-examples-project</artifactId>
+        <groupId>io.helidon.integrations</groupId>
+        <artifactId>helidon-integrations-project</artifactId>
         <version>2.3.0-SNAPSHOT</version>
     </parent>
-    <groupId>io.helidon.examples.integrations</groupId>
-    <artifactId>helidon-examples-integrations-project</artifactId>
-    <name>Helidon Integrations Examples</name>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.integrations-oci</groupId>
+    <artifactId>helidon-integrations-oci-project</artifactId>
     <packaging>pom</packaging>
+    <name>Helidon OCI Integrations</name>
 
     <modules>
-        <module>cdi</module>
-        <module>micronaut</module>
         <module>oci</module>
+        <module>oci-objectstorage</module>
     </modules>
-
 </project>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -44,6 +44,7 @@
         <module>graal</module>
         <module>db</module>
         <module>micronaut</module>
+        <module>oci</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This is the initial proposal for Helidon OCI integration, based on OCI SDK.
The integration works for both SE and MP.

Currently the main entry point for OCI is the configured via AuthenticationDetailsProvider.
The configuration can be obtained via standard Helidon SE and MP config.

There are three ways to configure the provider:

Default: the OCI configuration will will be looked up and loaded from ~/.oci/config
Path: specify path of the OCI config file, load the location from the file specified.
Direct properties in microprofile-config.properties or application.yaml under "oci." key.
In current PR "default" and "direct" properties examples are provided.

Since OCI SDK is a vast library, still AuthenticationDetailsProvider is the main entry point. Another SDKs parts may be integrated in even more tight way.

In the current PR OciObjectStorage support is implemented and examples provided.
For MP ObjectStorage may be directly injected. For SE OciObjectStorage object is provided