### PR TITLE
Avoid NaN values causing problems in metrics output

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,6 +185,9 @@ class ExponentiallyDecayingReservoir {
                         final WeightedSnapshot.WeightedSample sample = values.remove(key);
                         final WeightedSnapshot.WeightedSample newSample = new WeightedSnapshot.WeightedSample(sample.getValue(),
                                                                                                               sample.getWeight() * scalingFactor);
+                        if (Double.compare(newSample.getWeight(), 0) == 0) {
+                            continue;
+                        }
                         values.put(key * scalingFactor, newSample);
                     }
                 }

--- a/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/HelidonTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -287,7 +287,7 @@ final class HelidonTimer extends MetricImpl implements Timer {
             this.histogram = HelidonHistogram.create(repoType, Metadata.builder()
                     .withName(name)
                     .withType(MetricType.HISTOGRAM)
-                    .build());
+                    .build(), clock);
             this.clock = clock;
         }
 

--- a/metrics/metrics/src/main/java/io/helidon/metrics/WeightedSnapshot.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/WeightedSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,11 @@ class WeightedSnapshot extends Snapshot {
 
         for (int i = 0; i < copy.length; i++) {
             this.values[i] = copy[i].value;
-            this.normWeights[i] = copy[i].weight / sumWeight;
+            /*
+             * A zero denominator could cause the resulting double to be infinity or, if the numerator is also 0,
+             * NaN. Either causes problems when formatting for JSON output. Just use 0 instead.
+             */
+            this.normWeights[i] = sumWeight != 0 ? copy[i].weight / sumWeight : 0;
         }
 
         for (int i = 1; i < copy.length; i++) {

--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonHistogramTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 
+import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricType;
@@ -43,6 +44,8 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.metrics.HelidonMetricsMatcher.withinTolerance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -225,6 +228,27 @@ class HelidonHistogramTest {
         testSnapshot(1, "delegating integers", delegatingHistoInt.getSnapshot(), 50.6, 29.4389);
         testSnapshot(10, "longs", histoLong.getSnapshot(), 506.3, 294.389);
         testSnapshot(10, "delegating longs", delegatingHistoLong.getSnapshot(), 506.3, 294.389);
+    }
+
+    @Test
+    void testNaNAvoidance() {
+        Metadata metadata = Metadata.builder()
+                .withName("long_idle_test")
+                .withDisplayName("theDisplayName")
+                .withDescription("Simulates a long idle period")
+                .withType(MetricType.HISTOGRAM)
+                .withUnit(MetricUnits.SECONDS)
+                .build();
+        TestClock testClock = TestClock.create();
+        Histogram idleHistogram = HelidonHistogram.create("application", metadata, testClock);
+
+        idleHistogram.update(100);
+
+        for (int i = 1; i < 48; i++) {
+            testClock.add(1, TimeUnit.HOURS);
+            assertThat("Idle histogram failed after simulating " + i + " hours", idleHistogram.getSnapshot().getMean(),
+                    not(equalTo(Double.NaN)));
+        }
     }
 
     private void testSnapshot(int factor, String description, Snapshot snapshot, double mean, double stddev) {

--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonTimerTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,5 +220,24 @@ class HelidonTimerTest {
                                                           + "# HELP application_response_time_seconds Server response time for "
                                                           + "/index.html\n"
                                                           + "application_response_time_seconds_count 200"));
+    }
+
+    @Test
+    void testNaNAvoidance() {
+        TestClock testClock = TestClock.create();
+        HelidonTimer helidonTimer = HelidonTimer.create("application", meta, testClock);
+        MetricID metricID = new MetricID("idleTimer");
+
+        JsonObjectBuilder builder = MetricImpl.JSON.createObjectBuilder();
+        helidonTimer.update(1L, TimeUnit.MILLISECONDS);
+
+        for (int i = 1; i < 48; i++) {
+            testClock.add(1L, TimeUnit.HOURS);
+            try {
+                helidonTimer.jsonData(builder, metricID);
+            } catch (Throwable t) {
+                fail("Failed after simulating " + i + " hours");
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #464 

Long-running but very low (i.e., no) traffic servers would report problems when formatting timer output in JSON because there would be cases in which a `double` would be computed by dividing 0 by 0, yielding `Double.NaN`. 

This 0-by-0 division can occur when an underlying data structure used by the timer (and histogram) accumulates samples with zero weight and then attempts to compute the relative weight of one of those samples. That weight is zero, the total weight is zero, and the relative weight division results in `NaN`.

JSON formats a double value by converting it to a string and then converting the string as a `BigDecimal`. `BigDecimal` rejects this when the string is `NaN`, and that's the exception at the root of the stack trace.

The changes in this PR avoid storing samples in the underlying data structure that have no weight (and would not factor in any statistics anyway).

In the course of working on this, I found and fixed a bug unrelated to the problem. (The timer implementation accepts a clock, as does the histogram implementation. The timer delegates some work to a histogram but was not initializing the histogram with the same clock the timer itself uses. This caused several minutes of frustration in trying to create a timer-based test using a clock which the test artificially advances over several hours.)

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>