### PR TITLE
1.4: Revert "Force upgrade of thirft transitive dependency. Upgrade OWASP …

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -39,7 +39,7 @@
         <version.lib.activation-api>1.2.0</version.lib.activation-api>
         <version.lib.annotation-api>1.3.1</version.lib.annotation-api>
         <version.lib.apache-httpclient>4.5.13</version.lib.apache-httpclient>
-        <version.lib.apache-thrift>0.14.0</version.lib.apache-thrift>
+        <version.lib.apache-thrift>0.13.0</version.lib.apache-thrift>
         <version.lib.brave-opentracing>0.35.0</version.lib.brave-opentracing>
         <version.lib.cdi-api>2.0</version.lib.cdi-api>
         <version.lib.eclipselink>2.7.5</version.lib.eclipselink>
@@ -149,13 +149,6 @@
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
                 <version>${version.lib.apache-thrift}</version>
-                <!-- This is a test dependency. Get it out of here -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.tomcat.embed</groupId>
-                        <artifactId>tomcat-embed-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.plugin.spotbugs>3.1.12</version.plugin.spotbugs>
         <version.plugin.surefire.provider.junit>1.0.3</version.plugin.surefire.provider.junit>
         <version.plugin.surefire>2.19.1</version.plugin.surefire>
-        <version.plugin.dependency-check>6.1.1</version.plugin.dependency-check>
+        <version.plugin.dependency-check>6.0.2</version.plugin.dependency-check>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>


### PR DESCRIPTION
…plugin. (#2813)"

This reverts commit b673bb1674b4be1a86e24a33a222cbbbbf6e07b0.

libthrift introduced an incompatibility in 0.14.0. This was caught by a test in 2.x (see comments in PR #2814). So we need to stay with 0.13.0 until a new version of jaegertracing is released.
