### PR TITLE
Remove need to instantiate Application classes twice for OpenAPI support

### DIFF
--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -45,7 +45,7 @@ import org.jboss.jandex.IndexView;
 /**
  * Fluent builder for OpenAPISupport in Helidon MP.
  */
-public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPISupport, MPOpenAPIBuilder> {
+public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPIBuilder> {
 
     private static final Logger LOGGER = Logger.getLogger(MPOpenAPIBuilder.class.getName());
 

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019,2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.enterprise.inject.spi.CDI;
-import javax.enterprise.inject.spi.Unmanaged;
 import javax.ws.rs.core.Application;
 
 import io.helidon.microprofile.server.JaxRsApplication;
@@ -43,12 +45,23 @@ import org.jboss.jandex.IndexView;
 /**
  * Fluent builder for OpenAPISupport in Helidon MP.
  */
-public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
+public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPISupport, MPOpenAPIBuilder> {
+
+    private static final Logger LOGGER = Logger.getLogger(MPOpenAPIBuilder.class.getName());
 
     private Optional<OpenApiConfig> openAPIConfig;
-    private Optional<IndexView> indexView;
-    private List<FilteredIndexView> perAppFilteredIndexViews = null;
+
+    /*
+     * Provided by the OpenAPI CDI extension for retrieving a single IndexView of all scanned types for the single-app or
+     * synthetic app cases.
+     */
+    private Supplier<? extends IndexView> singleIndexViewSupplier = null;
+
     private Config mpConfig;
+
+    protected MPOpenAPIBuilder() {
+        super(MPOpenAPIBuilder.class);
+    }
 
     @Override
     public OpenApiConfig openAPIConfig() {
@@ -56,11 +69,10 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
     }
 
     @Override
-    public synchronized List<FilteredIndexView> perAppFilteredIndexViews() {
-        if (perAppFilteredIndexViews == null) {
-            perAppFilteredIndexViews = buildPerAppFilteredIndexViews();
-        }
-        return perAppFilteredIndexViews;
+    public MPOpenAPISupport build() {
+        MPOpenAPISupport result = new MPOpenAPISupport(this);
+        validate();
+        return result;
     }
 
     /**
@@ -84,12 +96,6 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
 
     private List<FilteredIndexView> buildPerAppFilteredIndexViews() {
         /*
-         * There are two cases that return a default filtered index view. Don't create it yet, just declare a supplier for it.
-         */
-        Supplier<List<FilteredIndexView>> defaultResultSupplier = () -> List.of(new FilteredIndexView(indexView.get(),
-                openAPIConfig.get()));
-
-        /*
          * Some JaxRsApplication instances might have an application instance already associated with them. Others might not in
          * which case we'll try to instantiate them ourselves (unless they are synthetic apps or lack no-args constructors).
          *
@@ -111,7 +117,7 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
              * Use normal scanning with a FilteredIndexView containing no class restrictions (beyond what might already be in
              * the configuration).
              */
-            return defaultResultSupplier.get();
+            return List.of(new FilteredIndexView(singleIndexViewSupplier.get(), openAPIConfig.get()));
         }
         return appClassesToScan.stream()
                 .map(this::appRelatedClassesToFilteredIndexView)
@@ -125,9 +131,9 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
     /**
      * Returns the classes that should be scanned for the given JAX-RS application.
      * <p>
-     *     If there is already a pre-existing {@code Application} instance for the JAX-RS application, then
-     *     use it to invoke {@code getClasses} and {@code getSingletons}. Otherwise use CDI to create
-     *     an unmanaged instance of the {@code Application}, then invoke those methods, then dispose of the unmanaged instance.
+     *     This should always run after the server has instantiated the {@code Application}
+     *     instance for each JAX-RS application, so we just
+     *     use it to invoke {@code getClasses} and {@code getSingletons}.
      * </p>
      * @param jaxRsApplication
      * @return Set of classes to be scanned for annotations related to OpenAPI
@@ -145,15 +151,8 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
         if (app != null) {
             result.addAll(classesToScanForAppInstance(app));
         } else {
-            Unmanaged<? extends Application> unmanagedApp = new Unmanaged<>(appClass);
-            Unmanaged.UnmanagedInstance<? extends Application> unmanagedInstance = unmanagedApp.newInstance();
-            app = unmanagedInstance.produce()
-                    .inject()
-                    .postConstruct()
-                    .get();
-            result.addAll(classesToScanForAppInstance(app));
-            unmanagedInstance.preDestroy()
-                    .dispose();
+            LOGGER.log(Level.WARNING, String.format("Expected application instance not created yet for %s",
+                    appClass.getName()));
         }
         return result;
     }
@@ -183,7 +182,7 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
                 .map(Class::getName)
                 .forEach(scanClasses::add);
 
-        FilteredIndexView result = new FilteredIndexView(indexView.get(), openAPIFilteringConfig);
+        FilteredIndexView result = new FilteredIndexView(singleIndexViewSupplier.get(), openAPIFilteringConfig);
         return result;
     }
 
@@ -205,23 +204,23 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder {
         return this;
     }
 
-    /**
-     * Sets the IndexView instance to be passed to the smallrye OpenApi impl for
-     * annotation analysis.
-     *
-     * @param indexView {@link IndexView} instance containing endpoint classes
-     * @return updated builder instance
-     */
-    public MPOpenAPIBuilder indexView(IndexView indexView) {
-        this.indexView = Optional.of(indexView);
+    MPOpenAPIBuilder singleIndexViewSupplier(Supplier<? extends IndexView> singleIndexViewSupplier) {
+        this.singleIndexViewSupplier = singleIndexViewSupplier;
         return this;
     }
 
     @Override
+    protected Supplier<List<? extends IndexView>> indexViewsSupplier() {
+        return () -> buildPerAppFilteredIndexViews();
+    }
+
+    @Override
     public void validate() throws IllegalStateException {
+        super.validate();
         if (!openAPIConfig.isPresent()) {
             throw new IllegalStateException("OpenApiConfig has not been set in MPBuilder");
         }
+        Objects.requireNonNull(singleIndexViewSupplier, "singleIndexViewSupplier must be set but was not");
     }
 
 }

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPISupport.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPISupport.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.openapi;
+
+import io.helidon.openapi.OpenAPISupport;
+
+/**
+ * MP variant of OpenAPISupport.
+ */
+class MPOpenAPISupport extends OpenAPISupport<MPOpenAPISupport, MPOpenAPIBuilder> {
+
+    protected MPOpenAPISupport(Builder builder) {
+        super(builder);
+    }
+
+    // For visibility to the CDI extension
+    @Override
+    protected void prepareModel() {
+        super.prepareModel();
+    }
+}

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPISupport.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPISupport.java
@@ -21,9 +21,9 @@ import io.helidon.openapi.OpenAPISupport;
 /**
  * MP variant of OpenAPISupport.
  */
-class MPOpenAPISupport extends OpenAPISupport<MPOpenAPISupport, MPOpenAPIBuilder> {
+class MPOpenAPISupport extends OpenAPISupport {
 
-    protected MPOpenAPISupport(Builder builder) {
+    protected MPOpenAPISupport(MPOpenAPIBuilder builder) {
         super(builder);
     }
 

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -144,7 +144,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
     private final OpenApiStaticFile openApiStaticFile;
     private final Supplier<List<? extends IndexView>> indexViewsSupplier;
 
-    protected OpenAPISupport(Builder builder) {
+    protected OpenAPISupport(Builder<T, B> builder) {
         adjustTypeDescriptions(helper().types());
         implsToTypes = buildImplsToTypes(helper());
         webContext = builder.webContext();
@@ -614,7 +614,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      *
      * @return new Builder
      */
-    public static Builder builder() {
+    public static SEOpenAPISupportBuilder builder() {
         return builderSE();
     }
 
@@ -623,7 +623,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      *
      * @return new OpenAPISUpport
      */
-    public static OpenAPISupport create() {
+    public static OpenAPISupport<?, ?> create() {
         return builderSE().build();
     }
 
@@ -636,7 +636,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      * @return new {@code OpenAPISupport} instance created using the
      * helidonConfig settings
      */
-    public static OpenAPISupport create(Config config) {
+    public static OpenAPISupport<?, ?> create(Config config) {
         return builderSE().config(config).build();
     }
 
@@ -661,7 +661,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      * @param <B> concrete subclass of OpenAPISupport.Builder
      */
     public abstract static class Builder<T extends OpenAPISupport<T, B>, B extends Builder<T, B>>
-            implements io.helidon.common.Builder<OpenAPISupport> {
+            implements io.helidon.common.Builder<T> {
 
         /**
          * Config key to select the openapi node from Helidon config.
@@ -681,9 +681,6 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
         protected B me() {
             return builderClass.cast(this);
         }
-
-        @Override
-        public abstract T build();
 
         /**
          * Set various builder attributes from the specified {@code Config} object.

--- a/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/OpenAPISupport.java
@@ -95,10 +95,8 @@ import static io.helidon.webserver.cors.CorsEnabledServiceHelper.CORS_CONFIG_KEY
  * {@code openapi} file, then the {@code /openapi} endpoint responds with a
  * nearly-empty OpenAPI document.
  *
- * @param <T> concrete subclass which extends OpenAPISupport
- * @param <B> concrete builder subclass which extends OpenAPISupport.Builder
  */
-public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends OpenAPISupport.Builder<T, B>> implements Service {
+public abstract class OpenAPISupport implements Service {
 
     /**
      * Default path for serving the OpenAPI document.
@@ -144,7 +142,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
     private final OpenApiStaticFile openApiStaticFile;
     private final Supplier<List<? extends IndexView>> indexViewsSupplier;
 
-    protected OpenAPISupport(Builder<T, B> builder) {
+    protected OpenAPISupport(Builder<?> builder) {
         adjustTypeDescriptions(helper().types());
         implsToTypes = buildImplsToTypes(helper());
         webContext = builder.webContext();
@@ -623,7 +621,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      *
      * @return new OpenAPISUpport
      */
-    public static OpenAPISupport<?, ?> create() {
+    public static OpenAPISupport create() {
         return builderSE().build();
     }
 
@@ -636,7 +634,7 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      * @return new {@code OpenAPISupport} instance created using the
      * helidonConfig settings
      */
-    public static OpenAPISupport<?, ?> create(Config config) {
+    public static OpenAPISupport create(Config config) {
         return builderSE().config(config).build();
     }
 
@@ -657,11 +655,9 @@ public abstract class OpenAPISupport<T extends OpenAPISupport<T, B>, B extends O
      * service. This lets us constrain what use cases are possible from each
      * (for example, no anno processing from SE).
      *
-     * @param <T> concrete subclass of OpenAPISupport
      * @param <B> concrete subclass of OpenAPISupport.Builder
      */
-    public abstract static class Builder<T extends OpenAPISupport<T, B>, B extends Builder<T, B>>
-            implements io.helidon.common.Builder<T> {
+    public abstract static class Builder<B extends Builder<B>> implements io.helidon.common.Builder<OpenAPISupport> {
 
         /**
          * Config key to select the openapi node from Helidon config.

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupport.java
@@ -19,7 +19,7 @@ package io.helidon.openapi;
 /**
  * SE variant of OpenAPISupport.
  */
-class SEOpenAPISupport extends OpenAPISupport<SEOpenAPISupport, SEOpenAPISupportBuilder> {
+class SEOpenAPISupport extends OpenAPISupport {
 
     SEOpenAPISupport(SEOpenAPISupportBuilder builder) {
         super(builder);

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupport.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupport.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.openapi;
+
+/**
+ * SE variant of OpenAPISupport.
+ */
+class SEOpenAPISupport extends OpenAPISupport<SEOpenAPISupport, SEOpenAPISupportBuilder> {
+
+    SEOpenAPISupport(SEOpenAPISupportBuilder builder) {
+        super(builder);
+    }
+}

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,12 @@
  */
 package io.helidon.openapi;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 import io.helidon.config.Config;
 import io.helidon.openapi.internal.OpenAPIConfigImpl;
 
 import io.smallrye.openapi.api.OpenApiConfig;
-import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
 
 /**
  * Builds {@link OpenAPISupport} in a Helidon SE environment.
@@ -34,9 +31,13 @@ import io.smallrye.openapi.runtime.scanner.FilteredIndexView;
  * {@link OpenApiConfig} which is what the smallrye implementation uses to
  * control its behavior.
  */
-public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder {
+public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder<SEOpenAPISupport, SEOpenAPISupportBuilder> {
 
     private final OpenAPIConfigImpl.Builder apiConfigBuilder = OpenAPIConfigImpl.builder();
+
+    protected SEOpenAPISupportBuilder() {
+        super(SEOpenAPISupportBuilder.class);
+    }
 
     /**
      * Set various builder attributes from the specified openapi {@code Config} object.
@@ -55,13 +56,20 @@ public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder {
     }
 
     @Override
-    public OpenApiConfig openAPIConfig() {
-        return apiConfigBuilder.build();
+    public SEOpenAPISupport build() {
+        SEOpenAPISupport result = new SEOpenAPISupport(this);
+        /*
+         * In the SE case we can prepare the model immediately. In MP, we must defer this until the server has created the
+         * Application instances.
+         */
+        validate();
+        result.prepareModel();
+        return result;
     }
 
     @Override
-    public List<FilteredIndexView> perAppFilteredIndexViews() {
-        return Collections.emptyList();
+    public OpenApiConfig openAPIConfig() {
+        return apiConfigBuilder.build();
     }
 
     /**

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
@@ -31,7 +31,7 @@ import io.smallrye.openapi.api.OpenApiConfig;
  * {@link OpenApiConfig} which is what the smallrye implementation uses to
  * control its behavior.
  */
-public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder<SEOpenAPISupport, SEOpenAPISupportBuilder> {
+public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder<SEOpenAPISupportBuilder> {
 
     private final OpenAPIConfigImpl.Builder apiConfigBuilder = OpenAPIConfigImpl.builder();
 

--- a/openapi/src/test/java/io/helidon/openapi/ServerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerTest.java
@@ -53,13 +53,13 @@ public class ServerTest {
     private static final Config OPENAPI_CONFIG_RESTRICTED_CORS = Config.create(
             ConfigSources.classpath("serverCORSRestricted.yaml").build()).get(OpenAPISupport.Builder.CONFIG_KEY);
 
-    static final OpenAPISupport.Builder GREETING_OPENAPI_SUPPORT_BUILDER
+    static final OpenAPISupport.Builder<?> GREETING_OPENAPI_SUPPORT_BUILDER
             = OpenAPISupport.builder()
                     .staticFile("src/test/resources/openapi-greeting.yml")
                     .webContext(GREETING_PATH)
                     .config(OPENAPI_CONFIG_DISABLED_CORS);
 
-    static final OpenAPISupport.Builder TIME_OPENAPI_SUPPORT_BUILDER
+    static final OpenAPISupport.Builder<?> TIME_OPENAPI_SUPPORT_BUILDER
             = OpenAPISupport.builder()
                     .staticFile("src/test/resources/openapi-time-server.yml")
                     .webContext(TIME_PATH)

--- a/openapi/src/test/java/io/helidon/openapi/ServerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #2799 

If multiple `Application` classes exist in the user's app, we build separate OpenAPI models for each one. As part of that, we need to invoke each `Application`'s `getClasses` and `getSingletons` methods. The OpenAPI CDI extension needs to act before the server's CDI extension actually creates the `Application` instances because the OpenAPI extension needs to adjust the routing to include the OpenAPI endpoint. But at that time, the server had not created the `Application` instances. So to invoke `getClasses` and `getSingletons` the OpenAPI CDI extension would use CDI to create _unmanaged_ instances of each `Application`, invoke those methods, and then dispose of the unmanaged instances. 

This caused `@PostConstruct` methods to be invoked twice, once for the unmanaged instances and again when the server created the "live" instances. Developers found this disconcerting.

Avoiding the double-instantiation involves splitting the OpenAPI CDI extension's work into two steps: first, creating the `OpenAPISupport` object so its routing can be plugged in correctly, and second later on when the `Application` instances are available for use in building the in-memory OpenAPI model.

To do _that_ involved refactoring the model-building logic from the `Builder` class to the `OpenAPISupport` class. 

Allowing the MP CDI extension to prepare the model during start-up (rather than lazily upon first request for the OpenAPI document), but _without_ exposing a `prepareModel()` method as `public` involved creating SE and MP variants of the `OpenAPISupport` class. The now-abstract superclass `OpenAPISupport` exposes a `protected prepareModel()` method which the MP variant overrides, also as `protected`, so the MP CDI extension in the same package can invoke it.

And doing _that_ in a type-safe way requires using type parameters on the `OpenAPISupport` class and its builder, which brought along another set of changes.

As a result, there is a seemingly large number of changes required for a conceptually simple improvement in user experience, but doing it this way avoids expanding the public surface area more than we want.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>