### PR TITLE
New implementation of WorkQueue that allows concurrent enqueuing of tasks

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
@@ -508,8 +508,11 @@ public class ThreadPool extends ThreadPoolExecutor {
             if (!semaphoreWrite.tryAcquire()) {
                return false;
             }
-            enqueue(task);
-            semaphoreRead.release();
+            try {
+                enqueue(task);
+            } finally {
+                semaphoreRead.release();
+            }
             return true;
         }
 
@@ -527,8 +530,11 @@ public class ThreadPool extends ThreadPoolExecutor {
            if (!semaphoreWrite.tryAcquire(timeout, tu)) {
               return false;
            }
-           enqueue(task);
-           semaphoreRead.release();
+           try {
+               enqueue(task);
+           } finally {
+               semaphoreRead.release();
+           }
            return true;
         }
 
@@ -544,8 +550,11 @@ public class ThreadPool extends ThreadPoolExecutor {
         @Override
         public void put(Runnable task) throws InterruptedException {
            semaphoreWrite.acquire();
-           enqueue(task);
-           semaphoreRead.release();
+           try {
+               enqueue(task);
+           } finally {
+               semaphoreRead.release();
+           }
         }
 
         @Override

--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
@@ -510,9 +510,11 @@ public class ThreadPool extends ThreadPoolExecutor {
             }
             try {
                 enqueue(task);
-            } finally {
-                semaphoreRead.release();
+            } catch (Exception e) {
+                semaphoreWrite.release();
+                return false;
             }
+            semaphoreRead.release();
             return true;
         }
 
@@ -532,9 +534,11 @@ public class ThreadPool extends ThreadPoolExecutor {
            }
            try {
                enqueue(task);
-           } finally {
-               semaphoreRead.release();
+           } catch (Exception e) {
+               semaphoreWrite.release();
+               return false;
            }
+           semaphoreRead.release();
            return true;
         }
 
@@ -552,9 +556,11 @@ public class ThreadPool extends ThreadPoolExecutor {
            semaphoreWrite.acquire();
            try {
                enqueue(task);
-           } finally {
-               semaphoreRead.release();
+           } catch (Exception e) {
+               semaphoreWrite.release();
+               throw e;
            }
+           semaphoreRead.release();
         }
 
         @Override


### PR DESCRIPTION
New implementation of `WorkQueue` that allows concurrent enqueuing of tasks. Previous implementation was based on `LinkedBlockingQueue` which uses a lock to prevent concurrent additions to the queue. Under high concurrency, this effectively introduces a "chicane" that results in a lot of threads waiting and a poor CPU utilization. The new implementation uses a `ConcurrentLinkedQueue` and two semaphores to enable concurrent enqueuing of tasks. The poor CPU utilization was discovered while running DBClient tests that used a ThreadPool to execute blocking calls. Credit to @olotenko.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>