### PR TITLE
Multi to ByteChannel

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/ByteChannelSubscriber.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/ByteChannelSubscriber.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Flow;
+
+class ByteChannelSubscriber extends CompletionSingle<Void> implements Flow.Subscriber<ByteBuffer> {
+    private final ExecutorService executorService;
+    private Flow.Subscription subscription;
+    private final WritableByteChannel byteChannel;
+    private final Executor executor;
+    private final CompletableFuture<Void> completed = new CompletableFuture<>();
+    private volatile CompletableFuture<Void> lastWriteFinished = CompletableFuture.completedFuture(null);
+
+    ByteChannelSubscriber(WritableByteChannel byteChannel, ExecutorService executor) {
+        this.byteChannel = byteChannel;
+        this.executor = executor;
+        this.executorService = executor;
+    }
+
+    ByteChannelSubscriber(WritableByteChannel byteChannel, Executor executor) {
+        this.byteChannel = byteChannel;
+        this.executor = executor;
+        this.executorService = null;
+    }
+
+    @Override
+    public void onSubscribe(final Flow.Subscription subscription) {
+        this.subscription = subscription;
+        this.subscription.request(1L);
+    }
+
+    @Override
+    public void onNext(final ByteBuffer nextByteBuffer) {
+        lastWriteFinished = CompletableFuture.runAsync(() -> {
+            try {
+                for (;;) {
+                    byteChannel.write(nextByteBuffer);
+                    if (nextByteBuffer.remaining() == 0) break;
+                    Thread.onSpinWait();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, executor)
+                .exceptionally(throwable -> {
+                    subscription.cancel();
+                    completed.completeExceptionally(throwable);
+                    return null;
+                })
+                .thenRun(() -> {
+                    // request one by one, concurrent writes are not possible
+                    subscription.request(1L);
+                });
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        try {
+            byteChannel.close();
+        } catch (IOException e) {
+            throwable.addSuppressed(e);
+        }
+        completed.completeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        lastWriteFinished.thenRun(() -> {
+            try {
+                byteChannel.close();
+                completed.complete(null);
+            } catch (IOException e) {
+                completed.completeExceptionally(e);
+            } finally {
+                if (executorService != null) {
+                    executorService.shutdown();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void subscribe(final Flow.Subscriber<? super Void> subscriber) {
+        Single.create(completed, true).subscribe(subscriber);
+    }
+}

--- a/common/reactive/src/main/java/io/helidon/common/reactive/IoMulti.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/IoMulti.java
@@ -182,7 +182,6 @@ public interface IoMulti {
      *      .to(IoMulti.multiToByteChannel(fileChannel))
      *      .await();
      * }</pre>
-     * </br>
      *
      * @param writableChannel for consuming ByteBuffers from upstream
      * @return mapper consuming {@code Multi<ByteBuffer>} and returning Single for observing asynchronous writing.
@@ -203,7 +202,6 @@ public interface IoMulti {
      *              .build())
      *      .await();
      * }</pre>
-     * </br>
      *
      * @param byteChannel for consuming ByteBuffers from upstream
      * @return mapper consuming {@code Multi<ByteBuffer>} and returning Single for observing asynchronous writing.
@@ -224,7 +222,6 @@ public interface IoMulti {
      *              .build())
      *      .await();
      * }</pre>
-     * </br>
      *
      * @param filePath file for writing all ByteBuffers from upstream to
      * @return mapper consuming {@code Multi<ByteBuffer>} and returning Single for observing asynchronous writing.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/IoMulti.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/IoMulti.java
@@ -169,7 +169,7 @@ public interface IoMulti {
 
     /**
      * Creates function consuming {@code Multi<ByteBuffer>} to supplied {@link WritableByteChannel}.
-     * <br/>
+     * <br>
      * Example usage:
      * <pre>{@code
      * Multi.create(listOfByteBuffers)
@@ -177,6 +177,7 @@ public interface IoMulti {
      *      .to(IoMulti.multiToByteChannel(fileChannel))
      *      .await();
      * }</pre>
+     * </br>
      *
      * @param writableChannel for consuming ByteBuffers from upstream
      * @return mapper consuming {@code Multi<ByteBuffer>} and returning Single for observing asynchronous writing.
@@ -187,7 +188,7 @@ public interface IoMulti {
 
     /**
      * Creates function consuming {@code Multi<ByteBuffer>} to supplied {@link WritableByteChannel}.
-     * <br/>
+     * <br>
      * Example usage:
      * <pre>{@code
      * Multi.create(listOfByteBuffers)
@@ -197,6 +198,7 @@ public interface IoMulti {
      *              .build())
      *      .await();
      * }</pre>
+     * </br>
      *
      * @param byteChannel for consuming ByteBuffers from upstream
      * @return mapper consuming {@code Multi<ByteBuffer>} and returning Single for observing asynchronous writing.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -1086,4 +1086,13 @@ public interface Multi<T> extends Subscribable<T> {
         return single;
     }
 
+    /**
+     * Terminal stage, ignore all items and complete returned {@code Single<Void>}.
+     *
+     * @return Single completed when the stream terminates
+     */
+    default Single<Void> ignore() {
+        return forEach(t -> {});
+    }
+
 }

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -1087,11 +1087,11 @@ public interface Multi<T> extends Subscribable<T> {
     }
 
     /**
-     * Terminal stage, ignore all items and complete returned {@code Single<Void>}.
+     * Terminal stage, ignore all items and complete returned {@code Single<Void>} successfully or exceptionally.
      *
      * @return Single completed when the stream terminates
      */
-    default Single<Void> ignore() {
+    default Single<Void> ignoreElements() {
         return forEach(t -> {});
     }
 

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Multi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/Single.java
@@ -676,10 +676,19 @@ public interface Single<T> extends Subscribable<T>, CompletionStage<T>, Awaitabl
      * Terminal stage, invokes provided consumer when Single is completed.
      *
      * @param consumer consumer to be invoked
-     * @return Single completed when the stream terminates
+     * @return CompletionStage completed when the stream terminates
      */
     default CompletionAwaitable<Void> forSingle(Consumer<T> consumer) {
         return this.thenAccept(consumer);
+    }
+
+    /**
+     * Terminal stage, ignore onNext signals, only onComplete and onError signals are propagated.
+     *
+     * @return CompletionStage completed when the stream terminates
+     */
+    default CompletionAwaitable<Void> ignoreElement() {
+        return this.forSingle(t -> {});
     }
 
     /**

--- a/common/reactive/src/test/java/io/helidon/common/reactive/ByteChannelSubscriberTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/ByteChannelSubscriberTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class ByteChannelSubscriberTest {
+
+    final static List<String> EXPECTED_VALUES = List.of("line 1", "line 2", "line 3", "line 4", "line 5", "line 6", "line 7");
+
+    @Test
+    void writeToFile() throws IOException {
+        Path filePath = Files.createTempFile("writeToFile", ".tmp");
+        FileChannel fileChannel = FileChannel.open(filePath, StandardOpenOption.WRITE);
+        Multi.create(EXPECTED_VALUES)
+                .map(line -> line + "\n")
+                .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                .to(IoMulti.multiToByteChannel(fileChannel))
+                .await();
+
+        assertThat(Arrays.asList(Files.readString(filePath).split("\n")), Matchers.contains(EXPECTED_VALUES.toArray(new String[0])));
+    }
+
+    @Test
+    void shutdownDefaultExecutor() throws IOException, InterruptedException {
+        Path filePath = Files.createTempFile("writeToFile", ".tmp");
+        FileChannel fileChannel = FileChannel.open(filePath, StandardOpenOption.WRITE);
+        ExecutorService defaultExecutor = Executors.newSingleThreadExecutor();
+        try {
+            ByteChannelSubscriber byteChannelSubscriber = new ByteChannelSubscriber(fileChannel, defaultExecutor);
+            Multi.create(EXPECTED_VALUES)
+                    .map(line -> line + "\n")
+                    .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                    .to(m -> {
+                        m.subscribe(byteChannelSubscriber);
+                        return byteChannelSubscriber;
+                    })
+                    .await();
+        } finally {
+            assertThat("Default executor should have been shutdown on complete.",
+                    defaultExecutor.awaitTermination(500, TimeUnit.MILLISECONDS));
+        }
+        assertThat(Arrays.asList(Files.readString(filePath).split("\n")), Matchers.contains(EXPECTED_VALUES.toArray(new String[0])));
+    }
+
+    @Test
+    void writeToFileWithSuppliedExecutor() throws IOException {
+        Path filePath = Files.createTempFile("writeToFile", ".tmp");
+        FileChannel fileChannel = FileChannel.open(filePath, StandardOpenOption.WRITE);
+        ExecutorService customExecutor = Executors.newSingleThreadExecutor();
+        try {
+            Multi.create(EXPECTED_VALUES)
+                    .map(line -> line + "\n")
+                    .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                    .to(IoMulti.multiToByteChannelBuilder(fileChannel)
+                            .executor(customExecutor)
+                            .build())
+                    .await();
+        } finally {
+            customExecutor.shutdown();
+        }
+        assertThat(Arrays.asList(Files.readString(filePath).split("\n")), Matchers.contains(EXPECTED_VALUES.toArray(new String[0])));
+    }
+
+    @Test
+    void writePartToFileBeforeError() throws IOException {
+        RuntimeException expectedError = new RuntimeException("BOOM!");
+        AtomicReference<Throwable> resultError = new AtomicReference<>();
+        Path filePath = Files.createTempFile("writePartToFileBeforeError", ".tmp");
+        FileChannel fileChannel = FileChannel.open(filePath, StandardOpenOption.WRITE);
+        Multi.create(EXPECTED_VALUES)
+                .peek(line -> {
+                    if (line.endsWith("3")) throw expectedError;
+                })
+                .map(line -> line + "\n")
+                .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                .to(IoMulti.multiToByteChannel(fileChannel))
+                .onErrorResumeWithSingle(e -> {
+                    resultError.set(e);
+                    return Single.empty();
+                })
+                .await();
+
+        assertThat(resultError.get(), CoreMatchers.equalTo(expectedError));
+        assertThat(Arrays.asList(Files.readString(filePath).split("\n")), Matchers.contains(EXPECTED_VALUES.subList(0, 2).toArray(new String[0])));
+    }
+
+    @Test
+    void closesChannel() {
+        ArrayList<String> result = new ArrayList<>(EXPECTED_VALUES.size());
+        AtomicBoolean closed = new AtomicBoolean(false);
+        WritableByteChannel fileChannel = new WritableByteChannel() {
+            @Override
+            public int write(final ByteBuffer src) {
+                byte[] array = new byte[src.remaining()];
+                src.get(array);
+                result.add(new String(array));
+                return array.length;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return !closed.get();
+            }
+
+            @Override
+            public void close() throws IOException {
+                closed.set(true);
+            }
+        };
+        Multi.create(EXPECTED_VALUES)
+                .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                .to(IoMulti.multiToByteChannel(fileChannel))
+                .await();
+
+        assertThat("WritableByteChannel should have been closed when stream completed.", closed.get());
+        assertThat(result, Matchers.contains(EXPECTED_VALUES.toArray(new String[0])));
+    }
+
+    @Test
+    void readBytesOneByOne() {
+        String expected = String.join("", EXPECTED_VALUES);
+        ByteBuffer result = ByteBuffer.allocate(expected.getBytes(StandardCharsets.UTF_8).length);
+        AtomicBoolean closed = new AtomicBoolean(false);
+        WritableByteChannel fileChannel = new WritableByteChannel() {
+
+            final AtomicReference<ByteBuffer> lastBuffer = new AtomicReference<>();
+
+            @Override
+            public int write(final ByteBuffer src) {
+                if (src.hasRemaining()) {
+                    lastBuffer
+                            .updateAndGet(old -> old == null ? ByteBuffer.allocate(src.remaining()) : old)
+                            .put(src.get());
+                    if (!src.hasRemaining()) {
+                        result.put(lastBuffer.getAndSet(null).flip());
+                    }
+                    return 1;
+                }
+                return 0;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return !closed.get();
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        Multi.create(EXPECTED_VALUES)
+                .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+                .to(IoMulti.multiToByteChannel(fileChannel))
+                .await();
+
+        assertThat("WritableByteChannel should have been closed when stream completed.", closed.get());
+        assertThat(new String(result.flip().array()), Matchers.equalTo(expected));
+    }
+}

--- a/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
+++ b/common/reactive/src/test/java/io/helidon/common/reactive/IgnoreElementsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.common.reactive;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class IgnoreElementsTest {
+    @Test
+    void multiIgnoreTriggerSubscription() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(3);
+        Multi.just(1, 1, 1)
+                .peek(i -> latch.countDown())
+                .ignoreElements(); // should trigger subscription on its own
+
+        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void singleIgnoreTriggerSubscription() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        Single.just(1)
+                .peek(i -> latch.countDown())
+                .ignoreElement(); // should trigger subscription on its own
+
+        assertTrue(latch.await(200, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void multiIgnorePeek() {
+        List<Integer> result = new ArrayList<>(3);
+        Multi.just(1, 2, 3)
+                .peek(result::add)
+                .ignoreElements()
+                .await(200, TimeUnit.MILLISECONDS);
+
+        assertThat(result, Matchers.contains(1, 2, 3));
+    }
+
+    @Test
+    void singleIgnorePeek() {
+        AtomicInteger result = new AtomicInteger(0);
+        Single.just(3)
+                .peek(result::set)
+                .ignoreElement()
+                .await(200, TimeUnit.MILLISECONDS);
+
+        assertThat(result.get(), Matchers.is(3));
+    }
+
+    @Test
+    void completePropagation() throws ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<Void> multiOnComplete = new CompletableFuture<>();
+        CompletableFuture<Void> singleOnComplete = new CompletableFuture<>();
+        CompletableFuture<Void> thenAccept = new CompletableFuture<>();
+        Multi.just(1, 2, 3)
+                .onComplete(() -> multiOnComplete.complete(null))
+                .ignoreElements()
+                .onComplete(() -> singleOnComplete.complete(null))
+                .ignoreElement()
+                .thenAccept(unused -> thenAccept.complete(null));
+
+        multiOnComplete.get(200, TimeUnit.MILLISECONDS);
+        singleOnComplete.get(200, TimeUnit.MILLISECONDS);
+        thenAccept.get(200, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void errorPropagation() throws ExecutionException, InterruptedException, TimeoutException {
+        Exception exception = new Exception("Boom!!!");
+        CompletableFuture<Throwable> multiOnError = new CompletableFuture<>();
+        CompletableFuture<Throwable> singleOnError = new CompletableFuture<>();
+        CompletableFuture<Throwable> exceptionallyAccept = new CompletableFuture<>();
+        Multi.concat(Multi.just(1, 2, 3), Single.error(exception))
+                .onError(multiOnError::complete)
+                .ignoreElements()
+                .onError(singleOnError::complete)
+                .ignoreElement()
+                .exceptionallyAccept(exceptionallyAccept::complete);
+
+        assertThat(multiOnError.get(200, TimeUnit.MILLISECONDS), Matchers.is(exception));
+        assertThat(singleOnError.get(200, TimeUnit.MILLISECONDS), Matchers.is(exception));
+        assertThat(exceptionallyAccept.get(200, TimeUnit.MILLISECONDS).getCause(), Matchers.is(exception));
+    }
+}

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
@@ -106,7 +106,7 @@ public final class FileService implements Service {
                     res.headers().put(Http.Header.LOCATION, "/ui");
                     res.send();
                 })
-                .ignore();
+                .ignoreElements();
     }
 
     private void streamUpload(ServerRequest req, ServerResponse res) {
@@ -126,7 +126,7 @@ public final class FileService implements Service {
                     res.headers().put(Http.Header.LOCATION, "/ui");
                     res.send();
                 })
-                .ignore();
+                .ignoreElements();
     }
 
 }

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
@@ -15,22 +15,20 @@
  */
 package io.helidon.examples.media.multipart;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 
+import io.helidon.common.configurable.ThreadPoolSupplier;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.IoMulti;
 import io.helidon.media.multipart.ContentDisposition;
 import io.helidon.media.multipart.ReadableBodyPart;
 import io.helidon.media.multipart.ReadableMultiPart;
@@ -47,6 +45,8 @@ public final class FileService implements Service {
 
     private static final JsonBuilderFactory JSON_FACTORY = Json.createBuilderFactory(Map.of());
     private final FileStorage storage;
+    private final ExecutorService executor = ThreadPoolSupplier.create().get();
+
 
     /**
      * Create a new file upload service instance.
@@ -58,8 +58,8 @@ public final class FileService implements Service {
     @Override
     public void update(Routing.Rules rules) {
         rules.get("/", this::list)
-             .get("/{fname}", this::download)
-             .post("/", this::upload);
+                .get("/{fname}", this::download)
+                .post("/", this::upload);
     }
 
     private void list(ServerRequest req, ServerResponse res) {
@@ -88,72 +88,45 @@ public final class FileService implements Service {
     }
 
     private void bufferedUpload(ServerRequest req, ServerResponse res) {
-        req.content().as(ReadableMultiPart.class).thenAccept(multiPart -> {
-            for (ReadableBodyPart part : multiPart.fields("file[]")) {
-                writeBytes(storage.create(part.filename()), part.as(byte[].class));
-            }
-            res.status(Http.Status.MOVED_PERMANENTLY_301);
-            res.headers().put(Http.Header.LOCATION, "/ui");
-            res.send();
-        });
+        req.content().as(ReadableMultiPart.class)
+                .flatMapIterable(multiPart -> multiPart.fields("file[]"))
+                .flatMap(part -> part.content()
+                        .map(DataChunk::data)
+                        .flatMapIterable(Arrays::asList)
+                        .to(IoMulti.writeToFile(storage.create(part.filename()))
+                                .executor(executor)
+                                .build())
+                )
+                .onError(throwable -> {
+                    res.status(Http.Status.INTERNAL_SERVER_ERROR_500);
+                    res.send(throwable.toString());
+                })
+                .onComplete(() -> {
+                    res.status(Http.Status.MOVED_PERMANENTLY_301);
+                    res.headers().put(Http.Header.LOCATION, "/ui");
+                    res.send();
+                })
+                .ignore();
     }
 
     private void streamUpload(ServerRequest req, ServerResponse res) {
         req.content().asStream(ReadableBodyPart.class)
+                .filter(part -> "file[]".equals(part.name()))
+                .limit(1) // FIXME: Why there is no complete?
+                .flatMap(part -> part.content()
+                        .map(DataChunk::data)
+                        .flatMapIterable(Arrays::asList)
+                        .to(IoMulti.writeToFile(storage.create(part.filename()))
+                                .executor(executor)
+                                .build())
+                )
                 .onError(res::send)
                 .onComplete(() -> {
                     res.status(Http.Status.MOVED_PERMANENTLY_301);
                     res.headers().put(Http.Header.LOCATION, "/ui");
                     res.send();
-                }).forEach((part) -> {
-                    if ("file[]".equals(part.name())) {
-                        final ByteChannel channel = newByteChannel(storage.create(part.filename()));
-                        part.content()
-                                .forEach(chunk -> writeChunk(channel, chunk))
-                                .thenAccept(it -> closeChannel(channel));
-                    }
-                });
+                })
+                .ignore();
     }
 
-    private static void writeBytes(Path file, byte[] bytes) {
-        try {
-            Files.write(file, bytes,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.TRUNCATE_EXISTING);
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
-
-    private static void writeChunk(ByteChannel channel, DataChunk chunk) {
-        try {
-            for (ByteBuffer byteBuffer : chunk.data()) {
-                channel.write(byteBuffer);
-            }
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        } finally {
-            chunk.release();
-        }
-    }
-
-    private void closeChannel(ByteChannel channel) {
-        try {
-            channel.close();
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
-
-    private static ByteChannel newByteChannel(Path file) {
-        try {
-            return Files.newByteChannel(file,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.TRUNCATE_EXISTING);
-        } catch (IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
 }

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileStorage.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileStorage.java
@@ -79,6 +79,11 @@ public class FileStorage {
         if (!file.getParent().equals(storageDir)) {
             throw new BadRequestException("Invalid file name");
         }
+        try {
+            Files.createFile(file);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
         return file;
     }
 

--- a/examples/media/multipart/src/test/java/io/helidon/examples/media/multipart/FileServiceTest.java
+++ b/examples/media/multipart/src/test/java/io/helidon/examples/media/multipart/FileServiceTest.java
@@ -103,6 +103,23 @@ public class FileServiceTest {
 
     @Test
     @Order(2)
+    public void testStreamUpload() throws IOException {
+        Path file = Files.write( Files.createTempFile(null, null), "stream bar\n".getBytes(StandardCharsets.UTF_8));
+        Path file2 = Files.write( Files.createTempFile(null, null), "stream foo\n".getBytes(StandardCharsets.UTF_8));
+        WebClientResponse response = webClient
+                .post()
+                .queryParam("stream", "true")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .submit(FileFormParams.builder()
+                                      .addFile("file[]", "streamed-foo.txt", file)
+                                      .addFile("otherPart", "streamed-foo2.txt", file2)
+                                      .build())
+                .await(2, TimeUnit.SECONDS);
+        assertThat(response.status().code(), is(301));
+    }
+
+    @Test
+    @Order(3)
     public void testList() {
         WebClientResponse response = webClient
                 .get()
@@ -117,7 +134,7 @@ public class FileServiceTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     public void testDownload() {
         WebClientResponse response = webClient
                 .get()

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
@@ -42,7 +42,7 @@ public final class ReadableBodyPart implements BodyPart {
     }
 
     /**
-     * Release all chunks and complete publisher of part's content. 
+     * Release all chunks and complete publisher of part's content.
      */
     public void drain() {
         this.content().forEach(DataChunk::release);

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
@@ -18,6 +18,7 @@ package io.helidon.media.multipart;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.helidon.common.http.DataChunk;
 import io.helidon.media.common.MessageBodyReadableContent;
 
 /**
@@ -38,6 +39,13 @@ public final class ReadableBodyPart implements BodyPart {
     @Override
     public MessageBodyReadableContent content() {
         return content;
+    }
+
+    /**
+     * Release all chunks and complete publisher of part's content. 
+     */
+    public void drain() {
+        this.content().forEach(DataChunk::release);
     }
 
     @Override

--- a/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ReadableBodyPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #2840

```java
Multi.create(listOfByteBuffers)
          .map(s -> ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
          .to(IoMulti.multiToByteChannelBuilder(fileChannel)
                  .executor(customExecutor)
                  .build())
          .await();
```

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>