### PR TITLE
HTTP Signature fix to work according to specification.

### DIFF
--- a/security/providers/http-sign/pom.xml
+++ b/security/providers/http-sign/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -42,6 +42,11 @@
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-key-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.security</groupId>
+            <artifactId>helidon-security-util</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.helidon.security.integration</groupId>
             <artifactId>helidon-security-integration-jersey</artifactId>

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignHeader.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,5 +28,9 @@ public enum HttpSignHeader {
      * Creates (or validates) an "Authorization" header, that contains "Signature" as the
      * beginning of its content (the rest of the header is the same as for {@link #SIGNATURE}.
      */
-    AUTHORIZATION
+    AUTHORIZATION,
+    /**
+     * Custom provided using a {@link io.helidon.security.util.TokenHandler}.
+     */
+    CUSTOM
 }

--- a/security/providers/http-sign/src/main/java/module-info.java
+++ b/security/providers/http-sign/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@
  * Http signature provider.
  */
 module io.helidon.security.providers.httpsign {
+    requires java.logging;
+
     requires transitive io.helidon.config;
     requires transitive io.helidon.common;
     requires transitive io.helidon.security;
     requires transitive io.helidon.common.pki;
+    requires transitive io.helidon.security.util;
     requires transitive io.helidon.security.providers.common;
-    requires java.logging;
 
     exports io.helidon.security.providers.httpsign;
 

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/HttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/HttpSignProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,7 +235,7 @@ public abstract class HttpSignProviderTest {
             String algorithm,
             List<String> headers,
             String actualSignature) {
-        HttpSignature httpSignature = HttpSignature.fromHeader(signatureHeader);
+        HttpSignature httpSignature = HttpSignature.fromHeader(signatureHeader, true);
 
         String reason = httpSignature.getAlgorithm() + ", " + httpSignature.getHeaders() + ", " + httpSignature
                 .getSignedString(new HashMap<>(), env);


### PR DESCRIPTION
During integration with OCI I have discovered that our implementation of HTTP Signatures adds an unexpected end of line to the end of the signed text.
This fix is backward compatible, but allows configuration change to use "spec-compatible" version of the provider/outbound target.
The configuration key is `backward-compatible-eol`, defaults to `true`. Configuring it to `false` will make it behave as the spec requires.
This should be changed in 3.0.0

Also added support to use a custom `TokenHandler` to put the signature in any header.