### PR TITLE
Ensure that the context is set throughout the request lifecycle

### DIFF
--- a/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
+++ b/webserver/test-support/src/main/java/io/helidon/webserver/testsupport/TestClient.java
@@ -82,7 +82,7 @@ public class TestClient {
     /**
      * Creates new {@link TestClient} instance with specified routing.
      *
-     * @param routing      a routing to test
+     * @param routing a routing to test
      * @param mediaContext media context
      * @return new instance
      * @throws NullPointerException if routing parameter is null
@@ -94,15 +94,15 @@ public class TestClient {
     /**
      * Creates new {@link TestClient} instance with specified routing.
      *
-     * @param routing      a routing to test
+     * @param routing a routing to test
      * @param mediaSupport media support
      * @return new instance
      * @throws NullPointerException if routing parameter is null
      */
     public static TestClient create(Routing routing, MediaSupport mediaSupport) {
         MediaContext mediaContext = MediaContext.builder()
-                                                .addMediaSupport(mediaSupport)
-                                                .build();
+                .addMediaSupport(mediaSupport)
+                .build();
         return create(routing, mediaContext);
     }
 
@@ -130,15 +130,15 @@ public class TestClient {
     /**
      * Returns response as soon as it has composed headers.
      *
-     * @param method    an HTTP method
-     * @param version   an HTTP version
-     * @param path      a URI path
-     * @param headers   HTTP headers
+     * @param method an HTTP method
+     * @param version an HTTP version
+     * @param path a URI path
+     * @param headers HTTP headers
      * @param publisher a request body publisher
      * @return new response instance as soon as headers are composed
      * @throws InterruptedException if thread is interrupted
-     * @throws RuntimeException     if response is not composed but throws exception
-     * @throws TimeoutException     if request timeouts
+     * @throws RuntimeException if response is not composed but throws exception
+     * @throws TimeoutException if request timeouts
      */
     TestResponse call(Http.RequestMethod method,
                       Http.Version version,

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLEngine;
 
+import io.helidon.common.context.Context;
 import io.helidon.common.http.Http;
 import io.helidon.webserver.ByteBufRequestChunk.DataChunkHoldingQueue;
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
@@ -125,7 +126,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             return;
         }
 
-        if (requestContext.publisher().hasRequests()) {
+        if (requestContext.hasRequests()) {
             ctx.channel().read();
         }
     }
@@ -162,22 +163,22 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
             // Context, publisher and DataChunk queue for this request/response
             DataChunkHoldingQueue queue = new DataChunkHoldingQueue();
-            requestContext = new RequestContext(new HttpRequestScopedPublisher(queue), request);
+            HttpRequestScopedPublisher publisher = new HttpRequestScopedPublisher(queue);
+            requestContext = new RequestContext(publisher, request, Context.create(webServer.context()));
 
             // Closure local variables that cache mutable instance variables
             RequestContext requestContextRef = requestContext;
-            HttpRequestScopedPublisher publisherRef = requestContextRef.publisher();
 
             // Creates an indirect reference between publisher and queue so that when
             // publisher is ready for collection, we have access to queue by calling its
             // acquire method. We shall also attempt to release queue on completion of
             // bareResponse below.
             IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherPh =
-                    new IndirectReference<>(publisherRef, queues, queue);
+                    new IndirectReference<>(publisher, queues, queue);
 
             // Set up read strategy for channel based on consumer demand
-            publisherRef.onRequest((n, demand) -> {
-                if (publisherRef.isUnbounded()) {
+            publisher.onRequest((n, demand) -> {
+                if (publisher.isUnbounded()) {
                     LOGGER.finest("Netty autoread: true");
                     ctx.channel().config().setAutoRead(true);
                 } else {
@@ -185,7 +186,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                     ctx.channel().config().setAutoRead(false);
                 }
 
-                if (publisherRef.hasRequests()) {
+                if (publisher.hasRequests()) {
                     LOGGER.finest("Requesting next chunks from Netty.");
                     ctx.channel().read();
                 } else {
@@ -199,8 +200,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // If a problem with the request URI, return 400 response
             BareRequestImpl bareRequest;
             try {
-                bareRequest = new BareRequestImpl((HttpRequest) msg, requestContextRef.publisher(),
-                        webServer, ctx, sslEngine, requestId);
+                bareRequest = new BareRequestImpl((HttpRequest) msg, publisher, webServer, ctx, sslEngine, requestId);
             } catch (IllegalArgumentException e) {
                 send400BadRequest(ctx, e.getMessage());
                 return;
@@ -234,7 +234,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
             // Create response and handler for its completion
             BareResponseImpl bareResponse =
-                    new BareResponseImpl(ctx, request, publisherRef::isCompleted, prevRequestFuture, requestId);
+                    new BareResponseImpl(ctx, request, publisher::isCompleted, prevRequestFuture, requestId);
             prevRequestFuture = new CompletableFuture<>();
             CompletableFuture<?> thisResp = prevRequestFuture;
             bareResponse.whenCompleted()
@@ -243,7 +243,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                             requestContextRef.responseCompleted(true);
 
                             // Consume and release any buffers in publisher
-                            publisherRef.clearAndRelease();
+                            publisher.clearAndRelease();
 
                             // Cleanup for these queues is done in HttpInitializer, but
                             // we try to do it here if possible to reduce memory usage,
@@ -261,7 +261,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
             // If a problem during routing, return 400 response
             try {
-                routing.route(bareRequest, bareResponse);
+                requestContext.runInScope(() -> routing.route(bareRequest, bareResponse));
             } catch (IllegalArgumentException e) {
                 send400BadRequest(ctx, e.getMessage());
                 return;
@@ -315,10 +315,10 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                             ignorePayload = true;
                             send413PayloadTooLarge(ctx);
                         } else {
-                            requestContext.publisher().emit(content);
+                            requestContext.emit(content);
                         }
                     } else {
-                        requestContext.publisher().emit(content);
+                        requestContext.emit(content);
                     }
                 }
             }
@@ -326,7 +326,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             if (msg instanceof LastHttpContent) {
                 if (!isWebSocketUpgrade) {
                     lastContent = true;
-                    requestContext.publisher().complete();
+                    requestContext.complete();
                     requestContext = null; // just to be sure that current http req/res session doesn't interfere with other ones
                 }
             } else if (!content.isReadable()) {
@@ -343,7 +343,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             }
             // Simply forward raw bytebuf to Tyrus for processing
             LOGGER.finest(() -> "Received ByteBuf of WebSockets connection" + msg);
-            requestContext.publisher().emit((ByteBuf) msg);
+            requestContext.emit((ByteBuf) msg);
         }
     }
 
@@ -444,7 +444,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      */
     private void failPublisher(Throwable cause) {
         if (requestContext != null) {
-            requestContext.publisher().fail(cause);
+            requestContext.fail(cause);
         }
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -173,7 +173,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // publisher is ready for collection, we have access to queue by calling its
             // acquire method. We shall also attempt to release queue on completion of
             // bareResponse below.
-            IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherPh =
+            IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherRef =
                     new IndirectReference<>(publisher, queues, queue);
 
             // Set up read strategy for channel based on consumer demand
@@ -249,7 +249,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                             // we try to do it here if possible to reduce memory usage,
                             // especially for keep-alive connections
                             if (queue.release()) {
-                                publisherPh.acquire();      // clears reference to other
+                                publisherRef.acquire();      // clears reference to other
                             }
 
                             // Enables next response to proceed (HTTP pipelining)

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.StringTokenizer;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
@@ -75,7 +76,7 @@ abstract class Request implements ServerRequest {
         this.bareRequest = req;
         this.webServer = webServer;
         this.headers = headers;
-        this.context = Context.create(webServer.context());
+        this.context = Contexts.context().orElseGet(() -> Context.create(webServer.context()));
         this.queryParams = UriComponent.decodeQuery(req.uri().getRawQuery(), true);
         this.eventListener = new MessageBodyEventListener();
         MessageBodyReaderContext readerContext = MessageBodyReaderContext

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,35 +16,64 @@
 
 package io.helidon.webserver;
 
+import java.util.logging.Logger;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpRequest;
 
 /**
- * The RequestContext POJO holds single HTTP request associated objects.
+ * The request context.
  */
 class RequestContext {
 
+    private static final Logger LOGGER = Logger.getLogger(RequestContext.class.getName());
+
     private final HttpRequestScopedPublisher publisher;
     private final HttpRequest request;
+    private final Context scope;
     private volatile boolean responseCompleted;
 
-    RequestContext(HttpRequestScopedPublisher publisher, HttpRequest request) {
+    RequestContext(HttpRequestScopedPublisher publisher, HttpRequest request, Context scope) {
         this.publisher = publisher;
         this.request = request;
-    }
-
-    HttpRequestScopedPublisher publisher() {
-        return publisher;
+        this.scope = scope;
     }
 
     HttpRequest request() {
         return request;
     }
 
-    public void responseCompleted(boolean responseCompleted) {
+    void emit(ByteBuf data) {
+        runInScope(() -> publisher.emit(data));
+    }
+
+    void fail(Throwable throwable) {
+        runInScope(() -> publisher.fail(throwable));
+    }
+
+    void complete() {
+        runInScope(publisher::complete);
+    }
+
+    void runInScope(Runnable runnable) {
+        Contexts.runInContext(scope, () -> {
+            LOGGER.finest(() -> String.format("Running in context %s", scope.id()));
+            runnable.run();
+        });
+    }
+
+    boolean hasRequests() {
+        return publisher.hasRequests();
+    }
+
+    void responseCompleted(boolean responseCompleted) {
         this.responseCompleted = responseCompleted;
     }
 
-    public boolean responseCompleted() {
+    boolean responseCompleted() {
         return responseCompleted;
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -60,7 +60,7 @@ class RequestContext {
 
     void runInScope(Runnable runnable) {
         Contexts.runInContext(scope, () -> {
-            LOGGER.finest(() -> String.format("Running in context %s", scope.id()));
+            LOGGER.finest(() -> "Running in context " + scope.id());
             runnable.run();
         });
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ class RequestRouting implements Routing {
             RoutedRequest nextRequests = new RoutedRequest(bareRequest, response, webServer, crawler, errorHandlers,
                                                            requestHeaders);
             response.request(nextRequests);
-            Contexts.runInContext(nextRequests.context(), (Runnable) nextRequests::next);
+            nextRequests.next();
         } catch (Error | RuntimeException e) {
             LOGGER.log(Level.SEVERE, "Unexpected error occurred during routing!", e);
             throw e;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ContextLifeCycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ContextLifeCycleTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.Http.ResponseStatus;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests that {@link ServerRequest#context()} is returned by {@link Contexts#context()} throughout the request
+ * life-cycle.
+ */
+public class ContextLifeCycleTest {
+
+    private static String contextId() {
+        return Contexts.context().map(Context::id).orElse(null);
+    }
+
+    @Test
+    void testContextMediaSupport() {
+        Handler handler = (req, res) -> {
+            String cid = req.context().id();
+            req.content().as(String.class).thenAccept(payload -> {
+                if (cid.equals(contextId())) {
+                    res.send();
+                } else {
+                    res.status(400).send();
+                }
+            });
+        };
+
+        WebServer webServer = WebServer.builder(Routing.builder().post(handler))
+                                       .build()
+                                       .start()
+                                       .await(10, TimeUnit.SECONDS);
+
+        ResponseStatus responseStatus = WebClient.builder()
+                                                 .baseUri("http://localhost:" + webServer.port())
+                                                 .build()
+                                                 .post()
+                                                 .submit("some-payload")
+                                                 .map(WebClientResponse::status)
+                                                 .onTerminate(webServer::shutdown)
+                                                 .await(10, TimeUnit.SECONDS);
+
+        assertThat(responseStatus.code(), is(200));
+    }
+
+    @Test
+    void testContextReactive() {
+        Handler handler = (req, res) -> {
+            String cid = req.context().id();
+            req.content()
+               .subscribe(new Subscriber<>() {
+                   @Override
+                   public void onSubscribe(Subscription subscription) {
+                       subscription.request(Long.MAX_VALUE);
+                   }
+
+                   @Override
+                   public void onNext(DataChunk item) {
+                       item.release();
+                       if (!cid.equals(contextId())) {
+                           throw new IllegalStateException("Context invalid");
+                       }
+                   }
+
+                   @Override
+                   public void onError(Throwable throwable) {
+                       res.send(throwable);
+                   }
+
+                   @Override
+                   public void onComplete() {
+                       if (!cid.equals(contextId())) {
+                           res.send(new IllegalStateException("Context invalid"));
+                       } else {
+                           res.send();
+                       }
+                   }
+               });
+        };
+
+        WebServer webServer = WebServer.builder(Routing.builder().post(handler))
+                                       .build()
+                                       .start()
+                                       .await(10, TimeUnit.SECONDS);
+
+        ResponseStatus responseStatus = WebClient.builder()
+                                                 .baseUri("http://localhost:" + webServer.port())
+                                                 .build()
+                                                 .post()
+                                                 .submit("some-payload")
+                                                 .map(WebClientResponse::status)
+                                                 .onTerminate(webServer::shutdown)
+                                                 .await(10, TimeUnit.SECONDS);
+
+        assertThat(responseStatus.code(), is(200));
+    }
+
+    @Test
+    void testContextWhenSent() throws InterruptedException, ExecutionException, TimeoutException {
+        CompletableFuture<String> requestCid = new CompletableFuture<>();
+        CompletableFuture<String> whenSentCid = new CompletableFuture<>();
+        Handler handler = (req, res) -> {
+            requestCid.complete(req.context().id());
+            req.content().as(String.class).thenAccept(payload -> res.send());
+            res.whenSent().thenRun(() -> whenSentCid.complete(contextId()));
+        };
+
+        WebServer webServer = WebServer.builder(Routing.builder().post(handler))
+                                       .build()
+                                       .start()
+                                       .await(10, TimeUnit.SECONDS);
+
+        WebClient.builder()
+                 .baseUri("http://localhost:" + webServer.port())
+                 .build()
+                 .post()
+                 .submit("some-payload")
+                 .onTerminate(webServer::shutdown)
+                 .await(10, TimeUnit.SECONDS);
+
+        assertThat(whenSentCid.get(10, TimeUnit.SECONDS), is(requestCid.get(10, TimeUnit.SECONDS)));
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ContextLifeCycleTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ContextLifeCycleTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * Tests that {@link ServerRequest#context()} is returned by {@link Contexts#context()} throughout the request
  * life-cycle.
  */
-public class ContextLifeCycleTest {
+class ContextLifeCycleTest {
 
     private static String contextId() {
         return Contexts.context().map(Context::id).orElse(null);


### PR DESCRIPTION
- Added Context to RequestContext:
  - added a method "runInScope" to invoke Contexts.runInContext + logging
  - added "in-scope" short-hand methods for publisher.fail, publisher.emit, publisher.complete
  - removed "publisher()" to force the use of the in-scope short-hand methods
- Request only creates a new context if Contexts.context() is empty
   - NOT throwing an exception as that would impact Routing.route which is a public API
- Added a unit test

Fixes #2838