### PR TITLE
Fix imports to use Hamcrest and Junit5 instead of Junit4

### DIFF
--- a/config/config/src/test/java/io/helidon/config/ConfigSupplierTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 import io.helidon.config.spi.ConfigNode;
 import io.helidon.config.spi.ConfigNode.ObjectNode;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.config.ConfigTest.waitForAssert;
@@ -188,7 +188,7 @@ public class ConfigSupplierTest {
                       is(ConfigValues.simpleValue("NEW item 1")));
     }
 
-    @Ignore
+    @Disabled
     @Test
     // TODO cause of intermittent test failures:
     /*

--- a/config/config/src/test/java/io/helidon/config/ConfigTest.java
+++ b/config/config/src/test/java/io/helidon/config/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static io.helidon.config.Config.Type.LIST;
 import static io.helidon.config.Config.Type.OBJECT;
 import static io.helidon.config.Config.Type.VALUE;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 /**
  * General {@link Config} tests.

--- a/config/config/src/test/java/io/helidon/config/FileOverrideSourceTest.java
+++ b/config/config/src/test/java/io/helidon/config/FileOverrideSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests {@link io.helidon.config.FileOverrideSource}.

--- a/config/config/src/test/java/io/helidon/config/Gh1182Override.java
+++ b/config/config/src/test/java/io/helidon/config/Gh1182Override.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit test to reproduce (and validate fix) of

--- a/config/config/src/test/java/io/helidon/config/MultiConfigSourceProvider.java
+++ b/config/config/src/test/java/io/helidon/config/MultiConfigSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,9 @@ import java.util.Set;
 import io.helidon.config.spi.ConfigSource;
 import io.helidon.config.spi.ConfigSourceProvider;
 
-import org.junit.Assert;
-
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultiConfigSourceProvider implements ConfigSourceProvider {
 
@@ -39,7 +38,7 @@ public class MultiConfigSourceProvider implements ConfigSourceProvider {
 
     @Override
     public ConfigSource create(String type, Config metaConfig) {
-        Assert.fail("This should never be called. This should be tested as multi-source only.");
+        fail("This should never be called. This should be tested as multi-source only.");
         return ConfigSources.empty();
     }
 

--- a/config/config/src/test/java/io/helidon/config/PollingStrategiesTest.java
+++ b/config/config/src/test/java/io/helidon/config/PollingStrategiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import io.helidon.config.spi.PollingStrategy;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests {@link PollingStrategies}.

--- a/config/config/src/test/java/io/helidon/config/TreeStructureTests.java
+++ b/config/config/src/test/java/io/helidon/config/TreeStructureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test that nodes correctly return empty even for tree.


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Removing obsolete JUnit4 imports that were left over in config.