### PR TITLE
Fix injection of metrics registry in native image

### DIFF
--- a/microprofile/metrics/src/main/resources/META-INF/native-image/io.helidon/helidon-common/reflect-config.json
+++ b/microprofile/metrics/src/main/resources/META-INF/native-image/io.helidon/helidon-common/reflect-config.json
@@ -1,0 +1,6 @@
+[
+    {
+        "name": "org.eclipse.microprofile.metrics.annotation.RegistryType",
+        "allDeclaredMethods": true
+    }
+]

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/JaxRsResource.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/JaxRsResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,6 +214,9 @@ public final class Mp1Main {
                 return "timeout";
             }
         });
+
+        invoke(collector, "Application metric registry", "SimpleTimers.size(): 0", aBean::appRegistry);
+        invoke(collector, "Application metric registry", "SimpleTimers.size(): 0", aBean::baseRegistry);
 
         // JWT-Auth
         validateJwtProtectedResource(collector, target, jwtToken);

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/TestBean.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -56,6 +58,13 @@ public class TestBean {
 
     @Inject
     private ProducedBean producedBean;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.BASE)
+    private MetricRegistry baseRegistry;
 
     private final AtomicInteger retries = new AtomicInteger();
 
@@ -139,5 +148,13 @@ public class TestBean {
 
     public String produced() {
         return BeanProcessor.getProducedName(producedBean);
+    }
+
+    public String appRegistry() {
+        return "SimpleTimers.size(): " + metricRegistry.getSimpleTimers().size();
+    }
+
+    public String baseRegistry() {
+        return "SimpleTimers.size(): " + metricRegistry.getSimpleTimers().size();
     }
 }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/ResponseWriter.java
@@ -146,7 +146,6 @@ class ResponseWriter implements ContainerResponseWriter {
         private static final long CANCEL = Long.MIN_VALUE;
         private static final long ERROR = CANCEL + 1;
         private static final long WAIT = -1;
-        private static final ByteBuf ZERO_BUF = Unpooled.buffer(0);
 
         private byte[] oneByteArray;
         private ByteBuf byteBuf;
@@ -195,7 +194,7 @@ class ResponseWriter implements ContainerResponseWriter {
         public void flush() throws IOException {
             if (byteBuf == null) {
                 awaitRequest();
-                publish(true, ZERO_BUF);
+                publish(true, Unpooled.EMPTY_BUFFER);
             } else {
                 byteBuf = null;
                 publish(true, byteBufRef);

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -35,4 +35,14 @@ Args=--allow-incomplete-classpath \
   --initialize-at-run-time=io.netty.handler.ssl.ConscryptAlpnSslEngine \
   --initialize-at-run-time=io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine \
   --initialize-at-run-time=io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine \
-  --initialize-at-run-time=io.netty.util.internal.logging.Log4JLogger
+  --initialize-at-run-time=io.netty.util.internal.logging.Log4JLogger \
+  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslContext \
+  --initialize-at-run-time=io.netty.handler.codec.marshalling.CompatibleMarshallingDecoder \
+  --initialize-at-run-time=io.netty.handler.codec.marshalling.CompatibleMarshallingEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.marshalling.MarshallingDecoder \
+  --initialize-at-run-time=io.netty.handler.codec.protobuf.ProtobufDecoder \
+  --initialize-at-run-time=io.netty.handler.codec.marshalling.MarshallingEncoder \
+  --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameDecoder \
+  --initialize-at-run-time=io.netty.handler.codec.compression.LzmaFrameEncoder
+

--- a/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
+++ b/webserver/webserver/src/main/resources/META-INF/native-image/io.helidon.webserver/helidon-webserver/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,4 +45,3 @@ Args=--allow-incomplete-classpath \
   --initialize-at-run-time=io.netty.handler.codec.marshalling.MarshallingEncoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.Lz4FrameDecoder \
   --initialize-at-run-time=io.netty.handler.codec.compression.LzmaFrameEncoder
-


### PR DESCRIPTION
Resolves #2892 

Separated into meaningful commits:
- Update to Helidon reflection feature to reduce issues when registering for reflection in native image (ignore classes with fields or type parameters that are not on classpath)
- Fix a regression in Jersey integration that caused failures in native image build
- Reduce warnings by adding "initialize at runtime" for a few Netty classes
- Fix of the related bug
- Squashable (copyright fix)