### PR TITLE
Docs: consitently document maven coordinates

### DIFF
--- a/docs/about/04_managing-dependencies.adoc
+++ b/docs/about/04_managing-dependencies.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -26,10 +26,19 @@ This is a special Maven pom file that provides dependency management.
 Using the Helidon BOM allows you to use Helidon component dependencies with a
  single version: the Helidon version.
 
+== The Helidon Application POMs
+
+If you created your application using the <<about/05_cli.adoc,Helidon CLI>> or
+<<about/03_prerequisites.adoc,archetypes>> then your
+project will have a Helidon Application POM as its parent POM. In this case you
+will get Helidon's dependency management automatically.
+
+If your project doesn't use a Helidon Application POM as its parent, then
+you will need to import the Helidon BOM POM.
+
 == The Helidon BOM POM
 
-Add the following snippet to your pom.xml file in order to import the Helidon
- BOM.
+To import the Helidon BOM POM add the following snippet to your pom.xml file.
 
 [source,xml,subs="attributes+"]
 .Import the Helidon BOM

--- a/docs/mp/beanvalidation/01_overview.adoc
+++ b/docs/mp/beanvalidation/01_overview.adoc
@@ -22,12 +22,25 @@
 :description: Bean Validation Introduction
 :keywords: helidon, webserver, bean validation, validation
 :bean-validation-spec-url: https://projects.eclipse.org/projects/ee4j.bean-validation
+:feature-name: Bean Validation
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+
 
 Helidon supports Bean Validation via its integration with JAX-RS/Jersey. The
 {bean-validation-spec-url}[Jakarta Bean
 Validation specification] defines an API to validate Java beans.
 Bean Validation is supported in REST resource classes as well as in
 regular application beans.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source, xml]
+----
+<dependency>
+  <groupId>org.glassfish.jersey.ext</groupId>
+  <artifactId>jersey-bean-validation</artifactId>
+</dependency>
+----
 
 == Validation Example in Helidon MP
 
@@ -50,15 +63,3 @@ public class HelloWorld {
 }
 ----
 
-Validation typically requires an additional dependency from Jersey in your pom:
-
-[source, xml]
-----
-<dependency>
-  <groupId>org.glassfish.jersey.ext</groupId>
-  <artifactId>jersey-bean-validation</artifactId>
-</dependency>
-----
-
-If defined as a parent pom in your project, the version for this dependency
-is inherited from the Helidon application pom.

--- a/docs/mp/config/01_introduction.adoc
+++ b/docs/mp/config/01_introduction.adoc
@@ -24,6 +24,19 @@
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, config, encryption, reference
 :h1Prefix: MP
+:feature-name: MicroProfile Config
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+        <dependency>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
+        </dependency>
+----
 
 == About {spec-name}
 

--- a/docs/mp/cors/02_using-cors.adoc
+++ b/docs/mp/cors/02_using-cors.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -32,9 +32,21 @@
 :mp-cors-config-ref: {mp-pages-ref-prefix}/03_configuration-with-cors-mp.adoc
 :helidon-variant: MP
 :common-page-prefix-inc: ../../shared/cors/common_shared.adoc
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: CORS
 
 To enable CORS behavior for a resource in your Helidon MP application, you simply add the Helidon MP `@CrossOrigin`
 annotation to a particular method in your resource class.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>io.helidon.microprofile</groupId>
+    <artifactId>helidon-microprofile-cors</artifactId>
+</dependency>
+----
 
 == Understanding the `@CrossOrigin` Annotation
 You set up CORS in Helidon MP using the link:{javadoc-base-url-api}/CrossOrigin.html[`@CrossOrigin`] annotation.
@@ -49,31 +61,14 @@ using `DELETE` or `PUT`, and permits requests to include the non-standard header
              allowMethods = {HttpMethod.DELETE, HttpMethod.PUT})
 ----
 
-
-
-
 == Getting Started
 To add CORS support to your Helidon MP application:
 
-. Determine the type of cross-origin resource sharing you want to allow
+1. Determine the type of cross-origin resource sharing you want to allow
  for each endpoint in your application.
-. {blank}
-+
---
-Add a dependency on the Helidon {helidon-variant} CORS artifact to your Maven `pom.xml` file.
+2. Add a dependency on the Helidon {helidon-variant} CORS <<Maven Coordinates, artifact>>  to your Maven `pom.xml` file.
 
-include::{common-page-prefix-inc}[tag=add-cors-dependency]
-// tag::actual-cors-dependency[]
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>io.helidon.microprofile</groupId>
-    <artifactId>helidon-microprofile-cors</artifactId>
-</dependency>
-----
-// end::actual-cors-dependency[]
---
-. Edit each JAX-RS resource class in your application to add the desired CORS behavior as described in the following sections.
+3. Edit each JAX-RS resource class in your application to add the desired CORS behavior as described in the following sections.
 
 
 

--- a/docs/mp/extensions/02_cdi_datasource-hikaricp.adoc
+++ b/docs/mp/extensions/02_cdi_datasource-hikaricp.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,14 +25,14 @@
 :hikaricp-props-url: https://github.com/brettwooldridge/HikariCP/blob/dev/README.md#configuration-knobs-baby
 :cdi-extension-api-url: https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#spi
 :cdi-applicationscoped-api-url: http://docs.jboss.org/cdi/api/2.0/javax/enterprise/context/ApplicationScoped.html
+:feature-name: HikariCP Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This link:{cdi-extension-api-url}[CDI portable extension] provides support for
 injecting link:{hikaricp-project-url}[HikariCP data sources] in your Helidon
 MicroProfile applications.
 
-== Prerequisites
-
-Declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/mp/extensions/02_cdi_datasource-ucp.adoc
+++ b/docs/mp/extensions/02_cdi_datasource-ucp.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 :description: Helidon CDI extension for Oracle Universal Connection Pool
 :keywords: helidon, java, microservices, microprofile, extensions, cdi, ucp
 :hikaricp-props-url: https://github.com/brettwooldridge/HikariCP/blob/dev/README.md#configuration-knobs-baby
+:feature-name: Oracle UCP Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#spi[CDI portable extension] provides
 support for injecting
@@ -28,11 +30,9 @@ https://docs.oracle.com/en/database/oracle/oracle-database/19/jjucp/index.html[O
 Universal Connection Pool data sources] in your Helidon MicroProfile
 applications.
 
-== Prerequisites
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-Declare the following dependency in your project:
-
-[source,xml,subs="attributes+"]
+[source,xml]
 ----
 <dependency>
     <groupId>io.helidon.integrations.cdi</groupId>

--- a/docs/mp/extensions/03_cdi_jedis.adoc
+++ b/docs/mp/extensions/03_cdi_jedis.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,14 +29,14 @@
 :jedis-project-url: https://github.com/xetorthio/jedis
 :commons-pool-baseobjectpoolconfig-api-url: https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/BaseObjectPoolConfig.html
 :commons-pool-genericobjectpoolconfig-api-url: https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPoolConfig.html
+:feature-name: Jedis Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This link:{cdi-extension-api-url}[CDI portable extension] provides support for
  injecting link:{jedis-project-url}[Jedis clients] in your Helidon
  MicroProfile applications.
 
-== Prerequisites
-
-Declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/mp/extensions/04_cdi_oci-objectstorage.adoc
+++ b/docs/mp/extensions/04_cdi_oci-objectstorage.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 :cdi-extension-api-url: https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#spi
 :oci-objstore-url: https://docs.cloud.oracle.com/iaas/Content/Object/Concepts/objectstorageoverview.htm
 :oci-javasdk-url: https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/javasdk.htm
+:feature-name: OCI Object Storage Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This link:{cdi-extension-api-url}[CDI portable extension] provides support for
  injecting an link:{oci-objstore-url}[Oracle Cloud Infrastructure Object Storage client]

--- a/docs/mp/extensions/04_cdi_oci-objectstorage.adoc
+++ b/docs/mp/extensions/04_cdi_oci-objectstorage.adoc
@@ -30,9 +30,7 @@ This link:{cdi-extension-api-url}[CDI portable extension] provides support for
  injecting an link:{oci-objstore-url}[Oracle Cloud Infrastructure Object Storage client]
  in your Helidon MicroProfile applications.
 
-== Prerequisites
-
-Declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/mp/extensions/05_cdi_jta.adoc
+++ b/docs/mp/extensions/05_cdi_jta.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,14 +20,14 @@
 :h1Prefix: MP
 :description: Helidon CDI extension for JTA
 :keywords: helidon, java, microservices, microprofile, extensions, cdi, jta
+:feature-name: JTA Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#spi[CDI
 portable extension] provides support for JTA (Java Transaction API)
 transactions in your Helidon MicroProfile applications.
 
-== Prerequsites
-
-Declare the following dependency fragment in your project's `pom.xml`:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----
@@ -36,7 +36,6 @@ Declare the following dependency fragment in your project's `pom.xml`:
   <artifactId>helidon-integrations-cdi-jta-weld</artifactId>
   <scope>runtime</scope>
 </dependency>
-
 <dependency>
   <groupId>javax.transaction</groupId>
   <artifactId>javax.transaction-api</artifactId>

--- a/docs/mp/faulttolerance/01_overview.adoc
+++ b/docs/mp/faulttolerance/01_overview.adoc
@@ -24,11 +24,23 @@
 :fault-tolerance-spec-url: https://github.com/eclipse/microprofile-fault-tolerance
 :scheduled-executor-config: {javadoc-base-url}io.helidon.common.configurable/io/helidon/common/configurable/ScheduledThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
 :executor-config: {javadoc-base-url}io.helidon.common.configurable/io/helidon/common/configurable/ThreadPoolSupplier.Builder.html#config(io.helidon.config.Config)
+:feature-name: MicroProfile Fault Tolerance
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
 
 Fault Tolerance is part of the MicroProfile set of {fault-tolerance-spec-url}[specifications]. This API defines mostly
 annotations that improve application robustness by providing support to conveniently handle
 error conditions (faults) that may occur in real-world applications. Examples include
 service restarts, network delays, temporal infrastructure instabilities, etc.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+[source,xml]
+----
+     <dependency>
+         <groupId>io.helidon.microprofile</groupId>
+         <artifactId>helidon-microprofile-fault-tolerance</artifactId>
+     </dependency>
+----
 
 == Fault Tolerance in Helidon
 

--- a/docs/mp/graphql/01_mp_graphql.adoc
+++ b/docs/mp/graphql/01_mp_graphql.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@
 :pagename: microprofile-graphql
 :description: Helidon GraphQL MicroProfile
 :keywords: helidon, graphql, microprofile, micro-profile
-
+:feature-name: MicroProfile GraphQL
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
 The Microprofile GraphQL APIs are an extension to <<microprofile/01_introduction.adoc, Helidon MP>>
 to allow building of applications that can expose a GraphQL endpoint.
@@ -30,6 +32,16 @@ to allow building of applications that can expose a GraphQL endpoint.
 
 WARNING: The Helidon GraphQL feature is currently experimental and the APIs are
  subject to changes until GraphQL support is stabilized.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.microprofile.graphql</groupId>
+    <artifactId>helidon-microprofile-graphql-server</artifactId>
+</dependency>
+----
 
 == About the MicroProfile GraphQL Specification
 Helidon MP implements the MicroProfile GraphQL
@@ -40,19 +52,6 @@ and a runtime for fulfilling queries with existing data.
 It provides an alternative to, though not necessarily a replacement for, REST.
 
 For more information on GraphQL see https://graphql.org/.
-
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.microprofile.graphql</groupId>
-    <artifactId>helidon-microprofile-graphql-server</artifactId>
-</dependency>
-----
 
 == Getting Started
 

--- a/docs/mp/grpc/01_mp_server_side_services.adoc
+++ b/docs/mp/grpc/01_mp_server_side_services.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@
 :pagename: grpc-microprofile-server
 :description: Helidon gRPC MicroProfile Server-Side Services
 :keywords: helidon, grpc, microprofile, micro-profile
+:feature-name: gRPC MicroProfile Server
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
 The gRPC Microprofile APIs are an extension to <<microprofile/01_introduction.adoc, Helidon MP>> to allow building
 of gRPC services and clients that integrate with the Microprofile APIs. Using Helidon gRPC MP makes building gRPC services
@@ -31,10 +34,7 @@ in the MP http server.
 Building gRPC services using Helidon gRPC MP is very simple and allows the developer to concentrate on their
 application logic without needing to write a lot of boilerplate gRPC code.
 
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/mp/grpc/02_mp_clients.adoc
+++ b/docs/mp/grpc/02_mp_clients.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,16 +21,15 @@
 :pagename: grpc-microprofile-clients
 :description: Building Helidon gRPC MicroProfile Clients
 :keywords: helidon, grpc, microprofile, micro-profile
+:feature-name: gRPC MicroProfile Clients
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
 Building Java gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boiler plate code typically
 associated to more traditional approaches to writing gRPC Java clients. At it simplest a gRPC Java client can be written using
 nothing more than a suitably annotated interface.
 
-
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/mp/health/01_introduction.adoc
+++ b/docs/mp/health/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,6 +22,19 @@
 :keywords: helidon, mp, microprofile, health
 :h1Prefix: MP
 :health-release: {version.lib.microprofile-health}
+:feature-name: MicroProfile Health
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+        <dependency>
+            <groupId>io.helidon.microprofile.health</groupId>
+            <artifactId>helidon-microprofile-health</artifactId>
+        </dependency>
+----
 
 == Overview
 Microservices expose their health status primarily so external tools (for example, an orchestrator such as Kubernetes)

--- a/docs/mp/jpa/01_introduction.adoc
+++ b/docs/mp/jpa/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -44,9 +44,6 @@ The Jakarta Persistence API is a specification that governs how Java
 objects map to relational databases, and has existed since 2006.
 Hibernate and Eclipselink, two of the most popular JPA
 implementations, are supported by Helidon MP JPA. 
-
-
-
 
 == Next Steps
 Learn more about the 

--- a/docs/mp/jwtauth/01_introduction.adoc
+++ b/docs/mp/jwtauth/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,19 @@
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, security, jwt
 :h1Prefix: MP
+:feature-name: JWT Authentication
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+        <dependency>
+            <groupId>io.helidon.microprofile.jwt</groupId>
+            <artifactId>helidon-microprofile-jwt-auth</artifactId>
+        </dependency>
+----
 
 == Overview
 JSON Web Token (JWT) defines a compact and self-contained way for securely transmitting information between parties as a JSON object. With JWT Auth you can integrate security features such as single sign on into your Helidon MP applications.  

--- a/docs/mp/metrics/01_introduction.adoc
+++ b/docs/mp/metrics/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,19 @@
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, metrics
 :h1Prefix: MP
+:feature-name: MicroProfile Metrics
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+        <dependency>
+            <groupId>io.helidon.microprofile.metrics</groupId>
+            <artifactId>helidon-microprofile-metrics</artifactId>
+        </dependency>
+----
 
 == Overview
 Helidon provides three types of metrics: base, vendor, and application.  Helidon automatically provides built-in base and vendor metrics.

--- a/docs/mp/openapi/01_openapi.adoc
+++ b/docs/mp/openapi/01_openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,9 +30,30 @@
 :jandex-plugin-doc: https://github.com/wildfly/jandex-maven-plugin
 :model-reader-java: {mp-openapi-prefix}/api/src/main/java/org/eclipse/microprofile/openapi/OASModelReader.java
 :filter-java: {mp-openapi-prefix}/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+:feature-name: MicroProfile OpenAPI
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
 
 Easily allow your Helidon MP application to serve an OpenAPI document
 that describes your application's endpoints.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+[source,xml,subs="attributes+"]
+----
+<dependency> <!--1-->
+    <groupId>org.eclipse.microprofile.openapi</groupId>
+    <artifactId>microprofile-openapi-api</artifactId>
+</dependency>
+
+<dependency> <!--2-->
+    <groupId>io.helidon.microprofile.openapi</groupId>
+    <artifactId>helidon-microprofile-openapi</artifactId>
+    <scope>runtime</scope>
+</dependency>
+----
+<1> Defines the MicroProfile OpenAPI annotations so you can use them in your code.
+<2> Adds the Helidon MP OpenAPI runtime support.
+
 
 == OpenAPI support in Helidon MP
 
@@ -90,27 +111,6 @@ configured, might inadvertently miss information.
 
 We _strongly recommend_ using the Jandex plug-in to build the index into your app.
 ====
-
-==== Adding Helidon MP OpenAPI support to your app
-Add these two sections to the `<dependencies>` portion of your `pom.xml`:
-
-[source,xml,subs="attributes+"]
-----
-<dependency> <!--1-->
-    <groupId>org.eclipse.microprofile.openapi</groupId>
-    <artifactId>microprofile-openapi-api</artifactId>
-    <version>{microprofile-openapi-version}</version>
-</dependency>
-
-<dependency> <!--2-->
-    <groupId>io.helidon.microprofile.openapi</groupId>
-    <artifactId>helidon-microprofile-openapi</artifactId>
-    <version>{helidon-version}</version>
-    <scope>runtime</scope>
-</dependency>
-----
-<1> Defines the MicroProfile OpenAPI annotations so you can use them in your code.
-<2> Adds the Helidon MP OpenAPI runtime support.
 
 === Furnish OpenAPI information about your endpoints
 Helidon MP OpenAPI combines information from all of the following sources as it 

--- a/docs/mp/reactivemessaging/01_introduction.adoc
+++ b/docs/mp/reactivemessaging/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,29 @@
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, messaging
 :h1Prefix: MP
+:feature-name: MicroProfile Reactive Messaging
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+   <groupId>io.helidon.microprofile.messaging</groupId>
+   <artifactId>helidon-microprofile-messaging</artifactId>
+</dependency>
+----
+
+To include health checks for Messaging add the following dependency:
+
+[source,xml]
+----
+<dependency>
+   <groupId>io.helidon.microprofile.messaging</groupId>
+   <artifactId>helidon-microprofile-messaging-health</artifactId>
+</dependency>
+----
 
 == Reactive Messaging
 
@@ -150,32 +173,13 @@ public String processMessage(String msg) {
 }
 ----
 
-=== Dependency
-
-Declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-   <groupId>io.helidon.microprofile.messaging</groupId>
-   <artifactId>helidon-microprofile-messaging</artifactId>
-</dependency>
-----
-
 === Health check
+
 Messaging in Helidon has built in health probes for liveness and readiness. To activate it
-just add following dependency:
-[source,xml]
-----
-<dependency>
-   <groupId>io.helidon.microprofile.messaging</groupId>
-   <artifactId>helidon-microprofile-messaging-health</artifactId>
-</dependency>
-----
+add the <<maven-coordinates,health check dependency>>.
 
 * Liveness - channel is considered UP until `cancel` or `onError` signal is intercepted on it.
 * Readiness - channel is considered DOWN until `onSubscribe` signal is intercepted on it.
-
 
 If you check your health endpoints `/health/live` and `/health/ready` you will discover
 every messaging channel to have its own probe.

--- a/docs/mp/reactivemessaging/04_kafka.adoc
+++ b/docs/mp/reactivemessaging/04_kafka.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,22 +22,22 @@
 :description: Reactive Messaging support for Kafka in Helidon MP
 :keywords: helidon, mp, messaging, kafka
 :h1Prefix: MP
+:feature-name: Reactive Kafka Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
-== Reactive Kafka Connector
-Connecting streams to Kafka with Reactive Messaging couldn't be easier.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependencies needed:
 ----
-<dependency>
-    <groupId>io.helidon.microprofile.messaging</groupId>
-    <artifactId>helidon-microprofile-messaging</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.messaging.kafka</groupId>
     <artifactId>helidon-messaging-kafka</artifactId>
 </dependency>
 ----
+
+== Reactive Kafka Connector
+Connecting streams to Kafka with Reactive Messaging couldn't be easier.
 
 [source,yaml]
 .Example of connector config:

--- a/docs/mp/reactivemessaging/05_jms.adoc
+++ b/docs/mp/reactivemessaging/05_jms.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,23 +22,23 @@
 :description: Reactive Messaging support for JMS in Helidon MP
 :keywords: helidon, mp, messaging, jms
 :h1Prefix: MP
+:feature-name: JMS Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
-== Reactive JMS Connector
-
-Connecting streams to JMS with Reactive Messaging couldn't be easier.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependencies needed:
 ----
-<dependency>
-    <groupId>io.helidon.microprofile.messaging</groupId>
-    <artifactId>helidon-microprofile-messaging</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.messaging.jms</groupId>
     <artifactId>helidon-messaging-jms</artifactId>
 </dependency>
 ----
+
+== Reactive JMS Connector
+
+Connecting streams to JMS with Reactive Messaging couldn't be easier.
 
 === Config
 

--- a/docs/mp/reactivemessaging/06_aq.adoc
+++ b/docs/mp/reactivemessaging/06_aq.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,24 +22,23 @@
 :description: Reactive Messaging support for Oracle AQ in Helidon MP
 :keywords: helidon, mp, messaging, jms, aq
 :h1Prefix: MP
+:feature-name: AQ Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: false
 
-== Reactive Oracle Advanced Queueing Connector
-
-Connecting streams to Oracle AQ with Reactive Messaging couldn't be easier.
-This connector extends Helidon's JMS connector with Oracle AQ's specific API.
-
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 [source,xml]
-.Dependencies needed:
 ----
-<dependency>
-    <groupId>io.helidon.microprofile.messaging</groupId>
-    <artifactId>helidon-microprofile-messaging</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.messaging.aq</groupId>
     <artifactId>helidon-messaging-aq</artifactId>
 </dependency>
 ----
+
+== Reactive Oracle Advanced Queueing Connector
+
+Connecting streams to Oracle AQ with Reactive Messaging couldn't be easier.
+This connector extends Helidon's JMS connector with Oracle AQ's specific API.
 
 === Config
 

--- a/docs/mp/reactivestreams/02_engine.adoc
+++ b/docs/mp/reactivestreams/02_engine.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 :h1Prefix: MP
 :description: Dependecy-less reactive operators
 :keywords: helidon, reactive, streams, multi, single
+:feature-name: Reactive Engine
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 ==  Helidon Reactive Engine
 include::../../shared/reactivestreams/02_engine.adoc[lines=21..]

--- a/docs/mp/reactivestreams/03_rsoperators.adoc
+++ b/docs/mp/reactivestreams/03_rsoperators.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 :spec-name: MicroProfile Reactive Streams Operators
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, reactivestreams
+:feature-name: Reactive Streams
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 == Reactive Streams Operators
 include::../../shared/reactivestreams/03_rsoperators.adoc[lines=21..]

--- a/docs/mp/restclient/09_rest-client.adoc
+++ b/docs/mp/restclient/09_rest-client.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,13 +19,12 @@
 = Rest Client
 :h1Prefix: MP
 :description: Helidon MP Rest Client
+:feature-name: MicroProfile Rest Client
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
 = :keywords: helidon, rest, client, microprofile, micro-profile
 
-== Configuring Rest Client with Helidon MP
-MicroProfile Rest Client adds the capability to invoke remote microservices using a JAX-RS like interface to declare the
-operations.
-
-To use the rest client in your project, declare the following dependency:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----
@@ -34,6 +33,10 @@ To use the rest client in your project, declare the following dependency:
     <artifactId>helidon-microprofile-rest-client</artifactId>
 </dependency>
 ----
+
+== Configuring Rest Client with Helidon MP
+MicroProfile Rest Client adds the capability to invoke remote microservices using a JAX-RS like interface to declare the
+operations.
 
 == Creating a new client using a builder
 

--- a/docs/mp/scheduling/01_introduction.adoc
+++ b/docs/mp/scheduling/01_introduction.adoc
@@ -22,18 +22,20 @@
 :description: Scheduling in Helidon MP
 :keywords: helidon, mp, scheduling
 :h1Prefix: MP
+:feature-name: Scheduling
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Scheduling
-For scheduling tasks in Helidon you can choose from @Scheduled or @FixedRate annotations by required complexity of invocation interval. All you need is define method with one of the annotations in application scoped bean.
-
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 [source,xml]
-.Dependency for Scheduling feature
 ----
 <dependency>
     <groupId>io.helidon.microprofile.scheduling</groupId>
     <artifactId>helidon-microprofile-scheduling</artifactId>
 </dependency>
 ----
+
+== Scheduling
+For scheduling tasks in Helidon you can choose from @Scheduled or @FixedRate annotations by required complexity of invocation interval. All you need is define method with one of the annotations in application scoped bean.
 
 
 === Fixed rate

--- a/docs/mp/security/01_security.adoc
+++ b/docs/mp/security/01_security.adoc
@@ -20,15 +20,16 @@
 :h1Prefix: MP
 :description: Helidon MicroProfile security
 :keywords: helidon, microprofile, micro-profile
+:feature-name: Security
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 To add security, such as protecting
 resource methods with authentication, to a MicroProfile application, add the Helidon
  security integration dependency to your project.
 
-== Maven Coordinates
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Maven Dependency
 ----
 <dependency>
   <groupId>io.helidon.microprofile</groupId>

--- a/docs/mp/testing/01_testing.adoc
+++ b/docs/mp/testing/01_testing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@
 :pagename: testing
 :description: Helidon Testing
 :keywords: helidon, mp, test, testing
+:feature-name: Testing
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Helidon provides built-in test support for CDI testing in JUnit5.
 
-== Dependency
-
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 [source,xml]
-.Maven dependency
 ----
 <dependency>
     <groupId>io.helidon.microprofile.tests</groupId>

--- a/docs/mp/tracing/01_tracing.adoc
+++ b/docs/mp/tracing/01_tracing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@
 = Tracing
 :h1Prefix: MP
 :description: Helidon MP Tracing Support
+:feature-name: MicroProfile Tracing
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:microprofile-bundle: true
 = :keywords: helidon, tracing, microprofile, micro-profile
 
-== Configuring Tracing with Helidon MP
-Tracing support is implemented for both for Helidon MP Server and for Jersey client.
-
-Declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----
@@ -34,6 +34,8 @@ Declare the following dependency in your project:
 </dependency>
 ----
 
+== Configuring Tracing with Helidon MP
+Tracing support is implemented for both for Helidon MP Server and for Jersey client.
 In addition you need to add one of the tracer implementations:
 
 - <<tracing/02_zipkin.adoc,Zipkin>>

--- a/docs/se/config/01_introduction.adoc
+++ b/docs/se/config/01_introduction.adoc
@@ -22,10 +22,24 @@
 :h1Prefix: SE
 :description: Helidon config introduction
 :keywords: helidon, config
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Config
 
 The config component provides a Java API to load and process
 configuration properties from various sources into a `Config` object which the
 application can use to retrieve config data.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependencies>
+    <dependency>
+        <groupId>io.helidon.config</groupId>
+        <artifactId>helidon-config</artifactId>
+    </dependency>
+</dependencies>
+----
 
 == Getting Started
 
@@ -96,23 +110,14 @@ For this first example we can see the basic features of `Config`:
 An easy way to start with the link:{javadoc-base-url-api}/Config.html[Config] API
 is to follow these four steps:
 
-1. <<maven-coords,add config-related dependencies to your `pom.xml`>>
+1. <<add-maven-coords,add config-related dependencies to your `pom.xml`>>
 2. <<update-module-info, revise your `module-info.java` to refer to config (if you are using Java 9+)>>
 3. <<create-simple-config-props, create a simple config properties file>>
 4. <<Config-Basics-DefaultConfig, retrieve and use the default `Config` from your app>>
 
-==== Add Maven Dependency on Config [[maven-coords]]
-[source,xml]
-.Config Dependency in `pom.xml`
-----
-<dependencies>
-    <dependency>
-        <groupId>io.helidon.config</groupId>
-        <artifactId>helidon-config</artifactId>
-        <version>version-of-config-you-are-using</version>
-    </dependency>
-</dependencies>
-----
+==== Add Maven Dependency on Config [[add-maven-coords]]
+
+Add <<maven-coordinates,config-related dependencies>> to your `pom.xml.
 
 ==== Update `module-info.java` [[update-module-info]]
 If you are using Java 11 then create or update the `module-info.java` file for your application:

--- a/docs/se/config/08_supported-formats.adoc
+++ b/docs/se/config/08_supported-formats.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -60,12 +60,10 @@ Add the following dependency in your project:
 [source,xml]
 .Config YAML Dependency in `pom.xml`
 ----
-<dependencies>
     <dependency>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-yaml</artifactId>
     </dependency>
-</dependencies>
 ----
 
 [source,java]
@@ -138,12 +136,10 @@ Add the following dependency in your project:
 [source,xml]
 .Config HOCON Dependency in `pom.xml`
 ----
-<dependencies>
     <dependency>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-hocon</artifactId>
     </dependency>
-</dependencies>
 ----
 
 [source,java]
@@ -243,12 +239,10 @@ Add the following dependency to your project:
 [source,xml]
 .Config Etcd Dependency in `pom.xml`
 ----
-<dependencies>
     <dependency>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-etcd</artifactId>
     </dependency>
-</dependencies>
 ----
 
 [source,java]
@@ -351,12 +345,10 @@ Add the following dependency to your project:
 [source,xml]
 .Config git Dependency in `pom.xml`
 ----
-<dependencies>
     <dependency>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-git</artifactId>
     </dependency>
-</dependencies>
 ----
 
 [source,java]

--- a/docs/se/cors/02_using-the-api.adoc
+++ b/docs/se/cors/02_using-the-api.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -35,10 +35,24 @@
 :config-table-methods-column-header: Method
 :cors-config-table-exclude-keys:
 :common-page-prefix-inc: ../../shared/cors/common_shared.adoc
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: CORS
 
 Every Helidon SE application explicitly creates routing rules that govern how Helidon delivers each incoming
  request to the code that needs to respond. The Helidon CORS SE API provides a simple way to include CORS into
  the routing rules that you construct for your application.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+// tag::actual-cors-dependency[]
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>io.helidon.webserver</groupId>
+    <artifactId>helidon-webserver-cors</artifactId>
+</dependency>
+----
+// end::actual-cors-dependency[]
 
 == Understanding the Helidon SE CORS API
 
@@ -67,26 +81,10 @@ endpoint code for the resource.
 
 To add CORS support to your Helidon SE application:
 
-. Determine the type of cross origin sharing you want to allow for each endpoint in your
+1. Determine the type of cross origin sharing you want to allow for each endpoint in your
 application.
-. {blank}
-+
---
-Add a dependency on the Helidon {helidon-variant} CORS artifact to your Maven `pom.xml` file.
-
-include::{common-page-prefix-inc}[tag=add-cors-dependency]
-
-// tag::actual-cors-dependency[]
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>io.helidon.webserver</groupId>
-    <artifactId>helidon-webserver-cors</artifactId>
-</dependency>
-----
-// end::actual-cors-dependency[]
---
-. Modify how your application constructs routing rules so they include CORS as described in the following sections.
+2. Add a dependency on the Helidon {helidon-variant} CORS <<Maven Coordinates, artifact>> to your Maven `pom.xml` file.
+3. Modify how your application constructs routing rules so they include CORS as described in the following sections.
 
 == Adding CORS Support in Your Helidon SE Application [[adding-cors-support]]
 Because Helidon SE does not use annotation processing to identify endpoints, you need to

--- a/docs/se/dbclient/01_introduction.adoc
+++ b/docs/se/dbclient/01_introduction.adoc
@@ -20,8 +20,38 @@
 :description: Helidon DB Client
 :keywords: helidon, se, database, dbclient
 :h1Prefix: SE
+:feature-name: DB Client
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-The Helidon SE DB Client provides a unified, reactive API for working with databases in non-blocking way. 
+The Helidon SE DB Client provides a unified, reactive API for working with databases in non-blocking way.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+     <dependency>
+         <groupId>io.helidon.dbclient</groupId>
+         <artifactId>helidon-dbclient</artifactId>
+     </dependency>
+----
+
+To use with a JDBC client also add the following dependency:
+[source,xml]
+----
+     <dependency>
+         <groupId>io.helidon.dbclient</groupId>
+         <artifactId>helidon-dbclient-jdbc</artifactId>
+     </dependency>
+----
+
+Or to use with MongoDB client add the following dependency:
+[source,xml]
+----
+     <dependency>
+         <groupId>io.helidon.dbclient</groupId>
+         <artifactId>helidon-dbclient-mongodb</artifactId>
+     </dependency>
+----
 
 == Helidon DB Client Features Overview
 
@@ -62,14 +92,11 @@ The API offers support for health checks, metrics and tracing.
 
 Before you begin you must add the DB Client dependencies and configure the client.
 
-. Add the DB Client dependencies to the Maven `pom.xml` file. 
-+
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications.
+=== Add the DB Client dependencies to the Maven `pom.xml` file.
 
 For the DB Client using JDBC implementation and H2 database, you must include the following dependencies in your project:
 
-[source,java]
+[source,xml]
 ----
 <dependencies>
      <dependency>
@@ -90,7 +117,7 @@ For the DB Client using JDBC implementation and H2 database, you must include th
 <2> Specify JDBC or MongoDB
 <3> Add the database JDBC driver (only for JDBC)
 
-. Use Helidon Config to configure the client.
+=== Use Helidon Config to configure the client.
 
 The DB Client must be configured before you begin. In the example below we'll use Helidon Config to set up JDBC-based client:
 

--- a/docs/se/faulttolerance/01_faulttolerance.adoc
+++ b/docs/se/faulttolerance/01_faulttolerance.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -28,7 +28,19 @@
 :javadoc-base-url-reactive: {javadoc-base-url}io.helidon.common.reactive/io/helidon/common/reactive/package-summary.html
 :helidon-variant: SE
 :mp-microprofile: https://download.eclipse.org/microprofile/microprofile-fault-tolerance-2.1.1/microprofile-fault-tolerance-spec.html
+:feature-name: Fault Tolerance
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.fault-tolerance</groupId>
+    <artifactId>helidon-fault-tolerance</artifactId>
+</dependency>
+----
 
 == Introduction
 
@@ -56,18 +68,8 @@ link:{javadoc-base-url-faulttolerance}[Fault Toleance SE API Javadocs].
 
 === Updating your POM
 
-The following POM dependency is necessary to use the Fault Tolerance SE API in a
-Helidon application.
-
-[source,xml]
-.Fault Tolerance SE Dependency in `pom.xml`
-----
-<dependency>
-    <groupId>io.helidon.fault-tolerance</groupId>
-    <artifactId>helidon-fault-tolerance</artifactId>
-    <version>{helidon-version}</version>
-</dependency>
-----
+In order to use Fault Tolerance you first need to add the <<Maven Coordinates, maven dependency>> to
+your `pom.xml`.
 
 === Single<T> and Multi<T>
 

--- a/docs/se/graphql/01_introduction.adoc
+++ b/docs/se/graphql/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 :pagename: graphql-server-introduction
 :description: Helidon GraphQL Server Introduction
 :keywords: helidon, graphql, java
+:feature-name: GraphQL
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Helidon GraphQL Server provides a framework for creating link:https://github.com/graphql-java/graphql-java[GraphQL] applications.
 
@@ -28,6 +30,16 @@ Helidon GraphQL Server provides a framework for creating link:https://github.com
 
 WARNING: The Helidon GraphQL feature is currently experimental and the APIs are
  subject to changes until GraphQL support is stabilized.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.graphql</groupId>
+    <artifactId>helidon-graphql-server</artifactId>
+</dependency>
+----
 
 == Quick Start
 
@@ -103,15 +115,3 @@ curl -X POST http://127.0.0.1:PORT/graphql -d '{"query":"query { helloInDifferen
 {"data":{"helloInDifferentLanguages":["Bonjour","Hola","Zdravstvuyte","Nǐn hǎo","Salve","Gudday","Konnichiwa","Guten Tag"]}}
 ----
 
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Getting Started>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.graphql</groupId>
-    <artifactId>helidon-graphql-server</artifactId>
-</dependency>
-----

--- a/docs/se/grpc/01_introduction.adoc
+++ b/docs/se/grpc/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 :pagename: grpc-server-introduction
 :description: Helidon gRPC Server Introduction
 :keywords: helidon, grpc, java
+:feature-name: gRPC
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Helidon gRPC Server provides a framework for creating link:http://grpc.io/[gRPC] applications.
 
@@ -28,6 +30,16 @@ Helidon gRPC Server provides a framework for creating link:http://grpc.io/[gRPC]
 
 WARNING: The Helidon gRPC feature is currently experimental and the APIs are
  subject to changes until gRPC support is stabilized.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+    <dependency>
+        <groupId>io.helidon.grpc</groupId>
+        <artifactId>helidon-grpc-server</artifactId>
+    </dependency>
+----
 
 == Quick Start
 
@@ -65,18 +77,3 @@ Here is the code for a minimalist gRPC application that runs on a default port (
 The example above deploys a very simple service to the gRPC server that by default uses Java serialization to marshall
 requests and responses. We will look into deployment of "standard" gRPC services that use Protobuf for request and
 response marshalling, as well as how you can configure custom marshallers, later in this document.
-
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Getting Started>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.grpc</groupId>
-    <artifactId>helidon-grpc-server</artifactId> <!--1-->
-</dependency>
-----
-
-<1> Dependency on gRPC Server.

--- a/docs/se/grpc/08_security.adoc
+++ b/docs/se/grpc/08_security.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,15 +20,14 @@
 :h1Prefix: SE
 :description: Helidon Security gRPC integration
 :keywords: helidon, grpc, security
+:feature-name: gRPC Server Security
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Security integration of the  <<grpc/01_introduction.adoc,gRPC server>>
 
-== Prerequisites
-
-Declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Maven Dependency
 ----
 <dependency>
     <groupId>io.helidon.security.integration</groupId>

--- a/docs/se/grpc/21_client_introduction.adoc
+++ b/docs/se/grpc/21_client_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 :pagename: grpc-client-introduction
 :description: Helidon gRPC Client Introduction
 :keywords: helidon, grpc, java
+:feature-name: gRPC Client
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 = gRPC Client Introduction
 
@@ -34,20 +36,15 @@ The class `GrpcServiceClient` acts as the client object for accessing a gRPC ser
 
 In later sections in this document, you will see how to customize both `ClientServiceDescriptor` and the `Channel`.
 
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications. Then declare the following dependency in your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----
 <dependency>
     <groupId>io.helidon.grpc</groupId>
-    <artifactId>helidon-grpc-client</artifactId> <!--1-->
+    <artifactId>helidon-grpc-client</artifactId>
 </dependency>
 ----
-
-<1> Declare dependency on Helidon gRPC Client.
 
 == Quick Start
 

--- a/docs/se/health/01_health.adoc
+++ b/docs/se/health/01_health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,9 +21,30 @@
 :description: Helidon health checks
 :keywords: helidon, health-checks, health, check
 :javadoc-base-url-api: {javadoc-base-url}io.helidon.health.checks/io/helidon/health/checks
-
+:feature-name: Health Checks
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 This document describes the health check API available with Helidon SE.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.health</groupId>
+    <artifactId>helidon-health</artifactId>
+</dependency>
+----
+
+Optional dependency to use built-in health checks:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.health</groupId>
+    <artifactId>helidon-health-checks</artifactId>
+</dependency>
+----
 
 == About health checks
 
@@ -43,26 +64,6 @@ A typical health check combines the statuses of all the dependencies that
 * database
 * other services used by your application
 
-=== Prerequisites
-
-Declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.health</groupId>
-    <artifactId>helidon-health</artifactId>
-</dependency>
-----
-
-[source,xml]
-.Optional dependency to use built-in health checks:
-----
-<dependency>
-    <groupId>io.helidon.health</groupId>
-    <artifactId>helidon-health-checks</artifactId>
-</dependency>
-----
 
 == API overview
 

--- a/docs/se/metrics/01_metrics.adoc
+++ b/docs/se/metrics/01_metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 :h1Prefix: SE
 :description: Helidon metrics
 :keywords: helidon, metrics
+:feature-name: DB Client
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Helidon SE provides the following to support metrics:
 
@@ -28,12 +30,9 @@ Helidon SE provides the following to support metrics:
 2. A base set of metrics, available at `/metrics/base`, as specified by the MicroProfile Metrics specification.
 3. A set of Helidon-specific metrics, available at `/metrics/vendor`
 
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-== Prerequisites
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
+[source,xml]
 ----
     <dependency>
         <groupId>io.helidon.metrics</groupId>

--- a/docs/se/metrics/02_prometheus.adoc
+++ b/docs/se/metrics/02_prometheus.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 :h1Prefix: SE
 :description: Helidon Prometheus metrics
 :keywords: helidon, metrics, prometheus
+:feature-name: Prometheus Metrics
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Helidon WebServer can serve Prometheus metrics.
 
@@ -29,11 +31,9 @@ Prometheus documentation: https://prometheus.io/docs/introduction/overview/.
 
 Note that Helidon has an in-built metrics implementation. See <<metrics/01_metrics.adoc,Helidon Metrics>>.
 
-== Prerequisites
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
+[source,xml]
 ----
     <dependency>
         <groupId>io.helidon.metrics</groupId>

--- a/docs/se/openapi/01_openapi.adoc
+++ b/docs/se/openapi/01_openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,9 +30,21 @@
 :helidon-se-openapi-example: {helidon-tag}/examples/openapi
 :model-reader-java: {mp-openapi-prefix}/api/src/main/java/org/eclipse/microprofile/openapi/OASModelReader.java
 :filter-java: {mp-openapi-prefix}/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
+:feature-name: OpenAPI
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 Easily allow your Helidon SE application to serve an OpenAPI document
 that describes your application's endpoints.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.openapi</groupId>
+    <artifactId>helidon-openapi</artifactId>
+</dependency>
+----
 
 == OpenAPI support in Helidon SE
 
@@ -59,16 +71,7 @@ To use OpenAPI from your Helidon SE app:
 4. Update your application's Helidon configuration (optional).
 
 === Edit your `pom.xml`
-Add a dependency for Helidon SE OpenAPI runtime support:
-
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>io.helidon.openapi</groupId>
-    <artifactId>helidon-openapi</artifactId>
-    <version>{helidon-version}</version>
-</dependency>
-----
+Add a dependency for <<maven-coordinates,Helidon SE OpenAPI>> runtime support.
 This is a compile-time dependency, because your code must register
 `OpenAPISupport` (a class in that artifact) like this:
 

--- a/docs/se/reactivemessaging/01_introduction.adoc
+++ b/docs/se/reactivemessaging/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,18 @@
 :description: Reactive Messaging support in Helidon SE
 :keywords: helidon, se, messaging
 :h1Prefix: SE
+:feature-name: Reactive Messaging
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.messaging</groupId>
+    <artifactId>helidon-messaging</artifactId>
+</dependency>
+----
 
 == Reactive Messaging
 
@@ -119,16 +131,3 @@ Example of such a versatile connectors in Helidon:
 
  * <<se/reactivemessaging/04_kafka.adoc,Kafka connector>>
  * <<se/reactivemessaging/05_jms.adoc,JMS connector>>
-
-
-=== Dependency
-
-Declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.messaging</groupId>
-    <artifactId>helidon-messaging</artifactId>
-</dependency>
-----

--- a/docs/se/reactivemessaging/04_kafka.adoc
+++ b/docs/se/reactivemessaging/04_kafka.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,22 +22,21 @@
 :description: Reactive Messaging support for Kafka in Helidon SE
 :keywords: helidon, se, messaging, kafka
 :h1Prefix: SE
+:feature-name: Kafka Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Reactive Kafka Connector
-Connecting streams to Kafka with Reactive Messaging couldn't be easier.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependencies needed:
 ----
-<dependency>
-    <groupId>io.helidon.messaging</groupId>
-    <artifactId>helidon-messaging</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.messaging.kafka</groupId>
     <artifactId>helidon-messaging-kafka</artifactId>
 </dependency>
 ----
+
+== Reactive Kafka Connector
+Connecting streams to Kafka with Reactive Messaging couldn't be easier.
 
 === Explicit config with config builder
 

--- a/docs/se/reactivemessaging/05_jms.adoc
+++ b/docs/se/reactivemessaging/05_jms.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,22 +22,21 @@
 :description: Reactive Messaging support for JMS in Helidon SE
 :keywords: helidon, se, messaging, jms
 :h1Prefix: SE
+:feature-name: JMS Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Reactive JMS Connector
-Connecting streams to JMS with Reactive Messaging couldn't be easier.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependencies needed:
 ----
-<dependency>
-    <groupId>io.helidon.messaging</groupId>
-    <artifactId>helidon-messaging</artifactId>
-</dependency>
 <dependency>
     <groupId>io.helidon.messaging.jms</groupId>
     <artifactId>helidon-messaging-jms</artifactId>
 </dependency>
 ----
+
+== Reactive JMS Connector
+Connecting streams to JMS with Reactive Messaging couldn't be easier.
 
 === Explicit config with config builder
 

--- a/docs/se/reactivemessaging/06_aq.adoc
+++ b/docs/se/reactivemessaging/06_aq.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,19 +22,20 @@
 :description: Reactive Messaging support for Oracle AQ in Helidon SE
 :keywords: helidon, se, messaging, jms, aq
 :h1Prefix: SE
+:feature-name: AQ Connector
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Reactive Oracle AQ Connector
-
-Connecting streams to Oracle Advanced Queueing with Reactive Messaging needs nothing more than one dependency.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependencies needed:
 ----
 <dependency>
     <groupId>io.helidon.messaging.aq</groupId>
     <artifactId>helidon-messaging-aq</artifactId>
 </dependency>
 ----
+
+== Reactive Oracle AQ Connector
 
 === Sending and receiving
 

--- a/docs/se/reactivestreams/02_engine.adoc
+++ b/docs/se/reactivestreams/02_engine.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 :h1Prefix: SE
 :description: Dependency-less reactive operators
 :keywords: helidon, reactive, streams, multi, single
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Reactive Engine
 
-==  Helidon Reactive Engine
-include::../../shared/reactivestreams/02_engine.adoc[lines=21..]
+include::../../shared/reactivestreams/02_engine.adoc[]

--- a/docs/se/reactivestreams/03_rsoperators.adoc
+++ b/docs/se/reactivestreams/03_rsoperators.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 :spec-name: MicroProfile Reactive Streams Operators
 :description: {spec-name} support in Helidon SE
 :keywords: helidon, se, microprofile, reactivestreams
+:feature-name: Reactive Streams
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Reactive Streams Operators
-include::../../shared/reactivestreams/03_rsoperators.adoc[lines=21..]
+include::../../shared/reactivestreams/03_rsoperators.adoc[]

--- a/docs/se/scheduling/01_introduction.adoc
+++ b/docs/se/scheduling/01_introduction.adoc
@@ -22,12 +22,12 @@
 :description: Scheduling in Helidon SE
 :keywords: helidon, se, scheduling
 :h1Prefix: SE
+:feature-name: Scheduling
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Scheduling
-For scheduling periodic tasks it is possible to choose fixed rate setup or Cron expression.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
-.Dependency for Scheduling feature
 ----
 <dependency>
     <groupId>io.helidon.scheduling</groupId>
@@ -35,6 +35,8 @@ For scheduling periodic tasks it is possible to choose fixed rate setup or Cron 
 </dependency>
 ----
 
+== Scheduling
+For scheduling periodic tasks it is possible to choose fixed rate setup or Cron expression.
 
 === Fixed rate
 For simple fixed rate invocation use .

--- a/docs/se/security/01_introduction.adoc
+++ b/docs/se/security/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,22 @@
 :h1Prefix: SE
 :description: Helidon Security introduction
 :keywords: helidon, security
+:feature-name: Security
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+
+Helidon Security provides authentication, authroization and auditing for your Helidon application.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.security</groupId>
+    <artifactId>helidon-security</artifactId>
+</dependency>
+----
+
+== Overview
 
 Helidon Security provides the following features
 
@@ -168,17 +184,4 @@ Security security = Security.builder()
                 .addProvider()
                 .config(config)
                 .build();
-----
-
-== Maven Coordinates
-
-You need to declare the following dependency in your project:
-
-[source,xml]
-.Maven Dependency
-----
-<dependency>
-    <groupId>io.helidon.security</groupId>
-    <artifactId>helidon-security</artifactId>
-</dependency>
 ----

--- a/docs/se/tracing/01_tracing.adoc
+++ b/docs/se/tracing/01_tracing.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,7 +19,19 @@
 = Tracing
 :h1Prefix: SE
 :description: Helidon Tracing Support
-= :keywords: helidon, tracing
+:feature-name: Tracing
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:keywords: helidon, tracing
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.tracing</groupId>
+    <artifactId>helidon-tracing</artifactId>
+</dependency>
+----
 
 == Tracing Support
 Helidon includes support for tracing through the `https://opentracing.io/[OpenTracing]` APIs.
@@ -29,19 +41,7 @@ Support for specific tracers is abstracted. Your application can depend on
 the abstraction layer and provide a specific tracer implementation as a Java
 `ServiceLoader` service.
 
-
 == Configuring Tracing with Helidon SE
-
-Declare the following dependency in your project to use the tracer abstraction:
-
-[source,xml]
-.Tracer Abstraction
-----
-<dependency>
-    <groupId>io.helidon.tracing</groupId>
-    <artifactId>helidon-tracing</artifactId>
-</dependency>
-----
 
 === Configuring Tracing with WebServer
 

--- a/docs/se/tracing/03_jaeger.adoc
+++ b/docs/se/tracing/03_jaeger.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,5 +21,7 @@
 :keywords: helidon, tracing, jaeger
 :h1Prefix: SE
 :jager-page: ../../shared/tracing/tracer-jaeger.adoc
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Jaeger Tracing
 
 include::{jager-page}[]

--- a/docs/se/webclient/01_introduction.adoc
+++ b/docs/se/webclient/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,20 @@
 :pagename: WebClient-Introduction
 :description: Helidon WebClient
 :keywords: helidon, se, rest, httpclient, webclient, reactive
+:feature-name: WebClient
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.webclient</groupId>
+    <artifactId>helidon-webclient</artifactId>
+</dependency>
+----
+
+== Overview
 
 WebClient is an HTTP client for Helidon SE 2.0. It handles the responses to the HTTP requests in a reactive way.
 
@@ -223,28 +236,3 @@ requestBuilder.request(JsonObject.class)
 ----
 <1> Adds JSON-P writer only to this request.
 <2> Adds JSON-P reader only to this request.
-
-
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc,Managing Dependencies>> page describes how you should declare dependency management for Helidon applications. You must declare the following dependency in your project's pom.xml:
-
-[source,xml]
-.Dependency on WebClient.
-----
-<dependency>
-    <groupId>io.helidon.webclient</groupId>
-    <artifactId>helidon-webclient</artifactId>
-</dependency>
-----
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/se/webserver/01_introduction.adoc
+++ b/docs/se/webserver/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,9 +21,21 @@
 :pagename: webserver-introduction
 :description: Helidon Reactive WebServer Introduction
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: WebServer
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
 WebServer provides an asynchronous and reactive API for creating web applications.
 The API is inspired by popular NodeJS and Java frameworks.
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.webserver</groupId>
+    <artifactId>helidon-webserver</artifactId>
+</dependency>
+----
 
 == Quick Start
 
@@ -46,19 +58,3 @@ Here is the code for a minimalist web application that runs on a random free por
 <2> Start the server.
 <3> Wait for the server to start while throwing possible errors as runtime exceptions.
 <4> The server is bound to a random free port.
-
-== Maven Coordinates
-
-The <<about/04_managing-dependencies.adoc, Managing Dependencies>> page describes how you
-should declare dependency management for Helidon applications.
-Then declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
-----
-<dependency>
-    <groupId>io.helidon.webserver</groupId>
-    <artifactId>helidon-webserver</artifactId> <!--1-->
-</dependency>
-----
-
-<1> Dependency on WebServer.

--- a/docs/se/webserver/06_static-content-support.adoc
+++ b/docs/se/webserver/06_static-content-support.adoc
@@ -20,6 +20,18 @@
 :h1Prefix: SE
 :description: Helidon Reactive WebServer static content support
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: Static Content Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.webserver</groupId>
+    <artifactId>helidon-webserver-static-content</artifactId>
+</dependency>
+----
 
 == Static Content Support
 
@@ -29,19 +41,6 @@ Use the `io.helidon.webserver.staticcontent.StaticContentSupport` class to serve
 
 You can combine dynamic handlers with `StaticContentSupport` objects: if no file matches the request path, then the request is forwarded to
  the next handler.
-
-=== Maven Coordinates
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
-.WebServer Static Content Dependency
-----
-<dependency>
-    <groupId>io.helidon.webserver</groupId>
-    <artifactId>helidon-webserver-static-content</artifactId>
-</dependency>
-----
 
 === Registering Static Content
 

--- a/docs/se/webserver/07_jersey-support.adoc
+++ b/docs/se/webserver/07_jersey-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,23 +20,22 @@
 :h1Prefix: SE
 :description: Helidon Reactive WebServer Jersey JAX-RS support
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: Jersey (JAX-RS) Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== JAX-RS Support
-You can register a Jersey (JAX-RS) application at a _context root_ using the
- `JerseySupport` class.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-=== Maven Coordinates
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
-.WebServer Jersey Dependency
+[source,xml]
 ----
 <dependency>
     <groupId>io.helidon.webserver</groupId>
     <artifactId>helidon-webserver-jersey</artifactId>
 </dependency>
 ----
+
+== JAX-RS Support
+You can register a Jersey (JAX-RS) application at a _context root_ using the
+ `JerseySupport` class.
 
 === Registering a Jersey Application
 To register a *Jersey* application at a context root, use the

--- a/docs/se/webserver/08_json-support.adoc
+++ b/docs/se/webserver/08_json-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,23 +20,22 @@
 :h1Prefix: SE
 :description: Helidon Reactive WebServer JSON support
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: JSON Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Json Support
-The WebServer supports JSON-P. When enabled, you can send and
- receive JSON-P objects transparently.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-=== Maven Coordinates
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
-.Webserver JSON-P Dependency
+[source,xml]
 ----
 <dependency>
     <groupId>io.helidon.media</groupId>
     <artifactId>helidon-media-jsonp</artifactId>
 </dependency>
 ----
+
+== Json Support
+The WebServer supports JSON-P. When enabled, you can send and
+ receive JSON-P objects transparently.
 
 === Usage
 

--- a/docs/se/webserver/09_jsonb-support.adoc
+++ b/docs/se/webserver/09_jsonb-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +20,18 @@
 :h1Prefix: SE
 :description: Helidon Reactive WebServer JSON-B support
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: JSON-B Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.media</groupId>
+    <artifactId>helidon-media-jsonb</artifactId>
+</dependency>
+----
 
 == JSON-B Support
 The WebServer supports the http://json-b.net/[JSON-B
@@ -27,18 +39,6 @@ specification]. When this support is enabled, Java objects will be
 serialized to and deserialized from JSON automatically using
 https://github.com/eclipse-ee4j/yasson[Yasson], an implementation of
 the https://jcp.org/en/jsr/detail?id=367[JSON-B specification].
-
-=== Maven Coordinates
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
-----
-<dependency>
-    <groupId>io.helidon.media</groupId>
-    <artifactId>helidon-media-jsonb</artifactId>
-</dependency>
-----
 
 === Usage
 To enable JSON-B support, first create and register a

--- a/docs/se/webserver/10_jackson-support.adoc
+++ b/docs/se/webserver/10_jackson-support.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,24 +20,24 @@
 :h1Prefix: SE
 :description: Helidon Reactive WebServer Jackson support
 :keywords: helidon, reactive, reactive streams, reactive java, reactive webserver
+:feature-name: Jackson Support
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-== Jackson Support
-The WebServer supports
-https://github.com/FasterXML/jackson#jackson-project-home-github[Jackson].
-When this support is enabled, Java objects will be serialized to and
-deserialized from JSON automatically using Jackson.
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
-=== Maven Coordinates
-
-Declare the following dependency in your project:
-
-[source,xml,subs="verbatim,attributes"]
+[source,xml]
 ----
 <dependency>
     <groupId>io.helidon.media</groupId>
     <artifactId>helidon-media-jackson</artifactId>
 </dependency>
 ----
+
+== Jackson Support
+The WebServer supports
+https://github.com/FasterXML/jackson#jackson-project-home-github[Jackson].
+When this support is enabled, Java objects will be serialized to and
+deserialized from JSON automatically using Jackson.
 
 === Usage
 To enable Jackson support, first create and register a

--- a/docs/shared/dependencies/common_shared.adoc
+++ b/docs/shared/dependencies/common_shared.adoc
@@ -1,6 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,12 +15,16 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Zipkin Tracing
-:description: Helidon Tracing Support
-:keywords: helidon, tracing, zipkin
-:h1Prefix: SE
-:zipkin-page: ../../shared/tracing/tracer-zipkin.adoc
-:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
-:feature-name: Zipkin Tracing
 
-include::{zipkin-page}[]
+//Contains content about dependencies that is shared across documentation for the helidon modules
+:keywords: helidon, java, dependency, dependencies, maven
+
+// tag::maven-dependency[]
+== Maven Coordinates [[maven-coordinates]]
+
+To enable {feature-name}
+ifeval::["{microprofile-bundle}" == "true"]
+either add a dependency on the <<mp/introduction/02_microprofile.adoc, helidon-microprofile bundle>> or
+endif::[]
+add the following dependency to your project's `pom.xml` (see <<about/04_managing-dependencies.adoc, Managing Dependencies>>).
+// end::maven-dependency[]

--- a/docs/shared/reactivestreams/02_engine.adoc
+++ b/docs/shared/reactivestreams/02_engine.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,7 +15,19 @@
     limitations under the License.
 
 ///////////////////////////////////////////////////////////////////////////////
-= Reactive Engine
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Reactive Engine
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.common</groupId>
+    <artifactId>helidon-common-reactive</artifactId>
+</dependency>
+----
+
 == Reactive Engine
 
 Helidon has its own set of reactive operators that have no dependencies outside of the Helidon ecosystem.
@@ -136,14 +148,3 @@ In the situations when part of the operator chain needs to be prepared in advanc
 > Item received: BAR
 ----
 
-=== Dependency
-
-Declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.helidon.common</groupId>
-    <artifactId>helidon-common-reactive</artifactId>
-</dependency>
-----

--- a/docs/shared/reactivestreams/03_rsoperators.adoc
+++ b/docs/shared/reactivestreams/03_rsoperators.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,7 +15,19 @@
     limitations under the License.
 
 ///////////////////////////////////////////////////////////////////////////////
-= Reactive Streams Operators
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Reactive Streams
+
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
+
+[source,xml]
+----
+<dependency>
+   <groupId>io.helidon.microprofile.reactive-streams</groupId>
+   <artifactId>helidon-microprofile-reactive-streams</artifactId>
+</dependency>
+----
+
 == Reactive Streams Operators
 
 Implementation of
@@ -112,14 +124,3 @@ which can be combined together to closed graph with methods `via` and `to`.
 > Item received: BAR
 ----
 
-=== Dependency
-
-Declare the following dependency in your project:
-
-[source,xml]
-----
-<dependency>
-   <groupId>io.helidon.microprofile.reactive-streams</groupId>
-   <artifactId>helidon-microprofile-reactive-streams</artifactId>
-</dependency>
-----

--- a/docs/shared/tracing/tracer-jaeger.adoc
+++ b/docs/shared/tracing/tracer-jaeger.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
     limitations under the License.
 
 ///////////////////////////////////////////////////////////////////////////////
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Jaeger Tracing
 
 Helidon is integrated with the Jaeger tracer.
 
@@ -23,9 +25,7 @@ also use the Jaeger builder directly, though this would create a source-code dep
 on the Jaeger tracer.
 
 
-== Prerequisites
-To use Jaeger as a tracer,
-    add the following dependency to your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----

--- a/docs/shared/tracing/tracer-zipkin.adoc
+++ b/docs/shared/tracing/tracer-zipkin.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
     limitations under the License.
 
 ///////////////////////////////////////////////////////////////////////////////
+:common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:feature-name: Zipkin Tracing
 
 Helidon is integrated with the Zipkin tracer.
 
@@ -22,10 +24,7 @@ The Zipkin builder is loaded through `ServiceLoader` and configured. You could
 also use the Zipkin builder directly, though this would create a source-code dependency
 on the Zipkin tracer.
 
-
-== Prerequisites
-To use Zipkin as a tracer,
-    add the following dependency to your project:
+include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 [source,xml]
 ----


### PR DESCRIPTION
Fixes  #2889 

Updates documentation to consistently state maven coordinates at top of pages.