### PR TITLE
dbclient: Relax named parameter identifier rules and align with JPA 2.0 spec to fix #2922

### DIFF
--- a/dbclient/jdbc/src/test/java/io/helidon/dbclient/jdbc/JdbcStatementParserTest.java
+++ b/dbclient/jdbc/src/test/java/io/helidon/dbclient/jdbc/JdbcStatementParserTest.java
@@ -49,20 +49,20 @@ public class JdbcStatementParserTest {
     
     /**
      * Test simple SQL statement with parameters.
-     * Parameters contain both letters and numbers in proper order.
+     * Parameters names follow the same rules for identifiers defined in Section 4.4.1 of the JPA 2.0 specification
      */
     @Test
     void testStatementWithParameters() {
         String stmtIn =
                 "SELECT t.*, 'first' FROM table t\r\n" +
-                "  WHERE name = :n4m3\n" +
+                "  WHERE name = :my_n4m3\n" +
                 "   AND age > :ag3";
         String stmtExp =
                 "SELECT t.*, 'first' FROM table t\r\n" +
                 "  WHERE name = ?\n" +
                 "   AND age > ?";
         List<String> namesExp = new ArrayList<>(2);
-        namesExp.add("n4m3");
+        namesExp.add("my_n4m3");
         namesExp.add("ag3");
         Parser parser = new Parser(stmtIn);
         String stmtOut = parser.convert();


### PR DESCRIPTION
Currently, named parameter identifiers following the `:` are parsed in a stricter fashion than in JPA implementations offering similar functionality. Users coming from the JPA world will be inconvenienced while attempting to declare certain named parameters, as in Issue #2922.

This change relaxes the character requirements to include characters like underscores and dollar signs, aligning with the JPA 2.0 specification. 

Rules for named parameters on page 123, rules for the identifiers following the `:` of a named parameter on page 136:
https://download.oracle.com/otn-pub/jcp/persistence-2.0-fr-eval-oth-JSpec/persistence-2_0-final-spec.pdf