### PR TITLE
Consolidate Micrometer integration SE and MP into one feature

### DIFF
--- a/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
+++ b/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
@@ -348,9 +348,9 @@ final class FeatureCatalog {
                     "Micrometer integration",
                     "Micrometer");
         addMp("io.helidon.integrations.micrometer.cdi",
-                "Micrometer CDI",
-                "Micrometer CDI integration",
-                "Micrometer-CDI");
+                "Micrometer",
+                "Micrometer integration",
+                "Micrometer");
 
         /*
          * Common modules


### PR DESCRIPTION
Resolves #2929 

The original Micrometer integration identified SE and MP integration with Micrometer as separate features. This PR changes that to report a single feature.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>