### PR TITLE
Examples await

### DIFF
--- a/examples/cors/src/test/java/io/helidon/examples/cors/MainTest.java
+++ b/examples/cors/src/test/java/io/helidon/examples/cors/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,11 +55,7 @@ public class MainTest {
     public static void start() throws Exception {
         // the port is only available if the server started already!
         // so we need to wait
-        webServer = Main.startServer()
-                        .start()
-                        .toCompletableFuture()
-                        .get();
-
+        webServer = Main.startServer().await();
 
         webClient = WebClient.builder()
                         .baseUri("http://localhost:" + webServer.port())

--- a/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
+++ b/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
@@ -17,6 +17,7 @@
 package io.helidon.service.employee;
 
 import io.helidon.common.LogConfig;
+import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -49,7 +50,7 @@ public final class Main {
      * Start the server.
      * @return the created {@link WebServer} instance
      */
-    static WebServer startServer() {
+    static Single<WebServer> startServer() {
 
         // load logging configuration
         LogConfig.configureRuntime();
@@ -58,14 +59,13 @@ public final class Main {
         Config config = Config.create();
 
         // Get webserver config from the "server" section of application.yaml and JSON support registration
-        WebServer server = WebServer.builder(createRouting(config))
+        Single<WebServer> server = WebServer.builder(createRouting(config))
                 .config(config.get("server"))
                 .addMediaSupport(JsonbSupport.create())
-                .build();
+                .build()
+                .start();
 
-        // Try to start the server. If successful, print some info and arrange to
-        // print a message at shutdown. If unsuccessful, print the exception.
-        server.start().thenAccept(ws -> {
+        server.thenAccept(ws -> {
             System.out.println("WEB server is up!");
             System.out.println("Web client at: http://localhost:" + ws.port()
                                        + "/public/index.html");

--- a/examples/employee-app/src/test/java/io/helidon/service/employee/MainTest.java
+++ b/examples/employee-app/src/test/java/io/helidon/service/employee/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.Single;
 import io.helidon.webclient.WebClient;
 import io.helidon.webserver.WebServer;
 
@@ -35,17 +36,7 @@ public class MainTest {
 
     @BeforeAll
     public static void startTheServer() throws Exception {
-        webServer = Main.startServer();
-
-        long timeout = 2000; // 2 seconds should be enough to start the server
-        long now = System.currentTimeMillis();
-
-        while (!webServer.isRunning()) {
-            Thread.sleep(100);
-            if ((System.currentTimeMillis() - now) > timeout) {
-                Assertions.fail("Failed to start webserver");
-            }
-        }
+        webServer = Main.startServer().await();
 
         webClient = WebClient.builder()
                 .baseUri("http://localhost:" + webServer.port())

--- a/examples/integrations/neo4j/neo4j-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
+++ b/examples/integrations/neo4j/neo4j-se/src/test/java/io/helidon/examples/quickstart/se/MainTest.java
@@ -54,17 +54,7 @@ public class MainTest {
 
         System.setProperty("neo4j.uri", embeddedDatabaseServer.boltURI().toString());
 
-        webServer = Main.startServer();
-
-        long timeout = 2000; // 2 seconds should be enough to start the server
-        long now = System.currentTimeMillis();
-
-        while (!webServer.isRunning()) {
-            Thread.sleep(100);
-            if ((System.currentTimeMillis() - now) > timeout) {
-                Assertions.fail("Failed to start webserver");
-            }
-        }
+        webServer = Main.startServer().await();
 
         webClient = WebClient.builder()
                 .baseUri("http://localhost:" + webServer.port())

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.examples.openapi;
 
 import io.helidon.common.LogConfig;
+import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
@@ -49,7 +50,7 @@ public final class Main {
      * Start the server.
      * @return the created {@link WebServer} instance
      */
-    static WebServer startServer() {
+    static Single<WebServer> startServer() {
 
         // load logging configuration
         LogConfig.configureRuntime();
@@ -58,15 +59,15 @@ public final class Main {
         Config config = Config.create();
 
         // Get webserver config from the "server" section of application.yaml and register JSON support
-        WebServer server = WebServer.builder(createRouting(config))
+        Single<WebServer> server = WebServer.builder(createRouting(config))
                 .config(config.get("server"))
                 .addMediaSupport(JsonpSupport.create())
-                .build();
+                .build()
+                .start();
 
         // Try to start the server. If successful, print some info and arrange to
         // print a message at shutdown. If unsuccessful, print the exception.
-        server.start()
-            .thenAccept(ws -> {
+        server.thenAccept(ws -> {
                 System.out.println(
                         "WEB server is up! http://localhost:" + ws.port() + "/greet");
                 ws.whenShutdown().thenRun(()
@@ -77,9 +78,6 @@ public final class Main {
                 t.printStackTrace(System.err);
                 return null;
             });
-
-        // Server threads are not daemon. No need to block. Just react.
-
         return server;
     }
 

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -65,8 +65,6 @@ public final class Main {
                 .build()
                 .start();
 
-        // Try to start the server. If successful, print some info and arrange to
-        // print a message at shutdown. If unsuccessful, print the exception.
         server.thenAccept(ws -> {
                 System.out.println(
                         "WEB server is up! http://localhost:" + ws.port() + "/greet");

--- a/examples/openapi/src/test/java/io/helidon/examples/openapi/MainTest.java
+++ b/examples/openapi/src/test/java/io/helidon/examples/openapi/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,17 +52,7 @@ public class MainTest {
 
     @BeforeAll
     public static void startTheServer() throws Exception {
-        webServer = Main.startServer();
-
-        long timeout = 2000; // 2 seconds should be enough to start the server
-        long now = System.currentTimeMillis();
-
-        while (!webServer.isRunning()) {
-            Thread.sleep(100);
-            if ((System.currentTimeMillis() - now) > timeout) {
-                Assertions.fail("Failed to start webserver");
-            }
-        }
+        webServer = Main.startServer().await();
 
         webClient = WebClient.builder()
                 .baseUri("http://localhost:" + webServer.port())

--- a/examples/webserver/mutual-tls/src/main/java/io/helidon/webserver/examples/mtls/ServerBuilderMain.java
+++ b/examples/webserver/mutual-tls/src/main/java/io/helidon/webserver/examples/mtls/ServerBuilderMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.webserver.examples.mtls;
 import io.helidon.common.configurable.Resource;
 import io.helidon.common.http.Http;
 import io.helidon.common.pki.KeyConfig;
+import io.helidon.common.reactive.Single;
 import io.helidon.webserver.ClientAuthentication;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.SocketConfiguration;
@@ -49,20 +50,20 @@ public class ServerBuilderMain {
         startServer(8080, 443);
     }
 
-    static WebServer startServer(int unsecured, int secured) {
+    static Single<WebServer> startServer(int unsecured, int secured) {
         SocketConfiguration socketConf = SocketConfiguration.builder()
                 .name("secured")
                 .port(secured)
                 .tls(tlsConfig())
                 .build();
-        WebServer webServer = WebServer.builder()
+        Single<WebServer> webServer = WebServer.builder()
                 .port(unsecured)
                 .routing(createPlainRouting())
                 .addSocket(socketConf, createMtlsRouting())
-                .build();
+                .build()
+                .start();
 
-        webServer.start()
-                .thenAccept(ws -> {
+        webServer.thenAccept(ws -> {
                     System.out.println("WebServer is up!");
                     System.out.println("Unsecured: http://localhost:" + ws.port() + "/");
                     System.out.println("Secured: https://localhost:" + ws.port("secured") + "/");

--- a/examples/webserver/mutual-tls/src/main/java/io/helidon/webserver/examples/mtls/ServerConfigMain.java
+++ b/examples/webserver/mutual-tls/src/main/java/io/helidon/webserver/examples/mtls/ServerConfigMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.helidon.webserver.examples.mtls;
 
 import io.helidon.common.http.Http;
+import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
@@ -45,13 +46,14 @@ public class ServerConfigMain {
         startServer(config.get("server"));
     }
 
-    static WebServer startServer(Config config) {
-        WebServer webServer = WebServer.builder(createPlainRouting())
+    static Single<WebServer> startServer(Config config) {
+        Single<WebServer> webServer = WebServer.builder(createPlainRouting())
                 .config(config)
                 .addNamedRouting("secured", createMtlsRouting())
-                .build();
-        webServer.start()
-                .thenAccept(ws -> {
+                .build()
+                .start();
+
+         webServer.thenAccept(ws -> {
                     System.out.println("WebServer is up!");
                     System.out.println("Unsecured: http://localhost:" + ws.port() + "/");
                     System.out.println("Secured: https://localhost:" + ws.port("secured") + "/");


### PR DESCRIPTION
Update SE examples to use await() instead of polling loop to wait for server startup. Completes fix for #2845 