### PR TITLE
Handle startups with request scopes available from CDI

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -92,7 +92,7 @@ class RequestScopeHelper {
         if (state != State.STORED) {
             throw new IllegalStateException("Request scope state never stored");
         }
-        if (requestScope != null) {                     // Jersey and CDI
+        if (requestScope != null && requestContext != null) {       // Jersey and CDI
             return () -> requestScope.runInScope(requestContext,
                     (Callable<?>) (() -> {
                         InjectionManager old = WeldRequestScope.actualInjectorManager.get();

--- a/tests/functional/request-scope/pom.xml
+++ b/tests/functional/request-scope/pom.xml
@@ -31,19 +31,13 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>
-            <artifactId>helidon-microprofile-core</artifactId>
+            <artifactId>helidon-microprofile</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile</groupId>
-            <artifactId>helidon-microprofile-fault-tolerance</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.metrics</groupId>
-            <artifactId>helidon-microprofile-metrics</artifactId>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -64,10 +58,6 @@
             <groupId>io.helidon.microprofile.tests</groupId>
             <artifactId>helidon-microprofile-tests-junit5</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/StartupServices.java
+++ b/tests/functional/request-scope/src/main/java/io/helidon/tests/functional/requestscope/StartupServices.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.functional.requestscope;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.interceptor.Interceptor;
+import javax.ws.rs.ProcessingException;
+
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * Verifies that FT initializes its internal state correctly when a request scope
+ * is already initialized but a request context is not.
+ */
+@ApplicationScoped
+public class StartupServices {
+
+    /**
+     * Checked by tests to verify startup was successful.
+     */
+    public static final AtomicBoolean SUCCESSFUL_STARTUP = new AtomicBoolean(false);
+
+    private static ScheduledExecutorService execServiceApis;
+
+    private static void onStartup(@Observes @Priority(Interceptor.Priority.PLATFORM_AFTER + 101)
+                                  @Initialized(ApplicationScoped.class) final Object event, StartupServices self) {
+        execServiceApis = Executors.newSingleThreadScheduledExecutor();
+        execServiceApis.execute(() -> {
+            try {
+                self.loadApis();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private static void rightBeforeShutdown(@Observes @BeforeDestroyed(ApplicationScoped.class) final Object event) {
+        if (execServiceApis != null) {
+            execServiceApis.shutdown();
+        }
+    }
+
+    @Retry(delay = 1, delayUnit = ChronoUnit.SECONDS,
+            maxDuration = 60, durationUnit = ChronoUnit.SECONDS,
+            maxRetries = 10, abortOn = javax.ws.rs.ClientErrorException.class)
+    @Fallback(fallbackMethod = "loadApisFromDisk")
+    protected void loadApis() throws Exception {
+        if (SUCCESSFUL_STARTUP.compareAndSet(false, true)) {
+            throw new ProcessingException("oops");      // will throw exception once
+        }
+    }
+
+    protected void loadApisFromDisk() throws Exception {
+    }
+}

--- a/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
+++ b/tests/functional/request-scope/src/test/java/io/helidon/tests/functional/requestscope/TenantTest.java
@@ -28,6 +28,7 @@ import io.helidon.microprofile.tests.junit5.HelidonTest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 @HelidonTest
@@ -96,4 +97,8 @@ class TenantTest {
         assertThat(entityValue, is("1"));
     }
 
+    @Test
+    public void testStartup() {
+        assertThat(StartupServices.SUCCESSFUL_STARTUP.get(), is(true));
+    }
 }


### PR DESCRIPTION
Guard for the case in which a request scope object is already available from CDI but a request context is not. New test.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>