### PR TITLE
Mark Micrometer integration as experimental

### DIFF
--- a/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
+++ b/common/common/src/main/java/io/helidon/common/FeatureCatalog.java
@@ -169,6 +169,14 @@ final class FeatureCatalog {
                     .nativeDescription("Experimental support, tested on limited use cases")
                     .flavor(HelidonFlavor.SE)
                     .experimental(true));
+        add("io.helidon.integrations.micrometer",
+            FeatureDescriptor.builder()
+                    .name("Micrometer")
+                    .description("Micrometer integration")
+                    .path("Micrometer")
+                    .experimental(true)
+                    .nativeSupported(true)
+                    .flavor(HelidonFlavor.SE));
 
         /*
          * MP Modules
@@ -343,14 +351,14 @@ final class FeatureCatalog {
                     .experimental(true)
         );
 
-        addSe("io.helidon.integrations.micrometer",
-                    "Micrometer",
-                    "Micrometer integration",
-                    "Micrometer");
-        addMp("io.helidon.integrations.micrometer.cdi",
-                "Micrometer",
-                "Micrometer integration",
-                "Micrometer");
+        add("io.helidon.integrations.micrometer.cdi",
+            FeatureDescriptor.builder()
+                    .name("Micrometer")
+                    .description("Micrometer integration")
+                    .path("Micrometer")
+                    .experimental(true)
+                    .nativeSupported(true)
+                    .flavor(HelidonFlavor.MP));
 
         /*
          * Common modules


### PR DESCRIPTION
Resolves #2955 

Micrometer support has not had any external usage so we need to mark it as experimental for now.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>