### PR TITLE
Updating Jersey and MP Rest Client versions

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -79,7 +79,7 @@
         <!-- Force upgrade version used by maven-jaxb2-plugin. Needed to support Java 16 -->
         <version.lib.jaxb-runtime>2.3.3</version.lib.jaxb-runtime>
         <version.lib.jedis>3.1.0</version.lib.jedis>
-        <version.lib.jersey>2.33</version.lib.jersey>
+        <version.lib.jersey>2.34</version.lib.jersey>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
@@ -105,7 +105,7 @@
         <version.lib.microprofile-reactive-messaging-api>1.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>1.0.1</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>1.0.1</version.lib.microprofile-reactive-streams-operators-core>
-        <version.lib.microprofile-rest-client>1.4.1</version.lib.microprofile-rest-client>
+        <version.lib.microprofile-rest-client>2.0</version.lib.microprofile-rest-client>
         <version.lib.microprofile-tracing>1.3.3</version.lib.microprofile-tracing>
         <version.lib.mockito>2.23.4</version.lib.mockito>
         <version.lib.mongodb.reactivestreams>1.11.0</version.lib.mongodb.reactivestreams>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -992,6 +992,10 @@
                         <groupId>jakarta.json</groupId>
                         <artifactId>jakarta.json-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <!-- Micronaut integrations -->

--- a/microprofile/rest-client/pom.xml
+++ b/microprofile/rest-client/pom.xml
@@ -42,6 +42,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>

--- a/microprofile/rest-client/src/main/java/module-info.java
+++ b/microprofile/rest-client/src/main/java/module-info.java
@@ -19,7 +19,7 @@
  */
 module io.helidon.microprofile.restclient {
     requires java.logging;
-    requires transitive microprofile.rest.client.api;
+    requires microprofile.rest.client.api;
     requires io.helidon.common.context;
     requires jersey.common;
     requires jersey.mp.rest.client;

--- a/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
-  Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+  Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,14 +15,18 @@
   limitations under the License.
   -->
 <suite name="microprofile-rest-client-TCK" verbose="2" configfailurepolicy="continue">
-
     <test name="microprofile-rest-client TCK">
         <packages>
-            <package name="org.eclipse.microprofile.rest.client.tck.*"/>
+            <package name="org.eclipse.microprofile.rest.client.tck.*">
+            </package>
         </packages>
-<!--        <classes>-->
-<!--            <class name="org.eclipse.microprofile.rest.client.tck.cditests.HasRequestScopeTest"/>-->
-<!--        </classes>-->
+        <classes>
+            <class name="org.eclipse.microprofile.rest.client.tck.ProxyServerTest">
+                <methods>
+                    <!--https://github.com/eclipse/microprofile-rest-client/pull/298-->
+                    <exclude name="testProxy"/>
+                </methods>
+            </class>
+        </classes>
     </test>
-
 </suite>


### PR DESCRIPTION
This PR includes:

- Update to Jersey 2.34 and REST Client API 2.0
- New exclude list for REST Client TCK
- New exclusions in our dependencies pom file due to changes in Jersey
- Passes native integration tests
- Verified a couple of MP native samples by hand as well
- Fixed `microprofile-rest-client-api` dependency

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>