### PR TITLE
Update owasp script to do priming build if running in pipeline

### DIFF
--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -62,6 +62,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
     }
 
     if [ -n "${JENKINS_HOME}" ] ; then
+        export PIPELINE="true"
         export JAVA_HOME="/tools/jdk11"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.showDateTime=true"

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -28,6 +28,11 @@ readonly RESULT_FILE=$(mktemp -t XXXdependency-check-result)
 
 die() { cat ${RESULT_FILE} ; echo "Dependency report in ${WS_DIR}/target" ; echo "${1}" ; exit 1 ;}
 
+if [ "${PIPELINE}" = "true" ] ; then
+    # If in pipeline do a priming build before scan
+    mvn ${MAVEN_ARGS} -f ${WS_DIR}/pom.xml clean install -DskipTests
+fi
+
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f ${WS_DIR}/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \


### PR DESCRIPTION
Intermittently the owasp scan job fails in the pipeline due to unresolved project artifacts. This should address that.