### PR TITLE
Upgrade directory-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.plugin.checkstyle>3.1.0</version.plugin.checkstyle>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
         <version.plugin.dependency>3.1.2</version.plugin.dependency>
-        <version.plugin.directory>0.1</version.plugin.directory>
+        <version.plugin.directory>0.3.1</version.plugin.directory>
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
         <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>
         <version.plugin.exec>1.6.0</version.plugin.exec>


### PR DESCRIPTION
Upgrades the `directory-maven-plugin` to fix a minor issue. Earlier versions of the plugin did not correctly handle non-canonical paths to the project pom. For example `mvn -f helidon/pom.xml` would work, but `mvn -f ./helidon/pom.xml` would fail.  This upgrade fixes this so you can use any valid path and it should work.