### PR TITLE
Fix mixed-case H1 prefix when rendered

### DIFF
--- a/docs/mp/metrics/04_prometheus_exemplar_support.adoc
+++ b/docs/mp/metrics/04_prometheus_exemplar_support.adoc
@@ -16,10 +16,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Metrics Support for Exemplars
-
 :h1Prefix: MP
 :description: Helidon metrics
 :keywords: helidon, metrics, exemplar, prometheus, OpenMetrics
+
+= Metrics Support for Exemplars
 
 include::../../shared/metrics/prometheus-exemplar-support.adoc[]

--- a/docs/se/metrics/04_prometheus_exemplar_support.adoc
+++ b/docs/se/metrics/04_prometheus_exemplar_support.adoc
@@ -16,10 +16,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Metrics Support for Exemplars
-
 :h1Prefix: SE
 :description: Helidon metrics
 :keywords: helidon, metrics, exemplar, prometheus, OpenMetrics
+
+= Metrics Support for Exemplars
 
 include::../../shared/metrics/prometheus-exemplar-support.adoc[]


### PR DESCRIPTION
Resolves #3002 

The H1 line was followed by a blank line and then the `h1Prefix` definition.

It appears that _either_
* `h1Prefix` must be defined earlier in the file than the H1, _or_
* the `h1Prefix` definition must be in the attribute assignment block immediately following the H1 line _with no intervening blank lines_.

Moving all attribute assignments before the H1 line resolved this.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>