### PR TITLE
JMS connector: durable consumer support

### DIFF
--- a/docs/mp/reactivemessaging/05_jms.adoc
+++ b/docs/mp/reactivemessaging/05_jms.adoc
@@ -56,6 +56,7 @@ Connector name: `helidon-jms`
 |`transacted` | Indicates whether the session will use a local transaction. Default value: `false`
 |`message-selector` | JMS API message selector expression based on a subset of the SQL92.
 Expression can only access headers and properties, not the payload.
+|`client-id` | Client identifier for JMS connection.
 |`named-factory` | Select in case factory is injected as a named bean or configured with name.
 |`poll-timeout` | Timeout for polling for next message in every poll cycle in millis. Default value: `50`
 |`period-executions` | Period for executing poll cycles in millis. Default value: `100`

--- a/docs/mp/reactivemessaging/05_jms.adoc
+++ b/docs/mp/reactivemessaging/05_jms.adoc
@@ -57,6 +57,11 @@ Connector name: `helidon-jms`
 |`message-selector` | JMS API message selector expression based on a subset of the SQL92.
 Expression can only access headers and properties, not the payload.
 |`client-id` | Client identifier for JMS connection.
+|`durable` | True for creating durable consumer (only for topic). Default value: `false`
+|`subscriber-name` | Subscriber name for durable consumer used to identify subscription.
+|`non-local` | If true then any messages published to the topic using this session's connection,
+ or any other connection with the same client identifier,
+ will not be added to the durable subscription. Default value: `false`
 |`named-factory` | Select in case factory is injected as a named bean or configured with name.
 |`poll-timeout` | Timeout for polling for next message in every poll cycle in millis. Default value: `50`
 |`period-executions` | Period for executing poll cycles in millis. Default value: `100`

--- a/docs/mp/reactivemessaging/06_aq.adoc
+++ b/docs/mp/reactivemessaging/06_aq.adoc
@@ -58,6 +58,7 @@ Connector name: `helidon-aq`
 |`transacted` | Indicates whether the session will use a local transaction. Default value: `false`
 |`message-selector` | JMS API message selector expression based on a subset of the SQL92.
 Expression can only access headers and properties, not the payload.
+|`client-id` | Client identifier for JMS connection.
 |`named-factory` | Select in case factory is injected as a named bean or configured with name.
 |`poll-timeout` | Timeout for polling for next message in every poll cycle in millis. Default value: `50`
 |`period-executions` | Period for executing poll cycles in millis. Default value: `100`

--- a/docs/mp/reactivemessaging/06_aq.adoc
+++ b/docs/mp/reactivemessaging/06_aq.adoc
@@ -59,6 +59,11 @@ Connector name: `helidon-aq`
 |`message-selector` | JMS API message selector expression based on a subset of the SQL92.
 Expression can only access headers and properties, not the payload.
 |`client-id` | Client identifier for JMS connection.
+|`durable` | True for creating durable consumer (only for topic). Default value: `false`
+|`subscriber-name` | Subscriber name for durable consumer used to identify subscription.
+|`non-local` | If true then any messages published to the topic using this session's connection,
+or any other connection with the same client identifier,
+will not be added to the durable subscription. Default value: `false`
 |`named-factory` | Select in case factory is injected as a named bean or configured with name.
 |`poll-timeout` | Timeout for polling for next message in every poll cycle in millis. Default value: `50`
 |`period-executions` | Period for executing poll cycles in millis. Default value: `100`

--- a/messaging/connectors/jms/src/main/java/io/helidon/messaging/connectors/jms/JmsConnector.java
+++ b/messaging/connectors/jms/src/main/java/io/helidon/messaging/connectors/jms/JmsConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,10 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
      * Password used with ConnectionFactory.
      */
     protected static final String PASSWORD_ATTRIBUTE = "password";
+    /**
+     * Client identifier for JMS connection.
+     */
+    protected static final String CLIENT_ID_ATTRIBUTE = "client-id";
 
     static final String ACK_MODE_ATTRIBUTE = "acknowledge-mode";
     static final String TRANSACTED_ATTRIBUTE = "transacted";
@@ -445,12 +449,17 @@ public class JmsConnector implements IncomingConnectorFactory, OutgoingConnector
         } else {
             Optional<String> user = config.get(USERNAME_ATTRIBUTE).asString().asOptional();
             Optional<String> password = config.get(PASSWORD_ATTRIBUTE).asString().asOptional();
+            Optional<String> userId = config.get(CLIENT_ID_ATTRIBUTE).asString().asOptional();
 
             Connection connection;
             if (user.isPresent() && password.isPresent()) {
                 connection = factory.createConnection(user.get(), password.get());
             } else {
                 connection = factory.createConnection();
+            }
+            
+            if(userId.isPresent()){
+                connection.setClientID(userId.get());
             }
 
             boolean transacted = config.get(TRANSACTED_ATTRIBUTE)


### PR DESCRIPTION
Fixes #2982

- add config property `client-id` for defining JMS connection clientId
- fix broken graceful shutdown with AQ
- add support for durable consumers

Makes possible to define named durable JMS consumer:
```yaml
mp.messaging:
  
  incoming:
    
    from-multi-consumer-queue-red:
     connector: helidon-aq
     destination: MULTI_CONSUMER_QUEUE
     type: topic            # AQ multi consumer queue is mapped to JMS topic
     subscriber-name: RED   # AQ multi consumer queue recipient name
     durable: true          # needs to be durable for named consumer

    from-multi-consumer-queue-blue: 
      connector: helidon-aq
      destination: MULTI_CONSUMER_QUEUE
      type: topic
      subscriber-name: BLUE
      durable: true
```
So we can consume from multi consumer queue with defined subscribers:
```sql
DECLARE
    queue_name         VARCHAR2(32);
    queue_tab          VARCHAR2(32);
BEGIN
 queue_name := 'FRANK.MULTI_CONSUMER_QUEUE';
 queue_tab :=  queue_name || '_TAB';
 DBMS_AQADM.CREATE_QUEUE_TABLE(
     queue_table => queue_tab,
     multiple_consumers => TRUE,
     queue_payload_type => 'SYS.AQ$_JMS_TEXT_MESSAGE');
 DBMS_AQADM.CREATE_QUEUE(queue_name, queue_tab);
 DBMS_AQADM.START_QUEUE(queue_name);
 DBMS_AQADM.ADD_SUBSCRIBER(queue_name, sys.aq$_agent('RED', NULL, NULL));
 DBMS_AQADM.ADD_SUBSCRIBER(queue_name, sys.aq$_agent('BLUE', NULL, NULL));
END;
```
As a recipients of the multi consumer queue:
```sql
DECLARE
    enqueue_options    DBMS_AQ.ENQUEUE_OPTIONS_T;
    message_properties DBMS_AQ.MESSAGE_PROPERTIES_T;
    recipients         DBMS_AQ.AQ$_RECIPIENT_LIST_T;
    message_handle     RAW(16);
    msg                SYS.AQ$_JMS_TEXT_MESSAGE;
BEGIN
    msg := SYS.AQ$_JMS_TEXT_MESSAGE.construct;
    msg.set_text('for blue');
--     recipients(1) := SYS.AQ$_AGENT('RED', NULL, NULL);
    recipients(2) := SYS.AQ$_AGENT('BLUE', NULL, NULL);
    message_properties.recipient_list := recipients;
    DBMS_AQ.ENQUEUE(
            queue_name => 'FRANK.MULTI_CONSUMER_QUEUE',
            enqueue_options => enqueue_options,
            message_properties => message_properties,
            payload => msg,
            msgid => message_handle);
    COMMIT;
END;
```