### PR TITLE
Add extended key performance indicators metrics support

### DIFF
--- a/docs/common/guides/metrics.adoc
+++ b/docs/common/guides/metrics.adoc
@@ -1,0 +1,380 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+:description: Helidon metrics
+:keywords: helidon, metrics, microprofile, guide
+// tag::intro[]
+This guide describes how to create a sample Helidon {intro-project-name} project
+that can be used to run some basic examples using both built-in and custom metrics with Helidon {h1Prefix}.
+
+== What you need
+
+[width=50%,role="flex, sm7"]
+|===
+|About 30 minutes
+|<<about/03_prerequisites.adoc,Helidon Prerequisites>>
+|https://github.com/helm/helm[Helm]
+|===
+
+// end::intro[]
+
+// tag::create-sample-project[]
+=== Create a sample Helidon {h1Prefix} project
+
+Use the Helidon {h1Prefix} Maven archetype to create a simple project that can be used for the examples in this guide.
+
+[source,bash,subs="attributes+"]
+.Run the Maven archetype
+----
+mvn -U archetype:generate -DinteractiveMode=false \
+    -DarchetypeGroupId=io.helidon.archetypes \
+    -DarchetypeArtifactId=helidon-quickstart-{lower-case-flavor} \
+    -DarchetypeVersion={helidon-version} \
+    -DgroupId=io.helidon.examples \
+    -DartifactId=helidon-quickstart-{lower-case-flavor} \
+    -Dpackage=io.helidon.examples.quickstart.{lower-case-flavor}
+----
+// end::create-sample-project[]
+
+// tag::using-built-in-metrics-intro[]
+=== Using the built-in metrics
+
+Helidon provides three scopes of metrics: base, vendor, and application. Here are the metric endpoints:
+
+1. `/metrics/base` - Base metrics data as specified by the MicroProfile Metrics specification.
+2. `/metrics/vendor` - Helidon-specific metrics data.
+3. `/metrics/application` - Application-specific metrics data.
+
+NOTE: The `/metrics` endpoint will return data for all scopes.
+
+The following example will demonstrate how to use the built-in metrics.  All examples are executed
+from the root directory of your project (helidon-quickstart-{lower-case-flavor}).
+// end::using-built-in-metrics-intro[]
+
+// tag::build-and-run-intro[]
+
+[source,bash,subs="attributes+"]
+.Build the application, skipping unit tests, then run it:
+----
+mvn package -DskipTests=true
+java -jar target/helidon-quickstart-{lower-case-flavor}.jar
+----
+
+NOTE: Metrics can be returned in either text format (the default), or JSON.  The text format uses Prometheus Text Format,
+see https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details.
+
+[source,bash]
+.Verify the metrics endpoint in a new terminal window:
+----
+curl http://localhost:8080/metrics
+----
+// end::build-and-run-intro[]
+
+// tag::metrics-prometheus-output[]
+# TYPE base:classloader_current_loaded_class_count counter
+# HELP base:classloader_current_loaded_class_count Displays the number of classes that are currently loaded in the Java virtual machine.
+base:classloader_current_loaded_class_count 7511
+# TYPE base:classloader_total_loaded_class_count counter
+# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
+base:classloader_total_loaded_class_count 7512
+...
+// end::metrics-prometheus-output[]
+
+// tag::curl-metrics-json[]
+You can get the same data in JSON format.
+
+[source,bash]
+.Verify the metrics endpoint with an HTTP accept header:
+----
+curl -H "Accept: application/json"  http://localhost:8080/metrics
+----
+// end::curl-metrics-json[]
+
+// tag::base-metrics-json-output[]
+    "classloader.currentLoadedClass.count": 7534,
+    "classloader.totalLoadedClass.count": 7538,
+    "classloader.totalUnloadedClass.count": 1,
+    "cpu.availableProcessors": 4,
+    "cpu.systemLoadAverage": 2.83349609375,
+    "gc.PS MarkSweep.count": 2,
+    "gc.PS MarkSweep.time": 77,
+    "gc.PS Scavenge.count": 5,
+    "gc.PS Scavenge.time": 37,
+    "jvm.uptime": 727588,
+    "memory.committedHeap": 284164096,
+    "memory.maxHeap": 3817865216,
+    "memory.usedHeap": 53283088,
+    "thread.count": 44,
+    "thread.daemon.count": 35,
+    "thread.max.count": 44
+// end::base-metrics-json-output[]
+// tag::vendor-metrics-json-output[]
+  "vendor": {
+    "requests.count": 6,
+    "requests.meter": {
+      "count": 6,
+      "meanRate": 0.008275992296704147,
+      "oneMinRate": 0.01576418632772332,
+      "fiveMinRate": 0.006695060022357365,
+      "fifteenMinRate": 0.0036382699664488415
+    }
+  }
+// end::vendor-metrics-json-output[]
+
+// tag::get-single-metric[]
+You can get a single metric by specifying the name in the URL path.
+
+[source,bash]
+.Get the Helidon `requests.meter` metric:
+----
+curl -H "Accept: application/json"  http://localhost:8080/metrics/vendor/requests.meter
+----
+
+[source,json]
+.JSON response:
+----
+{
+  "requests.meter": {
+    "count": 6,
+    "meanRate": 0.008275992296704147,
+    "oneMinRate": 0.01576418632772332,
+    "fiveMinRate": 0.006695060022357365,
+    "fifteenMinRate": 0.0036382699664488415
+  }
+}
+----
+
+NOTE: You cannot get the individual fields of a metric. For example, you cannot target http://localhost:8080/metrics/vendor/requests.meter.count.
+// end::get-single-metric[]
+
+// tag::KPI[]
+==== Key Performance Indicator (KPI) Metrics
+Any time you include the Helidon metrics module in your application, Helidon tracks two basic performance indicator metrics:
+
+* a `Counter` of all requests received (`requests.count`), and
+* a `Meter` of all requests received (`requests.meter`).
+
+Helidon {h1Prefix} also includes additional, extended KPI metrics which are disabled by default:
+
+* current number of requests in-flight - a `ConcurrentGauge` (`requests.inFlight`) of requests currently being processed
+* long-running requests - a `Meter` (`requests.longRunning`) measuring the rate at which Helidon processes requests which take at least a given amount of time to complete; configurable, defaults to 10000 milliseconds (10 seconds)
+* load - a `Meter` (`requests.load`) measuring the rate at which requests are worked on (as opposed to received)
+* deferred - a `Meter` (`requests.deferred`) measuring the rate at which a request's processing is delayed after Helidon receives the request
+
+You can enable and control these metrics using configuration:
+[source,properties]
+.Configuration properties file controlling extended KPI metrics
+----
+metrics.key-performance-indicators.extended = true
+metrics.key-performance-indicators.long-running.threshold-ms = 2000
+----
+
+//ifeval::["{h1Prefix}" == "SE"]
+Your Helidon {h1Prefix} application can also control the behavior of the KPI metrics programmatically.
+
+. Prepare a `KeyPerformanceIndicatorSettings` object, using its builder, and then pass the builder when invoking the `MetricsSupport.Builder#keyPerformanceIndicatorMetricsSettings()` method.
+. Prepare a `Config` object and pass it to the `MetricsSupport.Builder#keyPerformanceIndicatorMetricsConfig()` method.
++
+[source,properties]
++
+.Example KPI metrics config fragment
+----
+extended = true
+long-running.threshold-ms = 2000
+----
+endif::[]
+
+// end::KPI[]
+
+// tag::metrics-metadata[]
+=== Metrics metadata
+
+Each metric has associated metadata that describes:
+
+1. name: The name of the metric.
+2. units: The unit of the metric such as time (seconds, millisecond), size (bytes, megabytes), etc.
+3. type: The type of metric: `Counter`, `Timer`, `Meter`, `Histogram`, `SimpleTimer`, or `Gauge`.
+
+You can get the metadata for any scope, such as `/metrics/base`, as shown below:
+
+[source,bash]
+.Get the metrics metadata using HTTP OPTIONS method:
+----
+ curl -X OPTIONS -H "Accept: application/json"  http://localhost:8080/metrics/base
+----
+
+[source,json]
+.JSON response (truncated):
+----
+{
+  "classloader.currentLoadedClass.count": {
+    "unit": "none",
+    "type": "counter",
+    "description": "Displays the number of classes that are currently loaded in the Java virtual machine.",
+    "displayName": "Current Loaded Class Count"
+  },
+...
+  "jvm.uptime": {
+    "unit": "milliseconds",
+    "type": "gauge",
+    "description": "Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.",
+    "displayName": "JVM Uptime"
+  },
+...
+  "memory.usedHeap": {
+    "unit": "bytes",
+    "type": "gauge",
+    "description": "Displays the amount of used heap memory in bytes.",
+    "displayName": "Used Heap Memory"
+  }
+}
+----
+
+// end::metrics-metadata[]
+
+
+// tag::k8s-and-prometheus-integration[]
+
+=== Integration with Kubernetes and Prometheus
+==== Kubernetes integration
+The following example shows how to integrate the Helidon {h1Prefix} application with Kubernetes.
+
+[source,bash,subs="attributes+"]
+.Stop the application and build the docker image:
+----
+docker build -t helidon-metrics-{lower-case-flavor} .
+----
+
+[source,yaml,subs="attributes+"]
+.Create the Kubernetes YAML specification, named `metrics.yaml`, with the following content:
+----
+kind: Service
+apiVersion: v1
+metadata:
+  name: helidon-metrics // <1>
+  labels:
+    app: helidon-metrics
+  annotations:
+    prometheus.io/scrape: 'true' // <2>
+spec:
+  type: NodePort
+  selector:
+    app: helidon-metrics
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: helidon-metrics
+spec:
+  replicas: 1 // <3>
+  template:
+    metadata:
+      labels:
+        app: helidon-metrics
+        version: v1
+    spec:
+      containers:
+        - name: helidon-metrics
+          image: helidon-metrics-{lower-case-flavor}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+----
+<1> A service of type `NodePort` that serves the default routes on port `8080`.
+<2> An annotation that will allow Prometheus to discover and scrape the application pod.
+<3> A deployment with one replica of a pod.
+
+
+[source,bash]
+.Create and deploy the application into Kubernetes:
+----
+kubectl apply -f ./metrics.yaml
+----
+
+[source,bash]
+.Get the service information:
+----
+kubectl get service/helidon-metrics
+----
+
+[source,bash]
+----
+NAME             TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+helidon-metrics   NodePort   10.99.159.2   <none>        8080:31143/TCP   8s // <1>
+----
+<1> A service of type `NodePort` that serves the default routes on port `31143`.
+
+[source,bash]
+.Verify the metrics endpoint using port `30116`, your port will likely be different:
+----
+curl http://localhost:31143/metrics
+----
+
+NOTE: Leave the application running in Kubernetes since it will be used for Prometheus integration.
+
+==== Prometheus integration
+
+The metrics service that you just deployed into Kubernetes is already annotated with `prometheus.io/scrape:`.  This will allow
+Prometheus to discover the service and scrape the metrics.  In this exercise, you will install Prometheus
+into Kubernetes, then verify that it discovered the Helidon metrics in your application.
+
+[source,bash]
+.Install Prometheus and wait until the pod is ready:
+----
+helm install stable/prometheus --name metrics
+export POD_NAME=$(kubectl get pods --namespace default -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
+kubectl get pod $POD_NAME
+----
+
+You will see output similar to the following.  Repeat the `kubectl get pod` command until you see `2/2` and `Running`. This may take up to one minute.
+
+[source,bash]
+----
+metrics-prometheus-server-5fc5dc86cb-79lk4   2/2     Running   0          46s
+----
+
+[source,bash]
+.Create a port-forward so you can access the server URL:
+----
+kubectl --namespace default port-forward $POD_NAME 7090:9090
+----
+
+Now open your browser and navigate to `http://localhost:7090/targets`.  Search for helidon on the page and you will see your
+Helidon application as one of the Prometheus targets.
+
+==== Final cleanup
+
+You can now delete the Kubernetes resources that were just created during this example.
+
+[source,bash]
+.Delete the Prometheus Kubernetes resources:
+----
+helm delete --purge metrics
+----
+
+[source,bash]
+.Delete the application Kubernetes resources:
+----
+kubectl delete -f ./metrics.yaml
+----
+
+// end::k8s-and-prometheus-integration[]

--- a/docs/mp/guides/05_metrics.adoc
+++ b/docs/mp/guides/05_metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,64 +20,17 @@
 :h1Prefix: MP
 :description: Helidon metrics
 :keywords: helidon, metrics, microprofile, guide
+:common-guides: ../../common/guides
+:metrics-common: {common-guides}/metrics.adoc
+:lower-case-flavor: mp
+:intro-project-name: MicroProfile (MP)
 
-This guide describes how to create a sample MicroProfile (MP) project
-that can be used to run some basic examples using both built-in and custom metrics with Helidon MP.
+include::{metrics-common}[tag=intro]
+include::{metrics-common}[tag=create-sample-project]
+include::{metrics-common}[tag=using-built-in-metrics-intro]
 
-== What you need
+include::{metrics-common}[tag=build-and-run-intro]
 
-[width=50%,role="flex, sm7"]
-|===
-|About 30 minutes
-|<<about/03_prerequisites.adoc,Helidon Prerequisites>>
-|https://github.com/helm/helm[Helm]
-|===
-
-=== Create a sample Helidon MP project
-
-Use the Helidon MP Maven archetype to create a simple project that can be used for the examples in this guide.
-
-[source,bash,subs="attributes+"]
-.Run the Maven archetype:
-----
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-mp \
-    -DarchetypeVersion={helidon-version} \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-mp \
-    -Dpackage=io.helidon.examples.quickstart.mp
-----
-
-=== Using the built-in metrics
-
-Helidon provides three scopes of metrics: base, vendor, and application.  Helidon automatically provides built-in base and vendor metrics.
-Applications can use these metrics without additional configuration or code changes.  Here are the metric endpoints:
-
-1. `/metrics/base` - Base metrics data as specified by the MicroProfile Metrics specification.
-2. `/metrics/vendor` - Helidon-specific metrics data.
-3. `/metrics/application` - Application-specific metrics data.
-
-NOTE: The `/metrics` endpoint will return data for all scopes.
-
-The following example will demonstrate how to use the built-in metrics.  All examples are executed
-from the root directory of your project (helidon-quickstart-mp).
-
-[source,bash]
-.Build the application, skipping unit tests, then run it:
-----
-mvn package -DskipTests=true
-java -jar target/helidon-quickstart-mp.jar
-----
-
-NOTE: Metrics can be returned in either text format (the default), or JSON.  The text format uses Prometheus Text Format,
-see https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details.
-
-[source,bash]
-.Verify the metrics endpoint in a new terminal window:
-----
-curl http://localhost:8080/metrics
-----
 
 [source,text]
 .Text response:
@@ -91,22 +44,10 @@ base_REST_request_total{class="io.helidon.examples.quickstart.mp.GreetResource",
 base_REST_request_elapsedTime_seconds{class="io.helidon.examples.quickstart.mp.GreetResource",method="getMessage_java.lang.String"} 0.0
 base_REST_request_total{class="io.helidon.examples.quickstart.mp.GreetResource",method="updateGreeting_javax.json.JsonObject"} 0
 base_REST_request_elapsedTime_seconds{class="io.helidon.examples.quickstart.mp.GreetResource",method="updateGreeting_javax.json.JsonObject"} 0.0
-# TYPE base:classloader_current_loaded_class_count counter
-# HELP base:classloader_current_loaded_class_count Displays the number of classes that are currently loaded in the Java virtual machine.
-base:classloader_current_loaded_class_count 7511
-# TYPE base:classloader_total_loaded_class_count counter
-# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
-base:classloader_total_loaded_class_count 7512
-...
+include::{metrics-common}[tag=metrics-prometheus-output]
 ----
 
-You can get the same data in JSON format.
-
-[source,bash]
-.Verify the metrics endpoint with an HTTP accept header:
-----
-curl -H "Accept: application/json"  http://localhost:8080/metrics
-----
+include::{metrics-common}[tag=curl-metrics-json]
 
 [source,json]
 .JSON response:
@@ -122,59 +63,12 @@ curl -H "Accept: application/json"  http://localhost:8080/metrics
         "count;class=io.helidon.examples.quickstart.mp.GreetResource;method=updateGreeting_javax.json.JsonObject":0,
         "elapsedTime;class=io.helidon.examples.quickstart.mp.GreetResource;method=updateGreeting_javax.json.JsonObject":0.0
       },
-    "classloader.currentLoadedClass.count": 7534,
-    "classloader.totalLoadedClass.count": 7538,
-    "classloader.totalUnloadedClass.count": 1,
-    "cpu.availableProcessors": 4,
-    "cpu.systemLoadAverage": 2.83349609375,
-    "gc.PS MarkSweep.count": 2,
-    "gc.PS MarkSweep.time": 77,
-    "gc.PS Scavenge.count": 5,
-    "gc.PS Scavenge.time": 37,
-    "jvm.uptime": 727588,
-    "memory.committedHeap": 284164096,
-    "memory.maxHeap": 3817865216,
-    "memory.usedHeap": 53283088,
-    "thread.count": 44,
-    "thread.daemon.count": 35,
-    "thread.max.count": 44
+include::{metrics-common}[tag=base-metrics-json-output]
   },
-  "vendor": {
-    "requests.count": 6,
-    "requests.meter": {
-      "count": 6,
-      "meanRate": 0.008275992296704147,
-      "oneMinRate": 0.01576418632772332,
-      "fiveMinRate": 0.006695060022357365,
-      "fifteenMinRate": 0.0036382699664488415
-    }
-  }
+include::{metrics-common}[tag=vendor-metrics-json-output]
 }
 ----
-
-You can get a single metric by specifying the name in the URL path.
-
-[source,bash]
-.Get the Helidon `requests.meter` metric:
-----
-curl -H "Accept: application/json"  http://localhost:8080/metrics/vendor/requests.meter
-----
-
-[source,json]
-.JSON response:
-----
-{
-  "requests.meter": {
-    "count": 6,
-    "meanRate": 0.008275992296704147,
-    "oneMinRate": 0.01576418632772332,
-    "fiveMinRate": 0.006695060022357365,
-    "fifteenMinRate": 0.0036382699664488415
-  }
-}
-----
-
-NOTE: You cannot get the individual fields of a metric. For example, you cannot target http://localhost:8080/metrics/vendor/requests.meter.count.
+include::{metrics-common}[tag=get-single-metric]
 
 ==== Controlling `REST.request` metrics
 Helidon implements the optional family of metrics, all with the name `REST.request`, as described in the
@@ -189,49 +83,9 @@ Note that the applications you generate using the full Helidon archetype _do_ en
 generated config file.
 You can see the results in the sample output shown in earlier example runs.
 
-=== Metrics metadata
+include::{metrics-common}[tag=KPI]
 
-Each metric has associated metadata that describes:
-
-1. name: The name of the metric.
-2. units: The unit of the metric such as time (seconds, millisecond), size (bytes, megabytes), etc.
-3. type: The type of metric: `Counter`, `Timer`, `Meter`, `Histogram`, or `Gauge`.
-
-You can get the metadata for any scope, such as `/metrics/base`, as shown below:
-
-[source,bash]
-.Get the metrics metadata using HTTP OPTIONS method:
-----
- curl -X OPTIONS -H "Accept: application/json"  http://localhost:8080/metrics/base
-----
-
-[source,json]
-.JSON response (truncated):
-----
-{
-  "classloader.currentLoadedClass.count": {
-    "unit": "none",
-    "type": "counter",
-    "description": "Displays the number of classes that are currently loaded in the Java virtual machine.",
-    "displayName": "Current Loaded Class Count"
-  },
-...
-  "jvm.uptime": {
-    "unit": "milliseconds",
-    "type": "gauge",
-    "description": "Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.",
-    "displayName": "JVM Uptime"
-  },
-...
-  "memory.usedHeap": {
-    "unit": "bytes",
-    "type": "gauge",
-    "description": "Displays the amount of used heap memory in bytes.",
-    "displayName": "Used Heap Memory"
-  }
-}
-----
-
+include::{metrics-common}[tag=metrics-metadata]
 
 === Application-specific metrics data
 
@@ -763,132 +617,7 @@ curl -H "Accept: application/json"  http://localhost:8080/metrics/application
 ----
 <1> The application has been running for 6 seconds.
 
-=== Integration with Kubernetes and Prometheus
-
-The following example shows how to integrate the Helidon MP application with Kubernetes.
-
-[source,bash]
-.Stop the application and build the docker image:
-----
-docker build -t helidon-metrics-mp .
-----
-
-[source,yaml]
-.Create the Kubernetes YAML specification, named `metrics.yaml`, with the following content:
-----
-kind: Service
-apiVersion: v1
-metadata:
-  name: helidon-metrics // <1>
-  labels:
-    app: helidon-metrics
-  annotations:
-    prometheus.io/scrape: 'true' // <2>
-spec:
-  type: NodePort
-  selector:
-    app: helidon-metrics
-  ports:
-    - port: 8080
-      targetPort: 8080
-      name: http
----
-kind: Deployment
-apiVersion: extensions/v1beta1
-metadata:
-  name: helidon-metrics
-spec:
-  replicas: 1 // <3>
-  template:
-    metadata:
-      labels:
-        app: helidon-metrics
-        version: v1
-    spec:
-      containers:
-        - name: helidon-metrics
-          image: helidon-metrics-mp
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 8080
-----
-<1> A service of type `NodePort` that serves the default routes on port `8080`.
-<2> An annotation that will allow Prometheus to discover and scrape the application pod.
-<3> A deployment with one replica of a pod.
-
-
-[source,bash]
-.Create and deploy the application into Kubernetes:
-----
-kubectl apply -f ./metrics.yaml
-----
-
-[source,bash]
-.Get the service information:
-----
-kubectl get service/helidon-metrics
-----
-
-[source,bash]
-----
-NAME             TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-helidon-metrics   NodePort   10.99.159.2   <none>        8080:31143/TCP   8s // <1>
-----
-<1> A service of type `NodePort` that serves the default routes on port `31143`.
-
-[source,bash]
-.Verify the metrics endpoint using port `30116`, your port will likely be different:
-----
-curl http://localhost:31143/metrics
-----
-
-NOTE: Leave the application running in Kubernetes since it will be used for Prometheus integration.
-
-==== Prometheus integration
-
-The metrics service that you just deployed into Kubernetes is already annotated with `prometheus.io/scrape:`.  This will allow
-Prometheus to discover the service and scrape the metrics.  In this exercise, you will install Prometheus
-into Kubernetes, then verify that it discovered the Helidon metrics in your application.
-
-[source,bash]
-.Install Prometheus and wait until the pod is ready:
-----
-helm install stable/prometheus --name metrics
-export POD_NAME=$(kubectl get pods --namespace default -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
-kubectl get pod $POD_NAME
-----
-
-You will see output similar to the following.  Repeat the `kubectl get pod` command until you see `2/2` and `Running`. This may take up to one minute.
-
-[source,bash]
-----
-metrics-prometheus-server-5fc5dc86cb-79lk4   2/2     Running   0          46s
-----
-
-[source,bash]
-.Create a port-forward so you can access the server URL:
-----
-kubectl --namespace default port-forward $POD_NAME 7090:9090
-----
-
-Now open your browser and navigate to `http://localhost:7090/targets`.  Search for helidon on the page and you will see your
-Helidon application as one of the Prometheus targets.
-
-==== Final cleanup
-
-You can now delete the Kubernetes resources that were just created during this example.
-
-[source,bash]
-.Delete the Prometheus Kubernetes resources:
-----
-helm delete --purge metrics
-----
-
-[source,bash]
-.Delete the application Kubernetes resources:
-----
-kubectl delete -f ./metrics.yaml
-----
+include::{metrics-common}[tag=k8s-and-prometheus-integration]
 
 === Summary
 

--- a/docs/se/guides/05_metrics.adoc
+++ b/docs/se/guides/05_metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,47 +20,17 @@
 :h1Prefix: SE
 :description: Helidon metrics
 :keywords: helidon, metrics, microprofile, guide
+:common-guides: ../../common/guides
+:metrics-common: {common-guides}/metrics.adoc
+:javadoc-base-url-api: {javadoc-base-url}io.helidon.metrics/io/helidon/metrics
+:metrics-support-builder-javadoc: {javadoc-base-url-api}/MetricsSupport.Builder.html
+:lower-case-flavor: se
+:intro-project-name: {h1Prefix}
 
-This guide describes how to create a sample Helidon SE project
-that can be used to run some basic examples using both built-in and custom metrics.
-
-== What you need
-
-[width=50%,role="flex, sm7"]
-|===
-|About 30 minutes
-|<<about/03_prerequisites.adoc,Helidon Prerequisites>>
-|https://github.com/helm/helm[Helm]
-|===
-
-=== Create a sample Helidon SE project
-
-Use the Helidon SE Maven archetype to create a simple project that can be used for the examples in this guide.
-
-[source,bash,subs="attributes+"]
-.Run the Maven archetype
-----
-mvn -U archetype:generate -DinteractiveMode=false \
-    -DarchetypeGroupId=io.helidon.archetypes \
-    -DarchetypeArtifactId=helidon-quickstart-se \
-    -DarchetypeVersion={helidon-version} \
-    -DgroupId=io.helidon.examples \
-    -DartifactId=helidon-quickstart-se \
-    -Dpackage=io.helidon.examples.quickstart.se
-----
-
-=== Using the built-in metrics
-
-Helidon provides three scopes of metrics: base, vendor, and application. Here are the metric endpoints:
-
-1. `/metrics/base` - Base metrics data as specified by the MicroProfile Metrics specification.
-2. `/metrics/vendor` - Helidon-specific metrics data.
-3. `/metrics/application` - Application-specific metrics data.
-
-NOTE: The `/metrics` endpoint will return data for all scopes.
-
-The following example will demonstrate how to use the built-in metrics.  All examples are executed
-from the root directory of your project (helidon-quickstart-se).  The generated source code is
+include::{metrics-common}[tag=intro]
+include::{metrics-common}[tag=create-sample-project]
+include::{metrics-common}[tag=using-built-in-metrics-intro]
+The generated source code is
 already configured for both metrics and health-checks, but the following example removes health-checks.
 
 
@@ -89,32 +59,12 @@ already configured for both metrics and health-checks, but the following example
 ----
 <1> Register the built-in base and vendor metrics.
 
-[source,bash]
-.Build the application, skipping unit tests, then run it:
-----
-mvn package -DskipTests=true
-java -jar target/helidon-quickstart-se.jar
-----
-
-NOTE: Metrics can be returned in either text format (the default), or JSON.  The text format uses Prometheus Text Format,
-see https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details.
-
-[source,bash]
-.Verify the metrics endpoint in a new terminal window:
-----
-curl http://localhost:8080/metrics
-----
+include::{metrics-common}[tag=build-and-run-intro]
 
 [source,text]
 .Text response:
 ----
-# TYPE base:classloader_current_loaded_class_count counter
-# HELP base:classloader_current_loaded_class_count Displays the number of classes that are currently loaded in the Java virtual machine.
-base:classloader_current_loaded_class_count 7511
-# TYPE base:classloader_total_loaded_class_count counter
-# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
-base:classloader_total_loaded_class_count 7512
-...
+include::{metrics-common}[tag=metrics-prometheus-output]
 ----
 
 You can get the same data in JSON format.
@@ -130,111 +80,19 @@ curl -H "Accept: application/json"  http://localhost:8080/metrics
 ----
 {
   "base": {
-    "classloader.currentLoadedClass.count": 7534,
-    "classloader.totalLoadedClass.count": 7538,
-    "classloader.totalUnloadedClass.count": 1,
-    "cpu.availableProcessors": 4,
-    "cpu.systemLoadAverage": 2.83349609375,
-    "gc.PS MarkSweep.count": 2,
-    "gc.PS MarkSweep.time": 77,
-    "gc.PS Scavenge.count": 5,
-    "gc.PS Scavenge.time": 37,
-    "jvm.uptime": 727588,
-    "memory.committedHeap": 284164096,
-    "memory.maxHeap": 3817865216,
-    "memory.usedHeap": 53283088,
-    "thread.count": 44,
-    "thread.daemon.count": 35,
-    "thread.max.count": 44
+include::{metrics-common}[tag=base-metrics-json-output]
   },
-  "vendor": {
-    "grpc.requests.count": 0,
-    "grpc.requests.meter": {
-      "count": 0,
-      "meanRate": 0.0,
-      "oneMinRate": 0.0,
-      "fiveMinRate": 0.0,
-      "fifteenMinRate": 0.0
-    },
-    "requests.count": 6,
-    "requests.meter": {
-      "count": 6,
-      "meanRate": 0.008275992296704147,
-      "oneMinRate": 0.01576418632772332,
-      "fiveMinRate": 0.006695060022357365,
-      "fifteenMinRate": 0.0036382699664488415
-    }
-  }
+include::{metrics-common}[tag=vendor-metrics-json-output]
 }
 ----
 
-You can get a single metric by specifying the name in the URL path.
+include::{metrics-common}[tag=get-single-metric]
 
-[source,bash]
-.Get the Helidon `requests.meter` metric:
-----
-curl -H "Accept: application/json"  http://localhost:8080/metrics/vendor/requests.meter
-----
+include::{metrics-common}[tag=KPI]
 
-[source,json]
-.JSON response:
-----
-{
-  "requests.meter": {
-    "count": 6,
-    "meanRate": 0.008275992296704147,
-    "oneMinRate": 0.01576418632772332,
-    "fiveMinRate": 0.006695060022357365,
-    "fifteenMinRate": 0.0036382699664488415
-  }
-}
-----
+Your Helidon SE application can also enable or disable the extended KPI metrics and control the long-running request threshold using methods on the link:{metrics-support-builder-javadoc}[MetricsSupport.Builder] class.
 
-NOTE: You cannot get the individual fields of a metric. For example, you cannot target http://localhost:8080/metrics/vendor/requests.meter.count.
-
-=== Metrics metadata
-
-Each metric has associated metadata that describes:
-
-1. name: The name of the metric.
-2. units: The unit of the metric such as time (seconds, millisecond), size (bytes, megabytes), etc.
-3. type: The type of metric: `Counter`, `Timer`, `Meter`, `Histogram`, or `Gauge`.
-
-You can get the metadata for any scope, such as `/metrics/base`, as shown below:
-
-[source,bash]
-.Get the metrics metadata using HTTP OPTIONS method:
-----
- curl -X OPTIONS -H "Accept: application/json"  http://localhost:8080/metrics/base
-----
-
-[source,json]
-.JSON response (truncated):
-----
-{
-  "classloader.currentLoadedClass.count": {
-    "unit": "none",
-    "type": "counter",
-    "description": "Displays the number of classes that are currently loaded in the Java virtual machine.",
-    "displayName": "Current Loaded Class Count"
-  },
-...
-  "jvm.uptime": {
-    "unit": "milliseconds",
-    "type": "gauge",
-    "description": "Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.",
-    "displayName": "JVM Uptime"
-  },
-...
-  "memory.usedHeap": {
-    "unit": "bytes",
-    "type": "gauge",
-    "description": "Displays the amount of used heap memory in bytes.",
-    "displayName": "Used Heap Memory"
-  }
-}
-----
-
+include::{metrics-common}[tag=metrics-metadata]
 
 === Application-specific metrics data
 
@@ -793,133 +651,7 @@ curl -H "Accept: application/json"  http://localhost:8080/metrics/application
 <1> How many times the `getDefaultMessageHandler` method ran.
 <2> Cumulative time spent in the `getDefaultMessageHandler` method during its executions.
 
-
-=== Integration with Kubernetes and Prometheus
-
-The following example shows how to integrate the Helidon SE application with Kubernetes.
-
-[source,bash]
-.Stop the application and build the docker image:
-----
-docker build -t helidon-metrics-se .
-----
-
-[source,yaml]
-.Create the Kubernetes YAML specification, named `metrics.yaml`, with the following content:
-----
-kind: Service
-apiVersion: v1
-metadata:
-  name: helidon-metrics // <1>
-  labels:
-    app: helidon-metrics
-  annotations:
-    prometheus.io/scrape: 'true' // <2>
-spec:
-  type: NodePort
-  selector:
-    app: helidon-metrics
-  ports:
-    - port: 8080
-      targetPort: 8080
-      name: http
----
-kind: Deployment
-apiVersion: extensions/v1beta1
-metadata:
-  name: helidon-metrics
-spec:
-  replicas: 1 // <3>
-  template:
-    metadata:
-      labels:
-        app: helidon-metrics
-        version: v1
-    spec:
-      containers:
-        - name: helidon-metrics
-          image: helidon-metrics-se
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 8080
-----
-<1> A service of type `NodePort` that serves the default routes on port `8080`.
-<2> An annotation that will allow Prometheus to discover and scrape the application pod.
-<3> A deployment with one replica of a pod.
-
-
-[source,bash]
-.Create and deploy the application into Kubernetes:
-----
-kubectl apply -f ./metrics.yaml
-----
-
-[source,bash]
-.Get the service information:
-----
-kubectl get service/helidon-metrics
-----
-
-[source,bash]
-----
-NAME             TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
-helidon-metrics   NodePort   10.99.159.2   <none>        8080:31143/TCP   8s // <1>
-----
-<1> A service of type `NodePort` that serves the default routes on port `31143`
-
-[source,bash]
-.Verify the metrics endpoint using port `31143`, your port will likely be different:
-----
-curl http://localhost:31143/metrics
-----
-
-NOTE: Leave the application running in Kubernetes since it will be used for Prometheus integration.
-
-==== Prometheus integration
-
-The metrics service that you just deployed into Kubernetes is already annotated with `prometheus.io/scrape:`.  This will allow
-Prometheus to discover the service and scrape the metrics.  In this exercise, you will install Prometheus
-into Kubernetes, then verify that it discovered the Helidon metrics in your application.
-
-[source,bash]
-.Install Prometheus and wait until the pod is ready:
-----
-helm install stable/prometheus --name metrics
-export POD_NAME=$(kubectl get pods --namespace default -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
-kubectl get pod $POD_NAME
-----
-
-You will see output similar to the following.  Repeat the `kubectl get pod` command until you see `2/2` and `Running`. This may take up to one minute.
-
-[source,bash]
-----
-metrics-prometheus-server-5fc5dc86cb-79lk4   2/2     Running   0          46s
-----
-
-[source,bash]
-.Create a port-forward so you can access the server URL:
-----
-kubectl --namespace default port-forward $POD_NAME 7090:9090
-----
-
-Now open your browser and navigate to `http://localhost:7090/targets`.  Search for helidon on the page and you will see your
-Helidon application as one of the Prometheus targets.
-
-==== Final cleanup
-
-You can now delete the Kubernetes resources that were just created during this example.
-
-[source,bash]
-.Delete the Prometheus Kubernetes resources:
-----
-helm delete --purge metrics
-----
-
-[source,bash]
-.Delete the application Kubernetes resources:
-----
-kubectl delete -f ./metrics.yaml
-----
+include::{metrics-common}[tag=k8s-and-prometheus-integration]
 
 === Summary
 

--- a/examples/metrics/kpi/README.md
+++ b/examples/metrics/kpi/README.md
@@ -1,0 +1,122 @@
+# Helidon Metrics Key Performance Indicators SE Example
+
+This project implements a simple Hello World REST service using Helidon SE and demonstrates 
+support in Helidon for extended key performance indicator (KPI) metrics.
+
+Your application can set up KPI metrics either programmatically or using configuration.
+The `Main` class of this example shows both techniques, checking the system property `useConfig` to 
+determine 
+which to use.
+You would typically write any given application to use only one of the approaches.
+
+## Build and run
+
+With JDK11+
+```bash
+mvn package
+```
+To use programmatic set-up:
+```bash
+java -jar target/helidon-examples-metrics-kpi.jar 
+```
+To use configuration:
+```bash
+java -DuseConfig=true -jar target/helidon-examples-metrics-kpi.jar
+````
+
+## Exercise the application
+
+```
+curl -X GET http://localhost:8080/greet
+{"message":"Hello World!"}
+
+curl -X GET http://localhost:8080/greet/Joe
+{"message":"Hello Joe!"}
+
+curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+
+curl -X GET http://localhost:8080/greet/Jose
+{"message":"Hola Jose!"}
+
+curl -X GET http://localhost:8080/greet          
+{"message":"Hola World!"}
+```
+
+## Retrieve vendor metrics with key performance indicators
+
+For brevity, the example output below shows only some of the KPI metrics. 
+
+Note that, even though the `curl` commands above access `/greet` endpoints five times, 
+the 
+`load` and (not shown here) 
+`count` and 
+`meter` are `6` in the Prometheus output example and `7` in the JSON output example. 
+Further, the `inFlight`
+current value is `1`.
+
+This is 
+because Helidon tallies 
+all
+requests, even those 
+to Helidon-provided services such as `/metrics` and `/health`, in the KPI metrics. 
+The request 
+to retrieve the metrics is the one that is in flight, and it contributes to the KPI metrics just 
+as requests to application endpoints do.
+
+Further, the request to `/metrics` is still in progress when Helidon prepares the 
+output by getting the values of the KPI metrics at that moment. 
+If _that_ request turns out to be long- running, Helidon would discover so only 
+_after_ preparing the metrics output and completing the request. 
+The `longRunning` `Meter` 
+values in _that_ 
+response 
+could 
+not reflect the fact that Helidon would subsequently conclude that _that_ request was 
+long-running.
+
+## Prometheus format
+```
+curl -s -X GET http://localhost:8080/metrics/vendor
+...
+# TYPE vendor_requests_inFlight_current concurrent gauge
+# HELP vendor_requests_inFlight_current Measures the number of currently in-flight requests
+vendor_requests_inFlight_current 1
+# TYPE vendor_requests_inFlight_min concurrent gauge
+vendor_requests_inFlight_min 0
+# TYPE vendor_requests_inFlight_max concurrent gauge
+vendor_requests_inFlight_max 1
+# TYPE vendor_requests_load_total counter
+# HELP vendor_requests_load_total Measures the total number of in-flight requests and rates at which they occur
+vendor_requests_load_total 6
+# TYPE vendor_requests_load_rate_per_second gauge
+vendor_requests_load_rate_per_second 0.04932913209653636
+# TYPE vendor_requests_load_one_min_rate_per_second gauge
+vendor_requests_load_one_min_rate_per_second 0.025499793037824785
+# TYPE vendor_requests_load_five_min_rate_per_second gauge
+vendor_requests_load_five_min_rate_per_second 0.012963147773962286
+# TYPE vendor_requests_load_fifteen_min_rate_per_second gauge
+vendor_requests_load_fifteen_min_rate_per_second 0.005104944851522425
+...
+```
+## JSON output
+
+
+```bash
+curl -s -X GET -H "Accept: application/json" http://localhost:8080/metrics/vendor
+{
+  ...
+  "requests.inFlight": {
+    "current": 1,
+    "max": 1,
+    "min": 0
+  },
+  "requests.load": {
+    "count": 7,
+    "meanRate": 0.01530869471741443,
+    "oneMinRate": 0.00016123154886115814,
+    "fiveMinRate": 0.005344110443653005,
+    "fifteenMinRate": 0.004286243527303867
+  },
+  ...
+}
+```

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+        <relativePath>../../../applications/se/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.examples.metrics</groupId>
+    <artifactId>helidon-examples-metrics-kpi</artifactId>
+    <name>Helidon Examples Metrics Key Performance Indicators</name>
+    <properties>
+        <mainClass>io.helidon.examples.metrics.kpi.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>check-for-inflight-with-config-settings</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <useConfig>true</useConfig>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.helidon.applications</groupId>
         <artifactId>helidon-se</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
         <relativePath>../../../applications/se/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.metrics.kpi;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+
+import io.helidon.common.http.Http;
+import io.helidon.config.Config;
+import io.helidon.metrics.RegistryFactory;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Timer;
+
+/**
+ * A simple service to greet you. Examples:
+ *
+ * Get default greeting message:
+ * curl -X GET http://localhost:8080/greet
+ *
+ * Get greeting message for Joe:
+ * curl -X GET http://localhost:8080/greet/Joe
+ *
+ * Change greeting
+ * curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Howdy"}' http://localhost:8080/greet/greeting
+ *
+ * The message is returned as a JSON object
+ */
+
+public class GreetService implements Service {
+
+    /**
+     * The config value for the key {@code greeting}.
+     */
+    private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    private static final Logger LOGGER = Logger.getLogger(GreetService.class.getName());
+
+    static final String TIMER_FOR_GETS = "timerForGets";
+    static final String COUNTER_FOR_PERSONALIZED_GREETINGS = "counterForPersonalizedGreetings";
+
+    private final Timer timerForGets;
+
+    private final Counter personalizedGreetingsCounter;
+
+    private final Config config;
+
+    GreetService(Config config) {
+        this.config = config;
+        greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
+        MetricRegistry registry = RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.APPLICATION);
+        Metadata metadata = Metadata.builder()
+                .withName(TIMER_FOR_GETS)
+                .withUnit(MetricUnits.NANOSECONDS)
+                .withType(MetricType.TIMER)
+                .build();
+        timerForGets = registry.timer(metadata);
+
+        metadata = Metadata.builder()
+                .withName(COUNTER_FOR_PERSONALIZED_GREETINGS)
+                .withUnit(MetricUnits.NONE)
+                .withType(MetricType.COUNTER)
+                .build();
+        personalizedGreetingsCounter = registry.counter(metadata);
+    }
+
+    /**
+     * A service registers itself by updating the routing rules.
+     * @param rules the routing rules.
+     */
+    @Override
+    public void update(Routing.Rules rules) {
+        rules
+            .get("/", this::timeGet, this::getDefaultMessageHandler)
+            .get("/{name}", this::countPersonalized, this::getMessageHandler)
+            .put("/greeting", this::updateGreetingHandler);
+    }
+
+    /**
+     * Return a worldly greeting message.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void getDefaultMessageHandler(ServerRequest request,
+                                   ServerResponse response) {
+        sendResponse(response, "World");
+    }
+
+    /**
+     * Return a greeting message using the name that was provided.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void getMessageHandler(ServerRequest request,
+                            ServerResponse response) {
+        String name = request.path().param("name");
+        sendResponse(response, name);
+    }
+
+    private void sendResponse(ServerResponse response, String name) {
+        String msg = String.format("%s %s!", greeting.get(), name);
+
+        JsonObject returnObject = JSON.createObjectBuilder()
+                .add("message", msg)
+                .build();
+        response.send(returnObject);
+    }
+
+    private static <T> T processErrors(Throwable ex, ServerRequest request, ServerResponse response) {
+
+         if (ex.getCause() instanceof JsonException){
+
+            LOGGER.log(Level.FINE, "Invalid JSON", ex);
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                .add("error", "Invalid JSON")
+                .build();
+            response.status(Http.Status.BAD_REQUEST_400).send(jsonErrorObject);
+        }  else {
+
+            LOGGER.log(Level.FINE, "Internal error", ex);
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                .add("error", "Internal error")
+                .build();
+            response.status(Http.Status.INTERNAL_SERVER_ERROR_500).send(jsonErrorObject);
+        }
+
+        return null;
+    }
+
+    private void updateGreetingFromJson(JsonObject jo, ServerResponse response) {
+
+        if (!jo.containsKey("greeting")) {
+            JsonObject jsonErrorObject = JSON.createObjectBuilder()
+                    .add("error", "No greeting provided")
+                    .build();
+            response.status(Http.Status.BAD_REQUEST_400)
+                    .send(jsonErrorObject);
+            return;
+        }
+
+        greeting.set(jo.getString("greeting"));
+        response.status(Http.Status.NO_CONTENT_204).send();
+    }
+
+    /**
+     * Set the greeting to use in future messages.
+     * @param request the server request
+     * @param response the server response
+     */
+    private void updateGreetingHandler(ServerRequest request,
+                                       ServerResponse response) {
+        request.content().as(JsonObject.class)
+            .thenAccept(jo -> updateGreetingFromJson(jo, response))
+            .exceptionally(ex -> processErrors(ex, request, response));
+    }
+
+    private void timeGet(ServerRequest request, ServerResponse response) {
+        timerForGets.time((Runnable) request::next);
+    }
+
+    private void countPersonalized(ServerRequest request, ServerResponse response) {
+        personalizedGreetingsCounter.inc();
+        request.next();
+    }
+}

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.metrics.kpi;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.reactive.Single;
+import io.helidon.config.Config;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.metrics.KeyPerformanceIndicatorMetricsSettings;
+import io.helidon.metrics.MetricsSupport;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+/**
+ * The application main class.
+ */
+public final class Main {
+
+    /**
+     * Cannot be instantiated.
+     */
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     * @param args command line arguments.
+     */
+    public static void main(final String[] args) {
+        startServer();
+    }
+
+    /**
+     * Start the server.
+     * @return the created {@link WebServer} instance
+     */
+    static Single<WebServer> startServer() {
+
+        // load logging configuration
+        LogConfig.configureRuntime();
+
+        // By default this will pick up application.yaml from the classpath
+        Config config = Config.create();
+
+        WebServer server = WebServer.builder()
+                .routing(createRouting(config))
+                .config(config.get("server"))
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+
+        Single<WebServer> webserver = server.start();
+
+        // Try to start the server. If successful, print some info and arrange to
+        // print a message at shutdown. If unsuccessful, print the exception.
+        webserver.thenAccept(ws -> {
+                    System.out.println("WEB server is up! http://localhost:" + ws.port() + "/greet");
+                    ws.whenShutdown().thenRun(() -> System.out.println("WEB server is DOWN. Good bye!"));
+                })
+                .exceptionallyAccept(t -> {
+                    System.err.println("Startup failed: " + t.getMessage());
+                    t.printStackTrace(System.err);
+                });
+
+        return webserver;
+    }
+
+    /**
+     * Creates new {@link Routing}.
+     *
+     * @return routing configured with JSON support, a health check, and a service
+     * @param config configuration of this server
+     */
+    private static Routing createRouting(Config config) {
+
+        /*
+         * For purposes of illustration, the key performance indicator settings for the
+         * MetricsSupport instance are set up according to a system property so you can see,
+         * in one example, how to code each approach. Normally, you would choose one
+         * approach to use in an application.
+         */
+        MetricsSupport metricsSupport = Boolean.getBoolean("useConfig")
+                ? metricsSupportWithConfig(config.get("metrics"))
+                : metricsSupportWithoutConfig();
+
+        GreetService greetService = new GreetService(config);
+
+        return Routing.builder()
+                .register(metricsSupport)                  // Metrics at "/metrics"
+                .register("/greet", greetService)
+                .build();
+    }
+
+    /**
+     * Creates a {@link MetricsSupport} instance using a "metrics" configuration node.
+     *
+     * @param metricsConfig {@link Config} node with key "metrics" if present; an empty node otherwise
+     * @return {@code MetricsSupport} object with metrics (including KPI) set up using the config node
+     */
+    private static MetricsSupport metricsSupportWithConfig(Config metricsConfig) {
+        return MetricsSupport.create(metricsConfig);
+    }
+
+    /**
+     * Creates a {@link MetricsSupport} instance explicitly turning on extended KPI metrics.
+     *
+     * @return {@code MetricsSupport} object with extended KPI metrics enabled
+     */
+    private static MetricsSupport metricsSupportWithoutConfig() {
+
+        KeyPerformanceIndicatorMetricsSettings.Builder settingsBuilder =
+                KeyPerformanceIndicatorMetricsSettings.builder()
+                        .extended(true)
+                        .longRunningRequestThresholdMs(2000);
+        return MetricsSupport.builder()
+                .keyPerformanceIndicatorsMetricsSettings(settingsBuilder)
+                .build();
+    }
+}

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/package-info.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Quickstart demo application for key performance metrics.
+ * <p>
+ * Start with {@link io.helidon.examples.metrics.kpi.Main} class.
+ * </p>
+ * @see io.helidon.examples.metrics.kpi.Main
+ */
+package io.helidon.examples.metrics.kpi;

--- a/examples/metrics/kpi/src/main/resources/application.yaml
+++ b/examples/metrics/kpi/src/main/resources/application.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+app:
+  greeting: "Hello"
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+metrics:
+  key-performance-indicators:
+    extended: true
+    long-running:
+      threshold-ms: 2000 # two seconds

--- a/examples/metrics/kpi/src/main/resources/logging.properties
+++ b/examples/metrics/kpi/src/main/resources/logging.properties
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO

--- a/examples/metrics/kpi/src/test/java/io/helidon/examples/metrics/kpi/MainTest.java
+++ b/examples/metrics/kpi/src/test/java/io/helidon/examples/metrics/kpi/MainTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.examples.metrics.kpi;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+import io.helidon.webserver.WebServer;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MainTest {
+
+    private static final MetricRegistry.Type KPI_REGISTRY_TYPE = MetricRegistry.Type.VENDOR;
+    private static WebServer webServer;
+    private static WebClient webClient;
+    private static final JsonBuilderFactory JSON_BUILDER = Json.createBuilderFactory(Collections.emptyMap());
+    private static final JsonObject TEST_JSON_OBJECT;
+
+    static {
+        TEST_JSON_OBJECT = JSON_BUILDER.createObjectBuilder()
+                .add("greeting", "Hola")
+                .build();
+    }
+
+    @BeforeAll
+    public static void startTheServer() {
+        webServer = Main.startServer().await();
+
+        webClient = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port())
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testHelloWorld() {
+        JsonObject jsonObject;
+        WebClientResponse response;
+
+        jsonObject = webClient.get()
+                .path("/greet")
+                .request(JsonObject.class)
+                .await();
+        assertEquals("Hello World!", jsonObject.getString("message"));
+
+        jsonObject = webClient.get()
+                .path("/greet/Joe")
+                .request(JsonObject.class)
+                .await();
+        assertEquals("Hello Joe!", jsonObject.getString("message"));
+
+        response = webClient.put()
+                .path("/greet/greeting")
+                .submit(TEST_JSON_OBJECT)
+                .await();
+        assertEquals(204, response.status().code());
+
+        jsonObject = webClient.get()
+                .path("/greet/Joe")
+                .request(JsonObject.class)
+                .await();
+        assertEquals("Hola Joe!", jsonObject.getString("message"));
+
+        response = webClient.get()
+                .path("/metrics")
+                .request()
+                .await();
+        assertEquals(200, response.status().code());
+    }
+
+    @Test
+    public void testMetrics() {
+        WebClientResponse response;
+
+        String get = webClient.get()
+                .path("/greet")
+                .request(String.class)
+                .await();
+
+        assertTrue(get.contains("Hello World!"));
+
+        get = webClient.get()
+                .path("/greet/Joe")
+                .request(String.class)
+                .await();
+
+        assertTrue(get.contains("Hello Joe!"));
+
+        String openMetricsOutput = webClient.get()
+                .path("/metrics/" + KPI_REGISTRY_TYPE.getName())
+                .request(String.class)
+                .await();
+
+        assertTrue(openMetricsOutput.contains(
+                "# TYPE " + KPI_REGISTRY_TYPE.getName() + "_requests_inFlight_current"),
+                "Returned KPI metrics contains inFlight");
+
+    }
+}

--- a/examples/metrics/pom.xml
+++ b/examples/metrics/pom.xml
@@ -33,6 +33,7 @@
     <modules>
 
         <module>exemplar</module>
+        <module>kpi</module>
     </modules>
 
 </project>

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -95,8 +95,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-surefire-plugin</artifactId>
                     <executions>
+                        <execution>
+                            <id>default-test</id>
+                            <configuration>
+                                <excludes>
+                                    <exclude>**/TestServerWithKeyPerformanceIndicatorMetrics.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
                         <execution>
                             <!-- Run this test in default-test and also here with an env var set -->
                             <id>metrics-global-tags-set</id>
@@ -110,6 +118,18 @@
                             <environmentVariables>
                                 <MP_METRICS_TAGS>globalTag1=gVal1,globalTag2=gVal2</MP_METRICS_TAGS>
                             </environmentVariables>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- Run in separate invocation so service loader gets the correct, non-default set-up. -->
+                            <id>key-performance-indicator-metrics-enabled</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/TestServerWithKeyPerformanceIndicatorMetrics.java</include>
+                                </includes>
                             </configuration>
                         </execution>
                     </executions>

--- a/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsImpls.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsImpls.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.helidon.webserver.KeyPerformanceIndicatorSupport;
+
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+class KeyPerformanceIndicatorMetricsImpls {
+
+    /**
+     * Prefix for key performance indicator metrics names.
+     */
+    static final String METRICS_NAME_PREFIX = "requests";
+
+    /**
+     * Name for metric counting total requests received.
+     */
+    static final String REQUESTS_COUNT_NAME = "count";
+
+    /**
+     * Name for metric recording rate of requests received.
+     */
+    static final String REQUESTS_METER_NAME = "meter";
+
+    /**
+     * Name for metric recording current number of requests being processed.
+     */
+    static final String INFLIGHT_REQUESTS_NAME = "inFlight";
+
+    /**
+     * Name for metric recording rate of requests with processing time exceeding a threshold.
+     */
+    static final String LONG_RUNNING_REQUESTS_NAME = "longRunning";
+
+    /**
+     * Name for metric recording rate of requests processed.
+     */
+    static final String LOAD_NAME = "load";
+
+    /**
+     * Name for metric recording rate of requests deferred before processing.
+     */
+    public static final String DEFERRED_NAME = "deferred";
+
+    static final MetricRegistry.Type KPI_METRICS_REGISTRY_TYPE = MetricRegistry.Type.VENDOR;
+
+    private static final Map<String, KeyPerformanceIndicatorSupport.Metrics> KPI_METRICS = new HashMap<>();
+
+    private KeyPerformanceIndicatorMetricsImpls() {
+    }
+
+    /**
+     * Provides a KPI metrics instance.
+     *
+     * @param metricsNamePrefix prefix to use for the created metrics
+     * @param kpiConfig         KPI metrics config which may influence the construction of the metrics
+     * @return properly prepared new KPI metrics instance
+     */
+    static KeyPerformanceIndicatorSupport.Metrics get(String metricsNamePrefix,
+            KeyPerformanceIndicatorMetricsSettings kpiConfig) {
+        return KPI_METRICS.computeIfAbsent(metricsNamePrefix, prefix ->
+             kpiConfig.isExtended()
+                    ? new Extended(metricsNamePrefix, kpiConfig)
+                    : new Basic(metricsNamePrefix));
+    }
+
+    /**
+     * Basic KPI metrics.
+     */
+    private static class Basic implements KeyPerformanceIndicatorSupport.Metrics {
+
+        private final MetricRegistry kpiMetricRegistry;
+
+        private final Counter totalCount;
+        private final Meter totalMeter;
+
+        protected Basic(String metricsNamePrefix) {
+            kpiMetricRegistry = RegistryFactory.getInstance()
+                    .getRegistry(KPI_METRICS_REGISTRY_TYPE);
+            totalCount = kpiMetricRegistry().counter(Metadata.builder()
+                    .withName(metricsNamePrefix + REQUESTS_COUNT_NAME)
+                    .withDisplayName("Total number of HTTP requests")
+                    .withDescription("Each request (regardless of HTTP method) will increase this counter")
+                    .withType(MetricType.COUNTER)
+                    .withUnit(MetricUnits.NONE)
+                    .build());
+
+            totalMeter = kpiMetricRegistry().meter(Metadata.builder()
+                    .withName(metricsNamePrefix + REQUESTS_METER_NAME)
+                    .withDisplayName("Meter for overall HTTP requests")
+                    .withDescription("Each request will mark the meter to see overall throughput")
+                    .withType(MetricType.METERED)
+                    .withUnit(MetricUnits.NONE)
+                    .build());
+        }
+
+        @Override
+        public void onRequestReceived() {
+            totalCount.inc();
+            totalMeter.mark();
+        }
+
+        protected MetricRegistry kpiMetricRegistry() {
+            return kpiMetricRegistry;
+        }
+
+        protected Meter totalMeter() {
+            return totalMeter;
+        }
+    }
+
+    /**
+     * Extended KPI metrics.
+     */
+    private static class Extended extends Basic {
+
+        private final ConcurrentGauge inflightRequests;
+        private final Meter longRunningRequests;
+        private final Meter load;
+        private final long longRunningRequestThresdholdMs;
+        // The deferred-requests metric is derived from load and totalMeter, so no need to have a reference to update
+        // it directly.
+
+        protected static final String LOAD_DISPLAY_NAME = "Requests load";
+        protected static final String LOAD_DESCRIPTION =
+                "Measures the total number of in-flight requests and rates at which they occur";
+
+        protected Extended(String metricsNamePrefix, KeyPerformanceIndicatorMetricsSettings kpiConfig) {
+            super(metricsNamePrefix);
+            longRunningRequestThresdholdMs = kpiConfig.longRunningRequestThresholdMs();
+
+            inflightRequests = kpiMetricRegistry().concurrentGauge(Metadata.builder()
+                    .withName(metricsNamePrefix + INFLIGHT_REQUESTS_NAME)
+                    .withDisplayName("Current number of in-flight requests")
+                    .withDescription("Measures the number of currently in-flight requests")
+                    .withType(MetricType.CONCURRENT_GAUGE)
+                    .withUnit(MetricUnits.NONE)
+                    .build());
+
+            longRunningRequests = kpiMetricRegistry().meter(Metadata.builder()
+                    .withName(metricsNamePrefix + LONG_RUNNING_REQUESTS_NAME)
+                    .withDisplayName("Long-running requests")
+                    .withDescription("Measures the total number of long-running requests and rates at which they occur")
+                    .withType(MetricType.METERED)
+                    .withUnit(MetricUnits.NONE)
+                    .build());
+
+            load = kpiMetricRegistry().meter(Metadata.builder()
+                    .withName(metricsNamePrefix + LOAD_NAME)
+                    .withDisplayName(LOAD_DISPLAY_NAME)
+                    .withDescription(LOAD_DESCRIPTION)
+                    .withType(MetricType.METERED)
+                    .withUnit(MetricUnits.NONE)
+                    .build());
+
+            kpiMetricRegistry().register(Metadata.builder()
+                    .withName(metricsNamePrefix + DEFERRED_NAME)
+                    .withDisplayName("Deferred requests")
+                    .withDescription("Measures deferred requests")
+                    .withType(MetricType.METERED)
+                    .withUnit(MetricUnits.NONE)
+                    .build(), new DeferredRequestsMeter(totalMeter(), load));
+        }
+
+        @Override
+        public void onRequestStarted() {
+            super.onRequestStarted();
+            inflightRequests.inc();
+            load.mark();
+        }
+
+        @Override
+        public void onRequestCompleted(boolean isSuccessful, long processingTimeMs) {
+            super.onRequestCompleted(isSuccessful, processingTimeMs);
+            inflightRequests.dec();
+            if (processingTimeMs >= longRunningRequestThresdholdMs) {
+                longRunningRequests.mark();
+            }
+        }
+
+        /**
+         * {@code Meter} which exposes the number of deferred requests as derived from the hit meter (arrivals) - load meter
+         * (processing).
+         */
+        private static class DeferredRequestsMeter implements Meter {
+
+            private final Meter hitRate;
+            private final Meter load;
+
+            private DeferredRequestsMeter(Meter hitRate, Meter load) {
+                this.hitRate = hitRate;
+                this.load = load;
+            }
+
+            @Override
+            public void mark() {
+            }
+
+            @Override
+            public void mark(long n) {
+            }
+
+            @Override
+            public long getCount() {
+                return hitRate.getCount() - load.getCount();
+            }
+
+            @Override
+            public double getFifteenMinuteRate() {
+                return Double.max(0, hitRate.getFifteenMinuteRate() - load.getFifteenMinuteRate());
+            }
+
+            @Override
+            public double getFiveMinuteRate() {
+                return Double.max(0, hitRate.getFiveMinuteRate() - load.getFiveMinuteRate());
+            }
+
+            @Override
+            public double getMeanRate() {
+                return Double.max(0, hitRate.getMeanRate() - load.getMeanRate());
+            }
+
+            @Override
+            public double getOneMinuteRate() {
+                return Double.max(0, hitRate.getOneMinuteRate() - load.getOneMinuteRate());
+            }
+        }
+    }
+}

--- a/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettings.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettings.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+/**
+ * Settings for KPI metrics.
+ */
+public interface KeyPerformanceIndicatorMetricsSettings {
+
+    /**
+     * Creates a new builder for the settings.
+     *
+     * @return new {@link Builder}
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     *
+     * @return  whether extended KPI metrics are enabled in the settings
+     */
+    boolean isExtended();
+
+    /**
+     *
+     * @return the threshold (in ms) for long-running requests
+     */
+    long longRunningRequestThresholdMs();
+
+    /**
+     * Override default settings.
+     * <p>
+     * Configuration options:
+     *
+     * <table class="config">
+     * <caption>Key performance indicator metrics configuration ({@value CONFIG_KEY_PREFIX}</caption>
+     * <tr>
+     *     <th>Key</th>
+     *     <th>Default</th>
+     *     <th>Description</th>
+     *     <th>Builder method</th>
+     * </tr>
+     * <tr>
+     *     <td>
+     *         {@value KEY_PERFORMANCE_INDICATORS_EXTENDED_CONFIG_KEY}
+     *     </td>
+     *
+     *     <td>{@value KEY_PERFORMANCE_INDICATORS_EXTENDED_DEFAULT}</td>
+     *     <td>Whether the extended key performance indicator metrics should be enabled</td>
+     *     <td>{@link #extended(boolean)} </td>
+     * </tr>
+     * <tr>
+     *     <td>{@value LONG_RUNNING_REQUESTS_THRESHOLD_CONFIG_KEY}
+     *     </td>
+     *     <td>{@value LONG_RUNNING_REQUESTS_THRESHOLD_MS_DEFAULT}</td>
+     *     <td>Threshold (in milliseconds) for long-running requests</td>
+     *     <td>{@link #longRunningRequestThresholdMs(long)}</td>
+     * </tr>
+     * </table>
+     */
+    class Builder implements io.helidon.common.Builder<KeyPerformanceIndicatorMetricsSettings> {
+        private boolean isExtendedKpiEnabled = KEY_PERFORMANCE_INDICATORS_EXTENDED_DEFAULT;
+        private long longRunningRequestThresholdMs = LONG_RUNNING_REQUESTS_THRESHOLD_MS_DEFAULT;
+
+        /**
+         * Config key for extended key performance indicator metrics settings.
+         */
+        public static final String KEY_PERFORMANCE_INDICATORS_CONFIG_KEY = "key-performance-indicators";
+
+        /**
+         * Config key for {@code enabled} setting of the extended KPI metrics.
+         */
+        public static final String KEY_PERFORMANCE_INDICATORS_EXTENDED_CONFIG_KEY = "extended";
+
+        /**
+         * Default enabled setting for extended KPI metrics.
+         */
+        static final boolean KEY_PERFORMANCE_INDICATORS_EXTENDED_DEFAULT = false;
+
+        /**
+         * Config key for long-running requests threshold setting (in milliseconds).
+         */
+        public static final String LONG_RUNNING_REQUESTS_THRESHOLD_CONFIG_KEY = "threshold-ms";
+
+        /**
+         * Config key for long-running requests settings.
+         */
+        public static final String LONG_RUNNING_REQUESTS_CONFIG_KEY = "long-running-requests";
+
+        /**
+         * Default long-running requests threshold.
+         */
+        static final long LONG_RUNNING_REQUESTS_THRESHOLD_MS_DEFAULT = 10 * 1000; // 10 seconds
+
+        private static final String CONFIG_KEY_PREFIX = "metrics." + KEY_PERFORMANCE_INDICATORS_CONFIG_KEY;
+        private static final String QUALIFIED_LONG_RUNNING_REQUESTS_THRESHOLD_CONFIG_KEY =
+                LONG_RUNNING_REQUESTS_CONFIG_KEY + "." + KEY_PERFORMANCE_INDICATORS_EXTENDED_CONFIG_KEY;
+
+        /**
+         * Sets whether exntended KPI metrics should be enabled in the settings.
+         *
+         * @param value whether extended KPI metrics should be enabled
+         * @return updated builder instance
+         */
+        public Builder extended(boolean value) {
+            this.isExtendedKpiEnabled = value;
+            return this;
+        }
+
+        /**
+         * Sets the long-running request threshold (in ms).
+         *
+         * @param value long-running request threshold
+         * @return updated builder instance
+         */
+        public Builder longRunningRequestThresholdMs(long value) {
+            longRunningRequestThresholdMs = value;
+            return this;
+        }
+
+        /**
+         * Builds a {@link KeyPerformanceIndicatorMetricsSettings} using the settings from the builder.
+         *
+         * @return {@code KeyPerformanceIndicatorMetricsSettings} prepared according to the builder
+         */
+        public KeyPerformanceIndicatorMetricsSettings build() {
+            return new KeyPerformanceIndicatorMetricsSettingsImpl(this);
+        }
+
+        boolean isExtended() {
+            return isExtendedKpiEnabled;
+        }
+
+        long longRunningRequestThresholdMs() {
+            return longRunningRequestThresholdMs;
+        }
+    }
+}

--- a/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettingsImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettingsImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+class KeyPerformanceIndicatorMetricsSettingsImpl implements KeyPerformanceIndicatorMetricsSettings {
+
+    private final boolean isExtended;
+    private final long longRunningRequestThresholdMs;
+
+    KeyPerformanceIndicatorMetricsSettingsImpl(Builder builder) {
+        this.isExtended = builder.isExtended();
+        this.longRunningRequestThresholdMs = builder.longRunningRequestThresholdMs();
+    }
+
+    @Override
+    public boolean isExtended() {
+        return isExtended;
+    }
+
+    @Override
+    public long longRunningRequestThresholdMs() {
+        return longRunningRequestThresholdMs;
+    }
+}

--- a/metrics/metrics/src/main/java/module-info.java
+++ b/metrics/metrics/src/main/java/module-info.java
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import io.helidon.metrics.ExemplarService;
-
 /**
  * Helidon Metrics implementation.
  */
@@ -28,7 +26,7 @@ module io.helidon.metrics {
 
     requires transitive microprofile.metrics.api;
     requires java.management;
-    requires io.helidon.webserver;
+    requires transitive io.helidon.webserver; // webserver/webserver/Context is a public return value
     requires io.helidon.media.jsonp;
     requires java.json;
     requires io.helidon.config.mp;

--- a/metrics/metrics/src/test/java/io/helidon/metrics/GreetService.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/GreetService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.metrics;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+class GreetService implements Service {
+
+    static final int SLOW_DELAY_SECS = 1;
+
+    static final String GREETING_RESPONSE = "Hello World!";
+
+    private static ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    static CountDownLatch slowRequestInProgress = null;
+
+    static void initSlowRequest() {
+        slowRequestInProgress = new CountDownLatch(1);
+    }
+
+    static void awaitSlowRequestStarted() throws InterruptedException {
+        slowRequestInProgress.await();
+    }
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/greet/slow", this::greetSlow);
+    }
+
+    private void greetSlow(ServerRequest request, ServerResponse response) {
+        executorService.execute(() -> {
+            if (slowRequestInProgress != null) {
+                slowRequestInProgress.countDown();
+            }
+            try {
+                TimeUnit.SECONDS.sleep(SLOW_DELAY_SECS);
+            } catch (InterruptedException e) {
+                //absorb silently
+            }
+        });
+        response.send(GREETING_RESPONSE);
+    }
+}

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestServerWithKeyPerformanceIndicatorMetrics.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestServerWithKeyPerformanceIndicatorMetrics.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import io.helidon.common.http.MediaType;
+import io.helidon.common.reactive.Single;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+import io.helidon.webserver.WebServer;
+
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+class TestServerWithKeyPerformanceIndicatorMetrics {
+
+    private static WebServer webServer;
+
+    private static final MetricsSupport.Builder KPI_ENABLED_BUILDER = MetricsSupport.builder()
+            .keyPerformanceIndicatorsMetricsSettings(KeyPerformanceIndicatorMetricsSettings.builder()
+                    .extended(true));
+
+    private static MetricsSupport metricsSupport;
+
+    private WebClient.Builder webClientBuilder;
+
+    @BeforeAll
+    public static void startup() throws InterruptedException, ExecutionException, TimeoutException {
+        metricsSupport = KPI_ENABLED_BUILDER.build();
+        webServer = TestServer.startServer(metricsSupport, new GreetService());
+    }
+
+    @BeforeEach
+    public void prepareWebClientBuilder() {
+        webClientBuilder = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port() + "/")
+                .addMediaSupport(JsonpSupport.create());
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        TestServer.shutdownServer(webServer);
+    }
+
+    @Test
+    void checkInflightRequests() throws InterruptedException, ExecutionException {
+
+        boolean isKPIEnabled = MetricsSupport.keyPerformanceIndicatorMetricsConfig().isExtended();
+
+        MetricRegistry vendorRegistry = RegistryFactory.getInstance()
+                .getRegistry(MetricRegistry.Type.VENDOR);
+
+        Optional<ConcurrentGauge> inflightRequests =
+                vendorRegistry.getConcurrentGauges((metricID, metric) -> metricID.getName().endsWith(
+                        KeyPerformanceIndicatorMetricsImpls.INFLIGHT_REQUESTS_NAME))
+                        .values().stream()
+                        .findAny();
+        assertThat("In-flight concurrent gauge metric exists", inflightRequests.isPresent(), is(isKPIEnabled));
+
+        long inflightBefore = inflightRequests.get().getCount();
+
+        GreetService.initSlowRequest();
+        Single<String> response = webClientBuilder
+                .build()
+                .get()
+                .accept(MediaType.APPLICATION_JSON)
+                .path("greet/slow")
+                .request(String.class);
+        GreetService.awaitSlowRequestStarted();
+        long inflightDuring = inflightRequests.get().getCount();
+
+        String result = response.get();
+
+        assertThat("Returned result", result, is(GreetService.GREETING_RESPONSE));
+        assertThat("Change in inflight requests during invocation", inflightDuring - inflightBefore, is(1L));
+        assertThat("Net change in inflight requests after invocation", inflightRequests.get().getCount(), is(inflightBefore));
+
+    }
+}

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -83,6 +83,37 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/HelloWorldAsyncResponseTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run in separate invocation to enable extended KPI metrics (checked in the test) -->
+                        <id>key-performance-indicator-metrics-enabled</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/HelloWorldAsyncResponseTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>pipeline</id>

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/HelloWorldTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.microprofile.metrics.HelloWorldResource.MESSAGE_SIMPLE_TIMER;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -134,21 +135,6 @@ public class HelloWorldTest {
         SimpleTimer syntheticSimpleTimer = getSyntheticSimpleTimer("messageWithArg", String.class);
         assertThat("SimpleTimer from @SyntheticSimplyTimed", syntheticSimpleTimer, is(notNullValue()));
         assertThat("SimpleTimer from @SyntheticSimplyTimed count", syntheticSimpleTimer.getCount(), is(expectedSyntheticSimpleTimerCount));
-    }
-
-    @Test
-    public void checkMetricsVendorURL() {
-        Response response = webTarget
-                .path("metrics/vendor")
-                .request()
-                .accept(MediaType.APPLICATION_JSON_TYPE)
-                .get();
-
-        assertThat("Metrics /metrics/vendor URL HTTP status", response.getStatus(), is(Http.Status.OK_200.code()));
-
-        JsonObject vendorMetrics = response.readEntity(JsonObject.class);
-
-        assertThat("Vendor metric requests.count present", vendorMetrics.containsKey("requests.count"), is(true));
     }
 
     SimpleTimer getSyntheticSimpleTimer(String methodName, Class<?>... paramTypes) {

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestBasicPerformanceIndicators.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestBasicPerformanceIndicators.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+class TestBasicPerformanceIndicators {
+
+    @Inject
+    WebTarget webTarget;
+
+    @Test
+    void checkMetricsVendorURL() {
+        doCheckMetricsVendorURL(webTarget);
+    }
+
+    static void doCheckMetricsVendorURL(WebTarget webTarget) {
+        Response response = webTarget
+                .path("metrics/vendor")
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+
+        assertThat("Metrics /metrics/vendor URL HTTP status", response.getStatus(), is(Http.Status.OK_200.code()));
+
+        JsonObject vendorMetrics = response.readEntity(JsonObject.class);
+
+        assertThat("Vendor metric requests.count present", vendorMetrics.containsKey("requests.count"), is(true));
+
+        // This test runs with extended KPI metrics disabled. Make sure the count and meter are still updated.
+        int count = vendorMetrics.getInt("requests.count");
+        assertThat("requests.count", count, is(greaterThan(0)));
+
+        JsonObject meter = vendorMetrics.getJsonObject("requests.meter");
+        int meterCount = meter.getInt("count");
+        assertThat("requests.meter count", meterCount, is(greaterThan(0)));
+
+        double meterRate = meter.getJsonNumber("meanRate").doubleValue();
+        assertThat("requests.meter meanRate", meterRate, is(greaterThan(0.0)));
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/KeyPerformanceIndicatorContextFactory.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/KeyPerformanceIndicatorContextFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import io.helidon.webserver.KeyPerformanceIndicatorSupport.Context;
+import io.helidon.webserver.KeyPerformanceIndicatorSupport.Metrics;
+
+class KeyPerformanceIndicatorContextFactory {
+
+    static Context immediateRequestContext() {
+        return new ImmediateRequestContext();
+    }
+
+    static DeferrableRequestContext deferrableRequestContext() {
+        return new DeferrableRequestContext();
+    }
+
+    private KeyPerformanceIndicatorContextFactory() {
+    }
+
+    private static class ImmediateRequestContext implements Context {
+
+        // kpiMetrics is set from MetricsSupport, so in apps without metrics kpiMetrics will be null in this context.
+        private Metrics kpiMetrics;
+
+        private long requestStartTime;
+
+        @Override
+        public void requestHandlingStarted(Metrics kpiMetrics) {
+            recordStartTime();
+            kpiMetrics(kpiMetrics);
+            kpiMetrics.onRequestReceived();
+            kpiMetrics.onRequestStarted();
+        }
+
+        @Override
+        public void requestProcessingCompleted(boolean isSuccessful) {
+            if (kpiMetrics != null) {
+                kpiMetrics.onRequestCompleted(isSuccessful, System.currentTimeMillis() - requestStartTime);
+            }
+        }
+
+        protected void recordStartTime() {
+            requestStartTime = System.currentTimeMillis();
+        }
+
+        protected void kpiMetrics(Metrics kpiMetrics) {
+            this.kpiMetrics = kpiMetrics;
+        }
+
+        protected Metrics kpiMetrics() {
+            return kpiMetrics;
+        }
+    }
+
+    private static class DeferrableRequestContext extends ImmediateRequestContext
+            implements KeyPerformanceIndicatorSupport.DeferrableRequestContext {
+
+        @Override
+        public void requestHandlingStarted(Metrics kpiMetrics) {
+            kpiMetrics(kpiMetrics);
+            kpiMetrics.onRequestReceived();
+        }
+
+        @Override
+        public void requestProcessingStarted() {
+            recordStartTime();
+            Metrics kpiMetrics = kpiMetrics();
+            if (kpiMetrics != null) {
+                kpiMetrics().onRequestStarted();
+            }
+        }
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/KeyPerformanceIndicatorSupport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/KeyPerformanceIndicatorSupport.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+/**
+ * Definitions and factory methods for key performance indicator {@link Context} and {@link Metrics}.
+ * <p>
+ *     Helidon maintains two categories of KPI metrics:
+ *     <ol>
+ *         <li>basic - always collected (if the app depends on metrics) - count and meter of the number of arrived requests</li>
+ *         <li>extended - disabled by default, enabled using the {@code MetricsSupport} or {@code JerseySupport} builder or using
+ *         config
+ *         <ul>
+ *             <li>concurrent gauge of in-flight requests</li>
+ *             <li>meters (rates) of
+ *                 <ul>
+ *                     <li>long-running requests</li>
+ *                     <li>load (currently-running requests)</li>
+ *                     <li>deferred requests</li>
+ *                 </ul>
+ *             </li>
+ *         </ul>
+ *      </ol>
+ * <p>
+ *     Helidon updates the KPI metrics in the {@code MetricsSupport} vendor metrics handler.
+ * </p>
+ * <p>
+ *     using a per-request KPI metrics context which it notifies when the request
+ *     <ol>
+ *         <li>arrives,</li>
+ *         <li>begins processing, and</li>
+ *         <li>completes processing.</li>
+ *     </ol>
+ *     The KPI metrics context implementation updates the appropriate KPI
+ *     metrics as the request progresses through its processing.
+ */
+public interface KeyPerformanceIndicatorSupport {
+
+    /**
+     * Per-request key performance indicator context, with behavior common to immediately-processed requests and deferrable ones.
+     */
+    interface Context {
+
+        /**
+         * Provides a {@code Context} for use with an immediate (non-deferrable) request.
+         *
+         * @return the new {@code Context}
+         */
+        static Context create() {
+            return KeyPerformanceIndicatorContextFactory.immediateRequestContext();
+        }
+
+        /**
+         * No-op implementation of {@code Context}.
+         */
+        Context NO_OP = new Context() {
+        };
+
+        /**
+         * Records that handling of the request is about to begin.
+         *
+         * @param keyPerformanceIndicatorMetrics KPI metrics to update in this context
+         */
+        default void requestHandlingStarted(Metrics keyPerformanceIndicatorMetrics) {
+        }
+
+        /**
+         * Records that a request has completed its processing.
+         *
+         * @param isSuccessful whether the request completed successfully
+         */
+        default void requestProcessingCompleted(boolean isSuccessful) {
+        }
+
+        /**
+         * Records that handling of a request has completed.
+         *
+         * @param isSuccessful whether the request completed successfully
+         */
+        default void requestHandlingCompleted(boolean isSuccessful) {
+        }
+    }
+
+    /**
+     * Added per-request key performance indicator context behavior for requests for which processing might be deferred until
+     * some time after receipt of the request (i.e., some time after request handling begins).
+     */
+    interface DeferrableRequestContext extends Context {
+
+        /**
+         * Provides a {@code Context} for use with a deferrable request.
+         *
+         * @return new {@code Context}
+         */
+        static Context create() {
+            return KeyPerformanceIndicatorContextFactory.deferrableRequestContext();
+        }
+
+        /**
+         * A {@link Handler} which registers a KPI deferrable request context in the request's context.
+         */
+        Handler CONTEXT_SETTING_HANDLER = (req, res) -> {
+            req.context().register(KeyPerformanceIndicatorContextFactory.deferrableRequestContext());
+            req.next();
+        };
+
+        /**
+         * Records that a request is about to begin its processing.
+         */
+        default void requestProcessingStarted() {
+        }
+    }
+
+    /**
+     * Key performance indicator metrics behavior.
+     */
+    interface Metrics {
+
+        /**
+         * No-op implementation of {@code Metrics}.
+         */
+        Metrics NO_OP = new Metrics() {
+        };
+
+        /**
+         * Invoked when a request has been received.
+         */
+        default void onRequestReceived() {
+        }
+
+        /**
+         * Invoked when processing on a request has been started.
+         */
+        default void onRequestStarted() {
+        }
+
+        /**
+         * Invoked when processing on a request has finished.
+         *
+         * @param isSuccessful     indicates if the request processing succeeded
+         * @param processingTimeMs duration of the request processing in milliseconds
+         */
+        default void onRequestCompleted(boolean isSuccessful, long processingTimeMs) {
+        }
+    }
+}


### PR DESCRIPTION
Resolves #2688 
Resolves #2689 

# Overview
A key performance indicator (KPI) can be useful not only for measuring the performance of a server but also for building application-specific health checks using the KPI.

## Existing ("basic") KPI metrics and implementation

Previously, in any app including `metrics/metrics`, Helidon has published two KPI metrics whenever the app includes the module `metrics/metrics`:

1.  `counter` - `Counter` of the total number of requests received by the server
2. `meter` - `Meter` (rate) for above count.

The full metric names are the routing name for the routing (if any) plus `request.` so, typically, users see `requests.count` and `requests.meter`.

Recall that a `Meter` reports  an overall count, mean rate, and rates over the previous 1, 5, and 15-minute intervals.

These were created in `MetricsSupport#configureVendorMetrics` and a handler lambda declared in that same method would update the metrics before invoking `request.next()`.

## New ("extended") KPI metrics
The extended metrics are disabled by default, enabled by configuration or builder methods.

1.  `inFlight` - `ConcurrentGauge` of requests actively being processed at a given moment
2. `load` - `Meter` of `inFlight`
3. `longRunning` -`Meter` -  requests which take longer than a configurable threshold to complete their processing
4. `deferred` - `Meter` - received requests were not processed immediately

Some requests (for example, but not limited to, those executed by Jersey) might be deferred--received by Helidon but then delayed for some reason (e.g, queued due to a shortage of available threads) before actually being processed. This means there can be a difference between when Helidon receives a request and when it starts processing the request.

Similarly, some requests (again, for example, but not limited to, Jersey ones) might complete their work asynchronously, after the user code has invoked `request.next()` and, therefore, separate from when the `MetricsSupport` handler's call to `request.next()` returns.

Some of the new KPI metrics require action _after_ as well as before each request is handled and processed.

These complexities lead to code changes that are a little more more extensive and complicated than might be expected at first glance.

# Design
Introduce two abstractions:
* A KPI metrics-related `Context` which tracks the key events in a request's life cycle that are relevant to KPI metrics
* A KPI `Metrics` interface which encapsulates whether the basic or extended KPI metrics are set up and how to update them at various stages in the request's lifecycle

Make some small changes in the current request workflow:
*  `microprofile/server` `ServerCdiExtension` places a new instance of the KPI `Context` into the request's context store.
* `webserver/jersey` `JerseySupport`,  just before it submits each request to Jersey for processing, gets the KPI `Context`  and, if found, reports to it that request processing is starting.
* `MetricsSupport`, in its existing KPI-related handler:
    * retrieves the KPI `Context` from the request's request context, or, if there is no KPI `Context` present, creates one;
    * obtains the correct impl of the `Metrics` abstraction mentioned above;
    * invokes methods on the KPI `Context` to report the handling and processing of the request, passing the `Metrics` object mentioned just above.

This way, with no change needed in an MP app's code, the KPI metrics distinguish between Helidon's handling vs. processing of JAX-RS requests. By default, in SE apps Helidon treats the start of handling the request as the start of processing the request as well. An SE developer has the option of changing the app code slightly so the KPI metrics reflect the distinction between handling and processing. (See the Other Notes section below.)

The basic or extended KPI metrics are registered in the vendor registry when `MetricsSupport` instantiates the `Metrics` abstraction.

# Changed components
## `webserver/webserver` 
* New interface `KeyPerformanceIndicatorSupport` - defines the KPI behavior through nested interfaces
    * `Metrics`- abstracts the creation and collection of original (simple) and new (extended) KPI metrics
    * `Context` - abstracts the stages in a request's life cycle that are relevant to KPI metrics
        * Methods invoked when a request is received, work started, work completed
        * Static factory method
    *  `DeferrableRequestContext` - sub-interface of `Context` 
        * Adds a method invoked when processing actually begins on a deferrable request
        * Static factory method
* New package-private class `KeyPerformanceIndicatorContextImpls` - impls for the above `Context` interfaces.

The specific type of `Context` needed for a request varies from request to request. 
Callers of the `Context` factory methods always know which type they need.

## `webserver/jersey`
* Existing `JerseySupport` class now, just before starting the processing of the request, retrieves the KPI `DeferrableRequestContext` from the request `Context` and invokes `requestProcessingStarted`.

`JerseySupport` always invokes the `DeferrableRequestContext` if it's present. If `metrics/metrics` is not on the class or module path, the `DeferrableRequestContext#requestProcessingStarted` invocation done here acts as a no-op.

## `metrics/metrics`
* New interface `KeyPerformanceIndicatorMetricsSettings` 
   A POJO which holds all the configurable settings related to KPI metrics, currently:
    * whether the extended KPI metrics should be used, and
    * what threshold defines a "long-running" request

    A buildable object which encapsulates the KPI metrics settings (whether extended metrics are enabled and the threshold for long-running requests). The builder is used as a "sub-builder" for `MetricsSupport`.
* `KeyPerformanceIndicatorMetricsSettingsImpl` - impl for above
* `KeyPerformanceIndicatorMetricsImpls`
    * Basic and extended implementations of the KPI `Metrics` abstraction 
    * A factory method for the above
* `MetricsSupport`
    * Enhance `Builder` and constructor to incorporate KPI metrics config settings
    * In `configureVendorMetrics`
        * Gets the correct instance of `Metrics` via the `KeyPerformanceIndicatorMetricsImpls` factory method
        * In the existing metrics-updating handler in `configureVendorMetrics`:
            * Retrieves the KPI `Context` from the request Context or creates a suitable one
            * Invokes `requestHandlingStarted`, `requestProcessingCompleted`, and `requestHandlingCompleted` from appropriate points. This handler cannot invoke `requestProcessingStarted` because the request's processing might be deferred by a handler later in the chain.

## `microprofile/metrics`
Revise and add tests to check the extended KPI metrics.

## `microprofile/server`
`ServerCdiExtension` now adds a new handler to the handler chain. The handler adds a new `DeferrableRequestContext` to each app's handler chain in a position earlier than the handler added by `MetricsSupport`. 

This means:
* The handler added by `MetricsSupport` will find that `Context` and use it, rather than creating and using a non-extended one. 
* `JerseySupport` will also find that `DeferrableRequestContext` and use it to track when the processing of the request begins.

## `examples/metrics/kpi`
 New example app showing config and explicit set-up of extended KPI metrics.

## `docs`
Updates to the SE and MP metrics guides, involving refactoring duplicated text into a new common file.

# Other notes
## Non-Jersey apps with deferred requests 
Users can write their own non-Jersey apps which defer processing of requests. To work correctly with the enhanced KPI support, the developer needs to add code to:
* For each relevant routing path, insert an early handler which adds a `DeferrableRequestContext` to the request's `Context` (so `MetricsSupport` will use that KPI `Context` when it updates the KPI metrics), and
* During request processing, retrieve that context and invoke its `requestProcessingStarted()` method at the appropriate moment.

Note that if developers do not make these changes, nothing fails. The KPI metrics will not accurately reflect deferred requests; it will seem as if all requests are processed immediately upon receipt--the default SE behavior.

## SE apps using `JerseySupport`
Although we do not promote it (and coming changes in other technologies might remove this use case), developers can currently use `JerseySupport` in SE apps. Such apps can benefit from the KPI metrics improvements. 

To do so, these apps must add a handler to each routing that should participate in extended KPI metrics (as just described above) which adds a new `DeferrableRequestContext` to the request's context store. The application must add that handler earlier in the handler chain than it registers the `MetricsSupport` instance as a service. 