### PR TITLE
Add support for YAML configuration in Helidon Junit 5 testing

### DIFF
--- a/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigSources.java
+++ b/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigSources.java
@@ -25,14 +25,19 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @HelidonTest
-@Configuration(configSources = "testConfigSources.properties")
+@Configuration(configSources = {"testConfigSources.properties", "testConfigSources.yaml"})
 class TestConfigSources {
     @Inject
     @ConfigProperty(name = "some.key")
     private String someKey;
 
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
     @Test
     void testValue() {
         assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
     }
 }

--- a/microprofile/tests/junit5-tests/src/test/resources/testConfigSources.yaml
+++ b/microprofile/tests/junit5-tests/src/test/resources/testConfigSources.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+another:
+  key: "another.value"

--- a/microprofile/tests/junit5/pom.xml
+++ b/microprofile/tests/junit5/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>helidon-jersey-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
 import io.helidon.config.mp.MpConfigSources;
+import io.helidon.config.yaml.YamlMpConfigSource;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
@@ -78,6 +79,8 @@ class HelidonJunitExtension implements BeforeAllCallback,
     private static final Set<Class<? extends Annotation>> HELIDON_TEST_ANNOTATIONS =
             Set.of(AddBean.class, AddConfig.class, AddExtension.class, Configuration.class);
     private static final Map<Class<? extends Annotation>, Annotation> BEAN_DEFINING = new HashMap<>();
+
+    private static final List<String> YAML_SUFFIXES = List.of(".yml", ".yaml");
 
     static {
         BEAN_DEFINING.put(ApplicationScoped.class, ApplicationScoped.Literal.INSTANCE);
@@ -283,7 +286,13 @@ class HelidonJunitExtension implements BeforeAllCallback,
             ConfigBuilder builder = configProviderResolver.getBuilder();
 
             configMeta.additionalSources.forEach(it -> {
-                builder.withSources(MpConfigSources.classPath(it).toArray(new ConfigSource[0]));
+                // If not using a YAML extension, assume properties file
+                String fileName = it.trim();
+                if (YAML_SUFFIXES.stream().anyMatch(fileName::endsWith)) {
+                    builder.withSources(YamlMpConfigSource.classPath(it).toArray(new ConfigSource[0]));
+                } else {
+                    builder.withSources(MpConfigSources.classPath(it).toArray(new ConfigSource[0]));
+                }
             });
 
             config = builder

--- a/microprofile/tests/junit5/src/main/java/module-info.java
+++ b/microprofile/tests/junit5/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module io.helidon.microprofile.tests.junit5 {
 
     requires io.helidon.microprofile.cdi;
     requires io.helidon.config.mp;
+    requires io.helidon.config.yaml;
     requires org.junit.jupiter.api;
     requires transitive jakarta.enterprise.cdi.api;
     requires transitive java.ws.rs;


### PR DESCRIPTION
Add support for YAML configuration in Helidon Junit 5 testing. Issue #2992.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>