### PR TITLE
DOCS: added attribute for javadoc-base-url-api to fix broken links

### DIFF
--- a/docs/mp/config/01_introduction.adoc
+++ b/docs/mp/config/01_introduction.adoc
@@ -23,10 +23,13 @@
 :spec-name: MicroProfile Config
 :description: {spec-name} support in Helidon MP
 :keywords: helidon, mp, microprofile, config, encryption, reference
+:javadoc-base-url-api: {javadoc-base-url}/io.helidon.config/io/helidon/config/
 :h1Prefix: MP
 :feature-name: MicroProfile Config
 :common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 :microprofile-bundle: true
+
+Helidon's MicroProfile Config, an implementation of Eclipse MicroProfile Config, enables you to configure your applications using MicroProfile’s config configuration sources and APIs.
 
 include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
@@ -240,6 +243,6 @@ For more information on using Helidon Config APIs, see the Helidon SE Configurat
 
 == Additional Information
 
-- https://helidon.io/docs/latest/apidocs/io/helidon/config/spi/package-summary.html[Helidon Config SPI]
-- https://helidon.io/docs/latest/apidocs/io/helidon/config/package-summary.html[Helidon Config API]
-- https://download.eclipse.org/microprofile/microprofile-config-1.3/apidocs/[Eclipse MicroProfile API]
+- link:{javadoc-base-url-api}spi/package-summary.html[Helidon Config SPI]
+- link:{javadoc-base-url-api}package-summary.html[Helidon Config API]
+- link:https://download.eclipse.org/microprofile/microprofile-config-1.3/apidocs/[Eclispe MicroProfile API]


### PR DESCRIPTION
Issue* reported by user stating that links in the config intro were broken. Resolved to fix broken links by creating an attribute to javadoc-base-url-api. Links should now correctly resolve for each release. 

*Cannot find the original issue number. 

Broken links at bottom of page:
https://helidon.io/docs/v2/#/mp/config/01_introduction