### PR TITLE
Adds convenience method to clear/invalidate a cookie

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,15 @@ public class SetCookie {
         this.path = builder.path;
         this.secure = builder.secure;
         this.httpOnly = builder.httpOnly;
+    }
+
+    /**
+     * Gets cookie's name.
+     *
+     * @return the name.
+     */
+    public String name() {
+        return name;
     }
 
     /**

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,24 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     public void addCookie(SetCookie cookie) {
         Objects.requireNonNull(cookie, "Parameter 'cookie' is null!");
         add(Http.Header.SET_COOKIE, cookie.toString());
+    }
+
+    @Override
+    public void clearCookie(String name) {
+        SetCookie expiredCookie = SetCookie.builder(name, "deleted")
+                .path("/")
+                .expires(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT+0")))
+                .build();
+
+        List<String> values = remove(Http.Header.SET_COOKIE);
+        if (values.size() == 0) {
+            addCookie(expiredCookie);
+        } else {
+            List<String> newValues = values.stream().map(v ->
+                SetCookie.parse(v).name().equals(name) ? expiredCookie.toString() : v)
+                    .collect(Collectors.toList());
+            put(Http.Header.SET_COOKIE, newValues);
+        }
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.helidon.common.LazyValue;
 import io.helidon.common.http.AlreadyCompletedException;
 import io.helidon.common.http.HashParameters;
 import io.helidon.common.http.Http;
@@ -51,6 +52,9 @@ import io.helidon.common.reactive.Single;
 class HashResponseHeaders extends HashParameters implements ResponseHeaders {
 
     private static final String COMPLETED_EXCEPTION_MESSAGE = "Response headers are already completed (sent to the client)!";
+
+    private static final LazyValue<ZonedDateTime> START_OF_YEAR_1970 = LazyValue.create(
+            () -> ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT+0")));
 
     // status is by default null, so we can check if it was explicitly set
     private volatile Http.ResponseStatus httpStatus;
@@ -207,7 +211,7 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     public void clearCookie(String name) {
         SetCookie expiredCookie = SetCookie.builder(name, "deleted")
                 .path("/")
-                .expires(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT+0")))
+                .expires(START_OF_YEAR_1970.get())
                 .build();
 
         List<String> values = remove(Http.Header.SET_COOKIE);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,6 +199,13 @@ public interface ResponseHeaders extends Headers {
      * @throws NullPointerException if {@code cookie} parameter is {@code null}
      */
     void addCookie(SetCookie cookie) throws NullPointerException;
+
+    /**
+     * Clears a cookie by adding a {@code Set-Cookie} header with an expiration date in the past.
+     *
+     * @param name name of the cookie.
+     */
+    void clearCookie(String name);
 
     /**
      * Register a {@link Consumer} which is executed just before headers are send. {@code Consumer} can made 'last minute

--- a/webserver/webserver/src/test/java/io/helidon/webserver/HashResponseHeadersTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/HashResponseHeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,28 @@ public class HashResponseHeadersTest {
                                                            "who=me",
                                                            "itis=cool; Expires=Mon, 1 Jan 2080 00:00:00 GMT; Domain=oracle.com;"
                                                                    + " Path=/foo; Secure"));
+    }
+
+    @Test
+    public void addAndClearCookies() {
+        HashResponseHeaders h = new HashResponseHeaders(null);
+        h.addCookie("foo1", "bar1");
+        h.addCookie("foo2", "bar2");
+        assertThat(h.all(Http.Header.SET_COOKIE), contains(
+                "foo1=bar1",
+                "foo2=bar2"));
+        h.clearCookie("foo1");
+        assertThat(h.all(Http.Header.SET_COOKIE), contains(
+                "foo1=deleted; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Path=/",
+                "foo2=bar2"));
+    }
+
+    @Test
+    public void clearCookie() {
+        HashResponseHeaders h = new HashResponseHeaders(null);
+        h.clearCookie("foo1");
+        assertThat(h.all(Http.Header.SET_COOKIE), contains(
+                "foo1=deleted; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Path=/"));
     }
 
     @Test


### PR DESCRIPTION
Adds convenience method to clear/invalidate a cookie. Looks up a cookie by name and sets its expiration in the past.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>