### PR TITLE
Upgrade jgit to 5.11.1.202105131744-r

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -80,6 +80,7 @@
         <version.lib.jaxb-runtime>2.3.3</version.lib.jaxb-runtime>
         <version.lib.jedis>3.1.0</version.lib.jedis>
         <version.lib.jersey>2.34</version.lib.jersey>
+        <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.jms-api>2.0</version.lib.jms-api>
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
@@ -304,6 +305,11 @@
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${version.lib.activation-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>${version.lib.jgit}</version>
             </dependency>
             <dependency>
                 <groupId>javax.jms</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
         <version.lib.asm>6.0</version.lib.asm>
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
-        <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.kafka-junit5>3.2.1</version.lib.kafka-junit5>
         <version.lib.netty.tcnative>2.0.36.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
@@ -873,11 +872,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${version.lib.netty.tcnative}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jgit</groupId>
-                <artifactId>org.eclipse.jgit</artifactId>
-                <version>${version.lib.jgit}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,7 @@
         <version.lib.asm>6.0</version.lib.asm>
         <version.lib.checkstyle>8.29</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
-        <version.lib.jgit>4.9.9.201903122025-r</version.lib.jgit>
-        <version.lib.jsch>0.1.55</version.lib.jsch>
+        <version.lib.jgit>5.11.1.202105131744-r</version.lib.jgit>
         <version.lib.kafka-junit5>3.2.1</version.lib.kafka-junit5>
         <version.lib.netty.tcnative>2.0.36.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>
@@ -879,12 +878,6 @@
                 <groupId>org.eclipse.jgit</groupId>
                 <artifactId>org.eclipse.jgit</artifactId>
                 <version>${version.lib.jgit}</version>
-            </dependency>
-            <!-- Used to update version used by jgit -->
-            <dependency>
-                <groupId>com.jcraft</groupId>
-                <artifactId>jsch</artifactId>
-                <version>${version.lib.jsch}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
See #2978

New version of jgit core no longer has dependency on jsch so no longer need to manage its version.

Moved management of org.eclipse.jgit from project pom to `dependencies/pom.xml`. I think this was an oversight.


