### PR TITLE
Use reluctant instead of greedy to match username and password

### DIFF
--- a/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
+++ b/security/providers/http-auth/src/main/java/io/helidon/security/providers/httpauth/HttpBasicAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class HttpBasicAuthProvider extends SynchronousProvider implements Authen
     static final String BASIC_PREFIX = "basic ";
 
     private static final Logger LOGGER = Logger.getLogger(HttpBasicAuthProvider.class.getName());
-    private static final Pattern CREDENTIAL_PATTERN = Pattern.compile("(.*):(.*)");
+    static final Pattern CREDENTIAL_PATTERN = Pattern.compile("(.*?):(.*)");
 
     private final List<SecureUserStore> userStores;
     private final String realm;

--- a/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/CredentialPatternTest.java
+++ b/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/CredentialPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/CredentialPatternTest.java
+++ b/security/providers/http-auth/src/test/java/io/helidon/security/providers/httpauth/CredentialPatternTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.security.providers.httpauth;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CredentialPatternTest {
+
+    private final Pattern pattern = HttpBasicAuthProvider.CREDENTIAL_PATTERN;
+
+    @Test
+    void testPatternNormal() {
+        Matcher m = pattern.matcher("user:password");
+        assertTrue(m.matches());
+        assertThat(m.group(1), is("user"));
+        assertThat(m.group(2), is("password"));
+    }
+
+    @Test
+    void testPatternColonInPassword() {
+        Matcher m = pattern.matcher("user:pass:word");
+        assertTrue(m.matches());
+        assertThat(m.group(1), is("user"));
+        assertThat(m.group(2), is("pass:word"));
+
+        m = pattern.matcher("user::pass:word:");
+        assertTrue(m.matches());
+        assertThat(m.group(1), is("user"));
+        assertThat(m.group(2), is(":pass:word:"));
+    }
+}


### PR DESCRIPTION
Use reluctant instead of greedy to match username and password. This is necessary to support colons in passwords.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>