### PR TITLE
Fix Bug #3032 with SLF4J dependancy

### DIFF
--- a/microprofile/cdi/pom.xml
+++ b/microprofile/cdi/pom.xml
@@ -50,12 +50,7 @@
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>
-        <dependency>
-            <!-- redirecting Weld logging to JUL logging -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
This PR fixes Bug #3032 .
I've removed the SLF4j dependancy from helidon-microprofile-cdi.
I have rerun all the examples, they all work as expected. 