### PR TITLE
A few more cases of HTML encoding in error messages

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -423,13 +423,15 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     /**
-     * Returns a 400 (Bad Request) response with a message as content.
+     * Returns a 400 (Bad Request) response with a message as content. Message is encoded using
+     * HTML entities to prevent potential XSS attacks even if content type is text/plain.
      *
      * @param ctx Channel context.
      * @param message The message.
      */
     private void send400BadRequest(ChannelHandlerContext ctx, String message) {
-        byte[] entity = message.getBytes(StandardCharsets.UTF_8);
+        String encoded = HtmlEncoder.encode(message);
+        byte[] entity = encoded.getBytes(StandardCharsets.UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, BAD_REQUEST, Unpooled.wrappedBuffer(entity));
         response.headers().add(HttpHeaderNames.CONTENT_TYPE, "text/plain");
         response.headers().add(HttpHeaderNames.CONTENT_LENGTH, entity.length);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
@@ -16,6 +16,8 @@
 
 package io.helidon.webserver;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -68,6 +70,23 @@ class XssServerTest {
     void testScriptInjection() throws Exception {
         String s = SocketHttpClient.sendAndReceive("/bar%3cscript%3eevil%3c%2fscript%3e",
                 Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionIllegalUrlChar() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/bar<script/>evil</script>",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionContentType() throws Exception {
+        List<String> requestHeaders = Arrays.asList("Content-Type: <script>evil</script>");
+        String s = SocketHttpClient.sendAndReceive("/foo",
+                Http.Method.GET, null, requestHeaders, webServer);
         assertThat(s, not(containsString("<script>")));
         assertThat(s, not(containsString("</script>")));
     }


### PR DESCRIPTION
A few more cases in the webserver where HTML encoding of error messages is required.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>