### PR TITLE
1.4: revert libthrift forced upgrade for jaeger-client

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -39,7 +39,6 @@
         <version.lib.activation-api>1.2.0</version.lib.activation-api>
         <version.lib.annotation-api>1.3.1</version.lib.annotation-api>
         <version.lib.apache-httpclient>4.5.13</version.lib.apache-httpclient>
-        <version.lib.apache-thrift>0.13.0</version.lib.apache-thrift>
         <version.lib.brave-opentracing>0.35.0</version.lib.brave-opentracing>
         <version.lib.cdi-api>2.0</version.lib.cdi-api>
         <version.lib.eclipselink>2.7.5</version.lib.eclipselink>
@@ -143,12 +142,6 @@
                 <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-client</artifactId>
                 <version>${version.lib.jaegertracing}</version>
-            </dependency>
-            <dependency>
-                <!-- Enforce higher version than jaeger-client brings in -->
-                <groupId>org.apache.thrift</groupId>
-                <artifactId>libthrift</artifactId>
-                <version>${version.lib.apache-thrift}</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>

--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -136,4 +136,40 @@
    <cpe>cpe:/a:apache:httpclient</cpe>
 </suppress>
 
+<!-- These are suppressions for libthrift 0.12.0 that is brought in transitively by
+     jaeger-client 0.35.5. We can't upgrade libthrift because they broke compatibility
+     (see https://github.com/oracle/helidon/issues/3052). We can't upgrade jaeger-client
+     because this is the last version that supports opentracing 0.32.0. We can't upgrade
+     opentracing because future versions are incompatible with 0.32.0. We've
+     done these upgrades in Helidon 2.0 (since we could break compatibility in a
+     major release). But we can't do them in a 1.4.X micro release.
+     Fortunately these CVEs do not apply. See comments below.
+-->
+   <!-- this was fixed for the Java bindings in thrift version 0.11.0 so does not apply -->
+   <suppress>
+      <notes><![CDATA[
+   file name: libthrift-0.12.0.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+      <cve>CVE-2019-0205</cve>
+   </suppress>
+
+   <!-- This is against the thrift Go Server. We are Java and jaeger-client uses the thrift client only -->
+   <suppress>
+      <notes><![CDATA[
+   file name: libthrift-0.12.0.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+      <cve>CVE-2019-0210</cve>
+   </suppress>
+
+   <!-- This is against the thrift Server. jaeger-client uses the thrift client only -->
+   <suppress>
+      <notes><![CDATA[
+   file name: libthrift-0.12.0.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@.*$</packageUrl>
+      <cve>CVE-2020-13949</cve>
+   </suppress>
+
 </suppressions>

--- a/tests/integration/mp-jaeger-3052/pom.xml
+++ b/tests/integration/mp-jaeger-3052/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-tests-integration</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>1.4.9-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-jaeger-trace</artifactId>
+    <name>Helidon Tests Integration MP Jaeger </name>
+    <description>Test that we can run with Jaeger</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tracing</groupId>
+            <artifactId>helidon-microprofile-tracing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.tracing</groupId>
+            <artifactId>helidon-tracing-jaeger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-jaeger-3052/src/main/java/io/helidon/tests/integration/jaegertest/TestApplication.java
+++ b/tests/integration/mp-jaeger-3052/src/main/java/io/helidon/tests/integration/jaegertest/TestApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.jaegertest;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.Application;
+
+import io.helidon.common.CollectionsHelper;
+
+@ApplicationScoped
+public class TestApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        return CollectionsHelper.setOf(TestResource.class);
+    }
+}
+

--- a/tests/integration/mp-jaeger-3052/src/main/java/io/helidon/tests/integration/jaegertest/TestResource.java
+++ b/tests/integration/mp-jaeger-3052/src/main/java/io/helidon/tests/integration/jaegertest/TestResource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.tests.integration.jaegertest;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+@Path("/test")
+@RequestScoped
+public class TestResource {
+    @GET
+    public Response getTest(@QueryParam("throwError") final boolean throwError) {
+        StreamingOutput output = outputStream -> {
+            if (throwError) {
+                throw new WebApplicationException("Capacity Exceeded.", 429);
+            }
+            Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream));
+            writer.write("Test Message");
+            writer.flush();
+        };
+        return Response.ok().entity(output).build();
+    }
+}
+

--- a/tests/integration/mp-jaeger-3052/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/mp-jaeger-3052/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server.port=0
+tracing.service=helidon-full-http

--- a/tests/integration/mp-jaeger-3052/src/test/java/io/helidon/tests/integration/jaegertest/JaegerTest.java
+++ b/tests/integration/mp-jaeger-3052/src/test/java/io/helidon/tests/integration/jaegertest/JaegerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jaegertest;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import io.helidon.microprofile.server.Server;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JaegerTest {
+    private static Server server;
+    private static Client client;
+    private static WebTarget target;
+
+    @BeforeAll
+    static void initClass() {
+        server = Server.create(TestApplication.class).start();
+        client = ClientBuilder.newClient();
+        target = client.target("http://localhost:" + server.port() + "/test");
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        if (null != server) {
+            server.stop();
+        }
+        if (null != client) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testTracing() {
+        String response = target
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("Test Message"));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -33,6 +33,7 @@
     <name>Helidon Integration Tests</name>
 
     <modules>
+        <module>mp-jaeger-trace</module>
         <module>zipkin-mp-2.2</module>
         <module>mp-security-client</module>
         <module>health</module>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -33,7 +33,7 @@
     <name>Helidon Integration Tests</name>
 
     <modules>
-        <module>mp-jaeger-trace</module>
+        <module>mp-jaeger-3052</module>
         <module>zipkin-mp-2.2</module>
         <module>mp-security-client</module>
         <module>health</module>


### PR DESCRIPTION
See issue #3052.

The new test simply verifies that the server can start up and run with jaeger tracing configured.