### PR TITLE
Encode paths returned as part of 400 and 404 responses

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -67,7 +67,7 @@
         <version.lib.jaxrs-api>2.1</version.lib.jaxrs-api>
         <version.lib.jboss-transaction-spi>7.6.0.Final</version.lib.jboss-transaction-spi>
         <version.lib.jedis>3.1.0</version.lib.jedis>
-        <version.lib.jersey>2.29.1</version.lib.jersey>
+        <version.lib.jersey>2.33</version.lib.jersey>
         <version.lib.jsonb-api>1.0.1</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.2</version.lib.jsonp-api>
         <version.lib.jsonp-impl>1.1.2</version.lib.jsonp-impl>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -31,6 +31,47 @@
     <name>Helidon Microprofile Server</name>
     <description>Server of the microprofile implementation</description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <!--
+                      - Execute all tests except JerseyPropertiesTest in the same VM.
+                      -->
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/JerseyPropertiesTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <!--
+                      - Run JerseyPropertiesTest in its own VM to avoid conflicts.
+                      -->
+                    <execution>
+                        <id>jersey-properties-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <includes>
+                                <include>**/JerseyPropertiesTest.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/microprofile/server/pom.xml
+++ b/microprofile/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/JerseyPropertiesTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/JerseyPropertiesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.server;
+
+import java.util.Properties;
+
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.webserver.jersey.JerseySupport;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.glassfish.jersey.client.ClientProperties.IGNORE_EXCEPTION_RESPONSE;
+
+/**
+ * Test that it is possible to override {@code IGNORE_EXCEPTION_RESPONSE} in
+ * Jersey using config. See {@link JerseySupport}
+ * for more information.
+ */
+class JerseyPropertiesTest {
+
+    @Test
+    void testIgnoreExceptionResponseOverride() {
+        Properties properties = new Properties();
+        properties.setProperty("jersey.config.client.ignoreExceptionResponse", "false");
+        Config config = Config.builder(() -> ConfigSources.create(properties).build()).build();
+        JerseySupport jerseySupport = JerseySupport.builder().config(config).build();
+        assertNotNull(jerseySupport);
+        assertThat(System.getProperty(IGNORE_EXCEPTION_RESPONSE), is("false"));
+    }
+}

--- a/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
+++ b/microprofile/server/src/test/java/io/helidon/microprofile/server/ServerSseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,16 +103,19 @@ class ServerSseTest {
         @Produces(MediaType.SERVER_SENT_EVENTS)
         public void listenToEvents(@Context SseEventSink eventSink, @Context Sse sse) {
             while (true) {
-                eventSink.send(sse.newEvent("hello")).thenAccept(t -> {
-                    if (t != null) {
-                        System.out.println(t);
-                        connClosedFuture.complete(null);
-                    }
-                });
                 try {
-                    Thread.sleep(50);
+                    eventSink.send(sse.newEvent("hello")).thenAccept(t -> {
+                        if (t != null) {
+                            System.out.println(t);
+                            connClosedFuture.complete(null);
+                        }
+                    });
+                    TimeUnit.MILLISECONDS.sleep(5);
                 } catch (InterruptedException e) {
                     // falls through
+                } catch (IllegalStateException e) {
+                    //https://github.com/oracle/helidon/issues/1290
+                    connClosedFuture.complete(null);
                 }
             }
         }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -63,7 +63,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.model.Resource;
 
 import static java.util.Objects.requireNonNull;
-import static org.glassfish.jersey.CommonProperties.PROVIDER_DEFAULT_DISABLE;
 
 /**
  * The Jersey Support integrates Jersey (JAX-RS RI) into the Web Server.

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -44,6 +44,7 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpRequest;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigValue;
 import io.helidon.webserver.Handler;
 import io.helidon.webserver.HttpException;
 import io.helidon.webserver.Routing;
@@ -53,6 +54,7 @@ import io.helidon.webserver.Service;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.server.ApplicationHandler;
@@ -61,6 +63,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.model.Resource;
 
 import static java.util.Objects.requireNonNull;
+import static org.glassfish.jersey.CommonProperties.PROVIDER_DEFAULT_DISABLE;
 
 /**
  * The Jersey Support integrates Jersey (JAX-RS RI) into the Web Server.
@@ -116,6 +119,11 @@ public class JerseySupport implements Service {
     private final JerseyHandler handler = new JerseyHandler();
 
     /**
+     * If set to {@code "true"}, Jersey will ignore responses in exceptions.
+     */
+    static final String IGNORE_EXCEPTION_RESPONSE = "jersey.config.client.ignoreExceptionResponse";
+
+    /**
      * Creates a Jersey Support based on the provided JAX-RS application.
      *
      * @param builder builder with application (the JAX-RS application to build the Jersey Support from),
@@ -140,6 +148,16 @@ public class JerseySupport implements Service {
         }
 
         this.appHandler = new ApplicationHandler(builder.resourceConfig, new ServerBinder(executorService));
+
+        // This configuration via system properties is for the Jersey Client API. Any
+        // response in an exception will be mapped to an empty one to prevent data leaks
+        // unless property in config is set to false.
+        // See https://github.com/eclipse-ee4j/jersey/pull/4641.
+        if (!System.getProperties().contains(IGNORE_EXCEPTION_RESPONSE)) {
+            System.setProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, "true");
+            ConfigValue<String> ignore = builder.config.get(IGNORE_EXCEPTION_RESPONSE).asString();
+            System.setProperty(IGNORE_EXCEPTION_RESPONSE, ignore.orElse("true"));
+        }
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +208,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      * @param message The message.
      */
     private static void send400BadRequest(ChannelHandlerContext ctx, String message) {
-        byte[] entity = message.getBytes(StandardCharsets.UTF_8);
+        String encoded = HtmlEncoder.encode(message);
+        byte[] entity = encoded.getBytes(StandardCharsets.UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, BAD_REQUEST, Unpooled.wrappedBuffer(entity));
         response.headers().add(HttpHeaderNames.CONTENT_TYPE, "text/plain");
         response.headers().add(HttpHeaderNames.CONTENT_LENGTH, entity.length);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HtmlEncoder.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HtmlEncoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * HTML encoding of special characters to prevent cross site scripting (XSS) attacks.
+ * Any data that is "echoed" back from a request can be used to execute a script in a
+ * browser unless properly encoded.
+ */
+public final class HtmlEncoder {
+
+    private HtmlEncoder() {
+    }
+
+    /**
+     * Encode HTML string replacing the special characters by their corresponding
+     * entities.
+     *
+     * @param s string to encode.
+     * @return encoded string.
+     */
+    public static String encode(String s) {
+        int n = s.length();
+        StringBuilder result = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&':
+                    result.append("&amp;");
+                    break;
+                case '<':
+                    result.append("&lt;");
+                    break;
+                case '>':
+                    result.append("&gt;");
+                    break;
+                case '"':
+                    result.append("&quot;");
+                    break;
+                case '\'':
+                    result.append("&#x27;");
+                    break;
+                default:
+                    result.append(c);
+                    break;
+            }
+        }
+        return result.toString();
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,7 +289,8 @@ class RequestRouting implements Routing {
             Crawler.Item nextItem = crawler.next();
             if (nextItem == null) {
                 // 404 error
-                nextNoCheck(new NotFoundException("No handler found for path: " + path()));
+                nextNoCheck(new NotFoundException("No handler found for path: "
+                        + HtmlEncoder.encode(path().toString())));
             } else {
                 try {
                     RoutedResponse nextResponse = new RoutedResponse(response);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.utils.SocketHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class XssServerTest {
+    private static final Logger LOGGER = Logger.getLogger(XssServerTest.class.getName());
+
+    private static WebServer webServer;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        startServer(0);
+    }
+
+    @AfterAll
+    static void close() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void startServer(int port) throws Exception {
+        webServer = WebServer.create(
+                ServerConfiguration.builder().port(port).build(),
+                Routing.builder()
+                        .get("/foo", (req, res) -> {
+                            res.send(HtmlEncoder.encode("<script>bad</script>"));
+                        })
+                        .build())
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+    }
+
+    @Test
+    void testScriptInjection() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/bar%3cscript%3eevil%3c%2fscript%3e",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionIllegalUrlChar() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/bar<script/>evil</script>",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionContentType() throws Exception {
+        List<String> requestHeaders = Arrays.asList("Content-Type: <script>evil</script>");
+        String s = SocketHttpClient.sendAndReceive("/foo",
+                Http.Method.GET, null, requestHeaders, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testResponseEncoding() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/foo",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+}


### PR DESCRIPTION
Helidon 1.x branch: Encode paths returned as part of 400 and 404 responses.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>