### PR TITLE
Encode paths returned as part of 400 and 404 responses

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +208,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
      * @param message The message.
      */
     private static void send400BadRequest(ChannelHandlerContext ctx, String message) {
-        byte[] entity = message.getBytes(StandardCharsets.UTF_8);
+        String encoded = HtmlEncoder.encode(message);
+        byte[] entity = encoded.getBytes(StandardCharsets.UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, BAD_REQUEST, Unpooled.wrappedBuffer(entity));
         response.headers().add(HttpHeaderNames.CONTENT_TYPE, "text/plain");
         response.headers().add(HttpHeaderNames.CONTENT_LENGTH, entity.length);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HtmlEncoder.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HtmlEncoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+/**
+ * HTML encoding of special characters to prevent cross site scripting (XSS) attacks.
+ * Any data that is "echoed" back from a request can be used to execute a script in a
+ * browser unless properly encoded.
+ */
+public final class HtmlEncoder {
+
+    private HtmlEncoder() {
+    }
+
+    /**
+     * Encode HTML string replacing the special characters by their corresponding
+     * entities.
+     *
+     * @param s string to encode.
+     * @return encoded string.
+     */
+    public static String encode(String s) {
+        int n = s.length();
+        StringBuilder result = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&':
+                    result.append("&amp;");
+                    break;
+                case '<':
+                    result.append("&lt;");
+                    break;
+                case '>':
+                    result.append("&gt;");
+                    break;
+                case '"':
+                    result.append("&quot;");
+                    break;
+                case '\'':
+                    result.append("&#x27;");
+                    break;
+                default:
+                    result.append(c);
+                    break;
+            }
+        }
+        return result.toString();
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,7 +289,8 @@ class RequestRouting implements Routing {
             Crawler.Item nextItem = crawler.next();
             if (nextItem == null) {
                 // 404 error
-                nextNoCheck(new NotFoundException("No handler found for path: " + path()));
+                nextNoCheck(new NotFoundException("No handler found for path: "
+                        + HtmlEncoder.encode(path().toString())));
             } else {
                 try {
                     RoutedResponse nextResponse = new RoutedResponse(response);

--- a/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.helidon.common.http.Http;
+import io.helidon.webserver.utils.SocketHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class XssServerTest {
+    private static final Logger LOGGER = Logger.getLogger(XssServerTest.class.getName());
+
+    private static WebServer webServer;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        startServer(0);
+    }
+
+    @AfterAll
+    static void close() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void startServer(int port) throws Exception {
+        webServer = WebServer.create(
+                ServerConfiguration.builder().port(port).build(),
+                Routing.builder()
+                        .get("/foo", (req, res) -> {
+                            res.send(HtmlEncoder.encode("<script>bad</script>"));
+                        })
+                        .build())
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+    }
+
+    @Test
+    void testScriptInjection() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/bar%3cscript%3eevil%3c%2fscript%3e",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionIllegalUrlChar() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/bar<script/>evil</script>",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testScriptInjectionContentType() throws Exception {
+        List<String> requestHeaders = Arrays.asList("Content-Type: <script>evil</script>");
+        String s = SocketHttpClient.sendAndReceive("/foo",
+                Http.Method.GET, null, requestHeaders, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+
+    @Test
+    void testResponseEncoding() throws Exception {
+        String s = SocketHttpClient.sendAndReceive("/foo",
+                Http.Method.GET, null, webServer);
+        assertThat(s, not(containsString("<script>")));
+        assertThat(s, not(containsString("</script>")));
+    }
+}


### PR DESCRIPTION
Helidon 1.x branch: Encode paths returned as part of 400 and 404 responses.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>