### PR TITLE
Neo4j health check fix

### DIFF
--- a/examples/integrations/neo4j/neo4j-mp/pom.xml
+++ b/examples/integrations/neo4j/neo4j-mp/pom.xml
@@ -18,8 +18,8 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.applications</groupId>
@@ -76,6 +76,22 @@
                 <exclusion>
                     <groupId>org.junit.vintage</groupId>
                     <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.neo4j.app</groupId>
+                    <artifactId>neo4j-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>${neo4j-harness.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
+++ b/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
@@ -24,14 +24,9 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
-import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.SessionConfig;
-import org.neo4j.driver.exceptions.SessionExpiredException;
-import org.neo4j.driver.summary.ResultSummary;
-import org.neo4j.driver.summary.ServerInfo;
+
 
 /**
  * Health support module for Neo4j. Follows the standard MicroProfile HealthCheck pattern.
@@ -47,11 +42,22 @@ public class Neo4jHealthCheck implements HealthCheck {
 
     private final Driver driver;
 
+    /**
+     * Constructor for Health checks.
+     *
+     * @param driver Neo4j.
+     */
     @Inject //will be ignored out of CDI
     Neo4jHealthCheck(Driver driver) {
         this.driver = driver;
     }
 
+    /**
+     * Creates the Neo4j driver.
+     *
+     * @param driver Neo4j.
+     * @return Neo4jHealthCheck.
+     */
     public static Neo4jHealthCheck create(Driver driver) {
         return new Neo4jHealthCheck(driver);
     }


### PR DESCRIPTION
Current PR resolves #3060 : `Neo4jHealthCheck: Unable to build native image`. 

1. Comments by Michael Simonis to `Neo4jHealthCheck` applied. Tests working correctly.
2. Fixed native image generation with a dependancy workaround.
3. After some discussion, TestContainers usage is strongly recommended.