### PR TITLE
Ignore path parameters when matching routes

### DIFF
--- a/tests/integration/security/path-params/pom.xml
+++ b/tests/integration/security/path-params/pom.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2021 Oracle and/or its affiliates.
 
@@ -18,6 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <parent>
         <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
@@ -49,3 +50,4 @@
         </dependency>
     </dependencies>
 </project>
+

--- a/tests/integration/security/path-params/pom.xml
+++ b/tests/integration/security/path-params/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -18,26 +18,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
+        <artifactId>helidon-tests-integration-security</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <artifactId>helidon-tests-integration</artifactId>
         <version>2.3.1-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <packaging>pom</packaging>
-    <artifactId>helidon-tests-integration-security</artifactId>
-    <name>Helidon Integration Tests Security</name>
+    <artifactId>helidon-tests-integration-security-path-params</artifactId>
+    <name>Helidon Tests Integration Security Path Parameters</name>
 
     <description>
-        Security integration tests
+        Integration test for path parameters
     </description>
 
-    <modules>
-        <module>gh1487</module>
-        <module>gh2297</module>
-        <module>gh2455</module>
-        <module>path-params</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/tests/integration/security/path-params/src/main/java/io/helidon/tests/integration/security/pathparams/AdminResource.java
+++ b/tests/integration/security/path-params/src/main/java/io/helidon/tests/integration/security/pathparams/AdminResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.pathparams;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * An admin resource that should not be accessible without proper credentials.
+ */
+@Path("/admin")
+public class AdminResource {
+
+    /**
+     * The resource.
+     *
+     * @return admin secret.
+     */
+    @GET
+    public String admin() {
+        return "admin";
+    }
+}

--- a/tests/integration/security/path-params/src/main/java/io/helidon/tests/integration/security/pathparams/GreetResource.java
+++ b/tests/integration/security/path-params/src/main/java/io/helidon/tests/integration/security/pathparams/GreetResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.pathparams;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * A greet resource that is unprotected.
+ */
+@Path("/greet")
+public class GreetResource {
+
+    /**
+     * A hello resource.
+     *
+     * @return the greeting.
+     */
+    @GET
+    public String hello() {
+        return "Hello World";
+    }
+}

--- a/tests/integration/security/path-params/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/security/path-params/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/security/path-params/src/main/resources/application.yaml
+++ b/tests/integration/security/path-params/src/main/resources/application.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server.port: 0
+security:
+  providers:
+    - abac:
+    - http-basic-auth:
+        realm: "helidon"
+        users:
+          - login: "success"
+            password: "password"
+            roles: ["admin"]
+          - login: "fail"
+            password: "password"
+  web-server:
+    paths:
+      - path: "/admin"
+        authenticate: true
+        authorize: true
+        abac:
+          roles-allowed:
+            user:
+              - admin

--- a/tests/integration/security/path-params/src/main/resources/logging.properties
+++ b/tests/integration/security/path-params/src/main/resources/logging.properties
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+AUDIT.level=FINEST
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.microprofile.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO
+#org.glassfish.jersey.level=INFO
+#org.jboss.weld=INFO

--- a/tests/integration/security/path-params/src/main/resources/logging.properties
+++ b/tests/integration/security/path-params/src/main/resources/logging.properties
@@ -26,12 +26,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 # Global logging level. Can be overridden by specific loggers
 .level=INFO
 AUDIT.level=FINEST
-# Component specific log levels
-#io.helidon.webserver.level=INFO
-#io.helidon.config.level=INFO
-#io.helidon.security.level=INFO
-#io.helidon.microprofile.level=INFO
-#io.helidon.common.level=INFO
-#io.netty.level=INFO
-#org.glassfish.jersey.level=INFO
-#org.jboss.weld=INFO
+

--- a/tests/integration/security/path-params/src/test/java/io/helidon/tests/integration/security/pathparams/AdminTest.java
+++ b/tests/integration/security/path-params/src/test/java/io/helidon/tests/integration/security/pathparams/AdminTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.security.pathparams;
+
+import java.util.Base64;
+import java.util.function.Function;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.server.Server;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AdminTest {
+    private static Server server;
+    private static Client client;
+
+    private static Function<String, WebTarget> target;
+
+    @BeforeAll
+    static void initClass() {
+        server = Server.create()
+                .start();
+
+        client = ClientBuilder.newClient();
+
+        int port = server.port();
+        String baseUri = "http://localhost:" + port;
+        target = p -> client.target(baseUri + p);
+    }
+
+    @AfterAll
+    static void destroyClass() {
+        if (server != null) {
+            server.stop();
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    void testGreetResource() {
+        String response = target.apply("/greet").request().get(String.class);
+        assertThat(response, is("Hello World"));
+    }
+
+    @Test
+    void testAdminResource1() {
+        Response response = target.apply("/admin").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResource2() {
+        Response response = target.apply("/admin;a=b").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResource3() {
+        Response response = target.apply("/admin;a=b;c=d").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResource4() {
+        Response response = target.apply("/admin;").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResource5() {
+        Response response = target.apply("/admin/;").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResource6() {
+        Response response = target.apply("/admin/;/").request().get();
+        assertThat(response.getStatus(), is(Http.Status.UNAUTHORIZED_401.code()));
+    }
+
+    @Test
+    void testAdminResourceBasicAuth1() {
+        Response response = target.apply("/admin").request()
+                .header("Authorization", basic("success"))
+                .get();
+        assertThat(response.getStatus(), is(Http.Status.OK_200.code()));
+    }
+
+    @Test
+    void testAdminResourceBasicAuth2() {
+        Response response = target.apply("/admin;a=b").request()
+                .header("Authorization", basic("success"))
+                .get();
+        assertThat(response.getStatus(), is(Http.Status.OK_200.code()));
+    }
+
+    private String basic(String user) {
+        String uap = user + ":password";
+        return "basic " + Base64.getEncoder().encodeToString(uap.getBytes());
+    }
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HandlerRoute.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HandlerRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.helidon.common.http.Http;
+
+import static io.helidon.webserver.PathHelper.extractPathParams;
 
 /**
  * Represents a single routable {@link Handler} in the {@link Routing}.
@@ -139,14 +141,14 @@ class HandlerRoute implements Route {
     }
 
     /**
-     * Matches this against a URI path.
+     * Matches this against a URI path. Drops any path parameters before matching.
      *
      * @param path resolved and normalized URI path to test against.
      * @return a {@link PathMatcher.Result} of the test.
      * @throws NullPointerException in case that {@code path} parameter is {@code null}.
      */
     public PathMatcher.Result match(CharSequence path) {
-        return pathMatcher.match(path);
+        return pathMatcher.match(extractPathParams(path.toString()));
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathHelper.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathHelper.java
@@ -16,8 +16,6 @@
 
 package io.helidon.webserver;
 
-import java.text.Normalizer;
-
 class PathHelper {
 
     private PathHelper() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathHelper.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.text.Normalizer;
+
+class PathHelper {
+
+    private PathHelper() {
+    }
+
+    /**
+     * Canonicalizes a path by dropping a trailing '/'. Also if path is
+     * empty then it becomes '/'.
+     *
+     * @param p path to canonicalize.
+     * @return canonicalized path.
+     */
+    static String canonicalize(String p) {
+        if (p == null || p.isEmpty() || p.equals("/")) {
+            return "/";
+        }
+        int lastCharIndex = p.length() - 1;
+        return p.charAt(lastCharIndex) == '/' ? p.substring(0, lastCharIndex) : p;
+    }
+
+    private enum State {
+        NORMAL,
+        PATH_PARAM,
+        QUERY_PARAM
+    }
+
+    /**
+     * Drops any path parameters for the purpose of matching against patterns.
+     * The input to this method is assumed to be canonicalize but it may need
+     * canonicalization after transformation.
+     *
+     * Examples: /admin;a=b/list;c=d;e=f -> /admin/list
+     *
+     * @param path original path.
+     * @return path with path params removed.
+     */
+    static String extractPathParams(String path) {
+        // Avoid conversion for the common case of no params
+        if (!path.contains(";")) {
+            return path;
+        }
+
+        // Skip over any param paths
+        State state = State.NORMAL;
+        int n = path.length();
+        StringBuilder builder = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            char ch = path.charAt(i);
+            switch (ch) {
+                case ';':
+                    if (state == State.NORMAL) {
+                        state = State.PATH_PARAM;
+                    }
+                    break;
+                case '/':
+                    if (state == State.QUERY_PARAM) {
+                        throw new IllegalStateException("Unexpected state " + state);
+                    }
+                    state = State.NORMAL;
+                    builder.append(ch);
+                    break;
+                case '?':
+                    state = State.QUERY_PARAM;
+                    builder.append(ch);
+                    break;
+                default:
+                    if (state != State.PATH_PARAM) {
+                        builder.append(ch);
+                    }
+                    break;
+            }
+        }
+        return canonicalize(builder.toString());
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/BaseServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/BaseServerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import io.helidon.webclient.WebClient;
+import org.junit.jupiter.api.AfterAll;
+
+class BaseServerTest {
+    private static final Logger LOGGER = Logger.getLogger(BaseServerTest.class.getName());
+
+    private static WebServer webServer;
+    private static WebClient webClient;
+
+    @AfterAll
+    static void close() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    protected static WebServer webServer() {
+        return webServer;
+    }
+
+    protected static WebClient webClient() {
+        return webClient;
+    }
+
+    protected static void startServer(int port, Routing routing) throws Exception {
+        webServer = WebServer.builder()
+                .port(port)
+                .routing(routing)
+                .build()
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+
+        webClient = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port())
+                .validateHeaders(false)
+                .keepAlive(true)
+                .build();
+
+        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PathHelperTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PathHelperTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static io.helidon.webserver.PathHelper.extractPathParams;
+
+class PathHelperTest {
+
+    @Test
+    void ignorePathParamsMatch() {
+        assertThat(extractPathParams("/admin/list"), is("/admin/list"));
+        assertThat(extractPathParams("/admin;a=b"), is("/admin"));
+        assertThat(extractPathParams("/admin;a=b/list;c=d;e=f"), is("/admin/list"));
+        assertThat(extractPathParams("/admin;a=b/list;c=d;e=f;"), is("/admin/list"));
+        assertThat(extractPathParams("/admin;"), is("/admin"));
+        assertThat(extractPathParams("/admin;/list"), is("/admin/list"));
+        assertThat(extractPathParams("/admin/;/list/"), is("/admin//list"));
+        assertThat(extractPathParams("/;a=b"), is("/"));
+        assertThat(extractPathParams(";a=b;c=d;"), is("/"));
+        assertThat(extractPathParams("/admin/;"), is("/admin"));
+        assertThat(extractPathParams("/admin//;"), is("/admin/"));
+        assertThat(extractPathParams("/;"), is("/"));
+        assertThat(extractPathParams(";"), is("/"));
+        assertThat(extractPathParams(";/admin/"), is("/admin"));
+        assertThat(extractPathParams("/admin;a=b?b=c"), is("/admin?b=c"));
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/UriParamsServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/UriParamsServerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.concurrent.ExecutionException;
+
+import io.helidon.webclient.WebClientException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+class UriParamsServerTest extends BaseServerTest {
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        Routing routing = Routing.builder()
+                .get("/shop",
+                        (req, res) -> res.send("shop"))
+                .get("/admin",
+                        (req, res) -> res.send("admin"))
+                .build();
+        startServer(0, routing);
+    }
+
+    @Test
+    void testEndpoints() throws Exception {
+        String s = webClient().get()
+                .path("shop")
+                .request(String.class)
+                .get();
+        assertThat(s, is("shop"));
+        s = webClient().get()
+                .path("admin")
+                .request(String.class)
+                .get();
+        assertThat(s, is("admin"));
+    }
+
+    @Test
+    void testEndpointsWithParams() {
+        try {
+            String s = webClient().get()
+                    .path("shop;a=b")
+                    .request(String.class)
+                    .get();
+        } catch (ExecutionException | InterruptedException e) {
+            Throwable t = e.getCause();
+            assertThat(t, is(instanceOf(WebClientException.class)));
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/UriParamsServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/UriParamsServerTest.java
@@ -54,15 +54,16 @@ class UriParamsServerTest extends BaseServerTest {
     }
 
     @Test
-    void testEndpointsWithParams() {
-        try {
-            String s = webClient().get()
-                    .path("shop;a=b")
-                    .request(String.class)
-                    .get();
-        } catch (ExecutionException | InterruptedException e) {
-            Throwable t = e.getCause();
-            assertThat(t, is(instanceOf(WebClientException.class)));
-        }
+    void testEndpointsWithParams() throws Exception {
+        String s = webClient().get()
+                .path("shop;a=b")
+                .request(String.class)
+                .get();
+        assertThat(s, is("shop"));
+        s = webClient().get()
+                .path("admin;a=b")
+                .request(String.class)
+                .get();
+        assertThat(s, is("admin"));
     }
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/XssServerTest.java
@@ -18,12 +18,9 @@ package io.helidon.webserver;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.webserver.utils.SocketHttpClient;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -31,45 +28,21 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-class XssServerTest {
-    private static final Logger LOGGER = Logger.getLogger(XssServerTest.class.getName());
-
-    private static WebServer webServer;
+class XssServerTest extends BaseServerTest {
 
     @BeforeAll
     static void startServer() throws Exception {
-        startServer(0);
-    }
-
-    @AfterAll
-    static void close() throws Exception {
-        if (webServer != null) {
-            webServer.shutdown()
-                    .toCompletableFuture()
-                    .get(10, TimeUnit.SECONDS);
-        }
-    }
-
-    private static void startServer(int port) throws Exception {
-        webServer = WebServer.builder()
-                .port(port)
-                .routing(Routing.builder()
-                        .get("/foo", (req, res) -> {
+        Routing routing = Routing.builder()
+                .get("/foo", (req, res) -> {
                             res.send(HtmlEncoder.encode("<script>bad</script>"));
-                        })
-                        .build())
-                .build()
-                .start()
-                .toCompletableFuture()
-                .get(10, TimeUnit.SECONDS);
-
-        LOGGER.info("Started server at: https://localhost:" + webServer.port());
+                        }).build();
+        startServer(0, routing);
     }
 
     @Test
     void testScriptInjection() throws Exception {
         String s = SocketHttpClient.sendAndReceive("/bar%3cscript%3eevil%3c%2fscript%3e",
-                Http.Method.GET, null, webServer);
+                Http.Method.GET, null, webServer());
         assertThat(s, not(containsString("<script>")));
         assertThat(s, not(containsString("</script>")));
     }
@@ -77,7 +50,7 @@ class XssServerTest {
     @Test
     void testScriptInjectionIllegalUrlChar() throws Exception {
         String s = SocketHttpClient.sendAndReceive("/bar<script/>evil</script>",
-                Http.Method.GET, null, webServer);
+                Http.Method.GET, null, webServer());
         assertThat(s, not(containsString("<script>")));
         assertThat(s, not(containsString("</script>")));
     }
@@ -86,7 +59,7 @@ class XssServerTest {
     void testScriptInjectionContentType() throws Exception {
         List<String> requestHeaders = Arrays.asList("Content-Type: <script>evil</script>");
         String s = SocketHttpClient.sendAndReceive("/foo",
-                Http.Method.GET, null, requestHeaders, webServer);
+                Http.Method.GET, null, requestHeaders, webServer());
         assertThat(s, not(containsString("<script>")));
         assertThat(s, not(containsString("</script>")));
     }
@@ -94,7 +67,7 @@ class XssServerTest {
     @Test
     void testResponseEncoding() throws Exception {
         String s = SocketHttpClient.sendAndReceive("/foo",
-                Http.Method.GET, null, webServer);
+                Http.Method.GET, null, webServer());
         assertThat(s, not(containsString("<script>")));
         assertThat(s, not(containsString("</script>")));
     }


### PR DESCRIPTION
Ignore path parameters while matching routes. Some new tests, including a base class to avoid repeating code in some of the new tests.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>