### PR TITLE
Introduce backpressure to webserver

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -334,12 +334,13 @@ class BareResponseImpl implements BareResponse {
     @Override
     public void onSubscribe(Flow.Subscription subscription) {
         this.subscription = subscription;
-        subscription.request(2); // Because first chunk gets cached
+        subscription.request(1);
     }
 
     @Override
     public void onNext(DataChunk data) {
         if (internallyClosed.get()) {
+            subscription.request(1);
             throw new IllegalStateException("Response is already closed!");
         }
         if (data != null) {
@@ -355,6 +356,7 @@ class BareResponseImpl implements BareResponse {
 
             if (lengthOptimization && firstChunk == null) {
                 firstChunk = data.isReadOnly() ? data : data.duplicate();      // cache first chunk
+                subscription.request(1);
                 return;
             }
 
@@ -445,8 +447,9 @@ class BareResponseImpl implements BareResponse {
                             writeFuture.completeExceptionally(future.cause());
                         }
                     });
+                    boolean flush = data.flush();
                     data.release();
-                    if (data.flush()) {
+                    if (flush) {
                         subscription.request(1);
                     }
                     LOGGER.finest(() -> log("Data chunk sent with result: %s", future.isSuccess()));

--- a/webserver/webserver/src/test/java/io/helidon/webserver/BackpressureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/BackpressureTest.java
@@ -49,13 +49,14 @@ import static org.hamcrest.Matchers.is;
 public class BackpressureTest {
 
     private static final Logger LOGGER = Logger.getLogger(BackpressureTest.class.getName());
-    static final long TIMEOUT_SEC = 30;
+    static final long TIMEOUT_SEC = 40;
+    // 5 MB buffer size should be enough to cause incomplete write in Netty
+    static final int BUFFER_SIZE = 5 * 1024 * 1024;
 
     @Test
     void overloadEventLoopWithIoMulti() {
         Multi<DataChunk> pub = IoMulti.multiFromStreamBuilder(randomEndlessIs())
-                // 10 MB buffer size should be enough to cause incomplete write in Netty 
-                .byteBufferSize(10 * 1024 * 1024)
+                .byteBufferSize(BUFFER_SIZE)
                 .build()
                 .map(byteBuffer -> DataChunk.create(true, byteBuffer));
         overloadEventLoop(pub);
@@ -73,8 +74,7 @@ public class BackpressureTest {
             @Override
             public DataChunk next() {
                 try {
-                    // 10 MB buffer size should be enough to cause incomplete write in Netty
-                    return DataChunk.create(true, false, ByteBuffer.wrap(inputStream.readNBytes(10 * 1024 * 1024)));
+                    return DataChunk.create(true, false, ByteBuffer.wrap(inputStream.readNBytes(BUFFER_SIZE)));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/BackpressureTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/BackpressureTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+
+import io.helidon.common.LazyValue;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.reactive.IoMulti;
+import io.helidon.common.reactive.Multi;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BackpressureTest {
+
+    private static final Logger LOGGER = Logger.getLogger(BackpressureTest.class.getName());
+    static final long TIMEOUT_SEC = 30;
+
+    @Test
+    void overloadEventLoopWithIoMulti() {
+        Multi<DataChunk> pub = IoMulti.multiFromStreamBuilder(randomEndlessIs())
+                // 10 MB buffer size should be enough to cause incomplete write in Netty 
+                .byteBufferSize(10 * 1024 * 1024)
+                .build()
+                .map(byteBuffer -> DataChunk.create(true, byteBuffer));
+        overloadEventLoop(pub);
+    }
+
+    @Test
+    void overloadEventLoopWithMulti() {
+        InputStream inputStream = randomEndlessIs();
+        Multi<DataChunk> pub = Multi.create(() -> new Iterator<DataChunk>() {
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
+
+            @Override
+            public DataChunk next() {
+                try {
+                    // 10 MB buffer size should be enough to cause incomplete write in Netty
+                    return DataChunk.create(true, false, ByteBuffer.wrap(inputStream.readNBytes(10 * 1024 * 1024)));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        overloadEventLoop(pub);
+    }
+
+    /**
+     * Attempts to overload webserver subscriber with higher data flow than Netty's NioEventLoop can
+     * send at first iteration. By causing incomplete write leaves the rest of the bytebuffer to be written by the next
+     * event loop iteration.
+     * <p>
+     * This can overflow Netty buffer or, in case of single threaded unbounded request, prevent event loop from ever reaching next
+     * iteration.
+     * <p>
+     * Incomplete write is not flushed and its ChannelFuture's listener isn't executed, leaving DataChunk NOT released.
+     * That should lead to OutOfMemory error or assertion error in sample DataChunk batch,
+     * depends on the JVM memory settings.
+     *
+     * @param multi publisher providing endless stream of high volume(preferably more than 2 MB but not less than 1264 kB) data chunks
+     */
+    void overloadEventLoop(Multi<DataChunk> multi) {
+        AtomicBoolean firstChunk = new AtomicBoolean(true);
+        AtomicBoolean shuttingDown = new AtomicBoolean(false);
+        AtomicReference<Optional<Throwable>> serverUpstreamError = new AtomicReference<>(Optional.empty());
+        List<DataChunk> firstBatch = new ArrayList<>(5);
+
+        Multi<DataChunk> dataChunkMulti =
+                // Kill server publisher when client is done
+                multi.takeWhile(ch -> !shuttingDown.get())
+                        .peek(chunk -> {
+                            if (firstChunk.getAndSet(false)) {
+                                // skip first chunk, it gets released on complete
+                                return;
+                            }
+                            // Keep 2 - 6 chunk references
+                            if (firstBatch.size() < 5) {
+                                firstBatch.add(chunk);
+                            }
+                        })
+                        .onError(Throwable::printStackTrace)
+                        .onError(t -> serverUpstreamError.set(Optional.of(t)));
+
+        AtomicLong byteCnt = new AtomicLong();
+
+        LazyValue<Boolean> validateOnce = LazyValue.create(() -> {
+            Collection<DataChunk> snapshot = Collections.unmodifiableCollection(firstBatch);
+            LOGGER.info("======== DataChunk sample batch ========");
+            IntStream.range(0, snapshot.size())
+                    .forEach(i -> LOGGER.info("Chunk #" + (i + 2) + " released: " + firstBatch.get(i).isReleased()));
+
+            boolean result = firstBatch.stream()
+                    .allMatch(DataChunk::isReleased);
+
+            // clean up
+            firstBatch.forEach(DataChunk::release);
+
+            return result;
+        });
+
+        WebServer webServer = null;
+        try {
+            webServer = WebServer.builder()
+                    .routing(Routing.builder()
+                            .get("/", (req, res) -> res.send(dataChunkMulti))
+                            .build())
+                    .build()
+                    .start()
+                    .await(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+
+            WebClient.builder()
+                    .baseUri("http://localhost:" + webServer.port())
+                    .build()
+                    .get()
+                    .path("/")
+                    .request()
+                    .peek(res -> assertThat(res.status().reasonPhrase(), res.status().code(), is(200)))
+                    .flatMap(WebClientResponse::content)
+                    // limit reception to 300 MB
+                    .takeWhile(ws -> byteCnt.get() < (300 * 1024 * 1024))
+                    .forEach(chunk -> {
+                        long actCnt = byteCnt.addAndGet(chunk.bytes().length);
+                        if (actCnt % (100 * 1024 * 1024) == 0) {
+                            LOGGER.info("Client received " + (actCnt / (1024 * 1024)) + "MB");
+                        }
+                        if (actCnt > (200 * 1024 * 1024)) {
+                            // After 200 MB check fist 5 chunks if those are released
+                            // but keep the pressure and don't kill the stream
+                            assertThat("Not all chunks from the first batch are released!", validateOnce.get());
+                        }
+                        chunk.release();
+                    })
+                    // Kill server publisher we are done here
+                    .onTerminate(() -> shuttingDown.set(true))
+                    .await(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+        } finally {
+            if (webServer != null) {
+                webServer.shutdown().await(TIMEOUT_SEC, TimeUnit.SECONDS);
+            }
+        }
+        serverUpstreamError.get().ifPresent(Assertions::fail);
+    }
+
+    static InputStream randomEndlessIs() {
+        Random random = new Random();
+        return new InputStream() {
+            @Override
+            public synchronized int read() {
+                return random.nextInt(Byte.MAX_VALUE);
+            }
+        };
+    }
+}


### PR DESCRIPTION
There are basically 2 possibilities how to solve the problem with upstream being faster than the Netty event loop. 
Both solutions are introducing back-pressure.

* Request one-by-one - dead simple solution which can be less performant with publishers designed to produce data in batches(file reading, db access), that can be compensated with buffering on the publisher side on as needed basis(reactive operator for buffering)
* Requesting by batches depending on the state of newly introduced webserver buffer - this solution would make webserver responsible for additional buffering, solution woul have to be highly configurable for use-cases where buffering is not desirable

This PR fixes #3092 by requesting one-by-one item.

Introduction of the symmetrical back-pressure is expected to bring some small performance penalty:
[JMH comparison](https://github.com/danielkec/helidon-jmh/tree/webserver-backpressure/src/main/java/io/helidon/reactive/jmh/webserver)
```
# 1M100x means a stream of 100 DataChunks backed by 1MB ByteBuffer

Benchmark                Mode  Cnt    Score    Error  Units
OneByOne1M100x.test     thrpt    5    0.069 ±  0.002  ops/s
OneByOne1k10000x.test   thrpt    5    5.179 ±  0.224  ops/s
OneByOne1k100x.test     thrpt    5  502.839 ± 19.513  ops/s
Unbounded1M100x.test    thrpt    5    0.066 ±  0.002  ops/s
Unbounded1k10000x.test  thrpt    5    5.137 ±  0.346  ops/s
Unbounded1k100x.test    thrpt    5  494.400 ± 57.133  ops/s

  Unbounded1M100x.test  0.066
   OneByOne1M100x.test  0.069
Unbounded1k10000x.test █ 5.137
 OneByOne1k10000x.test █ 5.179
  Unbounded1k100x.test ██████████████████████████████████████████████████████████ 494.400
   OneByOne1k100x.test ████████████████████████████████████████████████████████████ 502.839
```
Compensation is possible by buffering on the publisher's size, this could be achieved by introducing buffering reactive operator.

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>