### PR TITLE
Fix JPMS and Maven dependency issue with MP Config in YAML module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 For Helidon 1.x releases please see [Helidon 1.x CHANGELOG.md](https://github.com/oracle/helidon/blob/helidon-1.x/CHANGELOG.md)
 
-## [2.3.2-SNAPSHOT]
+## [2.4.0-SNAPSHOT]
 
 ### Compatibility
+`YamlMpConfigSource` has been moved to module `io.helidon.config:helidon-config-yaml-mp`. This is due to wrong JPMS definition where we could not provide a service of an optional dependency. To fix the dependency graph (so we do not depend on MP config from SE config), we had to create a new module.
+If you use this class directly, please update your dependencies (this may not be required, as it is on classpath of all MP applications), and change the package to `io.helidon.config.yaml.mp`.
 
 ### CHANGES
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -253,6 +253,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.config</groupId>
+                <artifactId>helidon-config-yaml-mp</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.config</groupId>
                 <artifactId>helidon-config-git</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/config/config-mp/pom.xml
+++ b/config/config-mp/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -66,7 +66,7 @@ import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigMappers;
 import io.helidon.config.ConfigValue;
 import io.helidon.config.mp.spi.MpConfigFilter;
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.config.mp {
     requires java.logging;
     requires io.helidon.common;
     requires io.helidon.config;
-    requires io.helidon.config.yaml;
+    requires io.helidon.config.yaml.mp;
     requires transitive microprofile.config.api;
     requires java.annotation;
     requires io.helidon.common.serviceloader;

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -47,6 +47,7 @@
         <module>test-infrastructure</module>
         <module>tests</module>
         <module>config-mp</module>
+        <module>yaml-mp</module>
     </modules>
 
     <build>

--- a/config/yaml-mp/etc/spotbugs/exclude.xml
+++ b/config/yaml-mp/etc/spotbugs/exclude.xml
@@ -24,7 +24,7 @@
 
     <Match>
         <!-- Paths come from config/code -->
-        <Class name="io.helidon.config.yaml.YamlMpConfigSource"/>
+        <Class name="io.helidon.config.yaml.mp.YamlMpConfigSource"/>
         <Method name="create"/>
         <Bug pattern=" URLCONNECTION_SSRF_FD"/>
     </Match>

--- a/config/yaml-mp/pom.xml
+++ b/config/yaml-mp/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -13,45 +14,46 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-  -->
+
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.microprofile</groupId>
-        <artifactId>helidon-microprofile-project</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <groupId>io.helidon.config</groupId>
+        <artifactId>helidon-config-project</artifactId>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
-
-    <groupId>io.helidon.microprofile.tests</groupId>
-    <artifactId>helidon-microprofile-tests-junit5</artifactId>
-    <name>Helidon Microprofile Tests JUnit5</name>
+    <artifactId>helidon-config-yaml-mp</artifactId>
+    <name>Helidon Config YAML MP</name>
 
     <description>
-        Integration with Junit5 to support tests with CDI injection
+        YAML support for Helidon MP.
     </description>
+
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.microprofile.cdi</groupId>
-            <artifactId>helidon-microprofile-cdi</artifactId>
-            <scope>provided</scope>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.jersey</groupId>
-            <artifactId>helidon-jersey-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml-mp</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -59,5 +61,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/config/yaml-mp/pom.xml
+++ b/config/yaml-mp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.helidon.config</groupId>
         <artifactId>helidon-config-project</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <artifactId>helidon-config-yaml-mp</artifactId>
     <name>Helidon Config YAML MP</name>

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlConfigSourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.config.yaml;
+package io.helidon.config.yaml.mp;
 
 import java.io.IOException;
 import java.net.URL;
@@ -31,7 +31,7 @@ import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
  * YAML config source provider for MicroProfile config that supports file {@code application.yaml}.
  * This class should not be used directly - it is loaded automatically by Java service loader.
  */
-public class YamlMpConfigSourceProvider implements ConfigSourceProvider {
+public class YamlConfigSourceProvider implements ConfigSourceProvider {
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader classLoader) {
         Enumeration<URL> resources;

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.config.yaml;
+package io.helidon.config.yaml.mp;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -36,6 +36,8 @@ import java.util.Set;
 import io.helidon.config.ConfigException;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * MicroProfile {@link org.eclipse.microprofile.config.spi.ConfigSource} that can be used
@@ -72,6 +74,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * names.2=third
  * </pre>
  */
+@SuppressWarnings("rawtypes")
 public class YamlMpConfigSource implements ConfigSource {
     private final Map<String, String> properties;
     private final String name;
@@ -120,7 +123,7 @@ public class YamlMpConfigSource implements ConfigSource {
      * @return config source loaded from the content
      */
     public static ConfigSource create(String name, Reader content) {
-        Map yamlMap = YamlConfigParser.toMap(content);
+        Map yamlMap = toMap(content);
         if (yamlMap == null) { // empty source
             return new YamlMpConfigSource(name, Map.of());
         }
@@ -317,5 +320,12 @@ public class YamlMpConfigSource implements ConfigSource {
     @Override
     public String getName() {
         return name;
+    }
+
+    static Map toMap(Reader reader) {
+        // the default of Snake YAML is a Map, safe constructor makes sure we never deserialize into anything
+        // harmful
+        Yaml yaml = new Yaml(new SafeConstructor());
+        return (Map) yaml.loadAs(reader, Object.class);
     }
 }

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/package-info.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
-import io.helidon.config.yaml.YamlConfigParser;
-
 /**
- * YAML Parser implementation.
+ * YAML config source for MicroProfile config.
+ *
+ * @see io.helidon.config Configuration API
  */
-module io.helidon.config.yaml {
-
-    requires java.logging;
-
-    requires org.yaml.snakeyaml;
-
-    requires transitive io.helidon.config;
-    requires io.helidon.common;
-
-    exports io.helidon.config.yaml;
-
-    provides io.helidon.config.spi.ConfigParser with YamlConfigParser;
-}
+package io.helidon.config.yaml.mp;

--- a/config/yaml-mp/src/main/java/module-info.java
+++ b/config/yaml-mp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-import io.helidon.config.yaml.YamlConfigParser;
-
 /**
- * YAML Parser implementation.
+ * Support for YAML configuration sources.
  */
-module io.helidon.config.yaml {
-
-    requires java.logging;
-
+module io.helidon.config.yaml.mp {
     requires org.yaml.snakeyaml;
+    requires microprofile.config.api;
 
     requires transitive io.helidon.config;
-    requires io.helidon.common;
+    requires io.helidon.config.yaml;
 
-    exports io.helidon.config.yaml;
+    exports io.helidon.config.yaml.mp;
 
-    provides io.helidon.config.spi.ConfigParser with YamlConfigParser;
+    provides org.eclipse.microprofile.config.spi.ConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
 }

--- a/config/yaml-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml-mp/native-image.properties
+++ b/config/yaml-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml-mp/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args=--initialize-at-build-time=io.helidon.config.yaml
+Args=--initialize-at-build-time=io.helidon.config.yaml.mp

--- a/config/yaml-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml-mp/resource-config.json
+++ b/config/yaml-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml-mp/resource-config.json
@@ -1,0 +1,7 @@
+{
+    "resources": [
+        {
+            "pattern": "mp-meta-config.yaml"
+        }
+    ]
+}

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.config.yaml;
+package io.helidon.config.yaml.mp;
 
 import java.io.StringReader;
 

--- a/config/yaml/pom.xml
+++ b/config/yaml/pom.xml
@@ -33,10 +33,6 @@
         YAML Parser implementation.
     </description>
 
-    <properties>
-        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/config/yaml/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml/resource-config.json
+++ b/config/yaml/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-yaml/resource-config.json
@@ -5,6 +5,12 @@
         },
         {
             "pattern": "meta-config.yaml"
+        },
+        {
+            "pattern": "config-profile.yaml"
+        },
+        {
+            "pattern": "config-profile-.*\\.yaml$"
         }
     ]
 }

--- a/examples/integrations/oci/objectstorage-cdi/pom.xml
+++ b/examples/integrations/oci/objectstorage-cdi/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/examples/integrations/oci/objectstorage-cdi/src/main/java/io/helidon/examples/integrations/oci/objectstorage/cdi/ObjectStorageCdiMain.java
+++ b/examples/integrations/oci/objectstorage-cdi/src/main/java/io/helidon/examples/integrations/oci/objectstorage/cdi/ObjectStorageCdiMain.java
@@ -20,7 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 import io.helidon.microprofile.cdi.Main;
 
 import org.eclipse.microprofile.config.Config;

--- a/examples/integrations/oci/objectstorage-cdi/src/main/java/module-info.java
+++ b/examples/integrations/oci/objectstorage-cdi/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.helidon.examples.integrations.oci.objectstorage.cdi {
     requires jakarta.inject.api;
     requires microprofile.config.api;
 
-    requires io.helidon.config.yaml;
+    requires io.helidon.config.yaml.mp;
     requires io.helidon.common.http;
     requires io.helidon.integrations.common.rest;
     requires io.helidon.integrations.oci.cdi;

--- a/examples/integrations/oci/vault-cdi/pom.xml
+++ b/examples/integrations/oci/vault-cdi/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/integrations/oci/vault-cdi/src/main/java/io/helidon/examples/integrations/oci/vault/cdi/VaultCdiMain.java
+++ b/examples/integrations/oci/vault-cdi/src/main/java/io/helidon/examples/integrations/oci/vault/cdi/VaultCdiMain.java
@@ -19,7 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 import io.helidon.microprofile.cdi.Main;
 
 import org.eclipse.microprofile.config.Config;

--- a/examples/integrations/oci/vault-cdi/src/main/java/module-info.java
+++ b/examples/integrations/oci/vault-cdi/src/main/java/module-info.java
@@ -25,7 +25,7 @@ module io.helidon.examples.integrations.oci.vault.cdi {
 
     requires microprofile.config.api;
 
-    requires io.helidon.config.yaml;
+    requires io.helidon.config.yaml.mp;
     requires io.helidon.integrations.oci.vault;
     requires io.helidon.microprofile.cdi;
 

--- a/examples/integrations/vault/hcp-cdi/src/main/java/io/helidon/examples/integrations/vault/hcp/cdi/VaultCdiMain.java
+++ b/examples/integrations/vault/hcp-cdi/src/main/java/io/helidon/examples/integrations/vault/hcp/cdi/VaultCdiMain.java
@@ -20,7 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 import io.helidon.microprofile.cdi.Main;
 
 import org.eclipse.microprofile.config.Config;

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
@@ -49,7 +49,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
 import io.helidon.config.mp.MpConfigSources;
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;

--- a/microprofile/tests/junit5/src/main/java/module-info.java
+++ b/microprofile/tests/junit5/src/main/java/module-info.java
@@ -21,7 +21,7 @@ module io.helidon.microprofile.tests.junit5 {
 
     requires io.helidon.microprofile.cdi;
     requires io.helidon.config.mp;
-    requires io.helidon.config.yaml;
+    requires io.helidon.config.yaml.mp;
     requires org.junit.jupiter.api;
     requires transitive jakarta.enterprise.cdi.api;
     requires transitive java.ws.rs;

--- a/tests/integration/vault/mp/pom.xml
+++ b/tests/integration/vault/mp/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.integrations.vault.auths</groupId>

--- a/tests/integration/vault/mp/src/test/java/io/helidon/tests/integration/vault/mp/TestDbSecrets.java
+++ b/tests/integration/vault/mp/src/test/java/io/helidon/tests/integration/vault/mp/TestDbSecrets.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import io.helidon.config.mp.MpConfigSources;
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 import io.helidon.integrations.vault.cdi.VaultCdiExtension;
 import io.helidon.integrations.vault.secrets.database.DbCreateRole;
 import io.helidon.integrations.vault.secrets.database.DbCredentials;

--- a/tests/integration/vault/mp/src/test/java/io/helidon/tests/integration/vault/mp/TestKubernetesAuth.java
+++ b/tests/integration/vault/mp/src/test/java/io/helidon/tests/integration/vault/mp/TestKubernetesAuth.java
@@ -29,7 +29,7 @@ import javax.enterprise.inject.se.SeContainer;
 import javax.inject.Inject;
 
 import io.helidon.config.mp.MpConfigSources;
-import io.helidon.config.yaml.YamlMpConfigSource;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
 import io.helidon.integrations.vault.Vault;
 import io.helidon.integrations.vault.auths.k8s.ConfigureK8s;
 import io.helidon.integrations.vault.auths.k8s.CreateRole;


### PR DESCRIPTION
Resolves #2865 

This introduces and internal backward incompatible change. There is a chance somebody used the class explicitly from outside of Helidon. This fix will require code change for such customers.

I do not think this is a major version worthy change - it is a bugfix...

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>