### PR TITLE
Improved handling of Jaeger spans/scopes across threads

### DIFF
--- a/common/context/src/main/java/io/helidon/common/context/ContextAwareExecutorImpl.java
+++ b/common/context/src/main/java/io/helidon/common/context/ContextAwareExecutorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ class ContextAwareExecutorImpl implements ContextAwareExecutorService {
                     PROVIDERS.forEach(provider -> provider.propagateData(properties.get(provider.getClass())));
                     return Contexts.runInContext(context.get(), task);
                 } finally {
-                    PROVIDERS.forEach(DataPropagationProvider::clearData);
+                    PROVIDERS.forEach(provider -> provider.clearData(properties.get(provider.getClass())));
                 }
             };
         } else {
@@ -153,7 +153,7 @@ class ContextAwareExecutorImpl implements ContextAwareExecutorService {
                     PROVIDERS.forEach(provider -> provider.propagateData(properties.get(provider.getClass())));
                     Contexts.runInContext(context.get(), command);
                 } finally {
-                    PROVIDERS.forEach(DataPropagationProvider::clearData);
+                    PROVIDERS.forEach(provider -> provider.clearData(properties.get(provider.getClass())));
                 }
             };
         } else {

--- a/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
+++ b/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,9 @@ public interface DataPropagationProvider<T> {
 
     /**
      * Clears the propagated date from the new thread when it finishes.
+     *
+     * @param data dataa for propagation
      */
-    void clearData();
+    void clearData(T data);
 
 }

--- a/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
+++ b/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
@@ -16,7 +16,7 @@
 package io.helidon.common.context.spi;
 
 /**
- * This is SPI provider which helps user to propagate values from one thread to another.
+ * This is an SPI provider which helps user to propagate values from one thread to another.
  *
  * Every provider has its method {@link #data()} invoked before thread switch, to obtain
  * value for propagation. After the thread is switched, the new thread executes
@@ -41,10 +41,19 @@ public interface DataPropagationProvider<T> {
     void propagateData(T data);
 
     /**
-     * Clears the propagated date from the new thread when it finishes.
-     *
-     * @param data dataa for propagation
+     * Clears the propagated data from the new thread when it finishes. This
+     * method is deprecated in favor of {@link #clearData(Object)}.
      */
-    void clearData(T data);
+    @Deprecated
+    void clearData();
+
+    /**
+     * Clears the propagated data from the new thread when it finishes.
+     *
+     * @param data data for propagation
+     */
+    default void clearData(T data) {
+        clearData();
+    }
 
 }

--- a/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
+++ b/common/context/src/main/java/io/helidon/common/context/spi/DataPropagationProvider.java
@@ -45,7 +45,8 @@ public interface DataPropagationProvider<T> {
      * method is deprecated in favor of {@link #clearData(Object)}.
      */
     @Deprecated
-    void clearData();
+    default void clearData() {
+    }
 
     /**
      * Clears the propagated data from the new thread when it finishes.

--- a/common/context/src/test/java/io/helidon/common/context/DataPropagationProviderTest.java
+++ b/common/context/src/test/java/io/helidon/common/context/DataPropagationProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.common.context;
+
+import io.helidon.common.context.spi.DataPropagationProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Verifies backward compatibility of SPI after method deprecation.
+ */
+class DataPropagationProviderTest {
+
+    private boolean called = false;
+
+    class MyDataPropagationTest implements DataPropagationProvider<Object> {
+
+        @Override
+        public Object data() {
+            return null;
+        }
+
+        @Override
+        public void propagateData(Object data) {
+        }
+
+        /**
+         * Deprecated method should be called.
+         */
+        @Override
+        public void clearData() {
+            called = true;
+        }
+    }
+
+    @Test
+    void testDeprecation() {
+        MyDataPropagationTest dpt = new MyDataPropagationTest();
+        dpt.clearData("foo");       // should call deprecated method
+        assertThat(called, is(true));
+    }
+}

--- a/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcPropagator.java
+++ b/logging/jul/src/main/java/io/helidon/logging/jul/JulMdcPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class JulMdcPropagator implements DataPropagationProvider<Map<String, Str
     }
 
     @Override
-    public void clearData() {
+    public void clearData(Map<String, String> data) {
         JulMdc.clear();
     }
 

--- a/logging/log4j/src/main/java/io/helidon/logging/log4j/Log4jMdcPropagator.java
+++ b/logging/log4j/src/main/java/io/helidon/logging/log4j/Log4jMdcPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class Log4jMdcPropagator implements DataPropagationProvider<Map<String, S
     }
 
     @Override
-    public void clearData() {
+    public void clearData(Map<String, String> data) {
         ThreadContext.clearAll();
     }
 }

--- a/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcPropagator.java
+++ b/logging/slf4j/src/main/java/io/helidon/logging/slf4j/Slf4jMdcPropagator.java
@@ -39,7 +39,7 @@ public class Slf4jMdcPropagator implements DataPropagationProvider<Map<String, S
     }
 
     @Override
-    public void clearData() {
+    public void clearData(Map<String, String> data) {
         MDC.clear();
     }
 

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerDataPropagationProvider.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerDataPropagationProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.jaeger;
+
+import io.helidon.common.context.Contexts;
+import io.helidon.common.context.spi.DataPropagationProvider;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+/**
+ * A data propagation provider for Jaeger. Makes sure span are properly propagated
+ * across threads managed by {@link io.helidon.common.context.ContextAwareExecutorService}.
+ */
+public class JaegerDataPropagationProvider implements DataPropagationProvider<JaegerDataPropagationProvider.JaegerContext> {
+
+    static class JaegerContext {
+        private final Span span;
+        private final Tracer tracer;
+        private Scope scope;
+
+        JaegerContext(Tracer tracer, Span span) {
+            this.tracer = tracer;
+            this.span = span;
+        }
+
+        Scope scope() {
+            return scope;
+        }
+    }
+
+    /**
+     * Closes scope in primary thread and returns a context to activate
+     * new scope in secondary thread.
+     *
+     * @return active span.
+     */
+    @Override
+    public JaegerContext data() {
+        return Contexts.context().map(context -> {
+            context.get(Scope.class).ifPresent(Scope::close);
+            return context.get(Span.class).map(span -> {
+                Tracer tracer = context.get(Tracer.class).orElseGet(GlobalTracer::get);
+                return new JaegerContext(tracer, span);
+            }).orElse(null);
+        }).orElse(null);
+    }
+
+    /**
+     * Activates scope in secondary thread.
+     *
+     * @param context the context.
+     */
+    @Override
+    public void propagateData(JaegerContext context) {
+        if (context != null) {
+            context.scope = context.tracer.scopeManager().activate(context.span);
+        }
+    }
+
+    /**
+     * Closes scope in secondary thread.
+     */
+    @Override
+    public void clearData(JaegerContext context) {
+        if (context != null && context.scope != null) {
+            context.scope.close();
+        }
+    }
+}

--- a/tracing/jaeger/src/main/java/module-info.java
+++ b/tracing/jaeger/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.tracing.jaeger {
     requires io.helidon.common;
     requires io.helidon.config;
     requires io.helidon.tracing;
+    requires io.helidon.common.context;
 
     requires java.logging;
     requires io.opentracing.util;
@@ -30,8 +31,9 @@ module io.helidon.tracing.jaeger {
     // need to explicitly require transitive dependency, as jaeger is not a module
     requires com.google.gson;
 
-
     exports io.helidon.tracing.jaeger;
 
     provides io.helidon.tracing.spi.TracerProvider with io.helidon.tracing.jaeger.JaegerTracerProvider;
+    provides io.helidon.common.context.spi.DataPropagationProvider with io.helidon.tracing.jaeger.JaegerDataPropagationProvider;
+
 }

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerDataPropagationProviderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerDataPropagationProviderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.jaeger;
+
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class JaegerDataPropagationProviderTest {
+
+    private JaegerDataPropagationProvider provider = new JaegerDataPropagationProvider();
+    
+    @Test
+    void dataPropagationTest() {
+        Context context = Context.create();
+        Tracer tracer = new TestTracer();
+        context.register(tracer);
+        Span span = tracer.buildSpan("span").start();
+        context.register(span);
+        Scope scope = tracer.scopeManager().activate(span);
+        context.register(scope);
+
+        Contexts.runInContext(context, () -> {
+            assertThat(closed(scope), is(false));
+            JaegerDataPropagationProvider.JaegerContext data = provider.data();
+            assertThat(closed(scope), is(true));
+            provider.propagateData(data);
+            assertThat(closed(data.scope()), is(false));
+            provider.clearData(data);
+            assertThat(closed(data.scope()), is(true));
+        });
+    }
+
+    private boolean closed(Scope scope) {
+        return ((TestScope) scope).closed;
+    }
+
+    static class TestScope implements Scope {
+
+        private final Scope delegate;
+        private boolean closed = false;
+
+        TestScope(Scope delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+            closed = true;
+        }
+    }
+
+    static class TestScopeManager implements ScopeManager {
+
+        private final ScopeManager delegate;
+
+        TestScopeManager(ScopeManager delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Scope activate(Span span) {
+            return new TestScope(delegate.activate(span));
+        }
+
+        @Override
+        public Span activeSpan() {
+            return delegate.activeSpan();
+        }
+    }
+
+    static class TestTracer implements Tracer {
+
+        private final Tracer delegate = JaegerTracerBuilder.create().serviceName("test-service").build();
+
+        @Override
+        public ScopeManager scopeManager() {
+            return new TestScopeManager(delegate.scopeManager());
+        }
+
+        @Override
+        public Span activeSpan() {
+            return delegate.activeSpan();
+        }
+
+        @Override
+        public Scope activateSpan(Span span) {
+            return delegate.activateSpan(span);
+        }
+
+        @Override
+        public SpanBuilder buildSpan(String s) {
+            return delegate.buildSpan(s);
+        }
+
+        @Override
+        public <C> void inject(SpanContext spanContext, Format<C> format, C c) {
+            delegate.inject(spanContext, format, c);
+        }
+
+        @Override
+        public <C> SpanContext extract(Format<C> format, C c) {
+            return delegate.extract(format, c);
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+}

--- a/tracing/jersey/src/main/java/io/helidon/tracing/jersey/AbstractTracingFilter.java
+++ b/tracing/jersey/src/main/java/io/helidon/tracing/jersey/AbstractTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,11 +89,12 @@ public abstract class AbstractTracingFilter implements ContainerRequestFilter, C
             Span span = spanBuilder.start();
             Scope spanScope = tracer.scopeManager().activate(span);
 
-            requestContext.setProperty(SPAN_PROPERTY, span);
-            requestContext.setProperty(SPAN_SCOPE_PROPERTY, spanScope);
+            context.register(span);
+            context.register(spanScope);
             context.register(ClientTracingFilter.class, span.context());
+            requestContext.setProperty(SPAN_PROPERTY, span);
 
-            if (!context.get(TracingContext.class).isPresent()) {
+            if (context.get(TracingContext.class).isEmpty()) {
                 context.register(TracingContext.create(tracer, requestContext.getHeaders()));
             }
 
@@ -165,10 +166,8 @@ public abstract class AbstractTracingFilter implements ContainerRequestFilter, C
         requestContext.setProperty(SPAN_FINISHED_PROPERTY, true);
         span.finish();
 
-        Scope spanScope = (Scope) requestContext.getProperty(SPAN_SCOPE_PROPERTY);
-        if (null != spanScope) {
-            spanScope.close();
-        }
+        Context context = Contexts.context().orElseThrow(() -> new IllegalStateException("Context must be available in Jersey"));
+        context.get(Scope.class).ifPresent(Scope::close);
     }
 
     /**


### PR DESCRIPTION
Improved handling of Jaeger spans/scopes across threads. Fixes problems with MP async calls that resulted in memory leaks of `ThreadLocalScope` objects due to the failed attempt to close a scope from a different thread. 

New implementation uses a `DataPropagationProvider` to close a scope on the primary thread and re-open it on the secondary thread --and eventually close it there as well. Minor change to the `DataPropagationProvider` spi.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>