### PR TITLE
New note about the generation of passphrase protected PKCS#1 keys

### DIFF
--- a/docs/mp/oci/01_oci.adoc
+++ b/docs/mp/oci/01_oci.adoc
@@ -45,7 +45,7 @@ include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 NOTE: If you follow these instructions on how to
 https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two[Generate an API Signing Key],
-keep in mind that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
+be advised that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
 If generating a private key using those instructions, use the _no passphrase_ option.
 
 ===  Using Helidon MP Properties Configuration

--- a/docs/mp/oci/01_oci.adoc
+++ b/docs/mp/oci/01_oci.adoc
@@ -43,6 +43,11 @@ include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 
 == General Configuration
 
+NOTE: If you follow these instructions on how to
+https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two[Generate an API Signing Key],
+keep in mind that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
+If generating a private key using those instructions, use the _no passphrase_ option.
+
 ===  Using Helidon MP Properties Configuration
 
 The first option to configure connection to OCI is to directly specify properties in `microprofile-config.properties` file:

--- a/docs/se/oci/01_oci.adoc
+++ b/docs/se/oci/01_oci.adoc
@@ -33,6 +33,11 @@ WARNING: Helidon integration with Oracle Cloud Infrastructure is still experimen
 
 == General Configuration
 
+NOTE: If you follow these instructions on how to
+https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two[Generate an API Signing Key],
+keep in mind that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
+If generating a private key using those instructions, use the _no passphrase_ option.
+
 === Using Helidon SE Properties Configuration
 
 The first option to configure connection to OCI is to directly specify properties in `application.yaml` file:

--- a/docs/se/oci/01_oci.adoc
+++ b/docs/se/oci/01_oci.adoc
@@ -35,7 +35,7 @@ WARNING: Helidon integration with Oracle Cloud Infrastructure is still experimen
 
 NOTE: If you follow these instructions on how to
 https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two[Generate an API Signing Key],
-keep in mind that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
+be advised that Helidon does not currently support passphrase-protected private keys in PKCS#1 format.
 If generating a private key using those instructions, use the _no passphrase_ option.
 
 === Using Helidon SE Properties Configuration


### PR DESCRIPTION
New note about the generation of passphrase protected PKCS#1 keys.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>