### PR TITLE
Fix for exec:java to exec:exec

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -141,8 +141,13 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>${version.plugin.exec}</version>
                     <configuration>
-                        <!--suppress MavenModelInspection -->
-                        <mainClass>${mainClass}</mainClass>
+                        <executable>java</executable>
+                        <longClasspath>true</longClasspath>
+                        <arguments>
+                            <argument>-classpath</argument>
+                            <classpath/>
+                            <argument>${mainClass}</argument>
+                        </arguments>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ mvn package
 Usually you can then run the example using:
 
 ```
-mvn exec:java
+mvn exec:exec
 ```
 
 But always see the example's `README` for details.

--- a/examples/grpc/microprofile/basic-client/README.md
+++ b/examples/grpc/microprofile/basic-client/README.md
@@ -22,5 +22,5 @@ mvn package
 Ensure that the server in [Basic Implicit gRPC Server example](../basic-server-implicit/README.md) is started.
 Then in this module run:
 ```
-mvn exec:java
+mvn exec:exec
 ```

--- a/examples/grpc/microprofile/basic-server-implicit/README.md
+++ b/examples/grpc/microprofile/basic-server-implicit/README.md
@@ -25,7 +25,7 @@ mvn package
 ## Run
 
 ```
-mvn exec:java
+mvn exec:exec
 ```
 
 Then the services can be accessed on the gRPC endpoint `localhost:1408`

--- a/examples/grpc/microprofile/metrics/README.md
+++ b/examples/grpc/microprofile/metrics/README.md
@@ -16,7 +16,7 @@ mvn package
 ## Run
 
 ```
-mvn exec:java
+mvn exec:exec
 ```
 
 Then the services can be accessed on the gRPC endpoint `localhost:1408` When the server is running


### PR DESCRIPTION
Fix for "Switch from exec:java to exec:exec" #2194

Switched the usage of `exec:java` to `exec:exec` 
The fix is applied to `applications/pom.xml` to affect all examples.