### PR TITLE
Fix incorrect handling of omitted display name (and description) revealed by gRPC

### DIFF
--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -563,7 +563,7 @@ public class GrpcMetrics
          *
          * @see org.eclipse.microprofile.metrics.Metadata
          */
-        private String displayName;
+        private Optional<String> displayName = Optional.empty();
 
         /**
          * The unit of the metric.
@@ -623,9 +623,7 @@ public class GrpcMetrics
 
             this.description.ifPresent(builder::withDescription);
             this.units.ifPresent(builder::withUnit);
-
-            String displayName = this.displayName;
-            builder.withDisplayName(displayName == null ? name : displayName);
+            this.displayName.ifPresent(builder::withDisplayName);
 
             return builder.build();
         }
@@ -648,7 +646,7 @@ public class GrpcMetrics
 
         private MetricsRules displayName(String displayName) {
             MetricsRules rules = new MetricsRules(this);
-            rules.displayName = displayName;
+            rules.displayName = Optional.of(displayName);
             return rules;
         }
 

--- a/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/MetricsConfigurer.java
+++ b/microprofile/grpc/metrics/src/main/java/io/helidon/microprofile/grpc/metrics/MetricsConfigurer.java
@@ -229,8 +229,15 @@ public class MetricsConfigurer
 
             MetricAnnotationInfo<?> mInfo = METRIC_ANNOTATION_INFO.get(annotation.annotationType());
             if (mInfo != null && mInfo.annotationClass.isInstance(annotation)) {
-                interceptor = interceptor.description(mInfo.description(annotatedMethod))
-                        .displayName(mInfo.displayName(annotatedMethod))
+                String candidateDescription = mInfo.description(annotatedMethod);
+                if (candidateDescription != null && !candidateDescription.trim().isEmpty()) {
+                    interceptor = interceptor.description(candidateDescription.trim());
+                }
+                String candidateDisplayName = mInfo.displayName(annotatedMethod);
+                if (candidateDisplayName != null && !candidateDisplayName.trim().isEmpty()) {
+                    interceptor = interceptor.displayName(candidateDisplayName.trim());
+                }
+                interceptor = interceptor
                         .reusable(mInfo.reusable(annotatedMethod))
                         .units(mInfo.units(annotatedMethod));
             }


### PR DESCRIPTION
Resolves #3177 

In some of the metrics generalization done for 2.3.0 (to support MP metrics and Micrometer), some changes incorrectly assigned the `displayName` and `description` for a metric's metadata even if those were omitted from a metrics annotation. They should be left unassigned in that case.

The changes here correct that in the metrics code and in some similar code in gRPC metrics. 