### PR TITLE
Jaeger metrics test

### DIFF
--- a/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestJaegerMetrics.java
+++ b/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestJaegerMetrics.java
@@ -49,7 +49,7 @@ class TestJaegerMetrics {
     private MetricRegistry vendorRegistry;
 
     @Test
-    void checkForJaegerMetrics() throws InterruptedException {
+    void checkForJaegerMetrics() {
         String hello = webTarget
                 .path("/helloworld/hi")
                 .request(MediaType.TEXT_PLAIN)

--- a/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestJaegerMetrics.java
+++ b/metrics/jaeger/src/test/java/io/helidon/metrics/jaeger/TestJaegerMetrics.java
@@ -49,7 +49,7 @@ class TestJaegerMetrics {
     private MetricRegistry vendorRegistry;
 
     @Test
-    void checkForJaegerMetrics() {
+    void checkForJaegerMetrics() throws InterruptedException {
         String hello = webTarget
                 .path("/helloworld/hi")
                 .request(MediaType.TEXT_PLAIN)

--- a/metrics/jaeger/src/test/resources/META-INF/microprofile-config.properties
+++ b/metrics/jaeger/src/test/resources/META-INF/microprofile-config.properties
@@ -14,3 +14,6 @@
 # limitations under the License.
 #
 tracing.service=mp
+tracing.sampler-type=const
+# never sample, so test works even if Jaeger is running locally
+tracing.sampler-param=0

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ import io.opentracing.util.GlobalTracer;
  *     <tr>
  *         <td>{@code sampler-type}</td>
  *         <td>library default</td>
- *         <td>Sampler type ({@code probabilistic}, {@code ratelimiting}, or {@code remote}</td>
+ *         <td>Sampler type ({@code const}, {@code probabilistic}, {@code ratelimiting}, or {@code remote})</td>
  *     </tr>
  *     <tr>
  *         <td>{@code sampler-param}</td>


### PR DESCRIPTION
Fixes a problem when test would fail if Jaeger was running in docker on the same machine.

Why?

When running the test, it looks for a metric with tag `sampled=n` - e.g. it expects the spans not to be sampled.

1. When Jaeger is not running at all, none of the spans are sampled, as there is no server
2. When Jaeger runs from the full local installation, the sampler type is `probabilistic` and the param is `0.001` - e.g. only 1 in a thousand gets sampled, so there is a good chance there would be a `sampled=n` span
3. When Jaeger runs in docker, the sampler type is `constant` and the param is `1` - e.g. all spans get sampled, so the test always failed

This PR updates the test to configure sampler to const and its param to `0` - e.g. no spans get sampled, and the test should now consistently pass on any environment
