### PR TITLE
JEP-290, SerialConfig support

### DIFF
--- a/common/common/src/main/java/io/helidon/common/SerializationConfig.java
+++ b/common/common/src/main/java/io/helidon/common/SerializationConfig.java
@@ -19,181 +19,603 @@ package io.helidon.common;
 import java.io.IOException;
 import java.io.ObjectInputFilter;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Support for JEP 290 - deserialization filtering.
- * Helidon is implemented to support whitelists, automatically blacklisting
+ * Configuration options mentioned below will differ in Helidon 3.0.0, the following table lists the options:
+ * <p>
+ * <table class="config">
+ * <caption>Configuration Options</caption>
+ * <tr>
+ *     <th>system property</th>
+ *     <th>2.x default</th>
+ *     <th>3.x default</th>
+ *     <th>description</th>
+ * </tr>
+ * <tr>
+ *     <td>{@link #PROP_WRONG_CONFIG_ACTION}</td>
+ *     <td>{@code warn} - {@link io.helidon.common.SerializationConfig.Action#WARN}</td>
+ *     <td>{@code fail} - {@link io.helidon.common.SerializationConfig.Action#FAIL}</td>
+ *     <td>What to do if an existing global deserialization filter exists without a global blacklist.</td>
+ * </tr>
+ * <tr>
+ *     <td>{@link #PROP_NO_CONFIG_ACTION}</td>
+ *     <td>{@code warn} - {@link io.helidon.common.SerializationConfig.Action#WARN}</td>
+ *     <td>{@code configure} - {@link io.helidon.common.SerializationConfig.Action#CONFIGURE}</td>
+ *     <td>What to do if there is no global deserialization filter.</td>
+ * </tr>
+ * </table>
+ * Last option (not used by default) is to {@code ignore} the problem and do nothing (can be used both with wrong config
+ * and no config above).
+ * <h2>Deserialization filtering in Helidon</h2>
+ * Helidon serialization filter is implemented to support whitelists, automatically blacklisting
  * all classes.
  * Helidon restrictions are only enforced on the global filter.
- * <p>
+ * <h3>Custom pattern</h3>
  * To add patterns to the serial filter, use a system property {@value #PROP_PATTERN}.
  * This pattern follows the rules as defined by JDK. Helidon will add exclude all as the last
  * pattern.
  * <p>
- * To ignore this configuration, use system property {@value #PROP_IGNORE} and set it to {@code true}.
- * <p>
+ * As an alternative, a file {@link #PROPERTY_FILE} can be created on the classpath with the following content, to
+ * configure filter for a specific library. Do not add a global blacklist to these patterns!:
+ * {@code pattern=oracle.sql.converter.*}
+ * <h3>Deserialization tracing</h3>
  * A tracing filter can be configured using system property {@value #PROP_TRACE} to log information
  * messages for each deserialization request.
+ * <p>
+ * To discover class patterns needed, set "no config" and "wrong config" actions to warn or ignore, and configure {@code basic}
+ * tracing.
+ * <p>
+ * Options are:
+ * <ul>
+ *     <li>{@code none} to disable tracing (this is the default)</li>
+ *     <li>{@code basic} to enable basic tracing (only traces requests for class deserialization)</li>
+ *     <li>{@code full} to enable full tracing (including sizes, depth etc.)</li>
+ * </ul>
  */
 public final class SerializationConfig {
+    static final String PROP_WRONG_CONFIG_ACTION = "helidon.serialFilter.failure.action";
+    static final String PROP_NO_CONFIG_ACTION = "helidon.serialFilter.missing.action";
+    static final String PROP_PATTERN = "helidon.serialFilter.pattern";
+    static final String PROP_TRACE = "helidon.serialFilter.trace";
+    static final String PROP_IGNORE_FILES = "helidon.serialFilter.ignoreFiles";
     private static final Logger LOGGER = Logger.getLogger(SerializationConfig.class.getName());
-    private static final String PROP_IGNORE = "helidon.serialFilter.ignore";
-    private static final String PROP_PATTERN = "helidon.serialFilter.pattern";
-    private static final String PROP_TRACE = "helidon.serialFilter.trace";
-    private static final String PROPERTY = "META-INF/helidon/serial-config.properties";
+    private static final String PROPERTY_FILE = "META-INF/helidon/serial-config.properties";
+    private static final AtomicReference<ConfigOptions> EXISTING_CONFIG = new AtomicReference<>();
+    private final ConfigOptions options;
 
-    private SerializationConfig() {
+    private SerializationConfig(Builder builder) {
+        this.options = new ConfigOptions(builder.onWrongConfig,
+                                         builder.onNoConfig,
+                                         builder.filterPattern,
+                                         builder.traceSerialization);
     }
 
-    private static final AtomicBoolean HELIDON_CONFIGURED = new AtomicBoolean();
+    /**
+     * Fluent API builder to configure options programmatically.
+     * To use defaults (or system properties), see {@link #configureRuntime()}.
+     *
+     * @return a new builder for {@link io.helidon.common.SerializationConfig}
+     * @see #configure()
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
 
     /**
      * Make sure configuration is as expected.
+     * This is a one-off call to set up global filter.
      */
     public static void configureRuntime() {
-        ObjectInputFilter currentFilter = ObjectInputFilter.Config.getSerialFilter();
+        builder().build().configure();
+    }
 
-        if (currentFilter == null) {
-            if ("true".equals(System.getProperty(PROP_IGNORE))) {
-                LOGGER.finest("Serialization config is ignored by Helidon.");
-                // explicitly configured to be ignored
-                HELIDON_CONFIGURED.set(true);
-                return;
-            }
-            String pattern = getPattern();
-            LOGGER.finest("Using serialization pattern " + pattern);
-            ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(pattern);
-            if ("true".equals(System.getProperty(PROP_TRACE))) {
-                ObjectInputFilter.Config.setSerialFilter(new TracingObjectInputFilter(filter));
-            } else {
-                ObjectInputFilter.Config.setSerialFilter(filter);
-            }
-            HELIDON_CONFIGURED.set(true);
-        } else {
-            if (HELIDON_CONFIGURED.get()) {
-                // it was us
-                return;
-            }
+    /**
+     * Configure deserialization filtering in the current VM.
+     * Note that the global filter can be configured only once, so make sure this method is invoked as soon as possible.
+     * This class keeps static information about the initial configuration, so as long as the configuration is unchanged,
+     * this method may be called multiple times.
+     *
+     * @throws java.lang.IllegalStateException in case this method is called multiple times with different configuration.
+     */
+    public void configure() {
+        if (EXISTING_CONFIG.compareAndSet(null, options)) {
+            // this process is responsible for setting everything up, nobody else can reach this line
 
-            if ("true".equals(System.getProperty(PROP_IGNORE))) {
-                LOGGER.finest("Serialization config is ignored by Helidon.");
-                // explicitly configured to be ignored
-                HELIDON_CONFIGURED.set(true);
-                return;
-            }
+            ObjectInputFilter currentFilter = ObjectInputFilter.Config.getSerialFilter();
 
-            String currentFilterString = System.getProperty("jdk.serialFilter");
-            if (System.getProperty(PROP_PATTERN) != null) {
-                LOGGER.warning("You have defined " + PROP_PATTERN + " system property, yet serial filter is "
-                                       + " already configured "
-                                       + (currentFilterString == null ? " via jdk.serialFilter" : " programmatically"));
-            }
-
-            if (currentFilterString == null) {
-                LOGGER.finest("Programmatic filter configured: " + currentFilter);
-                // somebody manually configured the filter
-                ObjectInputFilter.Status status = currentFilter.checkInput(new ObjectInputFilter.FilterInfo() {
-                    @Override
-                    public Class<?> serialClass() {
-                        return SerializationConfig.class;
-                    }
-
-                    @Override
-                    public long arrayLength() {
-                        return 0;
-                    }
-
-                    @Override
-                    public long depth() {
-                        return 0;
-                    }
-
-                    @Override
-                    public long references() {
-                        return 0;
-                    }
-
-                    @Override
-                    public long streamBytes() {
-                        return 0;
-                    }
-                });
-                if (status == ObjectInputFilter.Status.ALLOWED || status == ObjectInputFilter.Status.UNDECIDED) {
-                    throw new IllegalStateException("Custom JDK Serialization Filter is not configured to blacklist all classes. "
-                                                            + "Helidon can only run with whitelists. Please add '!*' as the last "
-                                                            + "pattern.");
+            if (currentFilter == null) {
+                switch (options.onNoConfig()) {
+                case FAIL:
+                    throw new IllegalStateException("There is no global serial filter configured. To automatically configure"
+                                                            + " a filter, please set system property " + PROP_NO_CONFIG_ACTION
+                                                            + " to \"configure\"");
+                case WARN:
+                    AtomicBoolean logged = new AtomicBoolean();
+                    configureTracingFilter(options, it -> {
+                        if (it.serialClass() != null && logged.compareAndSet(false, true)) {
+                            LOGGER.warning("Deserialization attempted for class " + it.serialClass().getName()
+                                                   + ", yet there is no global serial filter configured. "
+                                                   + "To automatically configure"
+                                                   + " a filter, please set system property \"" + PROP_NO_CONFIG_ACTION
+                                                   + "\" to \"configure\"");
+                        }
+                        return ObjectInputFilter.Status.UNDECIDED;
+                    });
+                    return;
+                case IGNORE:
+                    LOGGER.finest("Ignoring that there is no global serial filter configured. To automatically configure"
+                                          + " a filter, please set system property " + PROP_NO_CONFIG_ACTION
+                                          + " to \"configure\"");
+                    configureTracingFilter(options, null);
+                    return;
+                default:
+                    throw new IllegalArgumentException("Unsupported no configuration action: " + options.onNoConfig());
+                case CONFIGURE:
+                    // this is the only option that continues with execution
+                    configureGlobalFilter(options);
+                    break;
                 }
             } else {
-                LOGGER.finest("System property filter configured: " + currentFilterString);
-                // make sure blacklist is for all
-                if (currentFilterString.startsWith("!*;")
-                        || currentFilterString.contains(";!*;")
-                        || currentFilterString.endsWith(";!*")
-                        || currentFilterString.equals("!*")) {
-                    // this is OK
+                Action action = options.onWrongConfig();
+
+                if (action == Action.IGNORE) {
+                    LOGGER.finest("Existing serialization config is ignored by Helidon.");
                     return;
                 }
-                throw new IllegalStateException("jdk.serialFilter is configured without blacklisting all other classes. Helidon "
-                                                        + "can only run with whitelists. Please add '!*' as the last pattern.");
+
+                validateExistingFilter(currentFilter, action);
             }
+        } else {
+            ConfigOptions existingOptions = EXISTING_CONFIG.get();
+            if (options.equals(existingOptions)) {
+                return;
+            }
+            throw new IllegalArgumentException("You are trying to reconfigure serialization config with different options. "
+                                                       + "This is not possible, as global filter can only be configured once."
+                                                       + "Existing options: " + existingOptions + ", your options: " + options);
         }
     }
 
-    private static String getPattern() {
-        List<String> parts = new LinkedList<>();
+    ConfigOptions options() {
+        return options;
+    }
 
-        try {
-            Enumeration<URL> resources = SerializationConfig.class
-                    .getClassLoader()
-                    .getResources(PROPERTY);
-            while (resources.hasMoreElements()) {
-                URL url = resources.nextElement();
-                Properties props = new Properties();
-                props.load(url.openStream());
+    private void validateExistingFilter(ObjectInputFilter currentFilter, Action action) {
+        String currentFilterString = System.getProperty("jdk.serialFilter");
 
-                String pattern = props.getProperty("pattern");
-                if (pattern == null) {
-                    LOGGER.warning("Could not find 'pattern' property in " + url);
-                } else {
-                    if (!pattern.isBlank()) {
-                        parts.add(pattern);
+        if (currentFilterString == null) {
+            LOGGER.finest("Programmatic filter configured: " + currentFilter);
+            // somebody manually configured the filter
+            ObjectInputFilter.Status status = currentFilter.checkInput(new ObjectInputFilter.FilterInfo() {
+                @Override
+                public Class<?> serialClass() {
+                    return SerializationConfig.class;
+                }
+
+                @Override
+                public long arrayLength() {
+                    return 0;
+                }
+
+                @Override
+                public long depth() {
+                    return 0;
+                }
+
+                @Override
+                public long references() {
+                    return 0;
+                }
+
+                @Override
+                public long streamBytes() {
+                    return 0;
+                }
+            });
+            if (status == ObjectInputFilter.Status.ALLOWED || status == ObjectInputFilter.Status.UNDECIDED) {
+                handleBadFilter(action,
+                                "Custom JDK Serialization Filter is not configured to blacklist all classes. "
+                                        + "Helidon can only run with whitelists. Please add '!*' as the last "
+                                        + "pattern.");
+            }
+        } else {
+            LOGGER.finest("System property filter configured: " + currentFilterString);
+            // make sure blacklist is for all
+            if (currentFilterString.startsWith("!*;")
+                    || currentFilterString.contains(";!*;")
+                    || currentFilterString.endsWith(";!*")
+                    || currentFilterString.equals("!*")) {
+                // this is OK
+                return;
+            }
+            handleBadFilter(action,
+                            "jdk.serialFilter is configured without blacklisting all other classes. Helidon "
+                                    + "can only run with whitelists. Please add '!*' as the last pattern.");
+        }
+    }
+
+    private void handleBadFilter(Action action, String message) {
+        switch (action) {
+        case FAIL:
+            throw new IllegalStateException(message);
+        case WARN:
+            LOGGER.warning(message);
+            break;
+        case CONFIGURE:
+            // TODO this will change with Java 17, where we can create a combined filter
+            throw new IllegalStateException("Cannot reconfigure current global deserialization filter."
+                                                    + " Original message: " + message);
+        case IGNORE:
+            LOGGER.finest("Ignoring global deserialization filter issue. Original message: " + message);
+            break;
+        default:
+            throw new IllegalStateException("Unexpected action to handle bad global deserialization filter: " + action);
+        }
+    }
+
+    private void configureTracingFilter(ConfigOptions options, ObjectInputFilter existing) {
+        ObjectInputFilter filter = existing;
+        switch (options.traceSerialization()) {
+        case BASIC:
+            if (existing == null) {
+                filter = emptyFilter();
+            }
+            ObjectInputFilter.Config.setSerialFilter(new TracingObjectInputFilter(filter, true));
+            break;
+        case FULL:
+            if (existing == null) {
+                filter = emptyFilter();
+            }
+            ObjectInputFilter.Config.setSerialFilter(new TracingObjectInputFilter(filter, false));
+            break;
+        case NONE:
+            if (existing == null) {
+                // no filter configured
+                return;
+            } else {
+                ObjectInputFilter.Config.setSerialFilter(existing);
+            }
+            break;
+        default:
+            throw new IllegalArgumentException("Unsupported trace serialization option: " + options.traceSerialization());
+        }
+    }
+
+    private ObjectInputFilter emptyFilter() {
+        return new ObjectInputFilter() {
+            @Override
+            public Status checkInput(FilterInfo filterInfo) {
+                return Status.UNDECIDED;
+            }
+        };
+    }
+
+    private void configureGlobalFilter(ConfigOptions options) {
+        String pattern = options.filterPattern();
+        LOGGER.finest("Using serialization pattern " + pattern);
+        ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(pattern);
+
+        configureTracingFilter(options, filter);
+    }
+
+    /**
+     * What action to take if there is no global filter configured,
+     * or if the configuration is not according to Helidon expectations.
+     */
+    public enum Action {
+        /**
+         * Fail by throwing an {@link java.lang.IllegalStateException}.
+         */
+        FAIL,
+        /**
+         * Warn in the log file.
+         */
+        WARN,
+        /**
+         * Attempt to configure the correct values.
+         * Note that this may behave as {@link #FAIL} for cases where reconfiguration
+         * is not possible.
+         */
+        CONFIGURE,
+        /**
+         * Ignore the problem and continue as if nothing happened.
+         */
+        IGNORE
+    }
+
+    /**
+     * Deserialization tracing options.
+     */
+    public enum TraceOption {
+        /**
+         * Basic tracing will only trace attempts to deserialize a class, and only once for each class.
+         */
+        BASIC,
+        /**
+         * Full tracing traces any request to the deserialization filter.
+         */
+        FULL,
+        /**
+         * No deserialization tracing done.
+         */
+        NONE
+    }
+
+    /**
+     * Fluent API builder to customize {@link io.helidon.common.SerializationConfig}.
+     * You can use system properties defined in the class to modify configuration, in which case you can just use
+     * {@link SerializationConfig#configureRuntime()} directly.
+     */
+    public static class Builder implements io.helidon.common.Builder<SerializationConfig> {
+        // TODO change default action to FAIL for 3.0.0
+        private Action onWrongConfig = configuredAction(PROP_WRONG_CONFIG_ACTION, Action.WARN);
+        // TODO change default action to CONFIGURE for 3.0.0
+        private Action onNoConfig = configuredAction(PROP_NO_CONFIG_ACTION, Action.WARN);
+        private String filterPattern = System.getProperty(PROP_PATTERN);
+        private TraceOption traceSerialization = configuredTrace(TraceOption.NONE);
+        private boolean ignoreFiles = Boolean.getBoolean(PROP_IGNORE_FILES);
+
+        private Builder() {
+        }
+
+        private static Action configuredAction(String sysProp, Action defaultValue) {
+            String property = System.getProperty(sysProp);
+            if (property == null) {
+                return defaultValue;
+            }
+            try {
+                return Action.valueOf(property.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                List<String> validActions = Arrays.stream(Action.values())
+                        .map(Action::toString)
+                        .map(String::toLowerCase)
+                        .collect(Collectors.toList());
+
+                LOGGER.warning("System property \"" + sysProp + "\" is configured to \"" + property + "\", which is"
+                                       + " not a valid Action. Valid actions: " + validActions
+                                       + ". Using: " + defaultValue.toString().toLowerCase());
+
+                return defaultValue;
+            }
+        }
+
+        private static TraceOption configuredTrace(TraceOption defaultValue) {
+            String property = System.getProperty(PROP_TRACE);
+            if (property == null) {
+                return defaultValue;
+            }
+            try {
+                return TraceOption.valueOf(property.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                List<String> validTraceOptions = Arrays.stream(TraceOption.values())
+                        .map(TraceOption::toString)
+                        .map(String::toLowerCase)
+                        .collect(Collectors.toList());
+
+                LOGGER.warning("System property \"" + PROP_TRACE + "\" is configured to \"" + property + "\", which is"
+                                       + " not a valid TraceOption. Valid trace options: " + validTraceOptions
+                                       + ". Using: " + defaultValue.toString().toLowerCase());
+
+                return defaultValue;
+            }
+        }
+
+        @Override
+        public SerializationConfig build() {
+            this.filterPattern = getPattern();
+            return new SerializationConfig(this);
+        }
+
+        /**
+         * What action to do in case of wrong configuration of the global filter.
+         *
+         * @param onWrongConfig action to do
+         * @return updated builder
+         */
+        public Builder onWrongConfig(Action onWrongConfig) {
+            this.onWrongConfig = onWrongConfig;
+            return this;
+        }
+
+        /**
+         * What action to do in case of no configuration of the global filter.
+         *
+         * @param onNoConfig action to do
+         * @return updated builder
+         */
+        public Builder onNoConfig(Action onNoConfig) {
+            this.onNoConfig = onNoConfig;
+            return this;
+        }
+
+        /**
+         * Filter pattern to use.
+         *
+         * @param filterPattern filter pattern
+         * @return updated builder
+         */
+        public Builder filterPattern(String filterPattern) {
+            this.filterPattern = filterPattern;
+            return this;
+        }
+
+        /**
+         * How to trace serialization.
+         *
+         * @param traceSerialization trace option
+         * @return updated builder
+         */
+        public Builder traceSerialization(TraceOption traceSerialization) {
+            this.traceSerialization = traceSerialization;
+            return this;
+        }
+
+        /**
+         * Whether to ignore {@value io.helidon.common.SerializationConfig#PROPERTY_FILE} property files defined in
+         * dependencies.
+         *
+         * @param ignoreFiles {@code true} to ignore files on classpath, defaults to {@code false}
+         * @return updated builder
+         */
+        public Builder ignoreFiles(boolean ignoreFiles) {
+            this.ignoreFiles = ignoreFiles;
+            return this;
+        }
+
+        private String getPattern() {
+            // first make sure we do not conflict with default JDK configuration options
+            String currentFilterString = System.getProperty("jdk.serialFilter");
+            if (currentFilterString != null) {
+                if (filterPattern != null && !filterPattern.isBlank()) {
+                    throw new IllegalArgumentException("jdk.serialFilter system property is configured and an explicit"
+                                                               + " filter pattern is configured as well. This is not supported.");
+                }
+                return "!*";
+            }
+
+            if (ignoreFiles) {
+                if (filterPattern == null || filterPattern.isBlank()) {
+                    return "!*";
+                }
+                return filterPattern + ";!*";
+            }
+
+            List<String> parts = new LinkedList<>();
+
+            try {
+                Enumeration<URL> resources = SerializationConfig.class
+                        .getClassLoader()
+                        .getResources(PROPERTY_FILE);
+                while (resources.hasMoreElements()) {
+                    URL url = resources.nextElement();
+                    Properties props = new Properties();
+                    props.load(url.openStream());
+
+                    String pattern = props.getProperty("pattern");
+                    if (pattern == null) {
+                        LOGGER.warning("Could not find 'pattern' property in " + url);
+                    } else {
+                        if (!pattern.isBlank()) {
+                            parts.add(pattern);
+                        }
                     }
                 }
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "Could not find " + PROPERTY_FILE + " resources", e);
             }
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Could not find " + PROPERTY + " resources", e);
+
+            if (!(filterPattern == null || filterPattern.isBlank())) {
+                parts.add(filterPattern.trim());
+            }
+            parts.add("!*");
+
+            return String.join(";", parts);
+        }
+    }
+
+    static final class ConfigOptions {
+        private final Action onWrongConfig;
+        private final Action onNoConfig;
+        private final String filterPattern;
+        private final TraceOption traceSerialization;
+
+        private ConfigOptions(Action onWrongConfig,
+                              Action onNoConfig,
+                              String filterPattern,
+                              TraceOption traceSerialization) {
+            this.onWrongConfig = onWrongConfig;
+            this.onNoConfig = onNoConfig;
+            this.filterPattern = filterPattern;
+            this.traceSerialization = traceSerialization;
         }
 
-        String pattern = System.getProperty(PROP_PATTERN);
-        if (!(pattern == null || pattern.isBlank())) {
-            parts.add(pattern.trim());
+        Action onWrongConfig() {
+            return onWrongConfig;
         }
-        parts.add("!*");
 
-        return String.join(";", parts);
+        Action onNoConfig() {
+            return onNoConfig;
+        }
+
+        String filterPattern() {
+            return filterPattern;
+        }
+
+        TraceOption traceSerialization() {
+            return traceSerialization;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ConfigOptions that = (ConfigOptions) o;
+            return onWrongConfig == that.onWrongConfig && onNoConfig == that.onNoConfig && filterPattern
+                    .equals(that.filterPattern) && traceSerialization == that.traceSerialization;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(onWrongConfig, onNoConfig, filterPattern, traceSerialization);
+        }
+
+        @Override
+        public String toString() {
+            return "ConfigOptions{"
+                    + "onWrongConfig=" + onWrongConfig
+                    + ", onNoConfig=" + onNoConfig
+                    + ", filterPattern='" + filterPattern + '\''
+                    + ", traceSerialization=" + traceSerialization
+                    + '}';
+        }
     }
 
     private static class TracingObjectInputFilter implements ObjectInputFilter {
         private static final Logger LOGGER = Logger.getLogger(TracingObjectInputFilter.class.getName());
-        private final ObjectInputFilter delegate;
 
-        private TracingObjectInputFilter(ObjectInputFilter filter) {
+        private final Set<Class<?>> reportedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private final ObjectInputFilter delegate;
+        private final boolean basic;
+
+        private TracingObjectInputFilter(ObjectInputFilter filter, boolean basic) {
             this.delegate = filter;
+            this.basic = basic;
         }
 
         @Override
         public Status checkInput(FilterInfo filterInfo) {
+            Class<?> clazz = filterInfo.serialClass();
+            if (clazz == null && basic) {
+                return delegate.checkInput(filterInfo);
+            }
             Status result = delegate.checkInput(filterInfo);
 
+            if (!reportedClasses.add(clazz)) {
+                if (basic) {
+                    return result;
+                }
+            }
             LOGGER.info(result
-                                + " class: " + filterInfo.serialClass()
+                                + " class: " + clazz
                                 + ", arrayLength: " + filterInfo.arrayLength()
                                 + ", depth: " + filterInfo.depth()
                                 + ", references: " + filterInfo.references()

--- a/common/common/src/main/java/io/helidon/common/SerializationConfig.java
+++ b/common/common/src/main/java/io/helidon/common/SerializationConfig.java
@@ -257,7 +257,6 @@ public final class SerializationConfig {
             LOGGER.warning(message);
             break;
         case CONFIGURE:
-            // TODO this will change with Java 17, where we can create a combined filter
             throw new IllegalStateException("Cannot reconfigure current global deserialization filter."
                                                     + " Original message: " + message);
         case IGNORE:
@@ -362,9 +361,7 @@ public final class SerializationConfig {
      * {@link SerializationConfig#configureRuntime()} directly.
      */
     public static class Builder implements io.helidon.common.Builder<SerializationConfig> {
-        // TODO change default action to FAIL for 3.0.0
         private Action onWrongConfig = configuredAction(PROP_WRONG_CONFIG_ACTION, Action.WARN);
-        // TODO change default action to CONFIGURE for 3.0.0
         private Action onNoConfig = configuredAction(PROP_NO_CONFIG_ACTION, Action.WARN);
         private String filterPattern = System.getProperty(PROP_PATTERN);
         private TraceOption traceSerialization = configuredTrace(TraceOption.NONE);

--- a/common/common/src/main/java/io/helidon/common/SerializationConfig.java
+++ b/common/common/src/main/java/io/helidon/common/SerializationConfig.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.io.IOException;
+import java.io.ObjectInputFilter;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Support for JEP 290 - deserialization filtering.
+ * Helidon is implemented to support whitelists, automatically blacklisting
+ * all classes.
+ * Helidon restrictions are only enforced on the global filter.
+ * <p>
+ * To add patterns to the serial filter, use a system property {@value #PROP_PATTERN}.
+ * This pattern follows the rules as defined by JDK. Helidon will add exclude all as the last
+ * pattern.
+ * <p>
+ * To ignore this configuration, use system property {@value #PROP_IGNORE} and set it to {@code true}.
+ * <p>
+ * A tracing filter can be configured using system property {@value #PROP_TRACE} to log information
+ * messages for each deserialization request.
+ */
+public final class SerializationConfig {
+    private static final Logger LOGGER = Logger.getLogger(SerializationConfig.class.getName());
+    private static final String PROP_IGNORE = "helidon.serialFilter.ignore";
+    private static final String PROP_PATTERN = "helidon.serialFilter.pattern";
+    private static final String PROP_TRACE = "helidon.serialFilter.trace";
+    private static final String PROPERTY = "META-INF/helidon/serial-config.properties";
+
+    private SerializationConfig() {
+    }
+
+    private static final AtomicBoolean HELIDON_CONFIGURED = new AtomicBoolean();
+
+    /**
+     * Make sure configuration is as expected.
+     */
+    public static void configureRuntime() {
+        ObjectInputFilter currentFilter = ObjectInputFilter.Config.getSerialFilter();
+
+        if (currentFilter == null) {
+            if ("true".equals(System.getProperty(PROP_IGNORE))) {
+                LOGGER.finest("Serialization config is ignored by Helidon.");
+                // explicitly configured to be ignored
+                HELIDON_CONFIGURED.set(true);
+                return;
+            }
+            String pattern = getPattern();
+            LOGGER.finest("Using serialization pattern " + pattern);
+            ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(pattern);
+            if ("true".equals(System.getProperty(PROP_TRACE))) {
+                ObjectInputFilter.Config.setSerialFilter(new TracingObjectInputFilter(filter));
+            } else {
+                ObjectInputFilter.Config.setSerialFilter(filter);
+            }
+            HELIDON_CONFIGURED.set(true);
+        } else {
+            if (HELIDON_CONFIGURED.get()) {
+                // it was us
+                return;
+            }
+
+            if ("true".equals(System.getProperty(PROP_IGNORE))) {
+                LOGGER.finest("Serialization config is ignored by Helidon.");
+                // explicitly configured to be ignored
+                HELIDON_CONFIGURED.set(true);
+                return;
+            }
+
+            String currentFilterString = System.getProperty("jdk.serialFilter");
+            if (System.getProperty(PROP_PATTERN) != null) {
+                LOGGER.warning("You have defined " + PROP_PATTERN + " system property, yet serial filter is "
+                                       + " already configured "
+                                       + (currentFilterString == null ? " via jdk.serialFilter" : " programmatically"));
+            }
+
+            if (currentFilterString == null) {
+                LOGGER.finest("Programmatic filter configured: " + currentFilter);
+                // somebody manually configured the filter
+                ObjectInputFilter.Status status = currentFilter.checkInput(new ObjectInputFilter.FilterInfo() {
+                    @Override
+                    public Class<?> serialClass() {
+                        return SerializationConfig.class;
+                    }
+
+                    @Override
+                    public long arrayLength() {
+                        return 0;
+                    }
+
+                    @Override
+                    public long depth() {
+                        return 0;
+                    }
+
+                    @Override
+                    public long references() {
+                        return 0;
+                    }
+
+                    @Override
+                    public long streamBytes() {
+                        return 0;
+                    }
+                });
+                if (status == ObjectInputFilter.Status.ALLOWED || status == ObjectInputFilter.Status.UNDECIDED) {
+                    throw new IllegalStateException("Custom JDK Serialization Filter is not configured to blacklist all classes. "
+                                                            + "Helidon can only run with whitelists. Please add '!*' as the last "
+                                                            + "pattern.");
+                }
+            } else {
+                LOGGER.finest("System property filter configured: " + currentFilterString);
+                // make sure blacklist is for all
+                if (currentFilterString.startsWith("!*;")
+                        || currentFilterString.contains(";!*;")
+                        || currentFilterString.endsWith(";!*")
+                        || currentFilterString.equals("!*")) {
+                    // this is OK
+                    return;
+                }
+                throw new IllegalStateException("jdk.serialFilter is configured without blacklisting all other classes. Helidon "
+                                                        + "can only run with whitelists. Please add '!*' as the last pattern.");
+            }
+        }
+    }
+
+    private static String getPattern() {
+        List<String> parts = new LinkedList<>();
+
+        try {
+            Enumeration<URL> resources = SerializationConfig.class
+                    .getClassLoader()
+                    .getResources(PROPERTY);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                Properties props = new Properties();
+                props.load(url.openStream());
+
+                String pattern = props.getProperty("pattern");
+                if (pattern == null) {
+                    LOGGER.warning("Could not find 'pattern' property in " + url);
+                } else {
+                    if (!pattern.isBlank()) {
+                        parts.add(pattern);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Could not find " + PROPERTY + " resources", e);
+        }
+
+        String pattern = System.getProperty(PROP_PATTERN);
+        if (!(pattern == null || pattern.isBlank())) {
+            parts.add(pattern.trim());
+        }
+        parts.add("!*");
+
+        return String.join(";", parts);
+    }
+
+    private static class TracingObjectInputFilter implements ObjectInputFilter {
+        private static final Logger LOGGER = Logger.getLogger(TracingObjectInputFilter.class.getName());
+        private final ObjectInputFilter delegate;
+
+        private TracingObjectInputFilter(ObjectInputFilter filter) {
+            this.delegate = filter;
+        }
+
+        @Override
+        public Status checkInput(FilterInfo filterInfo) {
+            Status result = delegate.checkInput(filterInfo);
+
+            LOGGER.info(result
+                                + " class: " + filterInfo.serialClass()
+                                + ", arrayLength: " + filterInfo.arrayLength()
+                                + ", depth: " + filterInfo.depth()
+                                + ", references: " + filterInfo.references()
+                                + ", streamBytes: " + filterInfo.streamBytes());
+
+            return result;
+        }
+    }
+}

--- a/common/common/src/main/resources/META-INF/native-image/io.helidon/helidon-common/resource-config.json
+++ b/common/common/src/main/resources/META-INF/native-image/io.helidon/helidon-common/resource-config.json
@@ -1,0 +1,7 @@
+{
+    "resources": [
+        {
+            "pattern": "META-INF/helidon/serial-config.properties"
+        }
+    ]
+}

--- a/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
+++ b/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 class SerializationConfigTest {
     @Test
-    void testDefaults() throws Exception {
+    void testDefaults() {
         SerializationConfig serializationConfig = SerializationConfig.builder().build();
 
         SerializationConfig.ConfigOptions options = serializationConfig.options();

--- a/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
+++ b/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.common;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Make sure you never call configure or configureRuntime, as that modifies the shape of
+ * current JRE without possibility to reverse it.
+ */
+class SerializationConfigTest {
+    @Test
+    void testDefaults() throws Exception {
+        SerializationConfig serializationConfig = SerializationConfig.builder().build();
+
+        SerializationConfig.ConfigOptions options = serializationConfig.options();
+        assertThat(options.traceSerialization(), is(SerializationConfig.TraceOption.NONE));
+        // TODO this will change in 3.0.0
+        assertThat(options.onNoConfig(), is(SerializationConfig.Action.WARN));
+        // TODO this will change in 3.0.0
+        assertThat(options.onWrongConfig(), is(SerializationConfig.Action.WARN));
+        assertThat(options.filterPattern(), is("!*"));
+    }
+
+    @Test
+    void testBuilder() {
+        SerializationConfig serializationConfig = SerializationConfig.builder()
+                .ignoreFiles(true)
+                .filterPattern(SerializationConfigTest.class.getName())
+                .onNoConfig(SerializationConfig.Action.IGNORE)
+                .onWrongConfig(SerializationConfig.Action.CONFIGURE)
+                .traceSerialization(SerializationConfig.TraceOption.FULL)
+                .build();
+
+        SerializationConfig.ConfigOptions options = serializationConfig.options();
+        assertThat(options.traceSerialization(), is(SerializationConfig.TraceOption.FULL));
+        assertThat(options.onNoConfig(), is(SerializationConfig.Action.IGNORE));
+        assertThat(options.onWrongConfig(), is(SerializationConfig.Action.CONFIGURE));
+        assertThat(options.filterPattern(), is(SerializationConfigTest.class.getName() + ";!*"));
+    }
+
+    @Test
+    void testSysProps() {
+        try {
+            System.setProperty(SerializationConfig.PROP_PATTERN, SerializationConfigTest.class.getName());
+            System.setProperty(SerializationConfig.PROP_NO_CONFIG_ACTION, "ignore");
+            System.setProperty(SerializationConfig.PROP_WRONG_CONFIG_ACTION, "configure");
+            System.setProperty(SerializationConfig.PROP_TRACE, "full");
+            System.setProperty(SerializationConfig.PROP_IGNORE_FILES, "true");
+
+            SerializationConfig serializationConfig = SerializationConfig.builder()
+                    .ignoreFiles(true)
+                    .filterPattern(SerializationConfigTest.class.getName())
+                    .onNoConfig(SerializationConfig.Action.IGNORE)
+                    .onWrongConfig(SerializationConfig.Action.CONFIGURE)
+                    .traceSerialization(SerializationConfig.TraceOption.FULL)
+                    .build();
+
+            SerializationConfig.ConfigOptions options = serializationConfig.options();
+            assertThat(options.traceSerialization(), is(SerializationConfig.TraceOption.FULL));
+            assertThat(options.onNoConfig(), is(SerializationConfig.Action.IGNORE));
+            assertThat(options.onWrongConfig(), is(SerializationConfig.Action.CONFIGURE));
+            assertThat(options.filterPattern(), is(SerializationConfigTest.class.getName() + ";!*"));
+        } finally {
+            Properties properties = System.getProperties();
+
+            properties.remove(SerializationConfig.PROP_PATTERN);
+            properties.remove(SerializationConfig.PROP_NO_CONFIG_ACTION);
+            properties.remove(SerializationConfig.PROP_WRONG_CONFIG_ACTION);
+            properties.remove(SerializationConfig.PROP_TRACE);
+            properties.remove(SerializationConfig.PROP_IGNORE_FILES);
+        }
+    }
+}

--- a/integrations/db/h2/pom.xml
+++ b/integrations/db/h2/pom.xml
@@ -40,6 +40,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/integrations/db/ojdbc/pom.xml
+++ b/integrations/db/ojdbc/pom.xml
@@ -36,6 +36,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8-production</artifactId>
             <type>pom</type>

--- a/integrations/db/ojdbc/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/integrations/db/ojdbc/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+pattern=oracle.sql.converter.*

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/HelidonContainerImpl.java
@@ -42,6 +42,7 @@ import javax.enterprise.inject.spi.Extension;
 import io.helidon.common.HelidonFeatures;
 import io.helidon.common.HelidonFlavor;
 import io.helidon.common.LogConfig;
+import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
@@ -244,6 +245,7 @@ final class HelidonContainerImpl extends Weld implements HelidonContainer {
             // already started
             return cdi;
         }
+        SerializationConfig.configureRuntime();
         LogConfig.configureRuntime();
         try {
             Contexts.runInContext(ROOT_CONTEXT, this::doStart);

--- a/tests/integration/jep290/check_f_f_ok/pom.xml
+++ b/tests/integration/jep290/check_f_f_ok/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-check_f_f_ok</artifactId>
+    <name>Helidon Tests Integration JEP-290 check_f_f_ok</name>
+
+    <description>
+        Explicit pattern configured using java, fail on wrong config and pattern is ok.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/check_f_f_ok/src/main/java/io/helidon/tests/integration/jep290/checkffok/Configured.java
+++ b/tests/integration/jep290/check_f_f_ok/src/main/java/io/helidon/tests/integration/jep290/checkffok/Configured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffok;
+
+import java.io.Serializable;
+
+class Configured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    Configured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_f_ok/src/main/java/io/helidon/tests/integration/jep290/checkffok/NotConfigured.java
+++ b/tests/integration/jep290/check_f_f_ok/src/main/java/io/helidon/tests/integration/jep290/checkffok/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffok;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_f_ok/src/test/java/io/helidon/tests/integration/jep290/checkffok/DeserializationTest.java
+++ b/tests/integration/jep290/check_f_f_ok/src/test/java/io/helidon/tests/integration/jep290/checkffok/DeserializationTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DeserializationTest {
     private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);
-    ;
 
     @BeforeAll
     static void configureDeserialization() {

--- a/tests/integration/jep290/check_f_f_ok/src/test/java/io/helidon/tests/integration/jep290/checkffok/DeserializationTest.java
+++ b/tests/integration/jep290/check_f_f_ok/src/test/java/io/helidon/tests/integration/jep290/checkffok/DeserializationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffok;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);
+    ;
+
+    @BeforeAll
+    static void configureDeserialization() {
+
+        ObjectInputFilter myFilter = filterInfo -> {
+            if (filterInfo.serialClass() == null) {
+                return ObjectInputFilter.Status.UNDECIDED;
+            }
+            if (filterInfo.serialClass().equals(Configured.class)) {
+                return ObjectInputFilter.Status.ALLOWED;
+            }
+            return ObjectInputFilter.Status.REJECTED;
+        };
+        ObjectInputFilter.Config.setSerialFilter(myFilter);
+        SerializationConfig sc = SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.FAIL)
+                .onNoConfig(SerializationConfig.Action.IGNORE)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build();
+
+        // should not fail, as we have a blacklist for all other
+        sc.configure();
+    }
+
+    @Test
+    void testConfigured() throws IOException, ClassNotFoundException {
+        Configured object = new Configured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(Configured.class));
+
+        object = (Configured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        // should be excluded
+        assertThrows(InvalidClassException.class, ois::readObject);
+    }
+}

--- a/tests/integration/jep290/check_f_f_w/pom.xml
+++ b/tests/integration/jep290/check_f_f_w/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-check_f_f_w</artifactId>
+    <name>Helidon Tests Integration JEP-290 check_f_f_w</name>
+
+    <description>
+        Explicit pattern configured using java, fail on wrong config and pattern is wrong.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/check_f_f_w/src/main/java/io/helidon/tests/integration/jep290/checkffw/Configured.java
+++ b/tests/integration/jep290/check_f_f_w/src/main/java/io/helidon/tests/integration/jep290/checkffw/Configured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffw;
+
+import java.io.Serializable;
+
+class Configured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    Configured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_f_w/src/main/java/io/helidon/tests/integration/jep290/checkffw/NotConfigured.java
+++ b/tests/integration/jep290/check_f_f_w/src/main/java/io/helidon/tests/integration/jep290/checkffw/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffw;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_f_w/src/test/java/io/helidon/tests/integration/jep290/checkffw/DeserializationTest.java
+++ b/tests/integration/jep290/check_f_f_w/src/test/java/io/helidon/tests/integration/jep290/checkffw/DeserializationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkffw;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        ObjectInputFilter myFilter = filterInfo -> {
+            if (filterInfo.serialClass() == null) {
+                return ObjectInputFilter.Status.UNDECIDED;
+            }
+            if (filterInfo.serialClass().equals(Configured.class)) {
+                return ObjectInputFilter.Status.ALLOWED;
+            }
+            return ObjectInputFilter.Status.UNDECIDED;
+        };
+        ObjectInputFilter.Config.setSerialFilter(myFilter);
+
+        // JDK Filter configured in pom.xml
+        SerializationConfig sc = SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.FAIL)
+                .onNoConfig(SerializationConfig.Action.IGNORE)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build();
+
+        // should fail, as we do not have a blacklist for all other
+        assertThrows(IllegalStateException.class, sc::configure);
+    }
+
+    @Test
+    void testConfigured() throws IOException, ClassNotFoundException {
+        Configured object = new Configured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(Configured.class));
+
+        object = (Configured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        Object o = ois.readObject();
+
+        // we did not configure blacklist, so all should pass
+        assertThat(o, CoreMatchers.instanceOf(NotConfigured.class));
+
+        object = (NotConfigured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+
+    }
+}

--- a/tests/integration/jep290/check_f_p_ok/pom.xml
+++ b/tests/integration/jep290/check_f_p_ok/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-check_f_p_ok</artifactId>
+    <name>Helidon Tests Integration JEP-290 check_f_p_ok</name>
+
+    <description>
+        Explicit pattern configured using system property, fail on wrong config and pattern is ok.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- cannot use systemProperties, as these are populated too late -->
+                    <argLine>-Djdk.serialFilter=io.helidon.tests.integration.jep290.checkfpok.Configured;!*</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/jep290/check_f_p_ok/src/main/java/io/helidon/tests/integration/jep290/checkfpok/Configured.java
+++ b/tests/integration/jep290/check_f_p_ok/src/main/java/io/helidon/tests/integration/jep290/checkfpok/Configured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpok;
+
+import java.io.Serializable;
+
+class Configured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    Configured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_p_ok/src/main/java/io/helidon/tests/integration/jep290/checkfpok/NotConfigured.java
+++ b/tests/integration/jep290/check_f_p_ok/src/main/java/io/helidon/tests/integration/jep290/checkfpok/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpok;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_p_ok/src/test/java/io/helidon/tests/integration/jep290/checkfpok/DeserializationTest.java
+++ b/tests/integration/jep290/check_f_p_ok/src/test/java/io/helidon/tests/integration/jep290/checkfpok/DeserializationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpok;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);
+
+    @BeforeAll
+    static void configureDeserialization() {
+        // JDK Filter configured in pom.xml
+        SerializationConfig sc = SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.FAIL)
+                .onNoConfig(SerializationConfig.Action.FAIL)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build();
+
+        // should not fail, as we have a blacklist for all other
+        sc.configure();
+    }
+
+    @Test
+    void testConfigured() throws IOException, ClassNotFoundException {
+        Configured object = new Configured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(Configured.class));
+
+        object = (Configured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        // should be excluded
+        assertThrows(InvalidClassException.class, ois::readObject);
+    }
+}

--- a/tests/integration/jep290/check_f_p_w/pom.xml
+++ b/tests/integration/jep290/check_f_p_w/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-check_f_p_w</artifactId>
+    <name>Helidon Tests Integration JEP-290 check_f_p_w</name>
+
+    <description>
+        Explicit pattern configured using system property, fail on wrong config and pattern is wrong.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- cannot use systemProperties, as these are populated too late -->
+                    <argLine>-Djdk.serialFilter=io.helidon.tests.integration.jep290.checkfpok.Configured</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/jep290/check_f_p_w/src/main/java/io/helidon/tests/integration/jep290/checkfpw/Configured.java
+++ b/tests/integration/jep290/check_f_p_w/src/main/java/io/helidon/tests/integration/jep290/checkfpw/Configured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpw;
+
+import java.io.Serializable;
+
+class Configured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    Configured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_p_w/src/main/java/io/helidon/tests/integration/jep290/checkfpw/NotConfigured.java
+++ b/tests/integration/jep290/check_f_p_w/src/main/java/io/helidon/tests/integration/jep290/checkfpw/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpw;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/check_f_p_w/src/test/java/io/helidon/tests/integration/jep290/checkfpw/DeserializationTest.java
+++ b/tests/integration/jep290/check_f_p_w/src/test/java/io/helidon/tests/integration/jep290/checkfpw/DeserializationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.checkfpw;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        // JDK Filter configured in pom.xml
+        SerializationConfig sc = SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.FAIL)
+                .onNoConfig(SerializationConfig.Action.IGNORE)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build();
+
+        // should fail, as we do not have a blacklist for all other
+        assertThrows(IllegalStateException.class, sc::configure);
+    }
+
+    @Test
+    void testConfigured() throws IOException, ClassNotFoundException {
+        Configured object = new Configured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(Configured.class));
+
+        object = (Configured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        Object o = ois.readObject();
+
+        // we did not configure blacklist, so all should pass
+        assertThat(o, CoreMatchers.instanceOf(NotConfigured.class));
+
+        object = (NotConfigured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+
+    }
+}

--- a/tests/integration/jep290/pom.xml
+++ b/tests/integration/jep290/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.tests.integration.jep290</groupId>
+    <artifactId>helidon-tests-integration-jep290-project</artifactId>
+    <packaging>pom</packaging>
+    <name>Helidon Tests Integration JEP-290</name>
+
+    <description>
+        A set of tests that validate deserialization filtering
+    </description>
+
+    <!--
+    The modules are named according to what they test.
+    First there is a set of tests that make sure the filter is configured by us (correctly):
+        Directory pattern: set_<onNoConfig>_<ignoreFiles>_<filterPattern>
+
+    onNoConfig:
+        fail: f
+        configure: c
+        other: o
+    ignoreFiles:
+        true: t
+        false: f
+    filterPattern:
+        default: d
+        custom: c
+
+    Second there is a set of tests that make sure the existing filter is validated:
+        Directory pattern: check_<onWrongConfig>_type_result
+
+    onWrongConfig:
+        fail: f
+        configure: c // not yet supported, maybe can work with JDK 17 and its combined filters?
+                    https://openjdk.java.net/jeps/415
+
+    type:
+        pattern: p (pattern config using system property)
+        filter: f (programmatic config)
+
+    result:
+        wrong: w (the existing configuration is wrong)
+        ok: ok
+
+    -->
+    <modules>
+        <module>check_f_f_ok</module>
+        <module>check_f_f_w</module>
+        <module>check_f_p_ok</module>
+        <module>check_f_p_w</module>
+        <module>set_c_f_d</module>
+        <module>set_c_t_d</module>
+        <module>set_c_f_c</module>
+        <module>set_f</module>
+        <module>set_o</module>
+    </modules>
+</project>

--- a/tests/integration/jep290/set_c_f_c/pom.xml
+++ b/tests/integration/jep290/set_c_f_c/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-set_c_f_c</artifactId>
+    <name>Helidon Tests Integration JEP-290 set_c_f_c</name>
+
+    <description>
+        Configure filter, do not ignore files, custom filter pattern
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/ConfiguredInFile.java
+++ b/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/ConfiguredInFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfc;
+
+import java.io.Serializable;
+
+class ConfiguredInFile implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInFile(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/ConfiguredInPattern.java
+++ b/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/ConfiguredInPattern.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfc;
+
+import java.io.Serializable;
+
+class ConfiguredInPattern implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInPattern(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/NotConfigured.java
+++ b/tests/integration/jep290/set_c_f_c/src/main/java/io/helidon/tests/integration/jep290/setcfc/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfc;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_f_c/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/tests/integration/jep290/set_c_f_c/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-grpc:
-  channels:
-    test-server:
-      host: localhost
-      port: 1408
-  marshaller:
-    java:
-      enabled: true
-
-mp.initializer:
-  allow: true
-  no-warn: true
+pattern=io.helidon.tests.integration.jep290.setcfc.ConfiguredInFile

--- a/tests/integration/jep290/set_c_f_c/src/test/java/io/helidon/tests/integration/jep290/setcfc/DeserializationTest.java
+++ b/tests/integration/jep290/set_c_f_c/src/test/java/io/helidon/tests/integration/jep290/setcfc/DeserializationTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static String testString;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.CONFIGURE)
+                .onNoConfig(SerializationConfig.Action.CONFIGURE)
+                .filterPattern(ConfiguredInPattern.class.getName())
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build()
+                .configure();
+
+        testString = "Hello_" + new Random().nextInt(10);
+    }
+
+    @Test
+    void testConfiguredInFile() throws IOException, ClassNotFoundException {
+        ConfiguredInFile object = new ConfiguredInFile(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(ConfiguredInFile.class));
+
+        object = (ConfiguredInFile) o;
+
+        assertThat(object.text(), is(testString));
+    }
+
+    @Test
+    void testConfiguredInPattern() throws IOException, ClassNotFoundException {
+        ConfiguredInPattern object = new ConfiguredInPattern(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(ConfiguredInPattern.class));
+
+        object = (ConfiguredInPattern) o;
+
+        assertThat(object.text(), is(testString));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        assertThrows(InvalidClassException.class, ois::readObject);
+
+    }
+}

--- a/tests/integration/jep290/set_c_f_d/pom.xml
+++ b/tests/integration/jep290/set_c_f_d/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-set_c_f_d</artifactId>
+    <name>Helidon Tests Integration JEP-290 set_c_f_d</name>
+
+    <description>
+        Configure filter, do not ignore files, default filter pattern
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/set_c_f_d/src/main/java/io/helidon/tests/integration/jep290/setcfd/ConfiguredInFile.java
+++ b/tests/integration/jep290/set_c_f_d/src/main/java/io/helidon/tests/integration/jep290/setcfd/ConfiguredInFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfd;
+
+import java.io.Serializable;
+
+class ConfiguredInFile implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInFile(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_f_d/src/main/java/io/helidon/tests/integration/jep290/setcfd/NotConfigured.java
+++ b/tests/integration/jep290/set_c_f_d/src/main/java/io/helidon/tests/integration/jep290/setcfd/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfd;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_f_d/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/tests/integration/jep290/set_c_f_d/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-grpc:
-  channels:
-    test-server:
-      host: localhost
-      port: 1408
-  marshaller:
-    java:
-      enabled: true
-
-mp.initializer:
-  allow: true
-  no-warn: true
+pattern=io.helidon.tests.integration.jep290.setcfd.ConfiguredInFile

--- a/tests/integration/jep290/set_c_f_d/src/test/java/io/helidon/tests/integration/jep290/setcfd/DeserializationTest.java
+++ b/tests/integration/jep290/set_c_f_d/src/test/java/io/helidon/tests/integration/jep290/setcfd/DeserializationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setcfd;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static String testString;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.CONFIGURE)
+                .onNoConfig(SerializationConfig.Action.CONFIGURE)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build()
+                .configure();
+
+        testString = "Hello_" + new Random().nextInt(10);
+    }
+
+    @Test
+    void testConfiguredInFile() throws IOException, ClassNotFoundException {
+        ConfiguredInFile object = new ConfiguredInFile(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(ConfiguredInFile.class));
+
+        object = (ConfiguredInFile) o;
+
+        assertThat(object.text(), is(testString));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        assertThrows(InvalidClassException.class, ois::readObject);
+
+    }
+}

--- a/tests/integration/jep290/set_c_t_d/pom.xml
+++ b/tests/integration/jep290/set_c_t_d/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-set_c_t_d</artifactId>
+    <name>Helidon Tests Integration JEP-290 set_c_t_d</name>
+
+    <description>
+        Configure filter, ignore files, default filter pattern
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/set_c_t_d/src/main/java/io/helidon/tests/integration/jep290/setctd/ConfiguredInFile.java
+++ b/tests/integration/jep290/set_c_t_d/src/main/java/io/helidon/tests/integration/jep290/setctd/ConfiguredInFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setctd;
+
+import java.io.Serializable;
+
+class ConfiguredInFile implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInFile(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_t_d/src/main/java/io/helidon/tests/integration/jep290/setctd/NotConfigured.java
+++ b/tests/integration/jep290/set_c_t_d/src/main/java/io/helidon/tests/integration/jep290/setctd/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setctd;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_c_t_d/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/tests/integration/jep290/set_c_t_d/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-grpc:
-  channels:
-    test-server:
-      host: localhost
-      port: 1408
-  marshaller:
-    java:
-      enabled: true
-
-mp.initializer:
-  allow: true
-  no-warn: true
+pattern=io.helidon.tests.integration.jep290.setctd.ConfiguredInFile

--- a/tests/integration/jep290/set_c_t_d/src/test/java/io/helidon/tests/integration/jep290/setctd/DeserializationTest.java
+++ b/tests/integration/jep290/set_c_t_d/src/test/java/io/helidon/tests/integration/jep290/setctd/DeserializationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setctd;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static String testString;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.CONFIGURE)
+                .onNoConfig(SerializationConfig.Action.CONFIGURE)
+                .ignoreFiles(true)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build()
+                .configure();
+
+        testString = "Hello_" + new Random().nextInt(10);
+    }
+
+    @Test
+    void testConfiguredInFile() throws IOException, ClassNotFoundException {
+        ConfiguredInFile object = new ConfiguredInFile(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        // because we ignore configuration files, this should fail
+        assertThrows(InvalidClassException.class, ois::readObject);
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(testString);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        assertThrows(InvalidClassException.class, ois::readObject);
+
+    }
+}

--- a/tests/integration/jep290/set_f/pom.xml
+++ b/tests/integration/jep290/set_f/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-set_f</artifactId>
+    <name>Helidon Tests Integration JEP-290 set_f</name>
+
+    <description>
+        Fail on unconfigured filter.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/set_f/src/main/java/io/helidon/tests/integration/jep290/setf/ConfiguredInFile.java
+++ b/tests/integration/jep290/set_f/src/main/java/io/helidon/tests/integration/jep290/setf/ConfiguredInFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setf;
+
+import java.io.Serializable;
+
+class ConfiguredInFile implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInFile(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_f/src/main/java/io/helidon/tests/integration/jep290/setf/NotConfigured.java
+++ b/tests/integration/jep290/set_f/src/main/java/io/helidon/tests/integration/jep290/setf/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setf;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_f/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/tests/integration/jep290/set_f/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-grpc:
-  channels:
-    test-server:
-      host: localhost
-      port: 1408
-  marshaller:
-    java:
-      enabled: true
-
-mp.initializer:
-  allow: true
-  no-warn: true
+pattern=io.helidon.tests.integration.jep290.setf.ConfiguredInFile

--- a/tests/integration/jep290/set_f/src/test/java/io/helidon/tests/integration/jep290/setf/DeserializationTest.java
+++ b/tests/integration/jep290/set_f/src/test/java/io/helidon/tests/integration/jep290/setf/DeserializationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.setf;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        SerializationConfig sc = SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.IGNORE)
+                .onNoConfig(SerializationConfig.Action.FAIL)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build();
+
+        assertThrows(IllegalStateException.class, sc::configure);
+    }
+
+    @Test
+    void testConfiguredInFile() throws IOException, ClassNotFoundException {
+        ConfiguredInFile object = new ConfiguredInFile(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(ConfiguredInFile.class));
+
+        object = (ConfiguredInFile) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        Object o = ois.readObject();
+
+        // we did not configure filter, so all should pass
+        assertThat(o, CoreMatchers.instanceOf(NotConfigured.class));
+
+        object = (NotConfigured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+
+    }
+}

--- a/tests/integration/jep290/set_o/pom.xml
+++ b/tests/integration/jep290/set_o/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.tests.integration.jep290</groupId>
+        <artifactId>helidon-tests-integration-jep290-project</artifactId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-jep290-set_o</artifactId>
+    <name>Helidon Tests Integration JEP-290 set_o</name>
+
+    <description>
+        Ignore unconfigured filter.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jep290/set_o/src/main/java/io/helidon/tests/integration/jep290/seto/ConfiguredInFile.java
+++ b/tests/integration/jep290/set_o/src/main/java/io/helidon/tests/integration/jep290/seto/ConfiguredInFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.seto;
+
+import java.io.Serializable;
+
+class ConfiguredInFile implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private final String text;
+
+    ConfiguredInFile(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_o/src/main/java/io/helidon/tests/integration/jep290/seto/NotConfigured.java
+++ b/tests/integration/jep290/set_o/src/main/java/io/helidon/tests/integration/jep290/seto/NotConfigured.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.seto;
+
+import java.io.Serializable;
+
+class NotConfigured implements Serializable {
+    private static final long serialVersionUID = 12L;
+
+    private String text;
+
+    NotConfigured(String text) {
+        this.text = text;
+    }
+
+    String text() {
+        return text;
+    }
+}

--- a/tests/integration/jep290/set_o/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/tests/integration/jep290/set_o/src/main/resources/META-INF/helidon/serial-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
 # limitations under the License.
 #
 
-grpc:
-  channels:
-    test-server:
-      host: localhost
-      port: 1408
-  marshaller:
-    java:
-      enabled: true
-
-mp.initializer:
-  allow: true
-  no-warn: true
+pattern=io.helidon.tests.integration.jep290.seto.ConfiguredInFile

--- a/tests/integration/jep290/set_o/src/test/java/io/helidon/tests/integration/jep290/seto/DeserializationTest.java
+++ b/tests/integration/jep290/set_o/src/test/java/io/helidon/tests/integration/jep290/seto/DeserializationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.jep290.seto;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Random;
+
+import io.helidon.common.SerializationConfig;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DeserializationTest {
+    private static final String TEST_STRING = "Hello_" + new Random().nextInt(10);;
+
+    @BeforeAll
+    static void configureDeserialization() {
+        SerializationConfig.builder()
+                .onWrongConfig(SerializationConfig.Action.IGNORE)
+                .onNoConfig(SerializationConfig.Action.IGNORE)
+                .ignoreFiles(false)
+                .traceSerialization(SerializationConfig.TraceOption.NONE)
+                .build()
+                .configure();
+    }
+
+    @Test
+    void testConfiguredInFile() throws IOException, ClassNotFoundException {
+        ConfiguredInFile object = new ConfiguredInFile(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+        Object o = ois.readObject();
+
+        assertThat(o, CoreMatchers.instanceOf(ConfiguredInFile.class));
+
+        object = (ConfiguredInFile) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+    }
+
+    @Test
+    void testNotConfigured() throws IOException, ClassNotFoundException {
+        NotConfigured object = new NotConfigured(TEST_STRING);
+
+        ByteArrayOutputStream ob = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(ob);
+
+        oos.writeObject(object);
+        oos.close();
+
+        byte[] bytes = ob.toByteArray();
+
+        ByteArrayInputStream ib = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(ib);
+
+        Object o = ois.readObject();
+
+        // we did not configure filter, so all should pass
+        assertThat(o, CoreMatchers.instanceOf(NotConfigured.class));
+
+        object = (NotConfigured) o;
+
+        assertThat(object.text(), is(TEST_STRING));
+
+    }
+}

--- a/tests/integration/native-image/mp-2/src/main/java/io/helidon/tests/integration/nativeimage/mp2/Mp2Main.java
+++ b/tests/integration/native-image/mp-2/src/main/java/io/helidon/tests/integration/nativeimage/mp2/Mp2Main.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.tests.integration.nativeimage.mp2;
 
+import java.util.logging.Logger;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -30,6 +32,8 @@ import static io.helidon.common.http.Http.Status.OK_200;
  * Main class of this integration test.
  */
 public final class Mp2Main {
+    private static final Logger LOGGER = Logger.getLogger(Mp2Main.class.getName());
+
     /**
      * Cannot be instantiated.
      */

--- a/tests/integration/native-image/mp-2/src/main/java/io/helidon/tests/integration/nativeimage/mp2/Mp2Main.java
+++ b/tests/integration/native-image/mp-2/src/main/java/io/helidon/tests/integration/nativeimage/mp2/Mp2Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 package io.helidon.tests.integration.nativeimage.mp2;
-
-import java.util.logging.Logger;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -32,8 +30,6 @@ import static io.helidon.common.http.Http.Status.OK_200;
  * Main class of this integration test.
  */
 public final class Mp2Main {
-    private static final Logger LOGGER = Logger.getLogger(Mp2Main.class.getName());
-
     /**
      * Cannot be instantiated.
      */

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -49,6 +49,7 @@
         <module>kafka</module>
         <module>jms</module>
         <module>config</module>
+        <module>jep290</module>
     </modules>
 
     <profiles>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyWebServer.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLContext;
 
 import io.helidon.common.HelidonFeatures;
 import io.helidon.common.HelidonFlavor;
+import io.helidon.common.SerializationConfig;
 import io.helidon.common.Version;
 import io.helidon.common.context.Context;
 import io.helidon.common.reactive.Single;
@@ -216,6 +217,7 @@ class NettyWebServer implements WebServer {
         }
 
         if (!started) {
+            SerializationConfig.configureRuntime();
 
             channelsUpFuture.thenAccept(this::started)
                             .exceptionally(throwable -> {


### PR DESCRIPTION
Helidon does not use Java serialization, though we want to be as secure as possible. This PR provides ground work to customize configuration that only allows whitelisting (everything should be blacklisted by default).
We cannot change the defaults in this version, as this would create a backward incompatible behavior.
The defaults will change in 3.0.0

Resolves #3158 