### PR TITLE
Fix missing CORS headers if response has 404 status

### DIFF
--- a/examples/microprofile/cors/src/test/java/io/helidon/microprofile/examples/cors/TestCORS.java
+++ b/examples/microprofile/cors/src/test/java/io/helidon/microprofile/examples/cors/TestCORS.java
@@ -125,7 +125,7 @@ public class TestCORS {
         assertThat("HTTP response payload", payload, is("Hola World!"));
         headers = r.headers();
         Optional<String> allowOrigin = headers.value(CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN);
-        assertThat("Expected CORS header " + CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN + " is absent",
+        assertThat("Expected CORS header " + CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN + " is present",
                 allowOrigin.isPresent(), is(true));
         assertThat("CORS header " + CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigin.get(), is("*"));
     }

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CorsDisabledTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CorsDisabledTest.java
@@ -18,6 +18,7 @@ package io.helidon.microprofile.cors;
 import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.AddConfig;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Entity;
@@ -30,6 +31,7 @@ import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_O
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 @HelidonTest
 @AddBean(CrossOriginTest.CorsResource0.class)
@@ -49,12 +51,13 @@ class CorsDisabledTest {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
     }
 
+    @Test
     void testCorsIsDisabled() {
         Response res = target.path("/cors2")
                 .request()
                 .header(ORIGIN, "http://foo.bar")
                 .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
         assertThat(res.getStatusInfo(), is(Response.Status.OK));
-        assertThat("Headers from successful response", res.getHeaders().keySet(), hasItem(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertThat("Headers from successful response", res.getHeaders().keySet(), not(hasItem(ACCESS_CONTROL_ALLOW_ORIGIN)));
     }
 }

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CorsDisabledTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CorsDisabledTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cors;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static io.helidon.common.http.Http.Header.ORIGIN;
+import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+@HelidonTest
+@AddBean(CrossOriginTest.CorsResource0.class)
+@AddBean(CrossOriginTest.CorsResource1.class)
+@AddBean(CrossOriginTest.CorsResource2.class)
+@AddBean(CrossOriginTest.CorsResource3.class)
+@AddConfig(key = "cors.paths.0.path-pattern", value = "/cors3")
+@AddConfig(key = "cors.paths.0.allow-origins", value = "http://foo.bar, http://bar.foo")
+@AddConfig(key = "cors.paths.0.allow-methods", value = "DELETE, PUT")
+@AddConfig(key = "cors.enabled", value="false")
+class CorsDisabledTest {
+
+    @Inject
+    private WebTarget target;
+
+    static {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+    }
+
+    void testCorsIsDisabled() {
+        Response res = target.path("/cors2")
+                .request()
+                .header(ORIGIN, "http://foo.bar")
+                .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
+        assertThat(res.getStatusInfo(), is(Response.Status.OK));
+        assertThat("Headers from successful response", res.getHeaders().keySet(), hasItem(ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+}

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/CrossOriginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -347,17 +347,6 @@ class CrossOriginTest {
                 .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
         assertThat(res.getStatusInfo(), is(Response.Status.OK));
         assertThat(res.getHeaders().getFirst(ACCESS_CONTROL_ALLOW_ORIGIN), is("http://foo.bar"));
-    }
-
-    @Test
-    void testErrorResponse() {
-        Response res = target.path("/notfound")
-                .request()
-                .header(ORIGIN, "http://foo.bar")
-                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
-                .put(Entity.entity("", MediaType.TEXT_PLAIN_TYPE));
-        assertThat(res.getStatusInfo(), is(Response.Status.NOT_FOUND));
-        assertThat(res.getHeaders().containsKey(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
     }
 
     @Test

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/ErrorResponseTest.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/ErrorResponseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.cors;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static io.helidon.common.http.Http.Header.ORIGIN;
+import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_REQUEST_METHOD;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddBean(CrossOriginTest.CorsResource0.class)
+@AddBean(CrossOriginTest.CorsResource1.class)
+@AddBean(CrossOriginTest.CorsResource2.class)
+@AddBean(CrossOriginTest.CorsResource3.class)
+@AddConfig(key = "cors.paths.0.path-pattern", value = "/cors3")
+@AddConfig(key = "cors.paths.0.allow-origins", value = "http://foo.bar, http://bar.foo")
+@AddConfig(key = "cors.paths.0.allow-methods", value = "DELETE, PUT")
+class ErrorResponseTest {
+
+    @Inject
+    private WebTarget target;
+
+    static {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+    }
+
+    @Test
+    void testErrorResponse() {
+        Response res = target.path("/notfound")
+                .request()
+                .header(ORIGIN, "http://foo.bar")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                .get();
+        assertThat("Status from missing endpoint request", res.getStatusInfo(), is(Response.Status.NOT_FOUND));
+        assertThat("With CORS enabled, headers in 404 response", res.getHeaders().keySet(), hasItem(ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+}

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,16 @@ class Aggregator {
      * @return if this aggregator will contribute to CORS processing
      */
     public boolean isActive() {
-        return isEnabled && !crossOriginConfigMatchables.isEmpty();
+        return isEnabled() && !crossOriginConfigMatchables.isEmpty();
+    }
+
+    /**
+     * Reports whether the aggregator (and, by implication, the config for CORS) is enabled or not.
+     *
+     * @return if CORS is enabled
+     */
+    public boolean isEnabled() {
+        return isEnabled;
     }
 
     static class Builder implements io.helidon.common.Builder<Aggregator>, CorsSetter<Builder> {

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -269,7 +269,7 @@ class CorsSupportHelper<Q, R> {
      * @return whether the helper might have any effect on requests or responses
      */
     public boolean isActive() {
-        return aggregator.isActive() || (secondaryCrossOriginLookup != EMPTY_SECONDARY_SUPPLIER);
+        return aggregator.isEnabled();
     }
 
     /**

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -341,10 +341,13 @@ class CorsSupportHelper<Q, R> {
         RequestType requestType = requestType(requestAdapter, true); // silent: already logged during req processing
 
         if (requestType == RequestType.CORS) {
-            // Aggregator knows only about expect paths. If response is 404, use a "catch-all" cross-origin config because
-            // the aggregator will not know about the path.
+            // Aggregator knows only about expect paths. If response is 404, use an ad hoc cross-origin config for the given
+            // origin and method, thus allowing the 404 to pass through the CORS handling in the client.
             CrossOriginConfig crossOrigin = responseAdapter.status() == Http.Status.NOT_FOUND_404.code()
-                ? CrossOriginConfig.CATCH_ALL
+                ? CrossOriginConfig.builder()
+                    .allowOrigins(requestAdapter.firstHeader(ORIGIN).orElse("*"))
+                    .allowMethods(requestAdapter.method())
+                    .build()
                 : aggregator.lookupCrossOrigin(
                                 requestAdapter.path(),
                                 requestAdapter.method(),

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.webserver.cors;
 
@@ -339,21 +338,20 @@ class CorsSupportHelper<Q, R> {
             return;
         }
 
-        // If not a successful response, skip CORS processing for response
-        if (responseAdapter.status() >= SUCCESS_RANGE) {
-            decisionLog(() -> String.format("CORS ignoring response of status code %d", responseAdapter.status()));
-            return;
-        }
-
         RequestType requestType = requestType(requestAdapter, true); // silent: already logged during req processing
 
         if (requestType == RequestType.CORS) {
-            CrossOriginConfig crossOrigin = aggregator.lookupCrossOrigin(
-                            requestAdapter.path(),
-                            requestAdapter.method(),
-                            secondaryCrossOriginLookup)
-                    .orElseThrow(() -> new IllegalArgumentException(
-                            "Could not locate expected CORS information while preparing response to request " + requestAdapter));
+            // Aggregator knows only about expect paths. If response is 404, use a "catch-all" cross-origin config because
+            // the aggregator will not know about the path.
+            CrossOriginConfig crossOrigin = responseAdapter.status() == Http.Status.NOT_FOUND_404.code()
+                ? CrossOriginConfig.CATCH_ALL
+                : aggregator.lookupCrossOrigin(
+                                requestAdapter.path(),
+                                requestAdapter.method(),
+                                secondaryCrossOriginLookup)
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "Could not locate expected CORS information while preparing response to request "
+                                        + requestAdapter));
             addCorsHeadersToResponse(crossOrigin, requestAdapter, responseAdapter);
         }
     }

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
@@ -52,10 +52,6 @@ import static io.helidon.webserver.cors.Aggregator.PATHLESS_KEY;
  */
 public class CrossOriginConfig {
 
-    static final CrossOriginConfig CATCH_ALL = CrossOriginConfig.builder()
-            .allowOrigins("*")
-            .build();
-
     /**
      * Key for the node within the CORS config that contains the list of path information.
      */

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CrossOriginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,10 @@ import static io.helidon.webserver.cors.Aggregator.PATHLESS_KEY;
  *
  */
 public class CrossOriginConfig {
+
+    static final CrossOriginConfig CATCH_ALL = CrossOriginConfig.builder()
+            .allowOrigins("*")
+            .build();
 
     /**
      * Key for the node within the CORS config that contains the list of path information.


### PR DESCRIPTION
Resolves #3188 

## Overview

Some code had been added a while ago to the CORS logic to explicitly avoid setting CORS headers for 404 responses. This PR removes that code.

An earlier unrelated change in Helidon's Jersey support was suppressing headers added to a response if the status was 404. This PR removes that header suppression.

## Two very slight behavioral changes
These are both truly bug fixes.
1. Previously, if the Helidon Jersey `ResponseWriter` detected a response with status 404 and no content, it would ignore any headers already set and immediately delegate to the next handler in the chain (if any). With these changes, any headers previously set on the `ContainerResponse` are _always_ copied to the `ServerResponse`. 
2. Previously, in MP, even if the `cars.enabled` config key was set to `false`, CORS processing would still occur for JAX-RS endpoints (as indicated by JAX-RS annotations). This PR includes changes so that config setting controls JAX-RS CORS behavior as well.

## Details of changes

* `webserver/jersey` 
    * `ResponseWriter#writeReponseStatusAndHeaders` - An earlier change deferred the transmission of the response to a later handler if the response status is 404 and the content length is 0. Change to return response (not defer) if there are any headers. This handles the case where CORS is in play and has added headers to the response even for the 404 case.
* `webserver/cors` 
    * `CorsSupportHelper#prepareResponse` - If response is 404, return valid CORS headers tailored to the (failed) request instead of suppressing CORS headers.
* `CrossOriginConfig` - add constant used for catch-all headers in 404 responses
* Added and modified some tests.


Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>