### PR TITLE
Modified Jaeger logic to not close scopes before switching threads 

### DIFF
--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerDataPropagationProvider.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerDataPropagationProvider.java
@@ -53,13 +53,10 @@ public class JaegerDataPropagationProvider implements DataPropagationProvider<Ja
      */
     @Override
     public JaegerContext data() {
-        return Contexts.context().map(context -> {
-            context.get(Scope.class).ifPresent(Scope::close);
-            return context.get(Span.class).map(span -> {
-                Tracer tracer = context.get(Tracer.class).orElseGet(GlobalTracer::get);
-                return new JaegerContext(tracer, span);
-            }).orElse(null);
-        }).orElse(null);
+        return Contexts.context().map(context -> context.get(Span.class).map(span -> {
+            Tracer tracer = context.get(Tracer.class).orElseGet(GlobalTracer::get);
+            return new JaegerContext(tracer, span);
+        }).orElse(null)).orElse(null);
     }
 
     /**

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerScopeManager.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerScopeManager.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.jaeger;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+/**
+ * An implementation of {@link ScopeManager} that closes a scope from any thread.
+ * This is necessary to support async calls where the close operation may be
+ * called from a different thread.
+ */
+class JaegerScopeManager implements ScopeManager {
+
+    private static final ConcurrentMap<Long, ThreadScope> SCOPES = new ConcurrentHashMap<>();
+
+    @Override
+    public Scope activate(Span span) {
+        return new ThreadScope(span);
+    }
+
+    @Override
+    public Span activeSpan() {
+        ThreadScope scope = SCOPES.get(Thread.currentThread().getId());
+        return scope == null ? null : scope.span();
+    }
+
+    void clearScopes() {
+        SCOPES.clear();
+    }
+
+    static class ThreadScope implements Scope {
+        private final Span span;
+        private final ThreadScope previousScope;
+        private final long creatingThreadId;
+        private boolean closed;
+
+        ThreadScope(Span span) {
+            this.span = span;
+            this.creatingThreadId = Thread.currentThread().getId();
+            this.previousScope = SCOPES.put(this.creatingThreadId, this);
+        }
+
+        @Override
+        public void close() {
+            if (!closed) {
+                if (previousScope == null) {
+                    SCOPES.remove(this.creatingThreadId, this);
+                } else {
+                    SCOPES.put(this.creatingThreadId, previousScope);
+                }
+                closed = true;
+            }
+        }
+
+        Span span() {
+            return span;
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+    }
+}

--- a/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
+++ b/tracing/jaeger/src/main/java/io/helidon/tracing/jaeger/JaegerTracerBuilder.java
@@ -27,6 +27,7 @@ import io.helidon.config.Config;
 import io.helidon.tracing.TracerBuilder;
 
 import io.jaegertracing.Configuration;
+import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.util.GlobalTracer;
@@ -444,7 +445,9 @@ public class JaegerTracerBuilder implements TracerBuilder<JaegerTracerBuilder> {
                         "Configuration must at least contain the 'service' key ('tracing.service` in MP) with service name");
             }
 
-            result = jaegerConfig().getTracer();
+            JaegerTracer.Builder builder = jaegerConfig().getTracerBuilder();
+            builder.withScopeManager(new JaegerScopeManager());     // use our scope manager
+            result = builder.build();
             LOGGER.info(() -> "Creating Jaeger tracer for '" + serviceName + "' configured with " + protocol + "://"
                     + host + ":" + port);
         } else {

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerDataPropagationProviderTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerDataPropagationProviderTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 class JaegerDataPropagationProviderTest {
 
-    private JaegerDataPropagationProvider provider = new JaegerDataPropagationProvider();
+    private final JaegerDataPropagationProvider provider = new JaegerDataPropagationProvider();
     
     @Test
     void dataPropagationTest() {
@@ -48,7 +48,6 @@ class JaegerDataPropagationProviderTest {
         Contexts.runInContext(context, () -> {
             assertThat(closed(scope), is(false));
             JaegerDataPropagationProvider.JaegerContext data = provider.data();
-            assertThat(closed(scope), is(true));
             provider.propagateData(data);
             assertThat(closed(data.scope()), is(false));
             provider.clearData(data);
@@ -97,7 +96,7 @@ class JaegerDataPropagationProviderTest {
 
     static class TestTracer implements Tracer {
 
-        private final Tracer delegate = JaegerTracerBuilder.create().serviceName("test-service").build();
+        private final Tracer delegate = JaegerTracerBuilder.create().serviceName("test-propagation").build();
 
         @Override
         public ScopeManager scopeManager() {

--- a/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerScopeManagerTest.java
+++ b/tracing/jaeger/src/test/java/io/helidon/tracing/jaeger/JaegerScopeManagerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tracing.jaeger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.opentracing.Span;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JaegerScopeManagerTest {
+
+    private final JaegerTracer tracer;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    JaegerScopeManagerTest() {
+        JaegerTracer.Builder builder = new JaegerTracer.Builder("test-scopes");
+        builder.withScopeManager(new JaegerScopeManager());
+        tracer = builder.build();
+    }
+
+    @BeforeEach
+    void clearScopes() {
+        JaegerScopeManager scopeManager = (JaegerScopeManager) tracer.scopeManager();
+        scopeManager.clearScopes();
+    }
+
+    @Test
+    void testScopeManager() {
+        JaegerScopeManager scopeManager = (JaegerScopeManager) tracer.scopeManager();
+        Span span = tracer.buildSpan("test-span").start();
+        JaegerScopeManager.ThreadScope scope = (JaegerScopeManager.ThreadScope) scopeManager.activate(span);
+        assertFalse(scope.isClosed());
+        assertEquals(scopeManager.activeSpan(), span);
+        scope.close();
+        assertNull(scopeManager.activeSpan());
+        assertTrue(scope.isClosed());
+    }
+
+    @Test
+    void testScopeManagerThreads() throws Exception {
+        JaegerScopeManager scopeManager = (JaegerScopeManager) tracer.scopeManager();
+        Span span = tracer.buildSpan("test-span").start();
+        JaegerScopeManager.ThreadScope scope = (JaegerScopeManager.ThreadScope) scopeManager.activate(span);
+        assertFalse(scope.isClosed());
+        assertEquals(scopeManager.activeSpan(), span);
+        executor.submit(scope::close).get(100, TimeUnit.MILLISECONDS);      // different thread
+        assertNull(scopeManager.activeSpan());
+        assertTrue(scope.isClosed());
+    }
+
+    @Test
+    void testScopeManagerStack() {
+        JaegerScopeManager scopeManager = (JaegerScopeManager) tracer.scopeManager();
+        Span span1 = tracer.buildSpan("test-span1").start();
+        JaegerScopeManager.ThreadScope scope1 = (JaegerScopeManager.ThreadScope) scopeManager.activate(span1);
+        assertEquals(scopeManager.activeSpan(), span1);
+        Span span2 = tracer.buildSpan("test-span2").start();
+        JaegerScopeManager.ThreadScope scope2 = (JaegerScopeManager.ThreadScope) scopeManager.activate(span2);
+        assertEquals(scopeManager.activeSpan(), span2);
+        scope2.close();
+        assertEquals(scopeManager.activeSpan(), span1);
+        scope1.close();
+        assertNull(scopeManager.activeSpan());
+    }
+}


### PR DESCRIPTION
Modified Jaeger logic to not close scopes before switching threads as this is problematic when running async operations (such as in auth) and continuing work on the request thread. Instead, provide our own implementation of `ScopeManager` that allows closing a scope from any thread, not just the one that created it. Some new tests.

Issue #3194

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>