### PR TITLE
Explicitly destroy bean instance obtained from CDI object

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -129,7 +129,10 @@ class RequestScopeHelper {
             requestContext.release();
             requestContext = null;
         }
-        requestScope = null;
+        if (requestScope != null) {
+            CDI.current().destroy(requestScope);
+            requestScope = null;
+        }
         requestController = null;
         injectionManager = null;
         state = State.CLEARED;


### PR DESCRIPTION
Explicitly destroy bean instance obtained from CDI object that is not in a normal scope. Not manually destroying these instances resulted in the context' map monotonically growing in size. See analysis and description in Issue #3199.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>