### PR TITLE
Upgrade jaeger-client to 1.6.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -66,7 +66,7 @@
         <version.lib.inject>1.0</version.lib.inject>
         <version.lib.interceptor-api>1.2.5</version.lib.interceptor-api>
         <version.lib.jackson>2.12.1</version.lib.jackson>
-        <version.lib.jaegertracing>1.1.0</version.lib.jaegertracing>
+        <version.lib.jaegertracing>1.6.0</version.lib.jaegertracing>
         <version.lib.jandex>2.1.1.Final</version.lib.jandex>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
         <version.lib.jaxb-core>2.3.0.1</version.lib.jaxb-core>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -1272,6 +1272,7 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- 4.x versions cause problems with native-image This is used by jaeger-client -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -118,6 +118,8 @@
         <version.lib.oci-java-sdk-objectstorage>1.37.2</version.lib.oci-java-sdk-objectstorage>
         <version.lib.ojdbc8>19.8.0.0</version.lib.ojdbc8>
         <version.lib.database.messaging>19.3.0.0</version.lib.database.messaging>
+        <version.lib.okhttp3>3.14.9</version.lib.okhttp3>
+        <version.lib.okio>1.17.5</version.lib.okio>
         <version.lib.opentracing>0.33.0</version.lib.opentracing>
         <version.lib.opentracing.grpc>0.2.1</version.lib.opentracing.grpc>
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
@@ -1269,6 +1271,23 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${version.lib.okhttp3}</version>
+            </dependency>
+            <dependency>
+                <!-- required for dependency convergence
+                used from both
+                com.squareup.okhttp3:mockwebserver:3.13.1
+                com.squareup.moshi:moshi:1.8.0
+                both referenced by
+                io.zipkin.zipkin2:zipkin-junit:2.12.5
+                -->
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${version.lib.okio}</version>
             </dependency>
             <!-- END OF Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,6 @@
         <version.lib.testng>6.13.1</version.lib.testng>
         <version.lib.zipkin.junit>2.12.5</version.lib.zipkin.junit>
         <version.lib.bedrock>5.0.11</version.lib.bedrock>
-        <version.lib.okhttp3>3.14.1</version.lib.okhttp3>
-        <version.lib.okio>1.17.2</version.lib.okio>
         <version.lib.awaitility>3.1.6</version.lib.awaitility>
         <version.lib.weld-junit>2.0.0.Final</version.lib.weld-junit>
         <version.lib.jmh>1.23</version.lib.jmh>
@@ -1066,23 +1064,6 @@
                         <artifactId>bsh</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${version.lib.okhttp3}</version>
-            </dependency>
-            <dependency>
-                <!-- required for dependency convergence
-                used from both
-                com.squareup.okhttp3:mockwebserver:3.13.1
-                com.squareup.moshi:moshi:1.8.0
-                both referenced by
-                io.zipkin.zipkin2:zipkin-junit:2.12.5
-                -->
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>${version.lib.okio}</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/tracing/jaeger/pom.xml
+++ b/tracing/jaeger/pom.xml
@@ -36,11 +36,16 @@
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
-        </dependency>
-        <dependency>
-            <!-- we need to enforce managed dependency, as otherwise we get a version 4.x that fails with native image -->
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <exclusions>
+                <!-- Bad dependency in libthrift introduced in 0.14.0. See bug
+                     https://github.com/apache/thrift/pull/2340
+                     Should be able to remove this once jaeger-client goes to libthrift 0.14.3
+                -->
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>


### PR DESCRIPTION
1. Upgrade jaeger-client to 1.6.0. This results in an upgrade of libthrift to 0.14.1 since it is a transitive dependency of jaeger-client
2. Move version management of okhttp3 and okio to `dependencies/pom.xml`
3. Exclude bad dependency that was introduced in libthrift 0.14.0. 

I have successfully built native-image for `tests/integration/native-image/mp-1` and run it.