### PR TITLE
New injection manager for Helidon

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -227,8 +227,10 @@ public class ServerCdiExtension implements Extension {
         if (jaxRsApplications.isEmpty()) {
             LOGGER.warning("There are no JAX-RS applications or resources. Maybe you forgot META-INF/beans.xml file?");
         } else {
-            // Creates a shared injection manager if more than one application
-            InjectionManager shared = jaxRsApplications.size() > 1 ? Injections.createInjectionManager() : null;
+            // Creates shared injection manager if multiple apps and "internal" property false
+            boolean singleManager = config.get("server.single-injection-manager").asBoolean().asOptional().orElse(false);
+            InjectionManager shared = jaxRsApplications.size() == 1 || singleManager ? null
+                    : Injections.createInjectionManager();
             jaxRsApplications.forEach(it -> addApplication(jaxRs, it, shared));
         }
     }

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -227,8 +227,9 @@ public class ServerCdiExtension implements Extension {
         if (jaxRsApplications.isEmpty()) {
             LOGGER.warning("There are no JAX-RS applications or resources. Maybe you forgot META-INF/beans.xml file?");
         } else {
-            InjectionManager injectionManager = Injections.createInjectionManager();
-            jaxRsApplications.forEach(it -> addApplication(jaxRs, it, injectionManager));
+            // Creates a shared injection manager if more than one application
+            InjectionManager shared = jaxRsApplications.size() > 1 ? Injections.createInjectionManager() : null;
+            jaxRsApplications.forEach(it -> addApplication(jaxRs, it, shared));
         }
     }
 

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter1.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter1.java
@@ -13,30 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+public class Filter1 implements ContainerResponseFilter {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("filter1", "");
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter2.java
@@ -13,30 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+public class Filter2 implements ContainerResponseFilter {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("filter2", "");
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication1.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication1.java
@@ -18,16 +18,18 @@ package io.helidon.tests.functional.multipleapps;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 /**
  * First application.
  */
 @ApplicationScoped
+@ApplicationPath("app1")
 public class GreetApplication1 extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource1.class);
+        return Set.of(GreetResource1.class, Filter1.class, SharedFilter.class);
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFilter.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFilter.java
@@ -13,30 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+0l
 /**
- * Second application.
+ * Shared filter that applies to both applications.
  */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+public class SharedFilter implements ContainerResponseFilter {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("sharedfilter", "");
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFilter.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFilter.java
@@ -19,7 +19,7 @@ package io.helidon.tests.functional.multipleapps;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-0l
+
 /**
  * Shared filter that applies to both applications.
  */

--- a/tests/functional/jax-rs-multiple-apps/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/functional/jax-rs-multiple-apps/src/main/resources/META-INF/microprofile-config.properties
@@ -16,3 +16,4 @@
 
 server.host=0.0.0.0
 app.greeting=Hello
+#server.single-injection-manager=true

--- a/tests/functional/jax-rs-multiple-apps/src/test/resources/logging.properties
+++ b/tests/functional/jax-rs-multiple-apps/src/test/resources/logging.properties
@@ -28,3 +28,6 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 
 # Component specific log levels
 AUDIT.level=FINEST
+
+io.helidon.webserver.jersey.level=FINEST
+io.helidon.microprofile.server.level=FINEST

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -72,7 +72,7 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
 
         HelidonInjectionManager(InjectionManager delegate, InjectionManager parent, ResourceConfig resourceConfig) {
             this.delegate = delegate;
-            this.parent = parent;
+            this.parent = parent != null ? parent : delegate;       // for testing
             this.resourceConfig = resourceConfig;
         }
 

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -42,7 +42,8 @@ import org.glassfish.jersey.server.ResourceConfig;
 /**
  * Overrides the injection manager factory from Jersey and provides a new implementation
  * of {@code InjectionManager}. This new injection manager will separate registrations
- * for those global (shared) providers and those returned by calling {@code getClasses}.
+ * for those global (shared) providers and those returned by calling {@code getClasses}
+ * and {@code getSingletons}.
  *
  * This separation is necessary to properly associate providers with JAX-RS applications,
  * of which there could be more than one in Helidon.
@@ -55,7 +56,6 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
     public InjectionManager create(Object parent) {
         InjectionManager result;
 
-        // If no parent, create manager single JAX-RS app or shared multiple JAX-RS apps
         if (parent == null) {
             result = super.create(null);
             LOGGER.finest(() -> "Creating injection manager " + result);

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -208,14 +208,20 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
 
         @Override
         public void inject(Object injectMe) {
-            delegate.inject(injectMe);
-            parent.inject(injectMe);
+            try {
+                delegate.inject(injectMe);
+            } catch (Throwable t) {
+                parent.inject(injectMe);
+            }
         }
 
         @Override
         public void inject(Object injectMe, String classAnalyzer) {
-            delegate.inject(injectMe, classAnalyzer);
-            parent.inject(injectMe, classAnalyzer);
+            try {
+                delegate.inject(injectMe, classAnalyzer);
+            } catch (Throwable t) {
+                parent.inject(injectMe, classAnalyzer);
+            }
         }
 
         @Override

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -17,19 +17,373 @@
 package io.helidon.webserver.jersey;
 
 import javax.annotation.Priority;
+import javax.inject.Singleton;
+import javax.ws.rs.core.Application;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory;
+import org.glassfish.jersey.internal.inject.Binder;
+import org.glassfish.jersey.internal.inject.Binding;
+import org.glassfish.jersey.internal.inject.ForeignDescriptor;
 import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.inject.InstanceBinding;
+import org.glassfish.jersey.internal.inject.ServiceHolder;
+import org.glassfish.jersey.server.ResourceConfig;
 
 /**
- * Overrides injection manager factory from Jersey to avoid creating a parent
- * injection manager and support cross-injection between JAX-RS applications.
+ * Overrides the injection manager factory from Jersey and provides a new implementation
+ * of {@code InjectionManager}. This new injection manager will separate registrations
+ * for those global (shared) providers and those returned by calling {@code getClasses}.
+ *
+ * This separation is necessary to properly associate providers with JAX-RS applications,
+ * of which there could be more than one in Helidon.
  */
 @Priority(11)   // overrides Jersey's
 public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactory {
 
     @Override
     public InjectionManager create(Object parent) {
-        return parent instanceof InjectionManager ? (InjectionManager) parent : super.create(parent);
+        if (parent == null) {
+            return super.create(null);
+        } else if (parent instanceof InjectionManagerWrapper) {
+            InjectionManagerWrapper wrapper = (InjectionManagerWrapper) parent;
+            return new HelidonInjectionManager(super.create(null),
+                    wrapper.injectionManager, wrapper.application);
+        } else {
+            throw new IllegalStateException("Invalid parent injection manager");
+        }
+    }
+
+    static class HelidonInjectionManager implements InjectionManager {
+        private static final Logger LOGGER = Logger.getLogger(HelidonInjectionManager.class.getName());
+
+        private Set<Class<?>> classes;
+        private Set<Object> singletons;
+        private final ResourceConfig resourceConfig;
+        private final InjectionManager parent;
+        private final InjectionManager delegate;
+
+        HelidonInjectionManager(InjectionManager delegate, InjectionManager parent, ResourceConfig resourceConfig) {
+            this.delegate = delegate;
+            this.parent = parent;
+            this.resourceConfig = resourceConfig;
+        }
+
+        @Override
+        public void completeRegistration() {
+            parent.completeRegistration();
+            delegate.completeRegistration();
+        }
+
+        @Override
+        public void shutdown() {
+            parent.shutdown();
+            delegate.shutdown();
+        }
+
+        /**
+         * Registers classes returned by {@code getClasses} in {@code delegate} and
+         * all other classes in {@code parent}. This is done to keep separation between
+         * global providers and those that are specific to an {@code Application} class.
+         *
+         * @param binding the binding to register.
+         */
+        @Override
+        public void register(Binding binding) {
+            if (returnedByApplication(binding)) {
+                delegate.register(binding);
+                LOGGER.info("register delegate " + toString(binding));
+            } else {
+                parent.register(binding);
+                LOGGER.info("register parent " + toString(binding));
+            }
+        }
+
+        @Override
+        public void register(Iterable<Binding> descriptors) {
+            descriptors.forEach(this::register);
+        }
+
+        @Override
+        public void register(Binder binder) {
+            binder.getBindings().forEach(this::register);
+        }
+
+        @Override
+        public void register(Object provider) throws IllegalArgumentException {
+            LOGGER.info("Register Object " + provider);
+            parent.register(provider);
+        }
+
+        @Override
+        public boolean isRegistrable(Class<?> clazz) {
+            return parent.isRegistrable(clazz);
+        }
+
+        @Override
+        public <T> T createAndInitialize(Class<T> createMe) {
+            return parent.createAndInitialize(createMe);
+        }
+
+        /**
+         * Collects all service holders, including those registered in the parent and the
+         * delegate.
+         *
+         * @param contractOrImpl contract or implementation class.
+         * @param qualifiers the qualifiers.
+         * @param <T> parameter type.
+         * @return list of service holders.
+         */
+        @Override
+        public <T> List<ServiceHolder<T>> getAllServiceHolders(Class<T> contractOrImpl, Annotation... qualifiers) {
+            List<ServiceHolder<T>> parentList = parent.getAllServiceHolders(contractOrImpl, qualifiers);
+            parentList.forEach(sh -> LOGGER.finest(() ->
+                    "getAllServiceHolders parent " + sh.getContractTypes().iterator().next()));
+            List<ServiceHolder<T>> delegateList = delegate.getAllServiceHolders(contractOrImpl, qualifiers);
+            delegateList.forEach(sh -> LOGGER.finest(() ->
+                    "getAllServiceHolders delegate " + sh.getContractTypes().iterator().next()));
+            return delegateList.size() == 0 ? parentList
+                    : Stream.concat(parentList.stream(), delegateList.stream()).collect(Collectors.toList());
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl, Annotation... qualifiers) {
+            T t = parent.getInstance(contractOrImpl, qualifiers);
+            return t != null ? t : delegate.getInstance(contractOrImpl, qualifiers);
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl, String classAnalyzer) {
+            T t = parent.getInstance(contractOrImpl, classAnalyzer);
+            return t != null ? t : delegate.getInstance(contractOrImpl, classAnalyzer);
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl) {
+            T t = parent.getInstance(contractOrImpl);
+            return t != null ? t : delegate.getInstance(contractOrImpl);
+        }
+
+        @Override
+        public <T> T getInstance(Type contractOrImpl) {
+            T t = parent.getInstance(contractOrImpl);
+            return t != null ? t : delegate.getInstance(contractOrImpl);
+        }
+
+        @Override
+        public Object getInstance(ForeignDescriptor foreignDescriptor) {
+            Object o = parent.getInstance(foreignDescriptor);
+            return o != null ? o : delegate.getInstance(foreignDescriptor);
+        }
+
+        @Override
+        public ForeignDescriptor createForeignDescriptor(Binding binding) {
+            return parent.createForeignDescriptor(binding);
+        }
+
+        @Override
+        public <T> List<T> getAllInstances(Type contractOrImpl) {
+            return parent.getAllInstances(contractOrImpl);
+        }
+
+        @Override
+        public void inject(Object injectMe) {
+            parent.inject(injectMe);
+        }
+
+        @Override
+        public void inject(Object injectMe, String classAnalyzer) {
+            parent.inject(injectMe, classAnalyzer);
+        }
+
+        @Override
+        public void preDestroy(Object preDestroyMe) {
+            parent.preDestroy(preDestroyMe);
+        }
+
+        /**
+         * Calls {@code getClasses} method and caches the result.
+         *
+         * @return set of classes returned from {@code Application} object.
+         */
+        private Set<Class<?>> getClasses() {
+            if (classes == null) {
+                Application application = resourceConfig.getApplication();
+                if (application != null) {
+                    classes = application.getClasses();
+                }
+            }
+            return classes != null ? classes : Collections.EMPTY_SET;
+        }
+
+        /**
+         * Calls {@code getSingletons} method and caches the result.
+         *
+         * @return set of singletons returned from {@code Application} object.
+         */
+        private Set<Object> getSingletons() {
+            if (singletons == null) {
+                Application application = resourceConfig.getApplication();
+                if (application != null) {
+                    singletons = application.getSingletons();
+                }
+            }
+            return singletons != null ? singletons : Collections.EMPTY_SET;
+        }
+
+        /**
+         * Convenience method to display a binding in logging messages.
+         *
+         * @param b the binding
+         * @return string representation of binding
+         */
+        private static String toString(Binding b) {
+            StringBuilder sb = new StringBuilder();
+            b.getContracts().forEach(c -> sb.append(" Cont " + c));
+            if (b.getImplementationType() != null) {
+                sb.append("\n\tImpl " + b.getImplementationType());
+            }
+            return sb.toString();
+        }
+
+        /**
+         * Checks if any of the contracts are returned by {@code getClasses()} or any of the
+         * instances are returned by {@code getSingletons}. For a provider such as a filter,
+         * the contracts will include both the class implementing the filter,
+         * returned by {@code getClasses()}, as well as the JAX-RS API filter interface.
+         *
+         * @param binding injection manager binding
+         * @return
+         */
+        private boolean returnedByApplication(Binding binding) {
+            if (Singleton.class.equals(binding.getScope())) {
+                try {
+                    InstanceBinding<?> instanceBinding = (InstanceBinding<?>) binding;
+                    return getSingletons().contains(instanceBinding.getService());
+                } catch (Exception e) {
+                    return false;
+                }
+            } else {
+                return binding.getContracts().stream().filter(
+                        c -> getClasses().contains(c)).findAny().isPresent();       // set intersection
+            }
+        }
+    }
+
+    /**
+     * A simple {@code InjectionManager} wrapper to keep track of a resource config.
+     * Methods in this class should never be called.
+     */
+    static class InjectionManagerWrapper implements InjectionManager {
+
+        private final InjectionManager injectionManager;
+        private final ResourceConfig application;
+
+        InjectionManagerWrapper(InjectionManager injectionManager, ResourceConfig application) {
+            this.injectionManager = injectionManager;
+            this.application = application;
+        }
+
+        @Override
+        public void completeRegistration() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void shutdown() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void register(Binding binding) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void register(Iterable<Binding> descriptors) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void register(Binder binder) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void register(Object provider) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public boolean isRegistrable(Class<?> clazz) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> T createAndInitialize(Class<T> createMe) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> List<ServiceHolder<T>> getAllServiceHolders(Class<T> contractOrImpl, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl, String classAnalyzer) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> contractOrImpl) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> T getInstance(Type contractOrImpl) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public Object getInstance(ForeignDescriptor foreignDescriptor) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public ForeignDescriptor createForeignDescriptor(Binding binding) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public <T> List<T> getAllInstances(Type contractOrImpl) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void inject(Object injectMe) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void inject(Object injectMe, String classAnalyzer) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void preDestroy(Object preDestroyMe) {
+            throw new UnsupportedOperationException("Not supported");
+        }
     }
 }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -16,9 +16,6 @@
 
 package io.helidon.webserver.jersey;
 
-import javax.annotation.Priority;
-import javax.inject.Singleton;
-import javax.ws.rs.core.Application;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -27,6 +24,10 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import javax.annotation.Priority;
+import javax.inject.Singleton;
+import javax.ws.rs.core.Application;
 
 import org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory;
 import org.glassfish.jersey.internal.inject.Binder;

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -53,9 +53,8 @@ import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
-
-import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.HelidonInjectionManager;
 import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.InjectionManagerWrapper;
+
 import io.opentracing.SpanContext;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -54,6 +54,8 @@ import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
 
+import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.HelidonInjectionManager;
+import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.InjectionManagerWrapper;
 import io.opentracing.SpanContext;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
@@ -147,7 +149,7 @@ public class JerseySupport implements Service {
         }
         this.handler = new JerseyHandler(builder.resourceConfig);
         this.appHandler = new ApplicationHandler(builder.resourceConfig, new ServerBinder(executorService),
-                builder.injectionManager);
+                new InjectionManagerWrapper(builder.injectionManager, builder.resourceConfig));
         this.container = new HelidonJerseyContainer(appHandler, builder.resourceConfig);
 
         // This configuration via system properties is for the Jersey Client API. Any

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -59,7 +59,6 @@ import io.opentracing.SpanContext;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.internal.inject.InjectionManager;
-import org.glassfish.jersey.internal.inject.Injections;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ContainerRequest;

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -59,6 +59,7 @@ import io.opentracing.SpanContext;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.internal.MapPropertiesDelegate;
 import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.inject.Injections;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ContainerRequest;
@@ -148,7 +149,9 @@ public class JerseySupport implements Service {
         }
         this.handler = new JerseyHandler(builder.resourceConfig);
         this.appHandler = new ApplicationHandler(builder.resourceConfig, new ServerBinder(executorService),
-                new InjectionManagerWrapper(builder.injectionManager, builder.resourceConfig));
+                builder.injectionManager != null
+                        ? new InjectionManagerWrapper(builder.injectionManager, builder.resourceConfig)
+                        : Injections.createInjectionManager());     // single JAX-RS application
         this.container = new HelidonJerseyContainer(appHandler, builder.resourceConfig);
 
         // This configuration via system properties is for the Jersey Client API. Any

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -149,9 +149,8 @@ public class JerseySupport implements Service {
         }
         this.handler = new JerseyHandler(builder.resourceConfig);
         this.appHandler = new ApplicationHandler(builder.resourceConfig, new ServerBinder(executorService),
-                builder.injectionManager != null
-                        ? new InjectionManagerWrapper(builder.injectionManager, builder.resourceConfig)
-                        : Injections.createInjectionManager());     // single JAX-RS application
+                builder.injectionManager == null ? null         // single JAX-RS application
+                        : new InjectionManagerWrapper(builder.injectionManager, builder.resourceConfig));
         this.container = new HelidonJerseyContainer(appHandler, builder.resourceConfig);
 
         // This configuration via system properties is for the Jersey Client API. Any

--- a/webserver/jersey/src/main/java/module-info.java
+++ b/webserver/jersey/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module io.helidon.webserver.jersey {
     requires java.logging;
     requires hk2.api;
     requires io.netty.buffer;
+    requires jersey.common;
 
     exports io.helidon.webserver.jersey;
 


### PR DESCRIPTION
New implementation of a Jersey injection manager to handle separation of JAX-RS applications. The new injection manager uses two underlying managers: one that is shared among all applications and one to register classes and singletons returned by the application. For a Helidon application that defines N JAX-RS applications, there will be N+1 of these _core_ managers. 

Lookups and injections are carried out by first consulting the shared manager and then the one for the application. This may potentially add some runtime overhead that would need to be tested using our micro-benchmarks.

PR #3166