### PR TITLE
Default to Epoll if available

### DIFF
--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -160,6 +160,11 @@
             <artifactId>netty-handler</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
             <scope>test</scope>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/NettyTransport.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/NettyTransport.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.webserver;
+
+import java.util.Optional;
+
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * Base {@link Transport} for Netty.
+ */
+public abstract class NettyTransport implements Transport {
+
+	@Override
+	public boolean isAvailableFor(WebServer webserver) {
+			return webserver instanceof NettyWebServer;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> Optional<T> createTransportArtifact(Class<T> artifactType,
+																								 String artifactName,
+																								 ServerConfiguration config) {
+			if (EventLoopGroup.class.isAssignableFrom(artifactType)) {
+					switch (artifactName) {
+					case "bossGroup":
+							return Optional.of((T) eventLoopGroup(config.sockets().size()));
+					case "workerGroup":
+							return Optional.of((T) eventLoopGroup(Math.max(0, config.workersCount())));
+					default:
+					}
+			} else if (ChannelFactory.class.isAssignableFrom(artifactType)) {
+					switch (artifactName) {
+					case "serverChannelFactory":
+							return Optional.of((T) channelFactory());
+					default:
+					}
+			}
+			return Optional.empty();
+	}
+
+	/**
+	 * Create a new instance for the given number of threads.
+	 *
+	 * @param nThreads the number of threads.
+	 * @return event loop group instance.
+	 */
+	protected abstract EventLoopGroup eventLoopGroup(int nThreads);
+
+	/**
+	 * @return channel factory instance.
+	 */
+	protected abstract ChannelFactory<? extends ServerChannel> channelFactory();
+
+	/**
+	 * Transport that leverages NIO Selector.
+	 */
+	static class NioTransport extends NettyTransport {
+
+		@Override
+		protected EventLoopGroup eventLoopGroup(int nThreads) {
+			return new NioEventLoopGroup(nThreads);
+		}
+
+		@Override
+		protected ChannelFactory<? extends ServerChannel> channelFactory() {
+			return NioServerSocketChannel::new;
+		}
+	}
+
+	/**
+	 * Transport that leverages Netty Epoll which should reap better performance than NIO.
+	 */
+	static class EpollTransport extends NettyTransport {
+
+		@Override
+		public boolean isAvailableFor(WebServer webserver) {
+			return super.isAvailableFor(webserver) && Epoll.isAvailable();
+		}
+
+		@Override
+		protected EventLoopGroup eventLoopGroup(int nThreads) {
+			return new EpollEventLoopGroup(nThreads);
+		}
+
+		@Override
+		protected ChannelFactory<? extends ServerChannel> channelFactory() {
+			return EpollServerSocketChannel::new;
+		}
+	}
+}

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -353,7 +353,6 @@ public interface WebServer {
         // for backward compatibility
         @SuppressWarnings("deprecation")
         private ServerConfiguration explicitConfig;
-        private Transport transport;
         private MessageBodyReaderContext readerContext;
         private MessageBodyWriterContext writerContext;
 

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -39,6 +39,7 @@ module io.helidon.webserver {
     requires io.netty.common;
     requires io.netty.buffer;
     requires io.netty.codec.http2;
+    requires io.netty.transport.epoll;
 
     exports io.helidon.webserver;
 }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/CompressionTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/CompressionTest.java
@@ -16,7 +16,7 @@
 
 package io.helidon.webserver;
 
-import java.util.Arrays;;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/webserver/webserver/src/test/java/io/helidon/webserver/NettyWebServerTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/NettyWebServerTest.java
@@ -16,6 +16,17 @@
 
 package io.helidon.webserver;
 
+import static io.helidon.config.testing.OptionalMatcher.present;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -30,23 +41,15 @@ import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.Http;
-import io.helidon.common.reactive.Multi;
-
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 
-import static io.helidon.config.testing.OptionalMatcher.present;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.core.AllOf.allOf;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assertions.fail;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.Http;
+import io.helidon.common.reactive.Multi;
+import io.helidon.webserver.NettyTransport.EpollTransport;
 
 /**
  * The NettyWebServerTest.
@@ -267,5 +270,14 @@ public class NettyWebServerTest {
                 .build();
 
         assertThat(webServer.configuration().namedSocket("matched"), present());
+    }
+
+    @Test
+    @EnabledIf("io.netty.channel.epoll.Epoll#isAvailable")
+    void epoll() {
+        var  webServer = (NettyWebServer) WebServer.create(
+                routing((bareRequest, bareResponse) -> { }));
+
+        assertThat(webServer.transport(), instanceOf(EpollTransport.class));
     }
 }


### PR DESCRIPTION
Open for feedback:
* As per the issue, defaults to Epoll if available,
* Unit test is conditional based on if Epoll is available so not to break on Mac or Windows,
* An `abstract` `NettyTransport` which gives scope to add a `io_uring` (#2670) implementation at a later date with few changes.