### PR TITLE
Upgrade brave-opentracing to 1.0.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -41,7 +41,7 @@
         <version.lib.animal-sniffer>1.18</version.lib.animal-sniffer>
         <version.lib.annotation-api>1.3.5</version.lib.annotation-api>
         <version.lib.apache-httpclient>4.5.13</version.lib.apache-httpclient>
-        <version.lib.brave-opentracing>0.35.0</version.lib.brave-opentracing>
+        <version.lib.brave-opentracing>1.0.0</version.lib.brave-opentracing>
         <version.lib.cdi-api>2.0.2</version.lib.cdi-api>
         <!-- commons-codec is for dependency convergence only -->
         <version.lib.commons-codec>1.15</version.lib.commons-codec>

--- a/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpentraceableClientFilterTest.java
+++ b/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpentraceableClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpentraceableClientFilterTest.java
+++ b/tracing/tests/it-tracing-client-zipkin/src/test/java/io/helidon/tracing/tests/it1/OpentraceableClientFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.tracing.jersey.client.ClientTracingFilter;
 
-import brave.internal.HexCodec;
+import brave.internal.codec.HexCodec;
 import brave.opentracing.BraveSpanContext;
 import brave.propagation.TraceContext;
 import io.opentracing.Span;


### PR DESCRIPTION
Upgrades brave-opentracing to 1.0.0.

I have successfully built native-image for `tests/integration/native-image/mp-1` and run it.