### PR TITLE
Upgrade typesafe-config to 1.4.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -134,7 +134,7 @@
         <version.lib.smallrye-openapi>1.2.3</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.27</version.lib.snakeyaml>
         <version.lib.transaction-api>1.3.3</version.lib.transaction-api>
-        <version.lib.typesafe-config>1.4.0</version.lib.typesafe-config>
+        <version.lib.typesafe-config>1.4.1</version.lib.typesafe-config>
         <version.lib.tyrus>1.17</version.lib.tyrus>
         <version.lib.validation-api>2.0.2</version.lib.validation-api>
         <version.lib.websockets-api>1.1.2</version.lib.websockets-api>


### PR DESCRIPTION
Upgrade typesafe-config to 1.4.1 

I have successfully built native-image for tests/integration/native-image/mp-1 and run it.