### PR TITLE
Metrics and routings

### DIFF
--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
@@ -95,12 +95,12 @@ public class MicrometerSupport extends HelidonRestServiceSupport {
 
     @Override
     public void update(Routing.Rules rules) {
-        configureEndpoint(rules);
+        configureEndpoint(rules, rules);
     }
 
     @Override
-    protected void postConfigureEndpoint(Routing.Rules rules) {
-        rules
+    protected void postConfigureEndpoint(Routing.Rules defaultRules, Routing.Rules serviceEndpointRoutingRules) {
+        defaultRules
                 .any(new MetricsContextHandler(meterRegistryFactory.meterRegistry()))
                 .get(context(), this::getOrOptions)
                 .options(context(), this::getOrOptions);

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -379,22 +379,26 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
      * {@link #update(io.helidon.webserver.Routing.Rules)} (e.g. you should not
      * use both, as otherwise you would register the endpoint twice)
      *
-     * @param rules routing rules (also accepts
-     * {@link io.helidon.webserver.Routing.Builder}
+     * @param defaultRules routing rules for default routing (also accepts {@link io.helidon.webserver.Routing.Builder})
+     * @param serviceEndpointRoutingRules possibly different rules for the metrics endpoint routing
      */
     @Override
-    protected void postConfigureEndpoint(Routing.Rules rules) {
+    protected void postConfigureEndpoint(Routing.Rules defaultRules, Routing.Rules serviceEndpointRoutingRules) {
         Registry base = rf.getARegistry(MetricRegistry.Type.BASE);
         Registry vendor = rf.getARegistry(MetricRegistry.Type.VENDOR);
         Registry app = rf.getARegistry(MetricRegistry.Type.APPLICATION);
 
         // register the metric registry and factory to be available to all
-        rules.any(new MetricsContextHandler(app, rf));
+        MetricsContextHandler metricsContextHandler = new MetricsContextHandler(app, rf);
+        defaultRules.any(metricsContextHandler);
+        if (defaultRules != serviceEndpointRoutingRules) {
+            serviceEndpointRoutingRules.any(metricsContextHandler);
+        }
 
-        configureVendorMetrics(null, rules);
+        configureVendorMetrics(null, defaultRules);
 
         // routing to root of metrics
-        rules.get(context(), (req, res) -> getMultiple(req, res, base, app, vendor))
+        serviceEndpointRoutingRules.get(context(), (req, res) -> getMultiple(req, res, base, app, vendor))
                 .options(context(), (req, res) -> optionsMultiple(req, res, base, app, vendor));
 
         // routing to each scope
@@ -402,7 +406,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
                 .forEach(registry -> {
                     String type = registry.type();
 
-                    rules.get(context() + "/" + type, (req, res) -> getAll(req, res, registry))
+                    serviceEndpointRoutingRules.get(context() + "/" + type, (req, res) -> getAll(req, res, registry))
                             .get(context() + "/" + type + "/{metric}", (req, res) -> getByName(req, res, registry))
                             .options(context() + "/" + type, (req, res) -> optionsAll(req, res, registry))
                             .options(context() + "/" + type + "/{metric}", (req, res) -> optionsOne(req, res, registry));
@@ -415,7 +419,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
      * {@link io.helidon.webserver.Routing.Builder#register(io.helidon.webserver.Service...)}
      * rather than calling this method directly. If multiple sockets (and
      * routings) should be supported, you can use the
-     * {@link #configureEndpoint(io.helidon.webserver.Routing.Rules)}, and
+     * {@link #configureEndpoint(io.helidon.webserver.Routing.Rules, io.helidon.webserver.Routing.Rules)}, and
      * {@link #configureVendorMetrics(String, io.helidon.webserver.Routing.Rules)}
      * methods.
      *
@@ -423,7 +427,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
      */
     @Override
     public void update(Routing.Rules rules) {
-        configureEndpoint(rules);
+        configureEndpoint(rules, rules);
     }
 
     private static KeyPerformanceIndicatorSupport.Context kpiContext(ServerRequest request) {

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -94,6 +94,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>**/HelloWorldAsyncResponseTest.java</exclude>
+                                <exclude>**/TestMetricsOnOwnSocket.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -106,6 +107,7 @@
                         <configuration>
                             <includes>
                                 <include>**/HelloWorldAsyncResponseTest.java</include>
+                                <include>**/TestMetricsOnOwnSocket.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricsOnOwnSocket.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestMetricsOnOwnSocket.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest()
+// Set up the metrics endpoint on its own socket
+@AddConfig(key = "server.sockets.0.name", value = "metrics")
+@AddConfig(key = "server.sockets.0.port", value = "8082")
+@AddConfig(key = "server.sockets.0.bind-address", value = "0.0.0.0")
+
+@AddConfig(key = "metrics.routing", value = "metrics")
+@AddConfig(key = "metrics.key-performance-indicators.extended", value = "true")
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TestMetricsOnOwnSocket {
+
+    private static Invocation metricsInvocation = ClientBuilder.newClient()
+            .target("http://localhost:8082/metrics/vendor")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .buildGet();
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Order(0)
+    @Test
+    void checkMetricsBeforeRequests() {
+
+        int load = getRequestsLoadCount("Pre-test");
+        assertThat("Pre-test load count", load, is(0));
+
+    }
+
+    @Order(1)
+    @Test
+    void checkMessageFromDefaultRouting() {
+        try (Response r = webTarget
+                .path("helloworld")
+                .request(MediaType.TEXT_PLAIN_TYPE)
+                .get()) {
+
+            assertThat("Response code getting greeting", r.getStatus(), is(Http.Status.OK_200.code()));
+        }
+    }
+
+    @Order(2)
+    @Test
+    void checkMetricsAfterGet() {
+        int load = getRequestsLoadCount("Post-test");
+        assertThat("Post-test load count", load, is(1));
+
+    }
+
+    private static int getRequestsLoadCount(String descr) {
+        try (Response r = metricsInvocation.invoke()) {
+            assertThat(descr + " metrics sampling response", r.getStatus(), is(Http.Status.OK_200.code()));
+
+            JsonObject metrics = r.readEntity(JsonObject.class);
+            assertThat("Check for requests.load", metrics.containsKey("requests.load"), is(true));
+            JsonObject load = metrics.getJsonObject("requests.load");
+            assertThat("JSON requests.load contains count", load.containsKey("count"), is(true));
+
+            return load.getInt("count");
+        }
+    }
+}

--- a/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/HelidonRestCdiExtension.java
+++ b/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/HelidonRestCdiExtension.java
@@ -46,7 +46,7 @@ import javax.enterprise.inject.spi.ProcessProducerMethod;
 import javax.interceptor.Interceptor;
 
 import io.helidon.config.Config;
-import io.helidon.config.ConfigValue;
+import io.helidon.microprofile.server.RoutingBuilders;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.servicecommon.rest.HelidonRestServiceSupport;
 import io.helidon.webserver.Routing;
@@ -239,23 +239,11 @@ public abstract class HelidonRestCdiExtension<T extends HelidonRestServiceSuppor
         Config config = ((Config) ConfigProvider.getConfig()).get(configPrefix);
         serviceSupport = serviceSupportFactory.apply(config);
 
-        ConfigValue<String> routingNameConfig = config.get("routing")
-                .asString();
-        Routing.Builder defaultRouting = server.serverRoutingBuilder();
+        RoutingBuilders routingBuilders = RoutingBuilders.create(config);
 
-        Routing.Builder endpointRouting = defaultRouting;
+        serviceSupport.configureEndpoint(routingBuilders.defaultRoutingBuilder(), routingBuilders.routingBuilder());
 
-        if (routingNameConfig.isPresent()) {
-            String routingName = routingNameConfig.get();
-            // support for overriding this back to default routing using config
-            if (!"@default".equals(routingName)) {
-                endpointRouting = server.serverNamedRoutingBuilder(routingName);
-            }
-        }
-
-        serviceSupport.configureEndpoint(endpointRouting);
-
-        return defaultRouting;
+        return routingBuilders.defaultRoutingBuilder();
     }
 
     protected T serviceSupport() {


### PR DESCRIPTION
Resolves #3239 

Two general issues:

1. The earlier refactoring which added `HelidonRestServiceSupport` in `service-common/rest` and `HelidonRestCdiExtendion` in `service-common/rest-cdi` failed to account fully for the fact that the service endpoint (such as `/metrics`) can be on a different socket from the normal traffic that is to be measured. The original refactoring passed the _service endpoint_ routing rules into `MetricsSupport` which then used that one set of rules both for setting up the `/metrics` endpoint and for adding a handler to actually measure the traffic. The result, as observed in the bug, was that only the traffic on the metrics socket was measured and, therefore, reported by the `/metrics` endpoint responses. This worked OK when the endpoint was on the default socket, but not when the endpoint and the regular traffic were on different sockets.//The fix: generalize the refactoring so both the default rules and the service endpoint rules are passed into `HelidonRestServiceSupport#postConfigureEndpoint` — MetricsSupport#postConfigureEndpoint` in this particular case. Also update `MetricsSupport` to use the different sets of rules correctly in establishing the `/metrics` endpoint and in setting up the handler to measure the normal traffic.//Note that this fix changes the signature of the public method `HelidonRestServiceSupport#configureEndpoint`. Although users are probably not extending this class themselves, it’s possible so these changes keep the original signature marked as `@Deprecated`.
2. The earlier enhancement to support extended KPI metrics changed `ServerCdiExtension` in `microprofile/server` so that it would register a handler, early in the request handler chain, to add to each request’s context a `KeyPerformanceIndicatorContext.DeferrableRequestContext`. This context allows downstream handlers to distinguish between receipt of a request and the start of processing of the request. Related changes to the `JerseySupport` class explicitly recorded the start of processing of the request.

But this did not account for the case, as with service endpoints like metrics, where the downstream handler chain might not include a handler that dealt with the start of processing distinctly from the receipt of the request. The incorrect result is that the extended KPI metrics would decrement the in-flight request measurement (this happens in the handler which is added by `MetricsSupport#configureVendorMetrics`) which had never been incremented by any handler. If you access the `/metrics` endpoint several times in a row, you would see the reported in-flight requests values decrease and perhaps become negative.

This PR repairs that problem. The `DeferrableRequestContext` now records the “start” time when the request is received and then overwrites it when a handler explicitly marks the start of processing (if that, in fact, occurs). Then, the end-of-processing code checks to see whether the context was ever explicitly marked as started. If not, it mimics a start to update the appropriate metrics before running the end-of-processing logic. This provides as close an approximation as we can to the actual processing time given the absence of a handler that would do better.
