### PR TITLE
Avoid exemplar labels such as {}

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExemplarServiceManager.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExemplarServiceManager.java
@@ -18,11 +18,11 @@ package io.helidon.metrics;
 
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.StringJoiner;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import io.helidon.common.serviceloader.HelidonServiceLoader;
 
@@ -41,9 +41,15 @@ class ExemplarServiceManager {
             : () -> EXEMPLAR_SERVICES.stream()
                         .map(ExemplarService::label)
                         .filter(Predicate.not(String::isBlank))
-                        .collect(Collectors.joining(",", "{", "}"));
+                        .collect(ExemplarServiceManager::labelsStringJoiner, StringJoiner::add, StringJoiner::merge)
+                        .toString();
 
     private ExemplarServiceManager() {
+    }
+
+    private static StringJoiner labelsStringJoiner() {
+        // A StringJoiner that suppresses the prefix and suffix if no strings were added
+        return new StringJoiner(",", "{", "}").setEmptyValue("");
     }
 
     /**


### PR DESCRIPTION
Resolves #3230

There can be cases in which a tracing span context exists but returns an empty label/trace ID. 

In such cases, Helidon would create an exemplar with labels `{}` (normally they look like `{trace_id="xyz"}` and that would cause errors in Prometheus.

This PR detects when none of the exemplar services (only tracing provides them currently) delivers a non-empty label, and in that case suppresses the empty label expression.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>