### PR TITLE
Use MP config instead of Config.create() in MP components.

### DIFF
--- a/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MeterRegistryProducer.java
+++ b/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MeterRegistryProducer.java
@@ -21,10 +21,12 @@ import javax.enterprise.inject.Produces;
 
 import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
+import io.helidon.config.mp.MpConfig;
 import io.helidon.integrations.micrometer.MeterRegistryFactory;
 import io.helidon.integrations.micrometer.MicrometerSupport;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 @ApplicationScoped
 class MeterRegistryProducer {
@@ -55,7 +57,7 @@ class MeterRegistryProducer {
     }
 
     private static MicrometerSupport createMicrometerSupport() {
-        Config micrometerConfig = Config.create().get(CONFIG_KEY);
+        Config micrometerConfig = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(CONFIG_KEY);
         MeterRegistryFactory factory = MeterRegistryFactory.getInstance(
                 MeterRegistryFactory.builder()
                     .config(micrometerConfig));

--- a/integrations/micrometer/cdi/src/main/java/module-info.java
+++ b/integrations/micrometer/cdi/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module io.helidon.integrations.micrometer.cdi {
     requires io.helidon.config;
     requires io.helidon.webserver.cors;
     requires io.helidon.integrations.micrometer;
+    requires io.helidon.config.mp;
 
     requires micrometer.core;
     requires micrometer.registry.prometheus;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 
 import io.helidon.common.configurable.ScheduledThreadPoolSupplier;
 import io.helidon.common.configurable.ThreadPoolSupplier;
+import io.helidon.config.mp.MpConfig;
 import io.helidon.faulttolerance.FaultTolerance;
 
 import org.eclipse.microprofile.config.Config;
@@ -270,7 +271,7 @@ public class FaultToleranceExtension implements Extension {
         }
 
         // Initialize executors for MP FT - default size of 16
-        io.helidon.config.Config config = io.helidon.config.Config.create();
+        io.helidon.config.Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig());
         scheduledThreadPoolSupplier = ScheduledThreadPoolSupplier.builder()
                 .threadNamePrefix("ft-mp-schedule-")
                 .corePoolSize(16)

--- a/microprofile/fault-tolerance/src/main/java/module-info.java
+++ b/microprofile/fault-tolerance/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.helidon.microprofile.faulttolerance {
     requires io.helidon.microprofile.config;
     requires io.helidon.microprofile.server;
     requires io.helidon.microprofile.metrics;
+    requires io.helidon.config.mp;
 
     requires jakarta.enterprise.cdi.api;
 

--- a/microprofile/grpc/server/src/main/java/module-info.java
+++ b/microprofile/grpc/server/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ module io.helidon.microprofile.grpc.server {
     requires transitive io.helidon.microprofile.grpc.core;
     requires io.helidon.common.serviceloader;
     requires io.helidon.microprofile.server;
+    requires io.helidon.config.mp;
 
     requires transitive io.grpc;
     requires grpc.protobuf.lite;


### PR DESCRIPTION
Backport to 2.3.3 for #3290 
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>