### PR TITLE
Config now registered before container initialization.

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/Server.java
@@ -173,7 +173,7 @@ public interface Server {
         public Server build() {
             STARTUP_LOGGER.entering(Builder.class.getName(), "build");
 
-            // configuration must be initialize before we start the container
+            // configuration must be initialized before we start the container
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
             if (null == config) {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -30,6 +30,10 @@ import io.helidon.microprofile.cdi.HelidonContainer;
  * Server to handle lifecycle of microprofile implementation.
  */
 public class ServerImpl implements Server {
+    private static final Logger LOGGER = Logger.getLogger(Server.class.getName());
+    // this constant is to ensure we initialize Helidon CDI at build time
+    private static final HelidonContainer CONTAINER = HelidonContainer.instance();
+
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
 
     private final HelidonContainer helidonContainer = HelidonContainer.instance();
@@ -41,6 +45,7 @@ public class ServerImpl implements Server {
 
     ServerImpl(Builder builder) {
         this.container = (SeContainer) CDI.current();
+        LOGGER.finest(() -> "Container context id: " + CONTAINER.context().id());
 
         InetAddress listenHost;
         if (null == builder.host()) {


### PR DESCRIPTION
Resolves #3289 

When config was set on `Server.builder()`, the container was initialized first, and only then was the config set as the MP wide config instance. This PR changes the ordering, so the MP configuration is first set, and only then the container gets initialized.

Note that when building native image the container is initialized immediately (as the build method is never called) as part of our native image process. This means that configuration at build time would differ.

It is still recommended to use default configuration or MP meta configuration when using Helidon MP with native image!

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>