### PR TITLE
Use MP OpenAPI 1.2 and adapt to SmallRye OpenAPI 2.0.26 which supports it

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -104,7 +104,7 @@
         <version.lib.microprofile-health>2.2</version.lib.microprofile-health>
         <version.lib.microprofile-jwt>1.1.1</version.lib.microprofile-jwt>
         <version.lib.microprofile-metrics-api>2.3.2</version.lib.microprofile-metrics-api>
-        <version.lib.microprofile-openapi-api>1.1.2</version.lib.microprofile-openapi-api>
+        <version.lib.microprofile-openapi-api>1.2</version.lib.microprofile-openapi-api>
         <version.lib.microprofile-reactive-messaging-api>1.0</version.lib.microprofile-reactive-messaging-api>
         <version.lib.microprofile-reactive-streams-operators-api>1.0.1</version.lib.microprofile-reactive-streams-operators-api>
         <version.lib.microprofile-reactive-streams-operators-core>1.0.1</version.lib.microprofile-reactive-streams-operators-core>
@@ -131,7 +131,7 @@
         <version.lib.reactive-streams-tck>1.0.3</version.lib.reactive-streams-tck>
         <version.lib.reactivestreams>1.0.3</version.lib.reactivestreams>
         <version.lib.slf4j>1.7.30</version.lib.slf4j>
-        <version.lib.smallrye-openapi>1.2.3</version.lib.smallrye-openapi>
+        <version.lib.smallrye-openapi>2.0.26</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.27</version.lib.snakeyaml>
         <version.lib.transaction-api>1.3.3</version.lib.transaction-api>
         <version.lib.typesafe-config>1.4.1</version.lib.typesafe-config>
@@ -741,6 +741,7 @@
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api</artifactId>
                 <version>${version.lib.smallrye-openapi}</version>
+                <type>pom</type>
             </dependency>
 
             <!-- Integrations related -->

--- a/microprofile/openapi/pom.xml
+++ b/microprofile/openapi/pom.xml
@@ -122,6 +122,16 @@
             <artifactId>snakeyaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.enterprise.inject.spi.CDI;
@@ -173,17 +174,30 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPIBuil
          * Create an OpenAPIConfig instance to limit scanning to this app's classes by overriding any inclusions of classes or
          * packages specified in the config with our own inclusions based on this app's classes.
          */
-        OpenApiConfigImpl openAPIFilteringConfig = new OpenApiConfigImpl(mpConfig);
-        Set<String> scanClasses = openAPIFilteringConfig.scanClasses();
-        scanClasses.clear();
-        openAPIFilteringConfig.scanPackages().clear();
+        Pattern appRelatedClassesPattern = Pattern.compile(
+                appRelatedClassesToScan.stream()
+                        .map(Class::getName)
+                        .map(Pattern::quote)
+                        .collect(Collectors.joining("|")));
 
-        appRelatedClassesToScan.stream()
-                .map(Class::getName)
-                .forEach(scanClasses::add);
-
-        FilteredIndexView result = new FilteredIndexView(singleIndexViewSupplier.get(), openAPIFilteringConfig);
+        FilteredIndexView result = new FilteredIndexView(singleIndexViewSupplier.get(),
+                new FilteringOpenApiConfigImpl(mpConfig, appRelatedClassesPattern));
         return result;
+    }
+
+    private static class FilteringOpenApiConfigImpl extends OpenApiConfigImpl {
+
+        private final Pattern appRelatedClassNamesToScan;
+
+        FilteringOpenApiConfigImpl(Config config, Pattern appRelatedClassNamesToScan) {
+            super(config);
+            this.appRelatedClassNamesToScan = appRelatedClassNamesToScan;
+        }
+
+        @Override
+        public Pattern scanClasses() {
+            return appRelatedClassNamesToScan;
+        }
     }
 
     /**

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -178,10 +178,19 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPIBuil
                 appRelatedClassesToScan.stream()
                         .map(Class::getName)
                         .map(Pattern::quote)
-                        .collect(Collectors.joining("|")));
+                        .map(name -> "^" + name + "$") // avoid false prefix matches
+                        .collect(Collectors.joining("|", "(", ")")));
 
         FilteredIndexView result = new FilteredIndexView(singleIndexViewSupplier.get(),
                 new FilteringOpenApiConfigImpl(mpConfig, appRelatedClassesPattern));
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, String.format("FilteredIndexView for %n"
+                    + "  application classes %s%n"
+                    + "  will use pattern: %s%n"
+                    + "  with known classes %s",
+                    appRelatedClassesToScan, appRelatedClassesPattern, result.getKnownClasses()));
+        }
+
         return result;
     }
 
@@ -225,7 +234,7 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPIBuil
 
     @Override
     protected Supplier<List<? extends IndexView>> indexViewsSupplier() {
-        return () -> buildPerAppFilteredIndexViews();
+        return this::buildPerAppFilteredIndexViews;
     }
 
     @Override

--- a/microprofile/openapi/src/main/java/module-info.java
+++ b/microprofile/openapi/src/main/java/module-info.java
@@ -22,7 +22,7 @@ import io.helidon.microprofile.openapi.OpenApiCdiExtension;
 module io.helidon.microprofile.openapi {
     requires java.logging;
     
-    requires smallrye.open.api;
+    requires smallrye.open.api.core;
 
     requires microprofile.config.api;
     requires io.helidon.microprofile.server;

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/BasicServerTest.java
@@ -16,61 +16,63 @@
  */
 package io.helidon.microprofile.openapi;
 
-import java.net.HttpURLConnection;
 import java.util.Map;
 
-import io.helidon.common.http.MediaType;
-import io.helidon.config.Config;
-import io.helidon.microprofile.openapi.other.TestApp2;
-import io.helidon.microprofile.server.Server;
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import io.helidon.openapi.OpenAPISupport;
+
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test that MP OpenAPI support works when retrieving the OpenAPI document
  * from the server's /openapi endpoint.
  */
+@HelidonTest
+@AddBean(TestApp.class)
+@AddBean(TestApp3.class)
 public class BasicServerTest {
-
-    private static final String OPENAPI_PATH = "/openapi";
-
-    private static Server server;
-
-    private static HttpURLConnection cnx;
 
     private static Map<String, Object> yaml;
 
+    @Inject
+    WebTarget webTarget;
+
+    private static Map<String, Object> retrieveYaml(WebTarget webTarget) {
+        try (Response response = webTarget
+                .path(OpenAPISupport.DEFAULT_WEB_CONTEXT)
+                .request(OpenAPISupport.DEFAULT_RESPONSE_MEDIA_TYPE.toString())
+                .get()) {
+            assertThat("Fetch of OpenAPI document from server status", response.getStatus(),
+                    is(equalTo(Http.Status.OK_200.code())));
+            String yamlText = response.readEntity(String.class);
+            return new Yaml().load(yamlText);
+        }
+    }
+
+    private static Map<String, Object> yaml(WebTarget webTarget) {
+        if (yaml == null) {
+            yaml = retrieveYaml(webTarget);
+        }
+        return yaml;
+    }
+
+    private Map<String, Object> yaml() {
+        return yaml(webTarget);
+    }
+
     public BasicServerTest() {
-    }
-
-    /**
-     * Start the server to run the test app and read the response from the
-     * /openapi endpoint into a map that all tests can use.
-     *
-     * @throws Exception in case of error reading the response as yaml
-     */
-    @BeforeAll
-    public static void startServer() throws Exception {
-        server = TestUtil.startServer(Config.create(), TestApp.class, TestApp3.class);
-        cnx = TestUtil.getURLConnection(
-                server.port(),
-                "GET",
-                OPENAPI_PATH,
-                MediaType.APPLICATION_OPENAPI_YAML);
-
-        yaml = TestUtil.yamlFromResponse(cnx);
-    }
-
-    /**
-     * Stop the server.
-     */
-    @AfterAll
-    public static void stopServer() {
-        TestUtil.cleanup(server, cnx);
     }
 
     /**
@@ -79,16 +81,18 @@ public class BasicServerTest {
      *
      * @throws Exception in case of errors reading the HTTP response
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void simpleTest() throws Exception {
-        String goSummary = TestUtil.fromYaml(yaml, "paths./testapp/go.get.summary", String.class);
-        assertEquals(TestApp.GO_SUMMARY, goSummary);
+        checkPathValue("paths./testapp/go.get.summary", TestApp.GO_SUMMARY);
     }
 
     @Test
     public void testMultipleApps() {
-        String goSummary3 = TestUtil.fromYaml(yaml, "paths./testapp3/go3.get.summary", String.class);
-        assertEquals(TestApp3.GO_SUMMARY, goSummary3);
+        checkPathValue("paths./testapp3/go3.get.summary", TestApp3.GO_SUMMARY);
+    }
+
+    private void checkPathValue(String pathExpression, String expected) {
+        String result = TestUtil.fromYaml(yaml(), pathExpression, String.class);
+        assertThat(pathExpression, result, is(equalTo(expected)));
     }
 }

--- a/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
+++ b/microprofile/openapi/src/test/java/io/helidon/microprofile/openapi/TestUtil.java
@@ -34,6 +34,7 @@ import io.helidon.microprofile.server.Server;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Useful utility methods during testing.
@@ -198,9 +199,14 @@ public class TestUtil {
      */
     @SuppressWarnings(value = "unchecked")
     public static <T> T fromYaml(Map<String, Object> map, String dottedPath, Class<T> cl) {
+        Map<String, Object> originalMap = map;
         String[] segments = dottedPath.split("\\.");
         for (int i = 0; i < segments.length - 1; i++) {
             map = (Map<String, Object>) map.get(segments[i]);
+            if (map == null) {
+                fail("Traversing dotted path " + dottedPath + " segment " + segments[i] + " not found in parsed map "
+                        + originalMap);
+            }
         }
         return cl.cast(map.get(segments[segments.length - 1]));
     }

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -73,7 +73,7 @@
                             <failOnMissingClassifierArtifact>true</failOnMissingClassifierArtifact>
                             <outputDirectory>${openapi-impls-dir}</outputDirectory>
                             <includeGroupIds>io.smallrye</includeGroupIds>
-                            <includeArtifactIds>smallrye-open-api</includeArtifactIds>
+                            <includeArtifactIds>smallrye-open-api-core</includeArtifactIds>
                             <includes>io/smallrye/openapi/api/models/**/*.java</includes>
                         </configuration>
                     </execution>
@@ -123,6 +123,7 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api</artifactId>
+            <type>pom</type>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/openapi/src/main/java/io/helidon/openapi/ImplTypeDescription.java
+++ b/openapi/src/main/java/io/helidon/openapi/ImplTypeDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,9 @@ class ImplTypeDescription extends TypeDescription {
         delegate = td;
     }
 
-    public ExpandedTypeDescription addRef() {
-        return delegate.addRef();
-    }
-
     @Override
     public Property getProperty(String name) {
-        return delegate.getProperty(name);
+        return name.equals("$ref") ? delegate.getProperty("ref") : delegate.getProperty(name);
     }
 
     @Override

--- a/openapi/src/main/java/module-info.java
+++ b/openapi/src/main/java/module-info.java
@@ -30,7 +30,7 @@ module io.helidon.openapi {
 
     requires org.jboss.jandex;
 
-    requires smallrye.open.api;
+    requires smallrye.open.api.core;
     requires java.json;
     requires java.desktop; // for java.beans package
     requires org.yaml.snakeyaml;

--- a/openapi/src/test/java/io/helidon/openapi/ParserTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,38 @@ class ParserTest {
         assertThat(first, is(instanceOf(String.class)));
         String f = (String) first;
         assertThat(f, is(equalTo("one")));
+    }
+
+
+    @Test
+    void testYamlRef() throws IOException {
+        OpenAPI openAPI = parse(helper, "/petstore.yaml", OpenAPISupport.OpenAPIMediaType.YAML);
+        Paths paths = openAPI.getPaths();
+        String ref = paths.getPathItem("/pets")
+                .getGET()
+                .getResponses()
+                .getAPIResponse("200")
+                .getContent()
+                .getMediaType("application/json")
+                .getSchema()
+                .getRef();
+
+        assertThat("ref value", ref, is(equalTo("#/components/schemas/Pets")));
+    }
+
+    @Test
+    void testJsonRef() throws IOException {
+        OpenAPI openAPI = parse(helper, "/petstore.json", OpenAPISupport.OpenAPIMediaType.JSON);
+        Paths paths = openAPI.getPaths();
+        String ref = paths.getPathItem("/user")
+                .getPOST()
+                .getRequestBody()
+                .getContent()
+                .getMediaType("application/json")
+                .getSchema()
+                .getRef();
+
+                assertThat("ref value", ref, is(equalTo("#/components/schemas/User")));
     }
 
     @Test

--- a/openapi/src/test/resources/petstore.yaml
+++ b/openapi/src/test/resources/petstore.yaml
@@ -37,7 +37,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        '200':
           description: An paged array of pets
           headers:
             x-next:
@@ -60,7 +60,7 @@ paths:
       tags:
         - pets
       responses:
-        201:
+        '201':
           description: Null response
         default:
           description: unexpected error
@@ -82,7 +82,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Expected response to a valid request
           content:
             application/json:

--- a/openapi/src/test/resources/petstore.yaml
+++ b/openapi/src/test/resources/petstore.yaml
@@ -37,7 +37,7 @@ paths:
             type: integer
             format: int32
       responses:
-        '200':
+        200:
           description: An paged array of pets
           headers:
             x-next:
@@ -60,7 +60,7 @@ paths:
       tags:
         - pets
       responses:
-        '201':
+        201:
           description: Null response
         default:
           description: unexpected error
@@ -82,7 +82,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        200:
           description: Expected response to a valid request
           content:
             application/json:


### PR DESCRIPTION
Resolves #2671 

Adopting MP OpenAPI 1.2 is simple in concept. There were no API changes.

We have been layering on SmallRye's OpenAPI implementation 1.x, and SmallRye built against MP OpenAPI 1.2 only starting with 2.0.26. That means we needed to step up to that release also.

There were several API changes in the SmallRye implementation, but almost all are internal to our code.

# Customer-visible changes
## Backward-incompatible changes
1. OpenAPI documents permit the use of `$ref` in input and output declarations to point to definitions elsewhere, rather than in-lining them (perhaps repeatedly). SmallRye used to support a config flag to disable that but in 2.0.26 that support is always on. 
    
    Helidon exposed an OpenAPI config setting `schema-references.enable` for this. With this PR Helidon logs a warning if the user sets this to _any_ value, announcing that references are always supported now.
    
    We expect it is extremely rare that users would have set this value, and even rarer that they would have set it to `false`. This should be a minimal-impact change.
    
    To preserve the behavior, we would have to add significant code in Helidon's OpenAPI implementation to disable `$ref` and the cost seems far higher than the benefit.
2. An internal Helidon class `OpenAPIConfigImpl` implements a SmallRye OpenAPI interface. That interface has changed four method return types from `Set<String>` to `Pattern` and removed two methods. This Helidon class is `public` in `helidon/openapi` only so our code in `helidon/microprofile/openapi` can use it. In fact, it resides in the `io.helidon.openapi.internal` package (which, yes, goes against our coding conventions but turns out to be useful for situations such as this!) to reinforce that users should not use it. Users have no need to use this class directly, in fact.

We will document these changes in a release note with 2.4.0 but impact on real users is very unlikely.

## New warnings
Earlier releases of Helidon silently accepted illegal OpenAPI documents which _did not_ enclose HTTP status values (keys in the `responses` section` in quotes. The OpenAPI spec says they should be quoted. 

With this PR, Helidon will continue to accept such documents but will log warnings about unquoted HTTP status values.

# Changes in SmallRye -> Changes in Helidon
Here are the changes in SmallRye and, in parentheses, the Helidon files that changed as a result.

1. Change in maven packaging - we now depend on the `io.smallrye.openapi.core` artifact/module (`pom.xml`, `module-info.java`).
2. Moved `Format` class from `OpenApiSerializer` to its own class (`OpenAPISupport`).
3. `MergeUtil.merge` method which combines two in-memory OpenAPI models now skips the `openapi` element in the input models, so we have to supply it ourselves explicitly in the resulting new document. (`OpenAPISupport`).
4. `OpenApiAnnotationScanner#scan` changed its return type from `OpenAPIImpl` to `OpenAPI` (`OpenAPISupport`).
5. SmallRye `OpenAPIConfig` supported a setting to control whether `$ref` references were followed or not, defaulted to `true`. This is not a standard setting from the MP OpenAPI spec. We let users assign this setting in previous Helidon releases, but because SmallRye no longer honors it we cannot either. It is _very_ unlikely that users would have turned this off, but the PR preserves the now-obsolete methods and logs a warning if the user explicitly sets the value, either via the API directly (they should not be using the class anyway) or in config. (`OpenAPIConfigImpl`)
6. SmallRye `ReferenceImpl` class changed field name from `$ref` to `ref`. (`ExpandedTypeDescription`, `ImplTypeDescription`, `Serializer`, new tests)
7. SmallRye changed how they express class and package inclusions and exclusions or scanning. They used to be `Set<String>`, but now they are `Pattern`s. Helidon never exposed this to users, except via an internal public class which users should not ever use. (`OpenAPIConfigImpl`, `MPOpenAPIBuilder`)

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>