### PR TITLE
Fix NPE in outbound of JWT provider. (#3295)

### DIFF
--- a/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
+++ b/examples/security/outbound-override/src/main/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,8 @@ public final class OutboundOverrideJwtExample {
      * @param args ignored
      */
     public static void main(String[] args) {
-        CompletionStage<Void> first = startClientService();
-        CompletionStage<Void> second = startServingService();
+        CompletionStage<Void> first = startClientService(8080);
+        CompletionStage<Void> second = startServingService(9080);
 
         first.toCompletableFuture().join();
         second.toCompletableFuture().join();
@@ -72,7 +72,7 @@ public final class OutboundOverrideJwtExample {
         System.out.println("http://localhost:" + servingPort + "/hello");
     }
 
-    private static CompletionStage<Void> startServingService() {
+    static CompletionStage<Void> startServingService(int port) {
         Config config = createConfig("serving-service-jwt");
 
         Routing routing = Routing.builder()
@@ -84,10 +84,10 @@ public final class OutboundOverrideJwtExample {
                             res.send(req.context().get(SecurityContext.class).flatMap(SecurityContext::user).map(
                                     Subject::principal).map(Principal::getName).orElse("Anonymous"));
                         }).build();
-        return startServer(routing, 9080, server -> servingPort = server.port());
+        return startServer(routing, port, server -> servingPort = server.port());
     }
 
-    private static CompletionStage<Void> startClientService() {
+    static CompletionStage<Void> startClientService(int port) {
         Config config = createConfig("client-service-jwt");
 
         Routing routing = Routing.builder()
@@ -95,7 +95,7 @@ public final class OutboundOverrideJwtExample {
                 .get("/override", OutboundOverrideJwtExample::override)
                 .get("/propagate", OutboundOverrideJwtExample::propagate)
                 .build();
-        return startServer(routing, 8080, server -> clientPort = server.port());
+        return startServer(routing, port, server -> clientPort = server.port());
     }
 
     private static void override(ServerRequest req, ServerResponse res) {
@@ -115,5 +115,9 @@ public final class OutboundOverrideJwtExample {
                 .request(String.class)
                 .thenAccept(result -> res.send("You are: " + context.userName() + ", backend service returned: " + result))
                 .exceptionally(throwable -> sendError(throwable, res));
+    }
+
+    static int clientPort() {
+        return clientPort;
     }
 }

--- a/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
+++ b/examples/security/outbound-override/src/test/java/io/helidon/security/examples/outbound/OutboundOverrideJwtExampleTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.security.examples.outbound;
+
+import java.util.concurrent.CompletionStage;
+
+import io.helidon.security.Security;
+import io.helidon.security.providers.httpauth.HttpBasicAuthProvider;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.security.WebClientSecurity;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.security.examples.outbound.OutboundOverrideJwtExample.clientPort;
+import static io.helidon.security.examples.outbound.OutboundOverrideJwtExample.startClientService;
+import static io.helidon.security.examples.outbound.OutboundOverrideJwtExample.startServingService;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test of security override example.
+ */
+public class OutboundOverrideJwtExampleTest {
+
+    private static WebClient webClient;
+
+    @BeforeAll
+    public static void setup() {
+        CompletionStage<Void> first = startClientService(-1);
+        CompletionStage<Void> second = startServingService(-1);
+
+        first.toCompletableFuture().join();
+        second.toCompletableFuture().join();
+
+        Security security = Security.builder()
+                .addProvider(HttpBasicAuthProvider.builder().build())
+                .build();
+
+        webClient = WebClient.builder()
+                .baseUri("http://localhost:" + clientPort())
+                .addService(WebClientSecurity.create(security))
+                .build();
+    }
+
+    @Test
+    public void testOverrideExample() {
+        String value = webClient.get()
+                .path("/override")
+                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
+                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .request(String.class)
+                .await();
+
+        assertThat(value, is("You are: jack, backend service returned: jill"));
+    }
+
+    @Test
+    public void testPropagateExample() {
+        String value = webClient.get()
+                .path("/propagate")
+                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_USER, "jack")
+                .property(HttpBasicAuthProvider.EP_PROPERTY_OUTBOUND_PASSWORD, "password")
+                .request(String.class)
+                .await();
+
+        assertThat(value, is("You are: jack, backend service returned: jack"));
+    }
+
+}

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -89,7 +89,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
     private JwtProvider(Builder builder) {
         this.optional = builder.optional;
         this.authenticate = builder.authenticate;
-        this.propagate = builder.propagate;
+        this.propagate = builder.propagate && builder.outboundConfig.targets().size() > 0;
         this.allowImpersonation = builder.allowImpersonation;
         this.subjectType = builder.subjectType;
         this.atnTokenHandler = builder.atnTokenHandler;
@@ -259,7 +259,8 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
     public boolean isOutboundSupported(ProviderRequest providerRequest,
                                        SecurityEnvironment outboundEnv,
                                        EndpointConfig outboundConfig) {
-        return propagate;
+        // only propagate if we have an actual target configured
+        return propagate && this.outboundConfig.findTarget(outboundEnv).isPresent();
     }
 
     @Override
@@ -603,7 +604,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
                 .tokenHeader("Authorization")
                 .tokenPrefix("bearer ")
                 .build();
-        private OutboundConfig outboundConfig;
+        private OutboundConfig outboundConfig = OutboundConfig.builder().build();
         private JwkKeys verifyKeys;
         private JwkKeys signKeys;
         private String issuer;

--- a/tests/integration/mp-gh-3246/pom.xml
+++ b/tests/integration/mp-gh-3246/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-tests-integration</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-3246</artifactId>
+    <name>Helidon Tests Integration MP GH 2461</name>
+    <description>Reproducer for Github issue #3246 - outbound JAX-RS failed with NPE with JWT provider</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile</groupId>
+            <artifactId>helidon-microprofile-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security.providers</groupId>
+            <artifactId>helidon-security-providers-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-3246/pom.xml
+++ b/tests/integration/mp-gh-3246/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>helidon-tests-integration</artifactId>
         <groupId>io.helidon.tests.integration</groupId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.3.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/integration/mp-gh-3246/src/test/java/io/helidon/tests/integration/gh3246/Gh3246Resource.java
+++ b/tests/integration/mp-gh-3246/src/test/java/io/helidon/tests/integration/gh3246/Gh3246Resource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh3246;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
+import io.helidon.security.annotations.Authenticated;
+
+@Path("/test")
+public class Gh3246Resource {
+    private Client client;
+
+    @PostConstruct
+    public void postConstruct() {
+        this.client = ClientBuilder.newClient();
+    }
+    @PreDestroy
+    public void preDestroy() {
+        this.client.close();
+    }
+
+    @GET
+    @Path("/hello")
+    public String hello() {
+        return "hello";
+    }
+
+    @GET
+    @Path("/callout")
+    public String callout(@QueryParam("port") int port) {
+        WebTarget webTarget = client.target("http://localhost:" + port + "/test/hello");
+
+        return webTarget.request()
+                .get(String.class);
+    }
+
+    @GET
+    @Path("/secured")
+    @Authenticated
+    public String secured(@QueryParam("port") int port) {
+        WebTarget webTarget = client.target("http://localhost:" + port + "/test/hello");
+
+        return webTarget.request()
+                .get(String.class);
+    }
+}

--- a/tests/integration/mp-gh-3246/src/test/java/io/helidon/tests/integration/gh3246/Gh3246Test.java
+++ b/tests/integration/mp-gh-3246/src/test/java/io/helidon/tests/integration/gh3246/Gh3246Test.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh3246;
+
+import java.time.Instant;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.http.Http;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import io.helidon.security.jwt.Jwt;
+import io.helidon.security.jwt.SignedJwt;
+import io.helidon.security.jwt.jwk.JwkKeys;
+import io.helidon.security.jwt.jwk.JwkRSA;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddBean(Gh3246Resource.class)
+public class Gh3246Test {
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void testUnsecuredCallout() {
+        int port = webTarget.getUri().getPort();
+
+        String response = webTarget.path("/test/callout")
+                .queryParam("port", port)
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("hello"));
+    }
+
+    @Test
+    void testUnsecuredDirect() {
+        String response = webTarget.path("/test/hello")
+                .request()
+                .get(String.class);
+
+        assertThat(response, is("hello"));
+    }
+
+    @Test
+    void testSecuredCallout() {
+        Jwt jwt = Jwt.builder()
+                .subject("jack")
+                .addUserGroup("admin")
+                .algorithm(JwkRSA.ALG_RS256)
+                .issuer("test-gh-3246")
+                .audience("http://example.helidon.io")
+                .issueTime(Instant.now())
+                .userPrincipal("jack")
+                .keyId("SIGNING_KEY")
+                .build();
+
+        JwkKeys jwkKeys = JwkKeys.builder()
+                .resource(Resource.create("sign-jwk.json"))
+                .build();
+
+        SignedJwt signed = SignedJwt.sign(jwt, jwkKeys.forKeyId("sign-rsa").get());
+        String tokenContent = signed.tokenContent();
+
+        int port = webTarget.getUri().getPort();
+
+        String response = webTarget.path("/test/secured")
+                .queryParam("port", port)
+                .request()
+                .header(Http.Header.AUTHORIZATION, "Bearer " + tokenContent)
+                .get(String.class);
+
+        assertThat(response, is("hello"));
+    }
+}

--- a/tests/integration/mp-gh-3246/src/test/resources/application.yaml
+++ b/tests/integration/mp-gh-3246/src/test/resources/application.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+security:
+  providers:
+    - abac:
+    - jwt:
+        atn-token:
+          jwk.resource.resource-path: "verify-jwk.json"
+          jwt-audience: "http://example.helidon.io"

--- a/tests/integration/mp-gh-3246/src/test/resources/sign-jwk.json
+++ b/tests/integration/mp-gh-3246/src/test/resources/sign-jwk.json
@@ -1,0 +1,17 @@
+{
+    "keys": [
+        {
+            "kty": "RSA",
+            "kid": "sign-rsa",
+            "use": "sig",
+            "n": "pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w",
+            "e": "AQAB",
+            "d": "ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q",
+            "p": "4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0",
+            "q": "ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8",
+            "dp": "lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE",
+            "dq": "mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk",
+            "qi": "ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"
+        }
+    ]
+}

--- a/tests/integration/mp-gh-3246/src/test/resources/verify-jwk.json
+++ b/tests/integration/mp-gh-3246/src/test/resources/verify-jwk.json
@@ -1,0 +1,11 @@
+{
+    "keys": [
+        {
+            "kty": "RSA",
+            "kid": "SIGNING_KEY",
+            "use": "sig",
+            "n": "pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w",
+            "e": "AQAB"
+        }
+    ]
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -46,6 +46,7 @@
         <module>mp-gh-1538</module>
         <module>mp-gh-2421</module>
         <module>mp-gh-2461</module>
+        <module>mp-gh-3246</module>
         <module>kafka</module>
         <module>jms</module>
         <module>config</module>


### PR DESCRIPTION
OutboundConfig now has default value (no NPE).
Outbound only supported if an outbound target exists.
Added tests to verify.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>