### PR TITLE
Change Micrometer integration to use MP config and use runtime, not build-time, config

### DIFF
--- a/examples/integrations/micrometer/mp/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/integrations/micrometer/mp/src/main/resources/META-INF/microprofile-config.properties
@@ -20,3 +20,6 @@ app.greeting=Hello
 # Microprofile server properties
 server.port=8080
 server.host=0.0.0.0
+
+micrometer.builtin-registries.0.type=prometheus
+micrometer.builtin-registries.0.prefix=myPrefix

--- a/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MeterRegistryProducer.java
+++ b/integrations/micrometer/cdi/src/main/java/io/helidon/integrations/micrometer/cdi/MeterRegistryProducer.java
@@ -18,54 +18,16 @@ package io.helidon.integrations.micrometer.cdi;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-
-import io.helidon.common.LazyValue;
-import io.helidon.config.Config;
-import io.helidon.config.mp.MpConfig;
-import io.helidon.integrations.micrometer.MeterRegistryFactory;
-import io.helidon.integrations.micrometer.MicrometerSupport;
+import javax.inject.Singleton;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 @ApplicationScoped
 class MeterRegistryProducer {
 
-    static final String CONFIG_KEY = "micrometer";
-
-    /*
-     * Also maintains a lazy refc to the single {@code MicrometerSupport} instance.
-     */
-    private static final LazyValue<MicrometerSupport> MICROMETER_SUPPORT_FACTORY =
-            LazyValue.create(MeterRegistryProducer::createMicrometerSupport);
-
-    private MeterRegistryProducer() {
-    }
-
     @Produces
-    static MeterRegistry getMeterRegistry() {
-        return getMicrometerSupport()
-                .registry();
-    }
-
-    static MicrometerSupport getMicrometerSupport() {
-        return MICROMETER_SUPPORT_FACTORY.get();
-    }
-
-    static void clear() {
-        getMeterRegistry().clear();
-    }
-
-    private static MicrometerSupport createMicrometerSupport() {
-        Config micrometerConfig = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(CONFIG_KEY);
-        MeterRegistryFactory factory = MeterRegistryFactory.getInstance(
-                MeterRegistryFactory.builder()
-                    .config(micrometerConfig));
-        MicrometerSupport result = MicrometerSupport.builder()
-                .config(micrometerConfig)
-                .meterRegistryFactorySupplier(factory)
-                .build();
-
-        return result;
+    @Singleton
+    private static MeterRegistry meterRegistry(MicrometerCdiExtension micrometerCdiExtension) {
+        return micrometerCdiExtension.meterRegistry();
     }
 }

--- a/integrations/micrometer/cdi/src/main/java/module-info.java
+++ b/integrations/micrometer/cdi/src/main/java/module-info.java
@@ -37,10 +37,8 @@ module io.helidon.integrations.micrometer.cdi {
     requires io.helidon.microprofile.server;
     requires io.helidon.webserver.cors;
     requires io.helidon.integrations.micrometer;
-    requires io.helidon.config.mp;
 
     requires micrometer.core;
-    requires micrometer.registry.prometheus;
     requires simpleclient;
 
     exports io.helidon.integrations.micrometer.cdi;

--- a/integrations/micrometer/cdi/src/main/java/module-info.java
+++ b/integrations/micrometer/cdi/src/main/java/module-info.java
@@ -33,6 +33,8 @@ module io.helidon.integrations.micrometer.cdi {
     requires io.helidon.servicecommon.rest;
     requires io.helidon.servicecommon.restcdi;
     requires io.helidon.config;
+    requires io.helidon.config.mp;
+    requires io.helidon.microprofile.server;
     requires io.helidon.webserver.cors;
     requires io.helidon.integrations.micrometer;
     requires io.helidon.config.mp;

--- a/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
+++ b/integrations/micrometer/micrometer/src/main/java/io/helidon/integrations/micrometer/MicrometerSupport.java
@@ -101,7 +101,7 @@ public class MicrometerSupport extends HelidonRestServiceSupport {
     @Override
     protected void postConfigureEndpoint(Routing.Rules defaultRules, Routing.Rules serviceEndpointRoutingRules) {
         defaultRules
-                .any(new MetricsContextHandler(meterRegistryFactory.meterRegistry()))
+                .any(new MetricsContextHandler(registry()))
                 .get(context(), this::getOrOptions)
                 .options(context(), this::getOrOptions);
     }

--- a/service-common/rest-cdi/pom.xml
+++ b/service-common/rest-cdi/pom.xml
@@ -53,6 +53,26 @@
             <artifactId>jakarta.activation-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/HelidonRestCdiExtension.java
+++ b/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/HelidonRestCdiExtension.java
@@ -46,6 +46,7 @@ import javax.enterprise.inject.spi.ProcessProducerMethod;
 import javax.interceptor.Interceptor;
 
 import io.helidon.config.Config;
+import io.helidon.config.mp.MpConfig;
 import io.helidon.microprofile.server.RoutingBuilders;
 import io.helidon.microprofile.server.ServerCdiExtension;
 import io.helidon.servicecommon.rest.HelidonRestServiceSupport;
@@ -236,7 +237,7 @@ public abstract class HelidonRestCdiExtension<T extends HelidonRestServiceSuppor
             @Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object adv,
             BeanManager bm, ServerCdiExtension server) {
 
-        Config config = ((Config) ConfigProvider.getConfig()).get(configPrefix);
+        Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(configPrefix);
         serviceSupport = serviceSupportFactory.apply(config);
 
         RoutingBuilders routingBuilders = RoutingBuilders.create(config);

--- a/service-common/rest-cdi/src/main/java/module-info.java
+++ b/service-common/rest-cdi/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.helidon.servicecommon.restcdi {
     requires microprofile.config.api;
     requires jakarta.interceptor.api;
     requires jakarta.inject.api;
+    requires io.helidon.config.mp;
     requires io.helidon.microprofile.server;
 
     // this is needed for CDI extensions that use non-public observer methods

--- a/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/ConfiguredTestCdiExtension.java
+++ b/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/ConfiguredTestCdiExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.servicecommon.restcdi;
+
+import java.util.logging.Logger;
+
+import javax.enterprise.inject.spi.ProcessManagedBean;
+
+/**
+ * Test MP extension that relies on the test SE service which itself reads a value from config, to make sure the config used
+ * is runtime not build-time config.
+ */
+public class ConfiguredTestCdiExtension extends HelidonRestCdiExtension<ConfiguredTestSupport> {
+
+    /**
+     * Common initialization for concrete implementations.
+     */
+    protected ConfiguredTestCdiExtension() {
+        super(Logger.getLogger(ConfiguredTestCdiExtension.class.getName()),
+                config -> ConfiguredTestSupport.builder().config(config).build(), "test");
+    }
+
+    @Override
+    protected void processManagedBean(ProcessManagedBean<?> processManagedBean) {
+    }
+}

--- a/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/ConfiguredTestSupport.java
+++ b/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/ConfiguredTestSupport.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.servicecommon.restcdi;
+
+import io.helidon.config.Config;
+import io.helidon.servicecommon.rest.HelidonRestServiceSupport;
+import io.helidon.webserver.Routing;
+
+import java.util.logging.Logger;
+
+/**
+ * Test SE service which does not really expose its own endpoint but does use config to set an "importance" value.
+ */
+public class ConfiguredTestSupport extends HelidonRestServiceSupport {
+
+
+    static final String ENDPOINT_PATH = "/testendpoint";
+
+    private final int importance;
+
+    /**
+     * Initialization.
+     *
+     * @param builder     builder for the service support instance.
+     */
+    private ConfiguredTestSupport(Builder builder) {
+        super(Logger.getLogger(ConfiguredTestSupport.class.getName()), builder, "testservice");
+        importance = builder.importance;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    protected void postConfigureEndpoint(Routing.Rules defaultRules, Routing.Rules serviceEndpointRoutingRules) {
+        // We are not exposing a service-specific endpoint, nor do we need to add handling to normal requests in the test.
+    }
+
+    @Override
+    public void update(Routing.Rules rules) {
+        configureEndpoint(rules, rules);
+    }
+
+    int importance() {
+        return importance;
+    }
+
+    static class Builder extends HelidonRestServiceSupport.Builder<ConfiguredTestSupport, Builder>
+            implements io.helidon.common.Builder<ConfiguredTestSupport> {
+
+
+        private int importance;
+
+        private Builder() {
+            super(Builder.class, ENDPOINT_PATH);
+        }
+
+        @Override
+        public ConfiguredTestSupport build() {
+            return new ConfiguredTestSupport(this);
+        }
+
+        @Override
+        public Builder config(Config config) {
+            super.config(config);
+            config.get("importance").asInt().ifPresent(this::importance);
+            return this;
+        }
+
+        public Builder importance(int value) {
+            importance = value;
+            return this;
+        }
+    }
+}

--- a/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestConfigTiming.java
+++ b/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestConfigTiming.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.servicecommon.restcdi;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@HelidonTest
+@AddBean(TestResource.class)
+@AddBean(TestSupportProducer.class)
+
+// Acts as runtime config, overriding the build-time setting in microprofile-config.properties
+@AddConfig(key = "test.importance", value = "3")
+
+public class TestConfigTiming {
+
+    @Inject
+    private WebTarget webTarget;
+
+    @Test
+    void checkImportance() {
+        String response = webTarget
+                .path("/test")
+                .request(MediaType.TEXT_PLAIN_TYPE)
+                .get(String.class);
+
+        assertThat("Returned importance", response, is(equalTo("3")));
+    }
+}

--- a/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestResource.java
+++ b/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.servicecommon.restcdi;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Test resource, exposing the /test endpoint which sends back a string reporting the configured "importance" value.
+ */
+@RequestScoped
+@Path("test")
+public class TestResource {
+
+    @Inject
+    private ConfiguredTestSupport configuredTestSupport;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getImportance() {
+        return Integer.toString(configuredTestSupport.importance());
+    }
+}

--- a/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestSupportProducer.java
+++ b/service-common/rest-cdi/src/test/java/io/helidon/servicecommon/restcdi/TestSupportProducer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.servicecommon.restcdi;
+
+import io.helidon.config.mp.MpConfig;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+/**
+ * Producer of the test service so the resource can inject the service.
+ */
+@ApplicationScoped
+public class TestSupportProducer {
+
+    static final String CONFIG_KEY = "test";
+
+    @Produces
+    static public ConfiguredTestSupport getConfiguredTestSupport() {
+        Config mpConfig = ConfigProvider.getConfig();
+        return ConfiguredTestSupport.builder().config(
+                        MpConfig.toHelidonConfig(mpConfig).get(CONFIG_KEY))
+                .build();
+    }
+}

--- a/service-common/rest-cdi/src/test/resources/META-INF/microprofile-config.properties
+++ b/service-common/rest-cdi/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The config which the test CDI extension retrieves at runtime should not reflect the following build-time setting.
+test.importance=1


### PR DESCRIPTION
Resolves #3286 

The commit messages convey pretty much the nature of the changes.

This PR will _not_ build successfully until after #3290 merges; the Micrometer example will not work correctly.

