### PR TITLE
Support for WebServer services loaded from configuration (alpha)

### DIFF
--- a/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service1.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service1.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.examples.signatures;
+
+import java.util.Optional;
+
+import io.helidon.common.http.Http;
+import io.helidon.common.http.MediaType;
+import io.helidon.security.SecurityContext;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.security.WebClientSecurity;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+/**
+ * Service 1 implementation.
+ * This service acts as a client to service 2.
+ */
+class Service1 implements Service {
+    private final WebClient client;
+
+    Service1() {
+        // at the time this instance is created, the second server is already started
+        client = WebClient.builder()
+                .baseUri("http://localhost:" + SignatureExampleUtil.server2Port())
+                .addService(WebClientSecurity.create())
+                .build();
+    }
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/", (req, res) -> this.processService1Request(req, res, "/service2"))
+                .get("/rsa", (req, res) -> this.processService1Request(req, res, "/service2/rsa"));
+    }
+
+    void processService1Request(ServerRequest req, ServerResponse res, String path) {
+        Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
+
+        res.headers().contentType(MediaType.TEXT_PLAIN.withCharset("UTF-8"));
+
+        securityContext.ifPresentOrElse(context -> {
+            client.get()
+                    .path(path)
+                    .request()
+                    .thenAccept(it -> {
+                        if (it.status() == Http.Status.OK_200) {
+                            it.content().as(String.class)
+                                    .thenAccept(res::send)
+                                    .exceptionally(throwable -> {
+                                        res.send("Getting server response failed!");
+                                        return null;
+                                    });
+                        } else {
+                            res.send("Request to service2 failed for path " + path + ", status: " + it.status());
+                        }
+                    });
+
+        }, () -> res.send("Security context is null"));
+    }
+}

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service1Provider.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service1Provider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.examples.signatures;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.spi.WebServerServiceProvider;
+
+/**
+ * ServiceLoader provider to add service 1 through configuration.
+ *
+ * See {@code src/main/META-INF/services/io.helidon.webserver.spi.WebServerServiceProvider}.
+ */
+public class Service1Provider implements WebServerServiceProvider {
+    @Override
+    public String configKey() {
+        return "example-service-1";
+    }
+
+    @Override
+    public Optional<String> defaultPathPattern() {
+        return Optional.of("/service1");
+    }
+
+    @Override
+    public Iterable<Service> create(Config config) {
+        return List.of(new Service1());
+    }
+
+}

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service2.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.examples.signatures;
+
+import java.util.Optional;
+
+import io.helidon.common.http.MediaType;
+import io.helidon.security.SecurityContext;
+import io.helidon.security.Subject;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+/**
+ * Service 1 implementation.
+ * This service acts as a client to service 2.
+ */
+class Service2 implements Service {
+    Service2() {
+    }
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get(this::handleAnyGet);
+    }
+
+    void handleAnyGet(ServerRequest req, ServerResponse res) {
+        Optional<SecurityContext> securityContext = req.context().get(SecurityContext.class);
+        res.headers().contentType(MediaType.TEXT_PLAIN.withCharset("UTF-8"));
+        res.send("Response from service2, you are: \n" + securityContext
+                .flatMap(SecurityContext::user)
+                .map(Subject::toString)
+                .orElse("Security context is null") + ", service: " + securityContext
+                .flatMap(SecurityContext::service)
+                .map(Subject::toString));
+    }
+}

--- a/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service2Provider.java
+++ b/examples/security/webserver-signatures/src/main/java/io/helidon/security/examples/signatures/Service2Provider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.examples.signatures;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.spi.WebServerServiceProvider;
+
+/**
+ * ServiceLoader provider to add service 2 through configuration.
+ *
+ * See {@code src/main/META-INF/services/io.helidon.webserver.spi.WebServerServiceProvider}.
+ */
+public class Service2Provider implements WebServerServiceProvider {
+    @Override
+    public String configKey() {
+        return "example-service-2";
+    }
+
+    @Override
+    public Optional<String> defaultPathPattern() {
+        return Optional.of("/service2");
+    }
+
+    @Override
+    public Iterable<Service> create(Config config) {
+        return List.of(new Service2());
+    }
+
+}

--- a/examples/security/webserver-signatures/src/main/resources/META-INF/services/io.helidon.webserver.spi.WebServerServiceProvider
+++ b/examples/security/webserver-signatures/src/main/resources/META-INF/services/io.helidon.webserver.spi.WebServerServiceProvider
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.helidon.security.examples.signatures.Service1Provider
+io.helidon.security.examples.signatures.Service2Provider

--- a/examples/security/webserver-signatures/src/main/resources/logging.properties
+++ b/examples/security/webserver-signatures/src/main/resources/logging.properties
@@ -1,0 +1,23 @@
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+# AUDIT.level=FINEST
+
+# Quiet Weld
+org.jboss.level=WARNING
+
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO

--- a/examples/security/webserver-signatures/src/main/resources/service1.yaml
+++ b/examples/security/webserver-signatures/src/main/resources/service1.yaml
@@ -14,6 +14,27 @@
 # limitations under the License.
 #
 
+# we want to override this using system properties
+server1.port: 8080
+
+server:
+  port: "${server1.port}"
+  services:
+    security:
+      config-key: "security"
+    example-service-1:
+      path-pattern: "/service1"
+      #    tracing:
+      #      config:
+      #        enabled: true
+#    config-based-routing:
+#      path-pattern: "/"
+#      config:
+#        path: "/fixed"
+#        status: 200
+#        entity: "Hello World"
+#        methods: ["GET"]
+
 security:
   config:
     # Configuration of secured config (encryption of passwords in property files)
@@ -55,7 +76,7 @@ security:
               hmac.secret: "${CLEAR=somePasswordForHmacShouldBeEncrypted}"
           - name: "service2-rsa"
             hosts: ["localhost"]
-            paths: ["/service2-rsa.*"]
+            paths: ["/service2/rsa"]
             signature:
               key-id: "service1-rsa"
               private-key:
@@ -78,6 +99,6 @@ security:
       - path: "/service1"
         methods: ["get"]
         roles-allowed: ["user"]
-      - path: "/service1-rsa"
+      - path: "/service1/rsa"
         methods: ["get"]
         roles-allowed: ["user"]

--- a/examples/security/webserver-signatures/src/main/resources/service2.yaml
+++ b/examples/security/webserver-signatures/src/main/resources/service2.yaml
@@ -14,6 +14,17 @@
 # limitations under the License.
 #
 
+# we want to override this using system properties
+server2.port: 9080
+
+server:
+  port: "${server2.port}"
+  services:
+    security:
+      config-key: "security"
+    example-service-2:
+      path-pattern: "/service2"
+
 security:
   config:
     # Configuration of secured config (encryption of passwords in property files)
@@ -23,9 +34,8 @@ security:
   provider-policy:
     type: "COMPOSITE"
     authentication:
-      # first resolve signature, then resolve basic-auth
+      # must be present
       - name: "http-signatures"
-        flag: "OPTIONAL"
       # must be present
       - name: "http-basic-auth"
   providers:
@@ -71,5 +81,5 @@ security:
     paths:
       - path: "/service2"
         roles-allowed: [ "user" ]
-      - path: "/service2-rsa"
+      - path: "/service2/rsa"
         roles-allowed: [ "user" ]

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleBuilderMainTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleBuilderMainTest.java
@@ -28,7 +28,8 @@ public class SignatureExampleBuilderMainTest extends SignatureExampleTest {
 
     @BeforeAll
     public static void initClass() {
-        SignatureExampleBuilderMain.main(null);
+        // using random ports for testing
+        SignatureExampleBuilderMain.startServers(0, 0);
         svc1Port = SignatureExampleBuilderMain.getService1Server().port();
         svc2Port = SignatureExampleBuilderMain.getService2Server().port();
     }

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleConfigMainTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleConfigMainTest.java
@@ -28,6 +28,9 @@ public class SignatureExampleConfigMainTest extends SignatureExampleTest {
 
     @BeforeAll
     public static void initClass() {
+        // override configuration to use random ports
+        System.setProperty("server1.port", "0");
+        System.setProperty("server2.port", "0");
         SignatureExampleConfigMain.main(null);
         svc1Port = SignatureExampleConfigMain.getService1Server().port();
         svc2Port = SignatureExampleConfigMain.getService2Server().port();

--- a/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleTest.java
+++ b/examples/security/webserver-signatures/src/test/java/io/helidon/security/examples/signatures/SignatureExampleTest.java
@@ -82,7 +82,7 @@ public abstract class SignatureExampleTest {
 
     @Test
     public void testService1Rsa() {
-        testProtected("http://localhost:" + getService1Port() + "/service1-rsa",
+        testProtected("http://localhost:" + getService1Port() + "/service1/rsa",
                       "jack",
                       "password",
                       Set.of("user", "admin"),

--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurityServiceProvider.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/WebSecurityServiceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.integration.webserver;
+
+import java.util.List;
+
+import javax.annotation.Priority;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.spi.WebServerServiceProvider;
+
+/**
+ * Provider for web server security.
+ */
+@Priority(100)
+public class WebSecurityServiceProvider implements WebServerServiceProvider {
+
+    @Override
+    public String configKey() {
+        return "security";
+    }
+
+    @Override
+    public Iterable<Service> create(Config config) {
+        return List.of(WebSecurity.create(config));
+    }
+}

--- a/security/integration/webserver/src/main/java/module-info.java
+++ b/security/integration/webserver/src/main/java/module-info.java
@@ -27,4 +27,7 @@ module io.helidon.security.integration.webserver {
     requires io.helidon.security.integration.common;
 
     exports io.helidon.security.integration.webserver;
+
+    provides io.helidon.webserver.spi.WebServerServiceProvider
+            with io.helidon.security.integration.webserver.WebSecurityServiceProvider;
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -234,6 +234,11 @@ public interface WebServer {
         return builder(routing).build();
     }
 
+    static WebServer create(Config config) {
+        return builder(Routing.create(config))
+                .config(config.get("server"))
+                .build();
+    }
     /**
      * Creates new instance from provided configuration and routing.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/spi/WebServerServiceProvider.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/spi/WebServerServiceProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver.spi;
+
+import java.util.Optional;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Service;
+
+/**
+ * Java service loader interface for server services.
+ * <p>
+ * Services provided by this interface will be registered with
+ * the web server using {@link io.helidon.webserver.Routing.Builder#register(io.helidon.webserver.Service...)}
+ * or {@link io.helidon.webserver.Routing.Builder#register(String, io.helidon.webserver.Service...)} depending
+ * on the presence of {@code path-pattern} configuration option.
+ * <p>
+ * Services are configured in order defined by priority (lowest priority is registered first),
+ *  {@code priority} key can be used to re-define service priority in
+ *  configuration.
+ * Default priority is defined through {@code @Priority} annotation on an
+ * implementation of this service, or
+ * by implementing the {@link io.helidon.common.Prioritized} interface.
+ * <p>
+ * You can control what configuration is given to this service by
+ * configuring either property {@code config-key} - a reference to another
+ * configuration key in the configuration root, or by configuring
+ * {@code config} node with values instead.
+ * If neither is present, empty configuration is provided to service.
+ */
+public interface WebServerServiceProvider {
+    /**
+     * Config key expected under {@code server.services}.
+     *
+     * @return name of the configuration node of this service
+     */
+    String configKey();
+
+    /**
+     * Path pattern to use if none is configured in config.
+     *
+     * @return default path pattern, or empty if none should be used
+     */
+    default Optional<String> defaultPathPattern() {
+        return Optional.empty();
+    }
+
+    /**
+     * Create new instance(s) based on configuration.
+     *
+     * @param config configuration of this service
+     * @return a new server service instance
+     */
+    Iterable<Service> create(Config config);
+}

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -41,4 +41,7 @@ module io.helidon.webserver {
     requires io.netty.codec.http2;
 
     exports io.helidon.webserver;
+    exports io.helidon.webserver.spi;
+
+    uses io.helidon.webserver.spi.WebServerServiceProvider;
 }


### PR DESCRIPTION
Related to #780

Support to load services based on configuration.
This is a simplistic approach (see example) where I just iterate through providers and look for config. Should be inversed (e.g. iterate through config and look for provider), so we can have more than one service instance with different configuration.
Should also be an array of objects (same reason - you cannot have the same key twice if this would be an object).

Just wanted to test the idea (and do the most "crazy" thing with it, e.g. implementing all of routing using configuration only).

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>