### PR TITLE
Make sure our built-in MP health checks are marked as built in

### DIFF
--- a/integrations/neo4j/health/pom.xml
+++ b/integrations/neo4j/health/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>microprofile-health-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.health</groupId>
+            <artifactId>helidon-health-common</artifactId>
+        </dependency>
+        <dependency>
             <!-- only needed for compilation, not required in runtime -->
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>

--- a/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
+++ b/integrations/neo4j/health/src/main/java/io/helidon/integrations/neo4j/health/Neo4jHealthCheck.java
@@ -20,6 +20,8 @@ package io.helidon.integrations.neo4j.health;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.helidon.health.common.BuiltInHealthCheck;
+
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
@@ -33,6 +35,7 @@ import org.neo4j.driver.Session;
  */
 @Readiness
 @ApplicationScoped
+@BuiltInHealthCheck
 public class Neo4jHealthCheck implements HealthCheck {
 
     /**

--- a/integrations/neo4j/health/src/main/java/module-info.java
+++ b/integrations/neo4j/health/src/main/java/module-info.java
@@ -21,6 +21,8 @@ module io.helidon.integrations.neo4j.health {
     requires microprofile.health.api;
     requires org.neo4j.driver;
 
+    requires io.helidon.health.common;
+
     requires static jakarta.enterprise.cdi.api;
     requires static jakarta.inject.api;
 

--- a/microprofile/messaging/health/src/main/java/io/helidon/microprofile/messaging/health/MessagingLivenessCheck.java
+++ b/microprofile/messaging/health/src/main/java/io/helidon/microprofile/messaging/health/MessagingLivenessCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.helidon.health.common.BuiltInHealthCheck;
 import io.helidon.microprofile.messaging.MessagingCdiExtension;
 
 import org.eclipse.microprofile.health.HealthCheck;
@@ -35,6 +36,7 @@ import org.eclipse.microprofile.health.Liveness;
  */
 @Liveness
 @ApplicationScoped
+@BuiltInHealthCheck
 public class MessagingLivenessCheck implements HealthCheck {
 
     private final MessagingCdiExtension messagingCdiExtension;

--- a/microprofile/messaging/health/src/main/java/io/helidon/microprofile/messaging/health/MessagingReadinessCheck.java
+++ b/microprofile/messaging/health/src/main/java/io/helidon/microprofile/messaging/health/MessagingReadinessCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import io.helidon.health.common.BuiltInHealthCheck;
 import io.helidon.microprofile.messaging.MessagingCdiExtension;
 
 import org.eclipse.microprofile.health.HealthCheck;
@@ -35,6 +36,7 @@ import org.eclipse.microprofile.health.Readiness;
  */
 @Readiness
 @ApplicationScoped
+@BuiltInHealthCheck
 public class MessagingReadinessCheck implements HealthCheck {
 
     private final MessagingCdiExtension messagingCdiExtension;

--- a/microprofile/messaging/health/src/main/java/module-info.java
+++ b/microprofile/messaging/health/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ module io.helidon.microprofile.messaging.health {
     requires io.helidon.microprofile.messaging;
     requires io.helidon.microprofile.health;
     requires microprofile.health.api;
+    requires io.helidon.health.common;
 
     exports io.helidon.microprofile.messaging.health;
 }


### PR DESCRIPTION
Using the `@BuiltInHealthCheck` annotation where appropriate. Issue #3313.