### PR TITLE
Migration of CDI contextual beans into new threads

### DIFF
--- a/microprofile/fault-tolerance/pom.xml
+++ b/microprofile/fault-tolerance/pom.xml
@@ -93,6 +93,14 @@
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-weld2-se</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-spi</artifactId>
+        </dependency>
         <!-- To keep HK2 from complaining when run with Java9+ -->
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -117,14 +117,12 @@ class RequestScopeHelper {
                         InjectionManager old = WeldRequestScope.actualInjectorManager.get();
                         BoundRequestContext boundRequestContext = null;
                         try {
-                            // requestController.activate();
                             boundRequestContext = migrateRequestContext();
                             WeldRequestScope.actualInjectorManager.set(injectionManager);
                             return supplier.get();
                         } catch (Throwable t) {
                             throw t instanceof Exception ? ((Exception) t) : new RuntimeException(t);
                         } finally {
-                            // requestController.deactivate();
                             if (boundRequestContext != null) {
                                 boundRequestContext.deactivate();
                             }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -15,18 +15,19 @@
  */
 package io.helidon.microprofile.faulttolerance;
 
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.spi.CDI;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.spi.CDI;
+
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.process.internal.RequestContext;
 import org.glassfish.jersey.process.internal.RequestScope;
 import org.glassfish.jersey.weld.se.WeldRequestScope;
-
 import org.jboss.weld.context.WeldAlterableContext;
 import org.jboss.weld.context.api.ContextualInstance;
 import org.jboss.weld.context.bound.BoundLiteral;

--- a/microprofile/fault-tolerance/src/main/java/module-info.java
+++ b/microprofile/fault-tolerance/src/main/java/module-info.java
@@ -38,6 +38,8 @@ module io.helidon.microprofile.faulttolerance {
     requires microprofile.fault.tolerance.api;
 
     requires jersey.weld2.se;
+    requires weld.api;
+    requires weld.spi;
 
     exports io.helidon.microprofile.faulttolerance;
 

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -41,6 +41,7 @@
         <module>mp-synthetic-app</module>
         <module>mp-compression</module>
         <module>request-scope</module>
+        <module>request-scope-cdi</module>
         <module>jax-rs-multiple-apps</module>
     </modules>
 </project>

--- a/tests/functional/request-scope-cdi/pom.xml
+++ b/tests/functional/request-scope-cdi/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>helidon-tests-functional-project</artifactId>
+        <groupId>io.helidon.tests.functional</groupId>
+        <version>2.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-functional-request-scope-cdi</artifactId>
+    <name>Helidon Functional Test: CDI Request Scopes and Fault Tolerance</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/AsyncWorker.java
+++ b/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/AsyncWorker.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.requestscopecdi;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+@RequestScoped
+public class AsyncWorker {
+
+    @Inject
+    private SharedBean shared;
+
+
+    @Asynchronous
+    public Future<String> asyncOp() {
+        return CompletableFuture.completedFuture(shared.secret());
+    }
+}

--- a/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/SecretResource.java
+++ b/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/SecretResource.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.requestscopecdi;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+@Path("/greet")
+@RequestScoped
+public class SecretResource {
+    private static final Logger LOGGER = Logger.getLogger(SecretResource.class.getName());
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    @Inject
+    private AsyncWorker worker;
+
+    @Inject
+    private SharedBean shared;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getDefaultMessage() {
+        try {
+            // Access shared bean to get it proxied before calling the async op
+            // for it to be migrated to FT thread
+            LOGGER.info("Secret is " + shared.secret());
+
+            // Call async operation
+            var f = worker.asyncOp();
+
+            // Both secrets returned should match
+            JsonObject o = JSON.createObjectBuilder()
+                    .add("secret1", shared.secret())
+                    .add("secret2", f.get())
+                    .build();
+            LOGGER.info("Response is " + o);
+
+            return Response.ok(o).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/SharedBean.java
+++ b/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/SharedBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.requestscopecdi;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import java.util.UUID;
+
+@RequestScoped
+public class SharedBean {
+
+    private String secret;
+
+    @PostConstruct
+    public void init() {
+        this.secret = UUID.randomUUID().toString();
+    }
+
+    public String secret() {
+        return secret;
+    }
+
+    @Override
+    public String toString() {
+        return "SharedBean [shared=" + secret + "]";
+    }
+}

--- a/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/package-info.java
+++ b/tests/functional/request-scope-cdi/src/main/java/io/helidon/tests/functional/requestscopecdi/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.requestscopecdi;

--- a/tests/functional/request-scope-cdi/src/main/resources/META-INF/beans.xml
+++ b/tests/functional/request-scope-cdi/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/functional/request-scope-cdi/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/functional/request-scope-cdi/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.host=0.0.0.0

--- a/tests/functional/request-scope-cdi/src/test/java/io/helidon/tests/functional/requestscopecdi/SecretTest.java
+++ b/tests/functional/request-scope-cdi/src/test/java/io/helidon/tests/functional/requestscopecdi/SecretTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.requestscopecdi;
+
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import io.helidon.common.http.MediaType;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@HelidonTest
+class SecretTest {
+
+    @Inject
+    private WebTarget baseTarget;
+
+    @Test
+    public void testSecrets() {
+        Response r = baseTarget.path("greet")
+                .request()
+                .accept(MediaType.APPLICATION_JSON.toString())
+                .get();
+        assertThat(r.getStatus(), is(HttpResponseStatus.OK.code()));
+        JsonObject o = r.readEntity(JsonObject.class);
+        assertEquals(o.get("secret1"), o.get("secret2"));
+    }
+}

--- a/tests/functional/request-scope-cdi/src/test/resources/logging.properties
+++ b/tests/functional/request-scope-cdi/src/test/resources/logging.properties
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+AUDIT.level=FINEST


### PR DESCRIPTION
Additional code is provided to not only active the request scope in the new thread but also migrate the beans in request scope. This is done according to the Weld documentation on context migration. 

A new test shows how a request-scoped bean created in thread A is the _same bean_ available in thread B using FT's `@Asynchronous` annotation. Note that the request-scoped bean in thread A _needs to be accessed_ for its proxy to be created and migration into thread B to be successful. 

Bean migration is one directional: from thread A (original request thread) to thread B and not the other way around. Application developers are responsible for properly synchronizing access to these beans that can potentially be accessed from multiple threads.

Issue #3319