### PR TITLE
Fix "Startup logging refactoring #2660"

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -113,6 +113,7 @@ public class ServerCdiExtension implements Extension {
             throw new IllegalStateException("There is another builder in progress, or another Server running. "
                                                     + "You cannot run more than one in parallel");
         }
+        LOGGER.finest("Builders ready");
     }
 
     private void prepareRuntime(@Observes @RuntimeStart Config config) {
@@ -217,6 +218,8 @@ public class ServerCdiExtension implements Extension {
         serverBuilder = null;
         routingBuilder = null;
         namedRoutings = null;
+
+        LOGGER.finest("Server created");
     }
 
     private void registerJaxRsApplications(BeanManager beanManager) {
@@ -232,6 +235,7 @@ public class ServerCdiExtension implements Extension {
                     : Injections.createInjectionManager();
             jaxRsApplications.forEach(it -> addApplication(jaxRs, it, shared));
         }
+        LOGGER.finest("Registered jersey application(s)");
     }
 
     private void registerDefaultRedirect() {
@@ -270,6 +274,7 @@ public class ServerCdiExtension implements Extension {
         } else {
             routingBuilder.register(staticContent);
         }
+        LOGGER.finest("Static path");
     }
 
     private void registerClasspathStaticContent(Config config) {
@@ -289,6 +294,7 @@ public class ServerCdiExtension implements Extension {
         } else {
             routingBuilder.register(staticContent);
         }
+        LOGGER.finest("Static classpath");
     }
 
     private void stopServer(@Observes @Priority(PLATFORM_BEFORE) @BeforeDestroyed(ApplicationScoped.class) Object event) {
@@ -400,6 +406,7 @@ public class ServerCdiExtension implements Extension {
             Service service = (Service) objBean.create(context);
             registerWebServerService(serviceBeans.remove(bean), service);
         }
+        LOGGER.finest("Registered WebServer services");
     }
 
     private static List<Bean<?>> prioritySort(Set<Bean<?>> beans) {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -78,6 +78,7 @@ import static javax.interceptor.Interceptor.Priority.PLATFORM_BEFORE;
  */
 public class ServerCdiExtension implements Extension {
     private static final Logger LOGGER = Logger.getLogger(ServerCdiExtension.class.getName());
+    private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
     private static final AtomicBoolean IN_PROGRESS_OR_RUNNING = new AtomicBoolean();
 
     // build time
@@ -113,7 +114,6 @@ public class ServerCdiExtension implements Extension {
             throw new IllegalStateException("There is another builder in progress, or another Server running. "
                                                     + "You cannot run more than one in parallel");
         }
-        LOGGER.finest("Builders ready");
     }
 
     private void prepareRuntime(@Observes @RuntimeStart Config config) {
@@ -219,7 +219,7 @@ public class ServerCdiExtension implements Extension {
         routingBuilder = null;
         namedRoutings = null;
 
-        LOGGER.finest("Server created");
+        STARTUP_LOGGER.finest("Server created");
     }
 
     private void registerJaxRsApplications(BeanManager beanManager) {
@@ -235,7 +235,7 @@ public class ServerCdiExtension implements Extension {
                     : Injections.createInjectionManager();
             jaxRsApplications.forEach(it -> addApplication(jaxRs, it, shared));
         }
-        LOGGER.finest("Registered jersey application(s)");
+        STARTUP_LOGGER.finest("Registered jersey application(s)");
     }
 
     private void registerDefaultRedirect() {
@@ -246,6 +246,7 @@ public class ServerCdiExtension implements Extension {
                     res.headers().put(Http.Header.LOCATION, basePath);
                     res.send();
                 }));
+        STARTUP_LOGGER.finest("Builders ready");
     }
 
     private void registerStaticContent() {
@@ -274,7 +275,7 @@ public class ServerCdiExtension implements Extension {
         } else {
             routingBuilder.register(staticContent);
         }
-        LOGGER.finest("Static path");
+        STARTUP_LOGGER.finest("Static path");
     }
 
     private void registerClasspathStaticContent(Config config) {
@@ -294,7 +295,7 @@ public class ServerCdiExtension implements Extension {
         } else {
             routingBuilder.register(staticContent);
         }
-        LOGGER.finest("Static classpath");
+        STARTUP_LOGGER.finest("Static classpath");
     }
 
     private void stopServer(@Observes @Priority(PLATFORM_BEFORE) @BeforeDestroyed(ApplicationScoped.class) Object event) {
@@ -406,7 +407,7 @@ public class ServerCdiExtension implements Extension {
             Service service = (Service) objBean.create(context);
             registerWebServerService(serviceBeans.remove(bean), service);
         }
-        LOGGER.finest("Registered WebServer services");
+        STARTUP_LOGGER.finest("Registered WebServer services");
     }
 
     private static List<Bean<?>> prioritySort(Set<Bean<?>> beans) {

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -69,18 +69,6 @@ public class ServerImpl implements Server {
                 .bindAddress(listenHost);
 
         serverExtension.listenHost(this.host);
-
-        STARTUP_LOGGER.finest("Builders ready");
-
-        STARTUP_LOGGER.finest("Static classpath");
-
-        STARTUP_LOGGER.finest("Static path");
-
-        STARTUP_LOGGER.finest("Registered jersey application(s)");
-
-        STARTUP_LOGGER.finest("Registered WebServer services");
-
-        STARTUP_LOGGER.finest("Server created");
     }
 
     @Override


### PR DESCRIPTION
Resolves  #2660 
"Startup logging refactoring"

All logging methods moved to corresponding CDI Extension methods.
