### PR TITLE
2.3.3: Uptake build-tools 2.2.2

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -47,8 +47,8 @@
         <version.plugin.dependency>3.1.2</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>2.2.0</version.plugin.helidon>
-        <version.plugin.helidon-cli>2.2.0</version.plugin.helidon-cli>
+        <version.plugin.helidon>2.2.2</version.plugin.helidon>
+        <version.plugin.helidon-cli>2.2.2</version.plugin.helidon-cli>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>

--- a/archetypes/catalog/pom.xml
+++ b/archetypes/catalog/pom.xml
@@ -150,7 +150,7 @@
                         <message> |  If you also want to test with a local Helidon CLI build, specify the version when building</message>
                         <message> |  this project, e.g.:</message>
                         <message> |</message>
-                        <message> |     mvn clean install -Dcli.build.tools.version=2.2.0-SNAPSHOT</message>
+                        <message> |     mvn clean install -Dcli.build.tools.version=2.2.2-SNAPSHOT</message>
                         <message> |</message>
                     </messages>
                 </configuration>

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -41,8 +41,8 @@
         <version.plugin.eclipselink>2.7.5.1</version.plugin.eclipselink>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>2.2.0</version.plugin.helidon>
-        <version.plugin.helidon-cli>2.2.0</version.plugin.helidon-cli>
+        <version.plugin.helidon>2.2.2</version.plugin.helidon>
+        <version.plugin.helidon-cli>2.2.2</version.plugin.helidon-cli>
         <version.plugin.jandex>1.0.6</version.plugin.jandex>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -40,8 +40,8 @@
         <version.plugin.dependency>3.0.0</version.plugin.dependency>
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
-        <version.plugin.helidon>2.2.0</version.plugin.helidon>
-        <version.plugin.helidon-cli>2.2.0</version.plugin.helidon-cli>
+        <version.plugin.helidon>2.2.2</version.plugin.helidon>
+        <version.plugin.helidon-cli>2.2.2</version.plugin.helidon-cli>
         <version.plugin.jar>3.0.2</version.plugin.jar>
         <version.plugin.os>1.5.0.Final</version.plugin.os>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <version.plugin.exec>1.6.0</version.plugin.exec>
         <version.plugin.failsafe>3.0.0-M5</version.plugin.failsafe>
         <version.plugin.glassfish-copyright>2.3</version.plugin.glassfish-copyright>
-        <version.plugin.helidon-build-tools>2.2.1</version.plugin.helidon-build-tools>
+        <version.plugin.helidon-build-tools>2.2.2</version.plugin.helidon-build-tools>
         <version.plugin.hibernate-enhance>${version.lib.hibernate}</version.plugin.hibernate-enhance>
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>1.0.6</version.plugin.jandex>
@@ -123,7 +123,7 @@
         <version.plugin.buildnumber>1.4</version.plugin.buildnumber>
         <version.plugin.wiremock>2.14.0</version.plugin.wiremock>
 
-        <version.helidon-cli>2.2.0</version.helidon-cli>
+        <version.helidon-cli>2.2.2</version.helidon-cli>
 
         <javadoc.link.jackson-annotations>https://fasterxml.github.io/jackson-annotations/javadoc/2.9/</javadoc.link.jackson-annotations>
         <javadoc.link.jackson-core>https://fasterxml.github.io/jackson-core/javadoc/2.9/</javadoc.link.jackson-core>


### PR DESCRIPTION
Upgrade helidon build-tools to 2.2.2, primarily to get fix for https://github.com/oracle/helidon-build-tools/issues/458