### PR TITLE
Added support for multiple URIs to Config Etcd API

### DIFF
--- a/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSource.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/EtcdConfigSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -52,15 +53,21 @@ public class EtcdConfigSource extends AbstractConfigSource
     private static final Logger LOGGER = Logger.getLogger(EtcdConfigSource.class.getName());
 
     private final EtcdEndpoint endpoint;
+    private final List<EtcdEndpoint> endpoints;
     private final EtcdClient client;
 
     EtcdConfigSource(EtcdConfigSourceBuilder builder) {
         super(builder);
 
-        endpoint = builder.target();
+        endpoints = builder.target();
+        if (endpoints.size() < 1) {
+            throw new IllegalArgumentException("At least one endpoint must be defined");
+        }
+
+        endpoint = endpoints.get(0);
         client = endpoint.api()
                 .clientFactory()
-                .createClient(endpoint.uri());
+                .createClient(endpoints.stream().map(EtcdEndpoint::uri).toArray(URI[]::new));
     }
 
     @Override

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/EtcdClientFactory.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/EtcdClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import java.net.URI;
 public interface EtcdClientFactory {
     /**
      * Create a new client.
-     * @param uri URI of etcd
+     * @param uris URIs of etcd
      * @return client
      */
-    EtcdClient createClient(URI uri);
+    EtcdClient createClient(URI... uris);
 }

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,10 @@ public class EtcdV2Client implements EtcdClient {
     /**
      * Init client with specified target Etcd uri.
      *
-     * @param uri target Etcd uri
+     * @param uris target Etcd uris
      */
-    EtcdV2Client(URI uri) {
-        etcd = new mousio.etcd4j.EtcdClient(uri);
+    EtcdV2Client(URI... uris) {
+        etcd = new mousio.etcd4j.EtcdClient(uris);
         etcd.setRetryHandler(new RetryWithTimeout(100, 2000));
     }
 

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2ClientFactory.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v2/EtcdV2ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import io.helidon.config.etcd.internal.client.EtcdClientFactory;
  */
 public class EtcdV2ClientFactory implements EtcdClientFactory {
     @Override
-    public EtcdClient createClient(URI uri) {
-        return new EtcdV2Client(uri);
+    public EtcdClient createClient(URI... uris) {
+        return new EtcdV2Client(uris);
     }
 }

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,13 @@ public class EtcdV3Client implements EtcdClient {
     /**
      * Init client with specified target Etcd uri.
      *
-     * @param uri target Etcd uri
+     * @param uris target Etcd uris
      */
-    public EtcdV3Client(URI uri) {
+    public EtcdV3Client(URI... uris) {
+        if (uris.length != 1) {
+            throw new IllegalArgumentException("EtcdV3Client only supports a single URI");
+        }
+        URI uri = uris[0];
         ManagedChannelBuilder mcb = ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort());
         this.channel = mcb.usePlaintext().build();
 

--- a/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3ClientFactory.java
+++ b/config/etcd/src/main/java/io/helidon/config/etcd/internal/client/v3/EtcdV3ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ import io.helidon.config.etcd.internal.client.EtcdClient;
 import io.helidon.config.etcd.internal.client.EtcdClientFactory;
 
 /**
- * Factor for V3 client.
+ * Factory for V3 client.
  */
 public class EtcdV3ClientFactory implements EtcdClientFactory {
     @Override
-    public EtcdClient createClient(URI uri) {
-        return new EtcdV3Client(uri);
+    public EtcdClient createClient(URI... uris) {
+        return new EtcdV3Client(uris);
     }
 }

--- a/config/etcd/src/test/java/io/helidon/config/etcd/EtcdApiTest.java
+++ b/config/etcd/src/test/java/io/helidon/config/etcd/EtcdApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,14 +26,30 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link EtcdApi}.
  */
 public class EtcdApiTest {
+
     @Test
     public void testClientVersion() {
         assertThat(EtcdApi.v2.clientFactory().createClient(URI.create("http://localhost")), instanceOf(EtcdV2Client.class));
         assertThat(EtcdApi.v3.clientFactory().createClient(URI.create("http://localhost")), instanceOf(EtcdV3Client.class));
+    }
+
+    @Test
+    public void testMultipleUrisV2() {
+        assertThat(EtcdApi.v2.clientFactory().createClient(
+                        URI.create("http://localhost"), URI.create("http://localhost")),
+                instanceOf(EtcdV2Client.class));
+    }
+
+    @Test
+    public void testMultipleUrisV3() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EtcdApi.v3.clientFactory().createClient(
+                        URI.create("http://localhost"), URI.create("http://localhost")));
     }
 }

--- a/config/etcd/src/test/java/io/helidon/config/etcd/EtcdConfigSourceBuilderTest.java
+++ b/config/etcd/src/test/java/io/helidon/config/etcd/EtcdConfigSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class EtcdConfigSourceBuilderTest {
     public void testBuilderWithoutUri() {
         assertThrows(IllegalArgumentException.class, () -> {
             EtcdConfigSource.builder()
-                    .uri(null)
+                    .uri()
                     .key("/registry")
                     .api(EtcdApi.v2)
                     .mediaType("my/media/type")
@@ -109,7 +109,7 @@ public class EtcdConfigSourceBuilderTest {
     @Test
     public void testPollingStrategy() {
         URI uri = URI.create("http://localhost:2379");
-        EtcdConfigSourceBuilder builder = EtcdConfigSource.builder()
+        EtcdConfigSource.builder()
                 .uri(uri)
                 .key("/registry")
                 .api(EtcdApi.v2)
@@ -131,9 +131,9 @@ public class EtcdConfigSourceBuilderTest {
                         "key", "/registry",
                         "api", "v3"))));
 
-        assertThat(builder.target().uri(), is(URI.create("http://localhost:2379")));
-        assertThat(builder.target().key(), is("/registry"));
-        assertThat(builder.target().api(), is(EtcdApi.v3));
+        assertThat(builder.target(0).uri(), is(URI.create("http://localhost:2379")));
+        assertThat(builder.target(0).key(), is("/registry"));
+        assertThat(builder.target(0).api(), is(EtcdApi.v3));
     }
 
     @Test
@@ -145,9 +145,9 @@ public class EtcdConfigSourceBuilderTest {
                         "api", "v3",
                         "polling-strategy.type", TestingEtcdPollingStrategyProvider.TYPE))));
 
-        assertThat(builder.target().uri(), is(URI.create("http://localhost:2379")));
-        assertThat(builder.target().key(), is("/registry"));
-        assertThat(builder.target().api(), is(EtcdApi.v3));
+        assertThat(builder.target(0).uri(), is(URI.create("http://localhost:2379")));
+        assertThat(builder.target(0).key(), is("/registry"));
+        assertThat(builder.target(0).api(), is(EtcdApi.v3));
     }
 
     @Test
@@ -159,9 +159,9 @@ public class EtcdConfigSourceBuilderTest {
                         "api", "v3",
                         "change-watcher.type", EtcdWatcherProvider.TYPE))));
 
-        assertThat(builder.target().uri(), is(URI.create("http://localhost:2379")));
-        assertThat(builder.target().key(), is("/registry"));
-        assertThat(builder.target().api(), is(EtcdApi.v3));
+        assertThat(builder.target(0).uri(), is(URI.create("http://localhost:2379")));
+        assertThat(builder.target(0).key(), is("/registry"));
+        assertThat(builder.target(0).api(), is(EtcdApi.v3));
     }
 
     @Test


### PR DESCRIPTION
Implementation is currently supported only for V2 which is based on Etcd4j. Attempting to pass more than one URI to a V3 factory will result in an exception. This change is source backward compatible since it only replaces `URI` for `URI...`. See #1426.