### PR TITLE
Defer creation of current-time-in-seconds thread until runtime

### DIFF
--- a/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
@@ -32,3 +32,4 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
 #io.netty.level=INFO
+io.helidon.metrics.ExponentiallyDecayingReservoir.level=FINER

--- a/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/resources/logging.properties
@@ -32,4 +32,3 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 #io.helidon.security.level=INFO
 #io.helidon.common.level=INFO
 #io.netty.level=INFO
-io.helidon.metrics.ExponentiallyDecayingReservoir.level=FINER

--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -102,6 +102,7 @@
                             <configuration>
                                 <excludes>
                                     <exclude>**/TestServerWithKeyPerformanceIndicatorMetrics.java</exclude>
+                                    <exclude>**/TestExponentiallyDecayingReservoir.java</exclude>
                                 </excludes>
                             </configuration>
                         </execution>
@@ -129,6 +130,19 @@
                             <configuration>
                                 <includes>
                                     <include>**/TestServerWithKeyPerformanceIndicatorMetrics.java</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- Run in separate invocation so we have only one task updating
+                                 ExponentiallyDecayingReservoir current time values. -->
+                            <id>exponentially-decaying-reservoir-check</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/TestExponentiallyDecayingReservoir.java</include>
                                 </includes>
                             </configuration>
                         </execution>

--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Logger;
 
 import static java.lang.Math.exp;
 import static java.lang.Math.min;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
@@ -154,7 +154,7 @@ class ExponentiallyDecayingReservoir {
     }
 
     private void updateTimeInSeconds() {
-        currentTimeInSeconds = System.currentTimeMillis() / 1000;
+        currentTimeInSeconds = TimeUnit.MILLISECONDS.toSeconds(clock.milliTime());
     }
 
     long currentTimeInSeconds() {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
@@ -57,8 +57,6 @@ class ExponentiallyDecayingReservoir {
     private static final double DEFAULT_ALPHA = 0.015;
     private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
 
-    private static final Logger LOGGER = Logger.getLogger(ExponentiallyDecayingReservoir.class.getName());
-
     private static final Duration CURRENT_TIME_IN_SECONDS_UPDATE_INTERVAL = Duration.ofMillis(250);
 
     private final ConcurrentSkipListMap<Double, WeightedSnapshot.WeightedSample> values;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/ExponentiallyDecayingReservoir.java
@@ -196,6 +196,10 @@ class ExponentiallyDecayingReservoir {
         }
     }
 
+    long currentTimeInSeconds() {
+        return currentTimeInSeconds;
+    }
+    
     private double weight(long t) {
         return exp(alpha * t);
     }

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -427,6 +427,8 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
      */
     @Override
     public void update(Routing.Rules rules) {
+        ExponentiallyDecayingReservoir.init();
+
         configureEndpoint(rules, rules);
     }
 

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -427,14 +427,14 @@ public final class MetricsSupport extends HelidonRestServiceSupport {
      */
     @Override
     public void update(Routing.Rules rules) {
-        ExponentiallyDecayingReservoir.init();
+        PeriodicExecutor.start();
 
         configureEndpoint(rules, rules);
     }
 
     @Override
     protected void onShutdown() {
-        ExponentiallyDecayingReservoir.onServerShutdown();
+        PeriodicExecutor.stop();
     }
 
     private static KeyPerformanceIndicatorSupport.Context kpiContext(ServerRequest request) {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/PeriodicExecutor.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/PeriodicExecutor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Manages a single-thread executor which will invoke callbacks to enrollees at a frequency they request.
+ * <p>
+ * Some enrollments might arrive before the manager is started. We save those and act on them once the
+ * manager starts. This makes sure the executor's thread starts only at native image runtime.
+ * </p>
+ * <p>
+ * In production use, starting and stopping the executor and even enrolling callbacks are not performance-critical operations,
+ * so simple synchronization on methods which access shared data is clear and sufficient.
+ * </p>
+ */
+class PeriodicExecutor {
+
+    static final PeriodicExecutor INSTANCE = create();
+
+    static PeriodicExecutor create() {
+        return new PeriodicExecutor();
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(PeriodicExecutor.class.getName());
+
+    enum State {
+        DORMANT, // never started
+        STARTED, // started and still running
+        STOPPED  // stopped
+    }
+
+    private static class Enrollment {
+        private final Runnable runnable;
+        private final Duration interval;
+
+        Enrollment(Runnable runnable, Duration interval) {
+            this.runnable = runnable;
+            this.interval = interval;
+        }
+    }
+
+    private State state = State.DORMANT;
+
+    private ScheduledExecutorService currentTimeUpdaterExecutorService;
+
+    private final Collection<Enrollment> deferredEnrollments = new ArrayList<>();
+
+    private PeriodicExecutor() {
+    }
+
+    static void enroll(Runnable runnable, Duration interval) {
+        INSTANCE.enrollRunner(runnable, interval);
+    }
+
+    static void start() {
+        INSTANCE.startExecutor();
+    }
+
+    static void stop() {
+        INSTANCE.stopExecutor();
+    }
+
+    static State state() {
+        return INSTANCE.executorState();
+    }
+
+    synchronized void enrollRunner(Runnable runnable, Duration interval) {
+
+        if (state == State.STARTED) {
+            currentTimeUpdaterExecutorService.scheduleAtFixedRate(
+                    runnable,
+                    interval.toMillis(),
+                    interval.toMillis(),
+                    TimeUnit.MILLISECONDS);
+        } else if (state == State.DORMANT) {
+            deferredEnrollments.add(new Enrollment(runnable, interval));
+        } else {
+            LOGGER.log(Level.WARNING,
+                    "Attempt to enroll when in unexpected state " + state + "; ignored",
+                    new IllegalStateException());
+        }
+    }
+
+    synchronized void startExecutor() {
+        if (state == State.DORMANT) {
+            LOGGER.log(Level.FINE, "Starting up with " + deferredEnrollments.size() + " deferred enrollments");
+            state = State.STARTED;
+            currentTimeUpdaterExecutorService = Executors.newSingleThreadScheduledExecutor();
+            for (Enrollment deferredEnrollment : deferredEnrollments) {
+                currentTimeUpdaterExecutorService.scheduleAtFixedRate(
+                        deferredEnrollment.runnable,
+                        deferredEnrollment.interval.toMillis(),
+                        deferredEnrollment.interval.toMillis(),
+                        TimeUnit.MILLISECONDS);
+            }
+            deferredEnrollments.clear();
+        } else {
+            LOGGER.log(Level.WARNING, String.format("Attempt to start; the expected state is %s but found %s; ignored",
+                    State.DORMANT,
+                    state),
+                    new IllegalStateException());
+        }
+    }
+
+    synchronized void stopExecutor() {
+        if (state == State.STARTED) {
+            LOGGER.log(Level.FINE, "Shutting down");
+            currentTimeUpdaterExecutorService.shutdownNow();
+        } else {
+            LOGGER.log(Level.WARNING, String.format(
+                    "Attempt to stop; the expected state is %s but found %s; ignored",
+                    State.DORMANT,
+                    state),
+                    new IllegalStateException());
+        }
+        state = State.STOPPED;
+    }
+
+    State executorState() {
+        return state;
+    }
+}

--- a/metrics/metrics/src/main/resources/META-INF/native-image/io.helidon.metrics/native-image.properties
+++ b/metrics/metrics/src/main/resources/META-INF/native-image/io.helidon.metrics/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args=--initialize-at-run-time=io.helidon.metrics.ExponentiallyDecayingReservoir
+Args=--initialize-at-build-time=io.helidon.metrics

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
@@ -27,12 +27,12 @@ class TestExponentiallyDecayingReservoir {
 
     @BeforeAll
     static void startExecutor() {
-        ExponentiallyDecayingReservoir.init();
+        PeriodicExecutor.start();
     }
 
     @AfterAll
     static void stopExecutor() {
-        ExponentiallyDecayingReservoir.onServerShutdown();
+        PeriodicExecutor.stop();
     }
 
     @Test

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class TestExponentiallyDecayingReservoir {
+
+    @BeforeAll
+    static void startExecutor() {
+        ExponentiallyDecayingReservoir.init();
+    }
+
+    @AfterAll
+    static void stopExecutor() {
+        ExponentiallyDecayingReservoir.onServerShutdown();
+    }
+
+    @Test
+    void checkCurrentTimeInSeconds() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        ExponentiallyDecayingReservoir edr = new ExponentiallyDecayingReservoir(Clock.system());
+        long startTime = edr.currentTimeInSeconds();
+        Thread.sleep(1100);
+        long currentTimeInSeconds = edr.currentTimeInSeconds();
+        assertThat("Difference in current time across a short delay", currentTimeInSeconds - startTime,
+                is(greaterThan(0L)));
+    }
+}

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestExponentiallyDecayingReservoir.java
@@ -36,12 +36,11 @@ class TestExponentiallyDecayingReservoir {
     }
 
     @Test
-    void checkCurrentTimeInSeconds() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+    void checkCurrentTimeInSeconds() throws InterruptedException {
         ExponentiallyDecayingReservoir edr = new ExponentiallyDecayingReservoir(Clock.system());
         long startTime = edr.currentTimeInSeconds();
         Thread.sleep(1100);
-        long currentTimeInSeconds = edr.currentTimeInSeconds();
-        assertThat("Difference in current time across a short delay", currentTimeInSeconds - startTime,
+        assertThat("Difference in current time across a short delay", edr.currentTimeInSeconds() - startTime,
                 is(greaterThan(0L)));
     }
 }

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestPeriodicExecutor.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestPeriodicExecutor.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class TestPeriodicExecutor {
+
+    private static final int SLEEP_TIME_MS = 1500;
+
+    private static final int FAST_INTERVAL = 250;
+    private static final int SLOW_INTERVAL = 400;
+
+    private static final double SLOWDOWN_FACTOR = 0.80; // for slow pipelines!
+
+    private static final double MIN_FAST_COUNT = 1500 / FAST_INTERVAL * SLOWDOWN_FACTOR;
+    private static final double MIN_SLOW_COUNT = 1500 / SLOW_INTERVAL * SLOWDOWN_FACTOR;
+
+    @Test
+    void testWithNoDeferrals() throws InterruptedException {
+
+        PeriodicExecutor exec = PeriodicExecutor.create();
+        try {
+            exec.startExecutor();
+            AtomicInteger countA = new AtomicInteger();
+            AtomicInteger countB = new AtomicInteger();
+
+            exec.enrollRunner(() -> countA.incrementAndGet(), Duration.ofMillis(FAST_INTERVAL));
+            exec.enrollRunner(() -> countB.incrementAndGet(), Duration.ofMillis(SLOW_INTERVAL));
+
+            Thread.sleep(SLEEP_TIME_MS);
+
+            assertThat("CountA", (double) countA.get(), is(greaterThan(MIN_FAST_COUNT)));
+            assertThat("CountB", (double) countB.get(), is(greaterThan(MIN_SLOW_COUNT)));
+        } finally {
+            if (exec.executorState() == PeriodicExecutor.State.STARTED) {
+                exec.stopExecutor();
+            }
+        }
+    }
+
+    @Test
+    void testWithDeferredEnrollments() throws InterruptedException {
+        PeriodicExecutor exec = PeriodicExecutor.create();
+        try {
+            AtomicInteger countA = new AtomicInteger();
+            AtomicInteger countB = new AtomicInteger();
+
+            exec.enrollRunner(() -> countA.incrementAndGet(), Duration.ofMillis(FAST_INTERVAL));
+
+            exec.startExecutor();
+
+            exec.enrollRunner(() -> countB.incrementAndGet(), Duration.ofMillis(SLOW_INTERVAL));
+
+            Thread.sleep(SLEEP_TIME_MS);
+
+            assertThat("CountA", (double) countA.get(), is(greaterThan(MIN_FAST_COUNT)));
+            assertThat("CountB", (double) countB.get(), is(greaterThan(MIN_SLOW_COUNT)));
+        } finally {
+            if (exec.executorState() == PeriodicExecutor.State.STARTED) {
+                exec.stopExecutor();
+            }
+        }
+    }
+
+    @Test
+    void testWithLateEnrollment() throws InterruptedException {
+        PeriodicExecutor exec = PeriodicExecutor.create();
+        try {
+            AtomicInteger countA = new AtomicInteger();
+            AtomicInteger countB = new AtomicInteger();
+
+            exec.enrollRunner(() -> countA.incrementAndGet(), Duration.ofMillis(FAST_INTERVAL));
+
+            exec.startExecutor();
+            Thread.sleep(SLEEP_TIME_MS);
+
+            exec.stopExecutor();
+
+            exec.enrollRunner(() -> countB.incrementAndGet(), Duration.ofMillis(SLOW_INTERVAL));
+
+            assertThat("CountA", (double) countA.get(), is(greaterThan(MIN_FAST_COUNT))); // should be 8
+            assertThat("CountB", (double) countB.get(), is(0.0));
+        } finally {
+            if (exec.executorState() == PeriodicExecutor.State.STARTED) {
+                exec.stopExecutor();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replaces #3374 
Resolves #3389 

This PR picks up Tomas's earlier one (#3374) and incorporates Daniel's comments.

The separate commits divide up the changes clearly, I hope. 

Aside from adopting Daniel's suggestion for a three-state model for the executor, the other main change is to maintain a list of `ExponentiallyDecayingReservoir`s for which their current-time-in-seconds should be updated periodically, rather than keep a list of `Runnable`; we don't need to be that general and it's clearer and probably faster this way.

Also, the earlier shutdown processing (`awaitTermination` to wait for the scheduled tasks to finish) seemed to time out rather than complete, so I've changed it to use `shutdownNow` instead.