### PR TITLE
Add JUnit profiles #3115

### DIFF
--- a/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigurationCustomProfile.java
+++ b/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigurationCustomProfile.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.junit5;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@Configuration(profile = "custom")
+public class TestConfigurationCustomProfile {
+
+    @Inject
+    @ConfigProperty(name = "mp.config.profile")
+    private String profile;
+
+    @Test
+    void testCustomProfile(){
+        assertThat(profile, is("custom"));
+    }
+}

--- a/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigurationDefaultProfile.java
+++ b/microprofile/tests/junit5-tests/src/test/java/io/helidon/microprofile/tests/junit5/TestConfigurationDefaultProfile.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.junit5;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@Configuration
+public class TestConfigurationDefaultProfile {
+
+    @Inject
+    @ConfigProperty(name = "mp.config.profile")
+    private String profile;
+
+    @Test
+    void testProfile(){
+        assertThat(profile, is("test"));
+    }
+}

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/Configuration.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,4 +48,11 @@ public @interface Configuration {
      * @return config sources to add
      */
     String[] configSources() default {};
+
+    /**
+     * Configuration profile.
+     *
+     * @return String with default value "test".
+     */
+    String profile() default "test";
 }

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
@@ -71,11 +71,11 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
  * Junit5 extension to support Helidon CDI container in tests.
  */
 class HelidonJunitExtension implements BeforeAllCallback,
-        AfterAllCallback,
-        BeforeEachCallback,
-        AfterEachCallback,
-        InvocationInterceptor,
-        ParameterResolver {
+                                       AfterAllCallback,
+                                       BeforeEachCallback,
+                                       AfterEachCallback,
+                                       InvocationInterceptor,
+                                       ParameterResolver {
     private static final Set<Class<? extends Annotation>> HELIDON_TEST_ANNOTATIONS =
             Set.of(AddBean.class, AddConfig.class, AddExtension.class, Configuration.class);
     private static final Map<Class<? extends Annotation>, Annotation> BEAN_DEFINING = new HashMap<>();
@@ -160,7 +160,7 @@ class HelidonJunitExtension implements BeforeAllCallback,
 
         Object result = Array.newInstance(annotClass, allAnnotations.size());
         for (int i = 0; i < allAnnotations.size(); i++) {
-            Array.set(result, i, allAnnotations.get(i));
+             Array.set(result, i, allAnnotations.get(i));
         }
 
         return (T[]) result;
@@ -211,9 +211,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
                 // a test method
                 if (hasHelidonTestAnnotation(method)) {
                     throw new RuntimeException("When a class is annotated with @HelidonTest, "
-                            + "there is a single CDI container used to invoke all "
-                            + "test methods on the class. Method " + method
-                            + " has an annotation that modifies container behavior.");
+                                                       + "there is a single CDI container used to invoke all "
+                                                       + "test methods on the class. Method " + method
+                                                       + " has an annotation that modifies container behavior.");
                 }
             }
         }
@@ -224,9 +224,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
                 // a test method
                 if (hasHelidonTestAnnotation(method)) {
                     throw new RuntimeException("When a class is annotated with @HelidonTest, "
-                            + "there is a single CDI container used to invoke all "
-                            + "test methods on the class. Method " + method
-                            + " has an annotation that modifies container behavior.");
+                                                       + "there is a single CDI container used to invoke all "
+                                                       + "test methods on the class. Method " + method
+                                                       + " has an annotation that modifies container behavior.");
                 }
             }
         }
@@ -245,13 +245,13 @@ class HelidonJunitExtension implements BeforeAllCallback,
         Constructor<?>[] constructors = testClass.getConstructors();
         if (constructors.length > 1) {
             throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                    + " the class must have only a single no-arg constructor");
+                                               + " the class must have only a single no-arg constructor");
         }
         if (constructors.length == 1) {
             Constructor<?> c = constructors[0];
             if (c.getParameterCount() > 0) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                        + " the class must have a no-arg constructor");
+                                                   + " the class must have a no-arg constructor");
             }
         }
 
@@ -259,9 +259,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
         for (Field field : fields) {
             if (field.getAnnotation(Inject.class) != null) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                        + " injection into fields or constructor is not supported, as each"
-                        + " test method uses a different CDI container. Field " + field
-                        + " is annotated with @Inject");
+                                                   + " injection into fields or constructor is not supported, as each"
+                                                   + " test method uses a different CDI container. Field " + field
+                                                   + " is annotated with @Inject");
             }
         }
 
@@ -269,9 +269,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
         for (Field field : fields) {
             if (field.getAnnotation(Inject.class) != null) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                        + " injection into fields or constructor is not supported, as each"
-                        + " test method uses a different CDI container. Field " + field
-                        + " is annotated with @Inject");
+                                                   + " injection into fields or constructor is not supported, as each"
+                                                   + " test method uses a different CDI container. Field " + field
+                                                   + " is annotated with @Inject");
             }
         }
     }

--- a/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
+++ b/microprofile/tests/junit5/src/main/java/io/helidon/microprofile/tests/junit5/HelidonJunitExtension.java
@@ -71,11 +71,11 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
  * Junit5 extension to support Helidon CDI container in tests.
  */
 class HelidonJunitExtension implements BeforeAllCallback,
-                                       AfterAllCallback,
-                                       BeforeEachCallback,
-                                       AfterEachCallback,
-                                       InvocationInterceptor,
-                                       ParameterResolver {
+        AfterAllCallback,
+        BeforeEachCallback,
+        AfterEachCallback,
+        InvocationInterceptor,
+        ParameterResolver {
     private static final Set<Class<? extends Annotation>> HELIDON_TEST_ANNOTATIONS =
             Set.of(AddBean.class, AddConfig.class, AddExtension.class, Configuration.class);
     private static final Map<Class<? extends Annotation>, Annotation> BEAN_DEFINING = new HashMap<>();
@@ -160,7 +160,7 @@ class HelidonJunitExtension implements BeforeAllCallback,
 
         Object result = Array.newInstance(annotClass, allAnnotations.size());
         for (int i = 0; i < allAnnotations.size(); i++) {
-             Array.set(result, i, allAnnotations.get(i));
+            Array.set(result, i, allAnnotations.get(i));
         }
 
         return (T[]) result;
@@ -211,9 +211,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
                 // a test method
                 if (hasHelidonTestAnnotation(method)) {
                     throw new RuntimeException("When a class is annotated with @HelidonTest, "
-                                                       + "there is a single CDI container used to invoke all "
-                                                       + "test methods on the class. Method " + method
-                                                       + " has an annotation that modifies container behavior.");
+                            + "there is a single CDI container used to invoke all "
+                            + "test methods on the class. Method " + method
+                            + " has an annotation that modifies container behavior.");
                 }
             }
         }
@@ -224,9 +224,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
                 // a test method
                 if (hasHelidonTestAnnotation(method)) {
                     throw new RuntimeException("When a class is annotated with @HelidonTest, "
-                                                       + "there is a single CDI container used to invoke all "
-                                                       + "test methods on the class. Method " + method
-                                                       + " has an annotation that modifies container behavior.");
+                            + "there is a single CDI container used to invoke all "
+                            + "test methods on the class. Method " + method
+                            + " has an annotation that modifies container behavior.");
                 }
             }
         }
@@ -245,13 +245,13 @@ class HelidonJunitExtension implements BeforeAllCallback,
         Constructor<?>[] constructors = testClass.getConstructors();
         if (constructors.length > 1) {
             throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                                               + " the class must have only a single no-arg constructor");
+                    + " the class must have only a single no-arg constructor");
         }
         if (constructors.length == 1) {
             Constructor<?> c = constructors[0];
             if (c.getParameterCount() > 0) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                                                   + " the class must have a no-arg constructor");
+                        + " the class must have a no-arg constructor");
             }
         }
 
@@ -259,9 +259,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
         for (Field field : fields) {
             if (field.getAnnotation(Inject.class) != null) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                                                   + " injection into fields or constructor is not supported, as each"
-                                                   + " test method uses a different CDI container. Field " + field
-                                                   + " is annotated with @Inject");
+                        + " injection into fields or constructor is not supported, as each"
+                        + " test method uses a different CDI container. Field " + field
+                        + " is annotated with @Inject");
             }
         }
 
@@ -269,9 +269,9 @@ class HelidonJunitExtension implements BeforeAllCallback,
         for (Field field : fields) {
             if (field.getAnnotation(Inject.class) != null) {
                 throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
-                                                   + " injection into fields or constructor is not supported, as each"
-                                                   + " test method uses a different CDI container. Field " + field
-                                                   + " is annotated with @Inject");
+                        + " injection into fields or constructor is not supported, as each"
+                        + " test method uses a different CDI container. Field " + field
+                        + " is annotated with @Inject");
             }
         }
     }
@@ -294,7 +294,6 @@ class HelidonJunitExtension implements BeforeAllCallback,
                     builder.withSources(MpConfigSources.classPath(it).toArray(new ConfigSource[0]));
                 }
             });
-
             config = builder
                     .withSources(MpConfigSources.create(configMeta.additionalKeys))
                     .addDefaultSources()
@@ -508,6 +507,7 @@ class HelidonJunitExtension implements BeforeAllCallback,
         private final Map<String, String> additionalKeys = new HashMap<>();
         private final List<String> additionalSources = new ArrayList<>();
         private boolean useExisting;
+        private String profile;
 
         private ConfigMeta() {
             // to allow SeContainerInitializer (forbidden by default because of native image)
@@ -517,6 +517,8 @@ class HelidonJunitExtension implements BeforeAllCallback,
             additionalKeys.put("server.port", "0");
             // higher ordinal then all the defaults, system props and environment variables
             additionalKeys.putIfAbsent(ConfigSource.CONFIG_ORDINAL, "1000");
+            // profile
+            additionalKeys.put("mp.config.profile", "test");
         }
 
         private void addConfig(AddConfig[] configs) {
@@ -530,7 +532,10 @@ class HelidonJunitExtension implements BeforeAllCallback,
                 return;
             }
             useExisting = config.useExisting();
+            profile = config.profile();
             additionalSources.addAll(List.of(config.configSources()));
+            //set additional key for profile
+            additionalKeys.put("mp.config.profile", profile);
         }
 
         ConfigMeta nextMethod() {
@@ -539,6 +544,7 @@ class HelidonJunitExtension implements BeforeAllCallback,
             methodMeta.additionalKeys.putAll(this.additionalKeys);
             methodMeta.additionalSources.addAll(this.additionalSources);
             methodMeta.useExisting = this.useExisting;
+            methodMeta.profile = this.profile;
 
             return methodMeta;
         }


### PR DESCRIPTION
This PR adds mp.config.profile config property with default test
The profile is being read from @Configuration annotation (default set to test as well).

Integrations tests included.