### PR TITLE
Fluent headers.

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/HashParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/HashParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -280,9 +280,9 @@ public class HashParameters implements Parameters {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public HashParameters putAll(Parameters parameters) {
         if (parameters == null) {
-            return;
+            return this;
         }
 
         for (Map.Entry<String, List<String>> entry : parameters.toMap().entrySet()) {
@@ -291,14 +291,15 @@ public class HashParameters implements Parameters {
                 content.put(entry.getKey(), Collections.unmodifiableList(values));
             }
         }
+        return this;
     }
 
     @Override
-    public void add(String key, String... values) {
+    public HashParameters add(String key, String... values) {
         Objects.requireNonNull(key, "Parameter 'key' is null!");
         if (values == null || values.length == 0) {
             // do not necessarily create an entry in the map, simply immediately return
-            return;
+            return this;
         }
 
         content.compute(key, (s, list) -> {
@@ -311,15 +312,16 @@ public class HashParameters implements Parameters {
                 return Collections.unmodifiableList(newValues);
             }
         });
+        return this;
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public HashParameters add(String key, Iterable<String> values) {
         Objects.requireNonNull(key, "Parameter 'key' is null!");
         List<String> vls = internalListCopy(values);
         if (vls == null) {
             // do not necessarily create an entry in the map, simply immediately return
-            return;
+            return this;
         }
 
         content.compute(key, (s, list) -> {
@@ -332,17 +334,19 @@ public class HashParameters implements Parameters {
                 return Collections.unmodifiableList(newValues);
             }
         });
+        return this;
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public HashParameters addAll(Parameters parameters) {
         if (parameters == null) {
-            return;
+            return this;
         }
         Map<String, List<String>> map = parameters.toMap();
         for (Map.Entry<String, List<String>> entry : map.entrySet()) {
             add(entry.getKey(), entry.getValue());
         }
+        return this;
     }
 
     @Override

--- a/common/http/src/main/java/io/helidon/common/http/Parameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,10 +172,11 @@ public interface Parameters {
      * (optional operation).
      *
      * @param parameters to copy.
+     * @return this instance of {@link Parameters}
      * @throws NullPointerException          if the specified {@code parameters} are null.
      * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Parameters).
      */
-    void putAll(Parameters parameters);
+    Parameters putAll(Parameters parameters);
 
     /**
      * Adds specified values tu association with the specified key (optional operation).
@@ -183,10 +184,11 @@ public interface Parameters {
      *
      * @param key    key with which the specified value is to be associated
      * @param values value to be add to association with the specified key
+     * @return this instance of {@link Parameters}
      * @throws NullPointerException          if the specified key is null.
      * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Parameters).
      */
-    void add(String key, String... values);
+    Parameters add(String key, String... values);
 
     /**
      * Adds specified values tu association with the specified key (optional operation).
@@ -194,20 +196,22 @@ public interface Parameters {
      *
      * @param key    key with which the specified value is to be associated
      * @param values value to be add to association with the specified key. If {@code null} then noting will be add.
+     * @return this instance of {@link Parameters}
      * @throws NullPointerException          if the specified key is null.
      * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Parameters).
      */
-    void add(String key, Iterable<String> values);
+    Parameters add(String key, Iterable<String> values);
 
     /**
      * Copies all of the mappings from the specified {@code parameters} to this instance adding values to existing associations
      * (optional operation).
      *
      * @param parameters to copy.
+     * @return this instance of {@link Parameters}
      * @throws NullPointerException          if the specified {@code parameters} are null.
      * @throws UnsupportedOperationException if put operation is not supported (unmodifiable Parameters).
      */
-    void addAll(Parameters parameters);
+    Parameters addAll(Parameters parameters);
 
     /**
      * Removes the mapping for a key if it is present (optional operation).

--- a/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/ReadOnlyParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,17 +120,17 @@ public class ReadOnlyParameters implements Parameters {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public ReadOnlyParameters putAll(Parameters parameters) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void add(String key, String... values) {
+    public ReadOnlyParameters add(String key, String... values) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public ReadOnlyParameters add(String key, Iterable<String> values) {
         throw new UnsupportedOperationException();
     }
 
@@ -140,7 +140,7 @@ public class ReadOnlyParameters implements Parameters {
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public ReadOnlyParameters addAll(Parameters parameters) {
         throw new UnsupportedOperationException();
     }
 

--- a/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
+++ b/common/http/src/main/java/io/helidon/common/http/UnmodifiableParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,22 +83,22 @@ class UnmodifiableParameters implements Parameters {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public UnmodifiableParameters putAll(Parameters parameters) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void add(String key, String... values) {
+    public UnmodifiableParameters add(String key, String... values) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public UnmodifiableParameters add(String key, Iterable<String> values) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public UnmodifiableParameters addAll(Parameters parameters) {
         throw new UnsupportedOperationException();
     }
 

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientQueryParams.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientQueryParams.java
@@ -97,33 +97,37 @@ class WebClientQueryParams implements Parameters {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public WebClientQueryParams putAll(Parameters parameters) {
         if (parameters == null) {
-            return;
+            return this;
         }
         rawParams.putAll(parameters);
         parameters.toMap().forEach((key, value) -> encodedParams.put(encode(key), encodeIterable(value)));
+        return this;
     }
 
     @Override
-    public void add(String key, String... values) {
+    public WebClientQueryParams add(String key, String... values) {
         rawParams.add(key, values);
         encodedParams.add(encode(key), encodeIterable(Arrays.asList(values)));
+        return this;
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public WebClientQueryParams add(String key, Iterable<String> values) {
         rawParams.add(key, values);
         encodedParams.add(encode(key), encodeIterable(values));
+        return this;
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public WebClientQueryParams addAll(Parameters parameters) {
         if (parameters == null) {
-            return;
+            return this;
         }
         rawParams.addAll(parameters);
         parameters.toMap().forEach((key, value) -> encodedParams.add(key, encodeIterable(value)));
+        return this;
     }
 
     private Iterable<String> encodeIterable(Iterable<String> iterable) {

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilder.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilder.java
@@ -152,6 +152,52 @@ public interface WebClientRequestBuilder {
     WebClientRequestBuilder headers(Function<WebClientRequestHeaders, Headers> headers);
 
     /**
+     * Adds header values for a specified name.
+     *
+     * @param name   header name
+     * @param values header values
+     * @return this instance of {@link WebClientRequestBuilder}
+     * @throws NullPointerException if the specified name is null.
+     * @see #headers()
+     * @see Parameters#add(String, String...)
+     * @see Http.Header header names constants
+     */
+    default WebClientRequestBuilder addHeader(String name, String... values) {
+        headers().add(name, values);
+        return this;
+    }
+
+    /**
+     * Adds header values for a specified name.
+     *
+     * @param name   header name
+     * @param values header values
+     * @return this instance of {@link WebClientRequestBuilder}
+     * @throws NullPointerException if the specified name is null.
+     * @see #headers()
+     * @see Parameters#add(String, Iterable)
+     * @see Http.Header header names constants
+     */
+    default WebClientRequestBuilder addHeader(String name, Iterable<String> values) {
+        headers().add(name, values);
+        return this;
+    }
+
+    /**
+     * Copies all of the mappings from the specified {@code parameters} to this response headers instance.
+     *
+     * @param parameters to copy.
+     * @return this instance of {@link WebClientRequestBuilder}
+     * @throws NullPointerException if the specified {@code parameters} are null.
+     * @see #headers()
+     * @see Parameters#addAll(Parameters)
+     */
+    default WebClientRequestBuilder addHeaders(Parameters parameters){
+        headers().addAll(parameters);
+        return this;
+    }
+
+    /**
      * Configure query parameters.
      *
      * Appends these query parameters to the query parameters defined in the request uri.

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeaders.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Optional;
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
+import io.helidon.common.http.Parameters;
 
 /**
  * Headers that can be modified (until request is sent) for
@@ -198,4 +199,15 @@ public interface WebClientRequestHeaders extends Headers {
      */
     void clear();
 
+    @Override
+    WebClientRequestHeaders putAll(Parameters parameters);
+
+    @Override
+    WebClientRequestHeaders add(String key, String... values);
+
+    @Override
+    WebClientRequestHeaders add(String key, Iterable<String> values);
+
+    @Override
+    WebClientRequestHeaders addAll(Parameters parameters);
 }

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestHeadersImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,23 +233,27 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public WebClientRequestHeaders putAll(Parameters parameters) {
         headers.putAll(parameters.toMap());
+        return this;
     }
 
     @Override
-    public void add(String key, String... values) {
+    public WebClientRequestHeaders add(String key, String... values) {
         headers.computeIfAbsent(key, k -> new ArrayList<>()).addAll(Arrays.asList(values));
+        return this;
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public WebClientRequestHeaders add(String key, Iterable<String> values) {
         headers.computeIfAbsent(key, k -> new ArrayList<>()).addAll(iterableToList(values));
+        return this;
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public WebClientRequestHeaders addAll(Parameters parameters) {
         parameters.toMap().forEach(this::add);
+        return this;
     }
 
     @Override

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HashResponseHeaders.java
@@ -266,7 +266,7 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     /**
      * Sets an HTTP status code. The code is managed with headers because it has the same lifecycle.
      *
-     * @status an HTTP status code.
+     * @param httpStatusCode an HTTP status code.
      */
     void httpStatus(Http.ResponseStatus httpStatusCode) {
         Objects.requireNonNull(httpStatusCode, "Parameter 'httpStatus' is null!");
@@ -309,23 +309,27 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     }
 
     @Override
-    public void putAll(Parameters parameters) {
+    public HashResponseHeaders putAll(Parameters parameters) {
         completable.runIfNotCompleted(() -> super.putAll(parameters), COMPLETED_EXCEPTION_MESSAGE);
+        return this;
     }
 
     @Override
-    public void add(String key, String... values) {
+    public HashResponseHeaders add(String key, String... values) {
         completable.runIfNotCompleted(() -> super.add(key, values), COMPLETED_EXCEPTION_MESSAGE);
+        return this;
     }
 
     @Override
-    public void add(String key, Iterable<String> values) {
+    public HashResponseHeaders add(String key, Iterable<String> values) {
         completable.runIfNotCompleted(() -> super.add(key, values), COMPLETED_EXCEPTION_MESSAGE);
+        return this;
     }
 
     @Override
-    public void addAll(Parameters parameters) {
+    public HashResponseHeaders addAll(Parameters parameters) {
         completable.runIfNotCompleted(() -> super.addAll(parameters), COMPLETED_EXCEPTION_MESSAGE);
+        return this;
     }
 
     @Override
@@ -354,7 +358,7 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     }
 
     /**
-     * If not yet completed then ompletes and return {@code true}, otherwise returns {@code false}.
+     * If not yet completed then completes and return {@code true}, otherwise returns {@code false}.
      * <p>
      * All possible exceptions are forwarded to {@link BareResponse#onError(Throwable)} method.
      *
@@ -370,7 +374,7 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
     private static class CompletionSupport {
 
         private enum State {
-            OPEN, COMPLETING, COMPLETED;
+            OPEN, COMPLETING, COMPLETED
         }
 
         // A simple locking mechanism.
@@ -382,7 +386,7 @@ class HashResponseHeaders extends HashParameters implements ResponseHeaders {
         /**
          * Creates new instance.
          *
-         * @param bareResponse
+         * @param bareResponse bare response
          */
         CompletionSupport(BareResponse bareResponse) {
             this.bareResponse = bareResponse;

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
@@ -246,5 +246,4 @@ public interface ResponseHeaders extends Headers {
      * @return a completion stage of sending process.
      */
     Single<ResponseHeaders> send();
-
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
@@ -246,4 +246,16 @@ public interface ResponseHeaders extends Headers {
      * @return a completion stage of sending process.
      */
     Single<ResponseHeaders> send();
+
+    @Override
+    ResponseHeaders putAll(Parameters parameters);
+
+    @Override
+    ResponseHeaders add(String key, String... values);
+
+    @Override
+    ResponseHeaders add(String key, Iterable<String> values);
+
+    @Override
+    ResponseHeaders addAll(Parameters parameters);
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.helidon.common.http.AlreadyCompletedException;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
+import io.helidon.common.http.Parameters;
 import io.helidon.common.reactive.Single;
 import io.helidon.media.common.MessageBodyFilter;
 import io.helidon.media.common.MessageBodyFilters;
@@ -92,6 +93,52 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * @return a response headers
      */
     ResponseHeaders headers();
+
+    /**
+     * Adds header values for a specified name.
+     *
+     * @param name   header name
+     * @param values header values
+     * @return this instance of {@link ServerResponse}
+     * @throws NullPointerException if the specified key is null.
+     * @see #headers()
+     * @see Parameters#add(String, String...)
+     * @see Http.Header header names constants
+     */
+    default ServerResponse addHeader(String name, String... values) {
+        headers().add(name, values);
+        return this;
+    }
+
+    /**
+     * Adds header values for a specified name.
+     *
+     * @param name   header name
+     * @param values header values
+     * @return this instance of {@link ServerResponse}
+     * @throws NullPointerException if the specified key is null.
+     * @see #headers()
+     * @see Parameters#add(String, Iterable)
+     * @see Http.Header header names constants
+     */
+    default ServerResponse addHeader(String name, Iterable<String> values) {
+        headers().add(name, values);
+        return this;
+    }
+
+    /**
+     * Copies all of the mappings from the specified {@code parameters} to this response headers instance.
+     *
+     * @param parameters to copy.
+     * @return this instance of {@link ServerResponse}
+     * @throws NullPointerException          if the specified {@code parameters} are null.
+     * @see #headers()
+     * @see Parameters#addAll(Parameters)
+     */
+    default ServerResponse addHeaders(Parameters parameters){
+        headers().addAll(parameters);
+        return this;
+    }
 
     /**
      * Get the writer context used to marshall data.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -100,7 +100,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * @param name   header name
      * @param values header values
      * @return this instance of {@link ServerResponse}
-     * @throws NullPointerException if the specified key is null.
+     * @throws NullPointerException if the specified name is null.
      * @see #headers()
      * @see Parameters#add(String, String...)
      * @see Http.Header header names constants
@@ -116,7 +116,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * @param name   header name
      * @param values header values
      * @return this instance of {@link ServerResponse}
-     * @throws NullPointerException if the specified key is null.
+     * @throws NullPointerException if the specified name is null.
      * @see #headers()
      * @see Parameters#add(String, Iterable)
      * @see Http.Header header names constants
@@ -131,7 +131,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      *
      * @param parameters to copy.
      * @return this instance of {@link ServerResponse}
-     * @throws NullPointerException          if the specified {@code parameters} are null.
+     * @throws NullPointerException if the specified {@code parameters} are null.
      * @see #headers()
      * @see Parameters#addAll(Parameters)
      */


### PR DESCRIPTION
Make the add/put methods fluent by return the parameters instance.
Add default methods on ServerResponse to add headers.

Fixes #3309
