### PR TITLE
Enhancements to OCI health checks

### DIFF
--- a/docs/mp/oci/02_object-storage.adoc
+++ b/docs/mp/oci/02_object-storage.adoc
@@ -183,11 +183,11 @@ public Response delete(@PathParam("file-name") String fileName) {
 <1> Use `deleteObject` function and configure a `DeleteObject.Request.builder()` to submit the delete request
 <2> Return the result
 
-== Object Storage Health Check
+== Object Storage Health Checks
 
 If your Helidon application depends on Object Storage accessibility, you may consider setting
-up a health check to verify connectivity with an OCI bucket. To do so, first add the following
-dependency in your pom file:
+up a health check to verify connectivity with one ore more OCI buckets in a namespace.
+To do so, first add the following dependency to your pom file:
 
 [source,xml]
 ----
@@ -199,8 +199,24 @@ dependency in your pom file:
 
 By adding this dependency to your application, you get a (built-in) health check automatically
 registered for you. This health check is controlled by the Config properties `oci.objectstorage.namespace`
-and `oci.objectstorage.bucket`, in addition to the user-specific configuration under `~/.oci/config`.
+and `oci.objectstorage.healthchecks`, in addition to the user-specific configuration under `~/.oci/config`.
 
-When executed, this health check will _ping_ the bucket to make sure it is accessible in your
-environment. For more information about health checks see <<mp/health/01_introduction.adoc,
+The value of `oci.objectstorage.healthchecks` must denote a list of bucket names to check. For example:
+
+[source,yaml]
+----
+oci:
+  objectstorage:
+    namespace: "mynamespace"
+    healthchecks: [ "myfirstbucket", "mysecondbucket" ]
+----
+
+When executed, this health check will _ping_ the buckets `myfirstbucket` and `mysecondbucket` in
+`mynamespace` to make sure they are accessible in your environment. The `data` object in a
+health check JSON response shall include a status code (e.g., 200) for each bucket in your
+list, as well as an `UP` status for the health check itself if and only if all buckets are
+successfully pinged.
+
+Note that OCI operations such as these may incur some significant latency.
+For more information about health checks see <<mp/health/01_introduction.adoc,
 MicroProfile Health>>.

--- a/docs/mp/oci/03_vault.adoc
+++ b/docs/mp/oci/03_vault.adoc
@@ -243,3 +243,40 @@ public String deleteSecret(@PathParam("id") String secretOcid) {
     return "Secret " + secretOcid + " was deleted";
 }
 ----
+
+== Vault Health Checks
+
+If your Helidon application depends on Vault accessibility, you may consider setting up a health
+check to verify connectivity with one ore more vaults. To do so, first add the following dependency
+to your pom file:
+
+[source,xml]
+----
+<dependency>
+    <groupId>io.helidon.integrations.oci</groupId>
+    <artifactId>helidon-integrations-oci-vault-health</artifactId>
+</dependency>
+----
+
+By adding this dependency to your application, you get a (built-in) health check automatically
+registered for you. This health check is controlled by the Config property `oci.vault.healthchecks`,
+in addition to the user-specific configuration under `~/.oci/config`.
+
+The value of `oci.vault.healthchecks` must denote a list of OCI vault IDs. For example:
+
+[source,yaml]
+----
+oci:
+  vault:
+    healthchecks: [ "ocid1.vault...aaa", "ocid1.vault....bbb" ]
+----
+
+When executed, this health check will _ping_ the vaults `ocid1.vault...aaa` and `ocid1.vault....bbb`
+to make sure they are accessible in your environment. The `data` object in a
+health check JSON response shall include a status code (e.g., 200) for each vault in your
+list (using its display name instead of its OCID if non-empty), as well as an `UP` status for the health
+check itself if and only if all vaults are successfully pinged.
+
+Note that OCI operations such as these may incur some significant latency.
+For more information about health checks see <<mp/health/01_introduction.adoc,
+MicroProfile Health>>.

--- a/examples/integrations/oci/objectstorage-cdi/src/main/java/io/helidon/examples/integrations/oci/objectstorage/cdi/ObjectStorageResource.java
+++ b/examples/integrations/oci/objectstorage-cdi/src/main/java/io/helidon/examples/integrations/oci/objectstorage/cdi/ObjectStorageResource.java
@@ -51,7 +51,7 @@ public class ObjectStorageResource {
 
     @Inject
     ObjectStorageResource(OciObjectStorage objectStorage,
-                          @ConfigProperty(name = "oci.objectstorage.bucket")
+                          @ConfigProperty(name = "oci.properties.objectstorage-bucket")
                                   String bucketName) {
         this.objectStorage = objectStorage;
         this.bucketName = bucketName;

--- a/examples/integrations/oci/objectstorage-cdi/src/main/resources/application.yaml
+++ b/examples/integrations/oci/objectstorage-cdi/src/main/resources/application.yaml
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 
-# The values are read from
-# ~/helidon/conf/examples.yaml
-# or you can just update them here
-
 server:
   port: 8080
 
+#
+# The following properties under oci are accessed by Helidon. Values
+# under oci.properties.* are read from ~/helidon/conf/examples.yaml.
+#
 oci:
   objectstorage:
     namespace: "${oci.properties.objectstorage-namespace}"
-    bucket: "${oci.properties.objectstorage-bucket}"
+    healthchecks: [ "${oci.properties.objectstorage-bucket}" ]

--- a/examples/integrations/oci/objectstorage-reactive/src/main/java/io/helidon/examples/integrations/oci/objecstorage/reactive/OciObjectStorageMain.java
+++ b/examples/integrations/oci/objectstorage-reactive/src/main/java/io/helidon/examples/integrations/oci/objecstorage/reactive/OciObjectStorageMain.java
@@ -62,7 +62,7 @@ public final class OciObjectStorageMain {
         HealthSupport health = HealthSupport.builder()
                 .addLiveness(OciObjectStorageHealthCheck.builder()
                         .ociObjectStorage(ociObjectStorage)
-                        .bucket(bucketName)
+                        .addBucket(bucketName)
                         .namespace(namespace)
                         .build())
                 .build();

--- a/examples/integrations/oci/vault-cdi/src/main/resources/application.yaml
+++ b/examples/integrations/oci/vault-cdi/src/main/resources/application.yaml
@@ -14,26 +14,31 @@
 # limitations under the License.
 #
 
-# The values are read from
-# ~/helidon/conf/examples.yaml
-# or you can just update them here
+#
+# The values under oci.properties are read from ~/helidon/conf/examples.yaml
+#
 
 server:
   port: 8080
 
+#
+# The following properties under app are accessed by the application
+#
 app:
   vault:
-    # Vault OCID (the vault you want to use for this example
+    # Vault OCID (the vault you want to use for this example)
     vault-ocid: "${oci.properties.vault-ocid}"
     compartment-ocid: "${oci.properties.compartment-ocid}"
     encryption-key-ocid: "${oci.properties.vault-key-ocid}"
     signature-key-ocid: "${oci.properties.vault-rsa-key-ocid}"
 
+#
+# The following properties under oci are accessed by Helidon
+#
 oci:
+  vault:
+    healthchecks: [ "${oci.properties.vault-ocid}" ]
   custom:
     vault:
       # named OCI configuration
       cryptographic-endpoint: "${oci.properties.cryptographic-endpoint}"
-  vault:
-    vault-ocid: "${oci.properties.vault-ocid}"    # Vault healthcheck property
-

--- a/examples/integrations/oci/vault-reactive/src/main/java/io/helidon/examples/integrations/oci/vault/reactive/OciVaultMain.java
+++ b/examples/integrations/oci/vault-reactive/src/main/java/io/helidon/examples/integrations/oci/vault/reactive/OciVaultMain.java
@@ -62,7 +62,7 @@ public final class OciVaultMain {
         // setup vault health check
         HealthSupport health = HealthSupport.builder()
                 .addLiveness(OciVaultHealthCheck.builder()
-                        .vaultId(vaultOcid)
+                        .addVaultId(vaultOcid)
                         .ociVault(ociVault)
                         .build())
                 .build();


### PR DESCRIPTION
This PR includes an enhancement to the OCI health check that enables support to ping multiple buckets and multiple vaults at the same time. Configuration was changed to allow a list of vault IDs and of bucket names, respectively. Experimental API has been updated accordingly.

Some changes to the examples to make it crystal clear what is Helidon config and what is application config (it was blurry before). Documentation has been updated as well to reflect these changes for Object Storage and new documentation was added for Vaults. It is recommended to start the review by looking at the doc changes.