### PR TITLE
Fix bad warning message during PeriodicExecutor shutdown

### DIFF
--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -85,6 +85,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Resolves #3405 

Normal states for `PeriodicExecutor` shutdown are `DORMANT` and `STARTED`. Improve logging for shutdown and add some logging tests.