### PR TITLE
Upgraded Hibernate to 5.5.7.Final.

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -63,7 +63,7 @@
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
-        <version.lib.hibernate>5.4.29.Final</version.lib.hibernate>
+        <version.lib.hibernate>5.5.7.Final</version.lib.hibernate>
         <version.lib.hikaricp>5.0.0</version.lib.hikaricp>
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.inject>1.0</version.lib.inject>

--- a/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/io/helidon/integrations/cdi/hibernate/CDISEJtaPlatform.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
-import org.dom4j.DocumentFactory;
 import org.hibernate.engine.jndi.spi.JndiService;
 import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
 
@@ -37,13 +36,6 @@ import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatfor
  */
 @ApplicationScoped
 public class CDISEJtaPlatform extends AbstractJtaPlatform {
-  static {
-    // this is needed for native image, since 21.0.0
-    // as the document factory gets initialized lazily and that causes
-    // native image to fail. This way we force eager initialization
-    DocumentFactory.getInstance();
-  }
-
   private final TransactionManager transactionManager;
 
   private final UserTransaction userTransaction;

--- a/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
+++ b/integrations/cdi/hibernate-cdi/src/main/java/module-info.java
@@ -29,8 +29,6 @@ module io.helidon.integrations.cdi.hibernate {
     requires jakarta.inject.api;
     requires jakarta.enterprise.cdi.api;
     requires org.hibernate.orm.core;
-    // needed only for native image, transitive dependency of hibernate-core
-    requires dom4j;
 
     exports io.helidon.integrations.cdi.hibernate;
 

--- a/tests/integration/native-image/mp-2/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/native-image/mp-2/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,4 +22,4 @@ features.print-details=true
 javax.sql.DataSource.test.dataSource.url=jdbc:oracle:thin:@localhost:1521/XE
 javax.sql.DataSource.test.dataSource.user=system
 javax.sql.DataSource.test.dataSource.password=oracle
-javax.sql.DataSource.test.dataSourceClassName=oracle.jdbc.xa.client.OracleXADataSource
+javax.sql.DataSource.test.dataSourceClassName=oracle.jdbc.pool.OracleDataSource


### PR DESCRIPTION
Fixed integration test.

Related to #2978 
Required for Java 17

Native image validated with mp-2 integration test

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>