### PR TITLE
Signed JWT should use base64 with no-padding when creating a token.

### DIFF
--- a/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/SignedJwt.java
@@ -40,7 +40,8 @@ public final class SignedJwt {
     private static final Pattern JWT_PATTERN = Pattern
             .compile("([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9/=+]+)\\.([a-zA-Z0-9_\\-/=+]*)");
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
-    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder();
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
     private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
     private final String tokenContent;

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkOctet.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkOctet.java
@@ -89,6 +89,7 @@ public class JwkOctet extends Jwk {
 
     /**
      * Create an instance from Json object.
+     * Note that the {@code "k"} must be base64 encoded.
      *
      * @param json with definition of this octet web key
      * @return new instance of this class constructed from json
@@ -160,6 +161,7 @@ public class JwkOctet extends Jwk {
 
         /**
          * Update this builder from JWK in json format.
+         * Note that the {@code "k"} must be base64 encoded.
          *
          * @param json JsonObject with the JWK
          * @return updated builder instance, just call {@link #build()} to build the {@link JwkOctet} instance


### PR DESCRIPTION
Resolves #3418 

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Using correct encoding (was already done): https://datatracker.ietf.org/doc/html/rfc4648#section-5
Not using padding: https://datatracker.ietf.org/doc/html/rfc7515#section-2