### PR TITLE
Request correlation 

### DIFF
--- a/common/reactive/src/main/java/io/helidon/common/reactive/BufferedEmittingPublisher.java
+++ b/common/reactive/src/main/java/io/helidon/common/reactive/BufferedEmittingPublisher.java
@@ -333,6 +333,9 @@ public class BufferedEmittingPublisher<T> implements Flow.Publisher<T> {
      * @return true if demand is higher than 0
      */
     public boolean hasRequests() {
+        if (isCompleted() || isCancelled()) {
+            return false;
+        }
         return requested.get() > emitted;
     }
 

--- a/webclient/webclient/src/main/java/io/helidon/webclient/HelidonReadTimeoutHandler.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/HelidonReadTimeoutHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webclient;
+
+import java.util.concurrent.TimeUnit;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+class HelidonReadTimeoutHandler extends ReadTimeoutHandler {
+    private final long timeoutMillis;
+    private boolean closed;
+
+    HelidonReadTimeoutHandler(long timeout, TimeUnit unit) {
+        super(timeout, unit);
+        this.timeoutMillis = unit.toMillis(timeout);
+    }
+
+    protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
+        if (!this.closed) {
+            ctx.fireExceptionCaught(new ReadTimeoutException("Read timeout after " + timeoutMillis
+                                                                     + " millis on socket " + ctx.channel()
+                    .localAddress()));
+            ctx.close();
+            this.closed = true;
+        }
+    }
+
+    static class ReadTimeoutException extends RuntimeException {
+        ReadTimeoutException(String message) {
+            super(message);
+        }
+    }
+}

--- a/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientInitializer.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientInitializer.java
@@ -38,7 +38,6 @@ import io.netty.handler.proxy.ProxyHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.FutureListener;
 
 import static io.helidon.webclient.WebClientRequestBuilderImpl.CONNECTION_IDENT;
@@ -71,7 +70,7 @@ class NettyClientInitializer extends ChannelInitializer<SocketChannel> {
 
         // read timeout (we also want to timeout waiting on a proxy)
         Duration readTimeout = configuration.readTimout();
-        pipeline.addLast("readTimeout", new ReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
+        pipeline.addLast("readTimeout", new HelidonReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
 
         // proxy configuration
         configuration.proxy()

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -53,6 +53,7 @@ import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;
 import io.helidon.webserver.Service;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.jersey.HelidonHK2InjectionManagerFactory.InjectionManagerWrapper;
 
 import io.opentracing.SpanContext;
@@ -300,7 +301,13 @@ public class JerseySupport implements Service {
 
                         service.execute(() -> { // No need to use submit() since the future is not used.
                             try {
-                                LOGGER.finer("Handling in Jersey started.");
+                                if (LOGGER.isLoggable(Level.FINER)) {
+                                    LOGGER.finer("Handling in Jersey started for connection: "
+                                                         + Contexts.context()
+                                            .flatMap(ctx -> ctx.get(WebServer.class.getName() + ".connection",
+                                                                    String.class))
+                                            .orElse("Unknown"));
+                                }
 
                                 // Register Application instance in context in case there is more
                                 // than one application. Class SecurityFilter requires this.

--- a/webserver/webserver/pom.xml
+++ b/webserver/webserver/pom.xml
@@ -139,6 +139,10 @@
             <artifactId>helidon-common-key-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
         </dependency>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/BareResponseImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.helidon.common.http.DataChunk;
@@ -299,7 +300,9 @@ class BareResponseImpl implements BareResponse {
         requestEntityAnalyzed = requestEntityAnalyzed.thenApply(listener -> {
             requestContext.runInScope(() -> {
                 if (ChannelFutureListener.CLOSE.equals(listener)) {
-                    LOGGER.finest(() -> log("Closing with an empty buffer; keep-alive: false", ctx));
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.finest(log("Closing with an empty buffer; keep-alive: false", ctx));
+                    }
                 } else {
                     LOGGER.finest(() -> log("Writing an empty last http content; keep-alive: true"));
                     ctx.channel().read();
@@ -558,9 +561,9 @@ class BareResponseImpl implements BareResponse {
     private String log(String template, Object... params) {
         List<Object> list = new ArrayList<>(params.length + 3);
         list.add(System.identityHashCode(this));
-        list.add(ctx != null ? System.identityHashCode(ctx.channel()) : "N/A");
+        list.add(ctx != null ? ctx.channel().id() : "N/A");
         list.add(http2StreamId != null ? http2StreamId : "N/A");
         list.addAll(Arrays.asList(params));
-        return String.format("[Response: %s, Channel: %s, StreamID: %s] " + template, list.toArray());
+        return String.format("[Response: %s, Channel: 0x%s, StreamID: %s] " + template, list.toArray());
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -26,12 +26,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.SSLEngine;
 
 import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.http.Http;
+import io.helidon.logging.common.HelidonMdc;
 import io.helidon.webserver.ByteBufRequestChunk.DataChunkHoldingQueue;
 import io.helidon.webserver.ReferenceHoldingQueue.IndirectReference;
 
@@ -72,6 +75,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
     private static final Logger LOGGER = Logger.getLogger(ForwardingHandler.class.getName());
     private static final AtomicLong REQUEST_ID_GENERATOR = new AtomicLong(0);
+    private static final String MDC_SCOPE_ID = "io.helidon.scope-id";
 
     private final Routing routing;
     private final NettyWebServer webServer;
@@ -145,261 +149,320 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     }
 
     @Override
-    @SuppressWarnings("checkstyle:methodlength")
     protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
         if (msg instanceof HttpRequest) {
-            hadContentAlready = false;
-            LOGGER.fine(() -> log("Received HttpRequest: %s", ctx, System.identityHashCode(msg)));
+            Context requestScope = Context.create(webServer.context());
+            requestScope.register(WebServer.class.getName() + ".connection",
+                                  "0x" + ctx.channel().id());
 
-            // On new request, use chance to cleanup queues in HttpInitializer
-            clearQueues.run();
+            HelidonMdc.set(MDC_SCOPE_ID, requestScope.id());
 
-            // Turns off auto read
-            ctx.channel().config().setAutoRead(false);
+            boolean shouldReturn = Contexts.runInContext(requestScope,
+                                                         () -> channelReadHttpRequest(ctx, requestScope, msg));
 
-            // Reset internal state on new request
-            reset();
-
-            // Check that HTTP decoding was successful or return 400
-            HttpRequest request = (HttpRequest) msg;
-            try {
-                checkDecoderResult(request);
-            } catch (Throwable e) {
-                send400BadRequest(ctx, e.getMessage());
-                return;
-            }
-
-            // Certificate management
-            request.headers().remove(Http.Header.X_HELIDON_CN);
-            Optional.ofNullable(ctx.channel().attr(CLIENT_CERTIFICATE_NAME).get())
-                    .ifPresent(name -> request.headers().set(Http.Header.X_HELIDON_CN, name));
-
-            // Context, publisher and DataChunk queue for this request/response
-            DataChunkHoldingQueue queue = new DataChunkHoldingQueue();
-            HttpRequestScopedPublisher publisher = new HttpRequestScopedPublisher(queue);
-            requestContext = new RequestContext(publisher, request, Context.create(webServer.context()));
-
-            // Watch for prematurely closed channel
-            ctx.channel().closeFuture()
-                    .addListener(f -> {
-                        if (requestContext != null && !publisher.isCompleted()) {
-                            IllegalStateException e =
-                                    new IllegalStateException("Channel closed prematurely by other side!", f.cause());
-                            failPublisher(e);
-                        }
-                    });
-
-            // Closure local variables that cache mutable instance variables
-            RequestContext requestContextRef = requestContext;
-
-            // Creates an indirect reference between publisher and queue so that when
-            // publisher is ready for collection, we have access to queue by calling its
-            // acquire method. We shall also attempt to release queue on completion of
-            // bareResponse below.
-            IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherRef =
-                    new IndirectReference<>(publisher, queues, queue);
-
-            // Set up read strategy for channel based on consumer demand
-            publisher.onRequest((n, demand) -> {
-                if (publisher.isUnbounded()) {
-                    LOGGER.finest(() -> log("Netty autoread: true", ctx));
-                    ctx.channel().config().setAutoRead(true);
-                } else {
-                    LOGGER.finest(() -> log("Netty autoread: false", ctx));
-                    ctx.channel().config().setAutoRead(false);
-                }
-
-                if (publisher.hasRequests()) {
-                    LOGGER.finest(() -> log("Requesting next chunks from Netty", ctx));
-                    ctx.channel().read();
-                } else {
-                    LOGGER.finest(() -> log("No hook action required", ctx));
-                }
-            });
-
-            // New request ID
-            long requestId = REQUEST_ID_GENERATOR.incrementAndGet();
-
-            // If a problem with the request URI, return 400 response
-            BareRequestImpl bareRequest;
-            try {
-                bareRequest = new BareRequestImpl((HttpRequest) msg, publisher, webServer, ctx, sslEngine, requestId);
-            } catch (IllegalArgumentException e) {
-                send400BadRequest(ctx, e.getMessage());
-                return;
-            }
-
-            // If context length is greater than maximum allowed, return 413 response
-            if (maxPayloadSize >= 0) {
-                String contentLength = request.headers().get(Http.Header.CONTENT_LENGTH);
-                if (contentLength != null) {
-                    try {
-                        long value = Long.parseLong(contentLength);
-                        if (value > maxPayloadSize) {
-                            LOGGER.fine(() -> log("Payload length over max %d > %d", ctx, value, maxPayloadSize));
-                            ignorePayload = true;
-                            send413PayloadTooLarge(ctx);
-                            return;
-                        }
-                    } catch (NumberFormatException e) {
-                        send400BadRequest(ctx, Http.Header.CONTENT_LENGTH + " header is invalid");
-                        return;
-                    }
-                }
-            }
-
-            // If prev response is done, the next can start writing right away (HTTP pipelining)
-            if (prevRequestFuture != null && prevRequestFuture.isDone()) {
-                prevRequestFuture = null;
-            }
-
-            requestEntityAnalyzed = new CompletableFuture<>();
-
-            //If the keep alive is not set, we know we will be closing the connection
-            if (!HttpUtil.isKeepAlive(requestContext.request())) {
-                this.requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
-            }
-            // Create response and handler for its completion
-            BareResponseImpl bareResponse =
-                    new BareResponseImpl(ctx,
-                                         request,
-                                         requestContext,
-                                         publisher::isCompleted,
-                                         publisher::hasRequests,
-                                         publisher::isCancelled,
-                                         prevRequestFuture,
-                                         requestEntityAnalyzed,
-                                         requestId);
-            prevRequestFuture = new CompletableFuture<>();
-            CompletableFuture<?> thisResp = prevRequestFuture;
-            bareResponse.whenCompleted()
-                        .thenRun(() -> {
-                            // Mark response completed in context
-                            requestContextRef.responseCompleted(true);
-
-                            // Consume and release any buffers in publisher
-                            publisher.clearAndRelease();
-
-                            // Cleanup for these queues is done in HttpInitializer, but
-                            // we try to do it here if possible to reduce memory usage,
-                            // especially for keep-alive connections
-                            if (queue.release()) {
-                                publisherRef.acquire();      // clears reference to other
-                            }
-
-                            // Enables next response to proceed (HTTP pipelining)
-                            thisResp.complete(null);
-
-                            LOGGER.fine(() -> log("Response complete: %s", ctx, System.identityHashCode(msg)));
-                        });
-            if (HttpUtil.is100ContinueExpected(request)) {
-                send100Continue(ctx);
-            }
-
-            // If a problem during routing, return 400 response
-            try {
-                requestContext.runInScope(() -> routing.route(bareRequest, bareResponse));
-            } catch (IllegalArgumentException e) {
-                send400BadRequest(ctx, e.getMessage());
-                return;
-            }
-
-            // If WebSockets upgrade, re-arrange pipeline and drop HTTP decoder
-            if (bareResponse.isWebSocketUpgrade()) {
-                LOGGER.fine(() -> log("Replacing HttpRequestDecoder by WebSocketServerProtocolHandler", ctx));
-                ctx.pipeline().replace(httpRequestDecoder, "webSocketsHandler",
-                        new WebSocketServerProtocolHandler(bareRequest.uri().getPath(), null, true));
-                removeHandshakeHandler(ctx);        // already done by Tyrus
-                isWebSocketUpgrade = true;
+            if (shouldReturn) {
+                HelidonMdc.remove(MDC_SCOPE_ID);
                 return;
             }
         }
 
-        if (msg instanceof HttpContent) {
-            LOGGER.fine(() -> log("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
+        if (requestContext != null) {
+            HelidonMdc.set(MDC_SCOPE_ID, requestContext.scope().id());
+        }
 
+        if (msg instanceof HttpContent) {
             if (requestContext == null) {
+                LOGGER.fine(() -> log("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
+                HelidonMdc.remove(MDC_SCOPE_ID);
                 throw new IllegalStateException("There is no request context associated with this http content. "
                                                 + "This is never expected to happen!");
             }
-            lastContent = false;
 
-            HttpContent httpContent = (HttpContent) msg;
-
-            ByteBuf content = httpContent.content();
-            if (content.isReadable()) {
-                HttpMethod method = requestContext.request().method();
-
-                // compliance with RFC 7231
-                if (HttpMethod.TRACE.equals(method)) {
-                    // regarding the TRACE method, we're failing when payload is present only when the payload is actually
-                    // consumed; if not, the request might proceed when payload is small enough
-                    requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
-                    LOGGER.finer(() -> log("Closing connection illegal payload; method: ", ctx, method));
-                    throw new BadRequestException("It is illegal to send a payload with http method: " + method);
-                }
-
-                // compliance with RFC 7231
-                if (requestContext.responseCompleted() && !(msg instanceof LastHttpContent)) {
-                    // payload is not consumed and the response is already sent; we must close the connection
-                    LOGGER.finer(() -> log("Closing connection unconsumed payload; method: ", ctx, method));
-                    ctx.close();
-                } else if (!ignorePayload) {
-                    // Check payload size if a maximum has been set
-                    if (maxPayloadSize >= 0) {
-                        actualPayloadSize += content.readableBytes();
-                        if (actualPayloadSize > maxPayloadSize) {
-                            LOGGER.finer(() -> log("Chunked Payload over max %d > %d", ctx,
-                                    actualPayloadSize, maxPayloadSize));
-                            ignorePayload = true;
-                            send413PayloadTooLarge(ctx);
-                        } else {
-                            requestContext.emit(content);
-                        }
-                    } else {
-                        requestContext.emit(content);
-                    }
-                }
-            }
-
-            if (msg instanceof LastHttpContent) {
-                LOGGER.fine(() -> log("Received LastHttpContent: %s", ctx, System.identityHashCode(msg)));
-
-                if (!isWebSocketUpgrade) {
-                    lastContent = true;
-                    requestContext.complete();
-                    requestContext = null; // just to be sure that current http req/res session doesn't interfere with other ones
-                }
-                requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE_ON_FAILURE);
-            } else if (!content.isReadable()) {
-                // this is here to handle the case when the content is not readable but we didn't
-                // exceptionally complete the publisher and close the connection
-                throw new IllegalStateException("It is not expected to not have readable content.");
-            } else if (!requestContext.hasRequests()
-                    && HttpUtil.isKeepAlive(requestContext.request())
-                    && !requestEntityAnalyzed.isDone()) {
-                if (hadContentAlready) {
-                    LOGGER.finest(() -> "More than one unhandled content present. Closing the connection.");
-                    requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
-                } else {
-                    //We are checking the unhandled entity, but we cannot be sure if connection should be closed or not.
-                    //Next content has to be checked if it is last chunk. If not close connection.
-                    hadContentAlready = true;
-                    LOGGER.finest(() -> "Requesting the next chunk to determine if the connection should be closed.");
-                    ctx.channel().read();
-                }
-            }
+            requestContext.runInScope(() -> channelReadHttpContent(ctx, msg));
         }
 
         // We receive a raw bytebuf if connection was upgraded to WebSockets
         if (msg instanceof ByteBuf) {
             if (!isWebSocketUpgrade) {
+                HelidonMdc.remove(MDC_SCOPE_ID);
                 throw new IllegalStateException("Received ByteBuf without upgrading to WebSockets");
             }
-            // Simply forward raw bytebuf to Tyrus for processing
-            LOGGER.finest(() -> log("Received ByteBuf of WebSockets connection: %s", ctx, msg));
-            requestContext.emit((ByteBuf) msg);
+            requestContext.runInScope(() -> {
+                // Simply forward raw bytebuf to Tyrus for processing
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest(log("Received ByteBuf of WebSockets connection: %s", ctx, msg));
+                }
+                requestContext.emit((ByteBuf) msg);
+            });
         }
+        HelidonMdc.remove(MDC_SCOPE_ID);
+    }
+
+    private void channelReadHttpContent(ChannelHandlerContext ctx, Object msg) {
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(log("Received HttpContent: %s", ctx, System.identityHashCode(msg)));
+        }
+        lastContent = false;
+
+        HttpContent httpContent = (HttpContent) msg;
+
+        ByteBuf content = httpContent.content();
+        if (content.isReadable()) {
+            HttpMethod method = requestContext.request().method();
+
+            // compliance with RFC 7231
+            if (HttpMethod.TRACE.equals(method)) {
+                // regarding the TRACE method, we're failing when payload is present only when the payload is actually
+                // consumed; if not, the request might proceed when payload is small enough
+                requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
+                if (LOGGER.isLoggable(Level.FINER)) {
+                    LOGGER.finer(log("Closing connection illegal payload; method: ", ctx, method));
+                }
+                throw new BadRequestException("It is illegal to send a payload with http method: " + method);
+            }
+
+            // compliance with RFC 7231
+            if (requestContext.responseCompleted() && !(msg instanceof LastHttpContent)) {
+                // payload is not consumed and the response is already sent; we must close the connection
+                LOGGER.finer(() -> log("Closing connection unconsumed payload; method: ", ctx, method));
+                ctx.close();
+            } else if (!ignorePayload) {
+                // Check payload size if a maximum has been set
+                if (maxPayloadSize >= 0) {
+                    actualPayloadSize += content.readableBytes();
+                    if (actualPayloadSize > maxPayloadSize) {
+                        LOGGER.finer(() -> log("Chunked Payload over max %d > %d", ctx,
+                                               actualPayloadSize, maxPayloadSize));
+                        ignorePayload = true;
+                        send413PayloadTooLarge(ctx);
+                    } else {
+                        requestContext.emit(content);
+                    }
+                } else {
+                    requestContext.emit(content);
+                }
+            }
+        }
+
+        if (msg instanceof LastHttpContent) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(log("Received LastHttpContent: %s", ctx, System.identityHashCode(msg)));
+            }
+
+            if (!isWebSocketUpgrade) {
+                lastContent = true;
+                requestContext.complete();
+                requestContext = null; // just to be sure that current http req/res session doesn't interfere with other ones
+            }
+            requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE_ON_FAILURE);
+        } else if (!content.isReadable()) {
+            // this is here to handle the case when the content is not readable but we didn't
+            // exceptionally complete the publisher and close the connection
+            throw new IllegalStateException("It is not expected to not have readable content.");
+        } else if (!requestContext.hasRequests()
+                && HttpUtil.isKeepAlive(requestContext.request())
+                && !requestEntityAnalyzed.isDone()) {
+            if (hadContentAlready) {
+                LOGGER.finest(() -> "More than one unhandled content present. Closing the connection.");
+                requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
+            } else {
+                //We are checking the unhandled entity, but we cannot be sure if connection should be closed or not.
+                //Next content has to be checked if it is last chunk. If not close connection.
+                hadContentAlready = true;
+                LOGGER.finest(() -> "Requesting the next chunk to determine if the connection should be closed.");
+                ctx.channel().read();
+            }
+        }
+    }
+
+    @SuppressWarnings("checkstyle:methodlength")
+    private boolean channelReadHttpRequest(ChannelHandlerContext ctx, Context requestScope, Object msg) {
+        hadContentAlready = false;
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(log("Received HttpRequest: %s. Remote address: %s. Scope id: %s",
+                                  ctx,
+                                  System.identityHashCode(msg),
+                                  ctx.channel().remoteAddress(),
+                                  requestScope.id()));
+        }
+
+        // On new request, use chance to cleanup queues in HttpInitializer
+        clearQueues.run();
+
+        // Turns off auto read
+        ctx.channel().config().setAutoRead(false);
+
+        // Reset internal state on new request
+        reset();
+
+        // Check that HTTP decoding was successful or return 400
+        HttpRequest request = (HttpRequest) msg;
+        try {
+            checkDecoderResult(request);
+        } catch (Throwable e) {
+            LOGGER.finest(() -> log("Invalid HTTP request. %s", ctx, e.getMessage()));
+            send400BadRequest(ctx, e.getMessage());
+            return true;
+        }
+
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(log("Requested URI: %s %s", ctx, request.method(), request.uri()));
+        }
+
+        // Certificate management
+        request.headers().remove(Http.Header.X_HELIDON_CN);
+        Optional.ofNullable(ctx.channel().attr(CLIENT_CERTIFICATE_NAME).get())
+                .ifPresent(name -> request.headers().set(Http.Header.X_HELIDON_CN, name));
+
+        // Context, publisher and DataChunk queue for this request/response
+        DataChunkHoldingQueue queue = new DataChunkHoldingQueue();
+        HttpRequestScopedPublisher publisher = new HttpRequestScopedPublisher(queue);
+        requestContext = new RequestContext(publisher, request, requestScope);
+
+        // Watch for prematurely closed channel
+        ctx.channel().closeFuture()
+                .addListener(f -> {
+                    if (requestContext != null && !publisher.isCompleted()) {
+                        IllegalStateException e =
+                                new IllegalStateException("Channel closed prematurely by other side!", f.cause());
+                        failPublisher(e);
+                    }
+                });
+
+        // Closure local variables that cache mutable instance variables
+        RequestContext requestContextRef = requestContext;
+
+        // Creates an indirect reference between publisher and queue so that when
+        // publisher is ready for collection, we have access to queue by calling its
+        // acquire method. We shall also attempt to release queue on completion of
+        // bareResponse below.
+        IndirectReference<HttpRequestScopedPublisher, DataChunkHoldingQueue> publisherRef =
+                new IndirectReference<>(publisher, queues, queue);
+
+        // Set up read strategy for channel based on consumer demand
+        publisher.onRequest((n, demand) -> {
+            if (publisher.isUnbounded()) {
+                LOGGER.finest(() -> log("Netty autoread: true", ctx));
+                ctx.channel().config().setAutoRead(true);
+            } else {
+                LOGGER.finest(() -> log("Netty autoread: false", ctx));
+                ctx.channel().config().setAutoRead(false);
+            }
+
+            if (publisher.hasRequests()) {
+                LOGGER.finest(() -> log("Requesting next chunks from Netty", ctx));
+                ctx.channel().read();
+            } else {
+                LOGGER.finest(() -> log("No hook action required", ctx));
+            }
+        });
+
+        // New request ID
+        long requestId = REQUEST_ID_GENERATOR.incrementAndGet();
+
+        // If a problem with the request URI, return 400 response
+        BareRequestImpl bareRequest;
+        try {
+            bareRequest = new BareRequestImpl((HttpRequest) msg, publisher, webServer, ctx, sslEngine, requestId);
+        } catch (IllegalArgumentException e) {
+            send400BadRequest(ctx, e.getMessage());
+            return true;
+        }
+
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(log("Request id: %s", ctx, bareRequest.requestId()));
+        }
+
+        // If context length is greater than maximum allowed, return 413 response
+        if (maxPayloadSize >= 0) {
+            String contentLength = request.headers().get(Http.Header.CONTENT_LENGTH);
+            if (contentLength != null) {
+                try {
+                    long value = Long.parseLong(contentLength);
+                    if (value > maxPayloadSize) {
+                        LOGGER.fine(() -> log("Payload length over max %d > %d", ctx, value, maxPayloadSize));
+                        ignorePayload = true;
+                        send413PayloadTooLarge(ctx);
+                        return true;
+                    }
+                } catch (NumberFormatException e) {
+                    send400BadRequest(ctx, Http.Header.CONTENT_LENGTH + " header is invalid");
+                    return true;
+                }
+            }
+        }
+
+        // If prev response is done, the next can start writing right away (HTTP pipelining)
+        if (prevRequestFuture != null && prevRequestFuture.isDone()) {
+            prevRequestFuture = null;
+        }
+
+        requestEntityAnalyzed = new CompletableFuture<>();
+
+        //If the keep alive is not set, we know we will be closing the connection
+        if (!HttpUtil.isKeepAlive(requestContext.request())) {
+            this.requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
+        }
+        // Create response and handler for its completion
+        BareResponseImpl bareResponse =
+                new BareResponseImpl(ctx,
+                                     request,
+                                     requestContext,
+                                     publisher::isCompleted,
+                                     publisher::hasRequests,
+                                     publisher::isCancelled,
+                                     prevRequestFuture,
+                                     requestEntityAnalyzed,
+                                     requestId);
+        prevRequestFuture = new CompletableFuture<>();
+        CompletableFuture<?> thisResp = prevRequestFuture;
+        bareResponse.whenCompleted()
+                .thenRun(() -> {
+                    // Mark response completed in context
+                    requestContextRef.responseCompleted(true);
+
+                    // Consume and release any buffers in publisher
+                    publisher.clearAndRelease();
+
+                    // Cleanup for these queues is done in HttpInitializer, but
+                    // we try to do it here if possible to reduce memory usage,
+                    // especially for keep-alive connections
+                    if (queue.release()) {
+                        publisherRef.acquire();      // clears reference to other
+                    }
+
+                    // Enables next response to proceed (HTTP pipelining)
+                    thisResp.complete(null);
+
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.fine(log("Response complete: %s", ctx, System.identityHashCode(msg)));
+                    }
+                });
+        if (HttpUtil.is100ContinueExpected(request)) {
+            send100Continue(ctx);
+        }
+
+        // If a problem during routing, return 400 response
+        try {
+            requestContext.runInScope(() -> routing.route(bareRequest, bareResponse));
+        } catch (IllegalArgumentException e) {
+            send400BadRequest(ctx, e.getMessage());
+            return true;
+        }
+
+        // If WebSockets upgrade, re-arrange pipeline and drop HTTP decoder
+        if (bareResponse.isWebSocketUpgrade()) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(log("Replacing HttpRequestDecoder by WebSocketServerProtocolHandler", ctx));
+            }
+            ctx.pipeline().replace(httpRequestDecoder, "webSocketsHandler",
+                                   new WebSocketServerProtocolHandler(bareRequest.uri().getPath(), null, true));
+            removeHandshakeHandler(ctx);        // already done by Tyrus
+            isWebSocketUpgrade = true;
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -523,8 +586,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     private String log(String template, ChannelHandlerContext ctx, Object... params) {
         List<Object> list = new ArrayList<>(params.length + 2);
         list.add(System.identityHashCode(this));
-        list.add(ctx != null ? System.identityHashCode(ctx.channel()) : "N/A");
+        list.add(ctx != null ? ctx.channel().id() : "N/A");
         list.addAll(Arrays.asList(params));
-        return String.format("[Handler: %s, Channel: %s] " + template, list.toArray());
+        return String.format("[Handler: %s, Channel: 0x%s] " + template, list.toArray());
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -268,11 +268,11 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
      * @param params template suffix paframs.
      * @return string to log.
      */
-    private String log(String template, Object channel, Object... params) {
+    private String log(String template, Channel channel, Object... params) {
         List<Object> list = new ArrayList<>(params.length + 2);
         list.add(System.identityHashCode(this));
-        list.add(channel != null ? System.identityHashCode(channel) : "N/A");
+        list.add(channel != null ? channel.id() : "N/A");
         list.addAll(Arrays.asList(params));
-        return String.format("[Initializer: %s, Channel: %s] " + template, list.toArray());
+        return String.format("[Initializer: %s, Channel: 0x%s] " + template, list.toArray());
     }
 }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -65,6 +65,10 @@ class RequestContext {
         });
     }
 
+    Context scope() {
+        return scope;
+    }
+
     boolean hasRequests() {
         return publisher.hasRequests();
     }

--- a/webserver/webserver/src/main/java/module-info.java
+++ b/webserver/webserver/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ module io.helidon.webserver {
     requires transitive io.helidon.config;
     requires transitive io.helidon.tracing.config;
     requires transitive io.opentracing.util;
+    requires io.helidon.logging.common;
 
     requires java.logging;
     requires io.opentracing.api;


### PR DESCRIPTION
Added better correlation to webserver requests for troubleshooting purposes.

1. logging remote address
2. logging requested path
3. logging request id
4. logging scope id (`io.helidon.common.Context`)
5. added MDC support with scope id registered under `io.helidon.scope-id` in `ForwardingHandler`)
6. using the same channel ID as Netty uses in its own logs

Now it is much easier to map client requests (such as from `curl` debug or TCP dump) to web server requests and to their processing in Helidon.

Adds `helidon-logging-common` dependency to webserver. To use this feature, one of the logging modules must be used (such as `helidon-logging-jul`) and configuration modified (see examples for logging).