### PR TITLE
Renamed classes to ascii names.

### DIFF
--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroIntercepted.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroIntercepted.java
@@ -28,7 +28,7 @@ import io.micronaut.context.annotation.Type;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Around
-@Type(µInterceptor.class)
+@Type(MicroInterceptor.class)
 @Inherited
-public @interface µIntercepted {
+public @interface MicroIntercepted {
 }

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroIntercepted.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroIntercepted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroInterceptor.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroInterceptor.java
@@ -22,7 +22,7 @@ import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 
 @Singleton
-public class µInterceptor implements MethodInterceptor<Object, Object> {
+public class MicroInterceptor implements MethodInterceptor<Object, Object> {
     @Override
     public Object intercept(MethodInvocationContext<Object, Object> context) {
         return context.proceed() + ".µ";

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroInterceptor.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/MicroInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestBean.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestBean.java
@@ -22,13 +22,13 @@ public interface TestBean {
         return name() + ".cdiAnnotated";
     }
 
-    @µIntercepted
+    @MicroIntercepted
     default String µAnnotated() {
         return name() + ".µAnnotated";
     }
 
     @CdiIntercepted
-    @µIntercepted
+    @MicroIntercepted
     default String bothAnnotated() {
         return name() + ".bothAnnotated";
     }

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestBean.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestMicronautBean.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestMicronautBean.java
@@ -19,13 +19,13 @@ package io.helidon.integrations.micronaut.cdi;
 @MicronautBeanDef
 public class TestMicronautBean implements TestBean {
     @Override
-    @µIntercepted
+    @MicroIntercepted
     public String µAnnotated() {
         return TestBean.super.µAnnotated();
     }
 
     @Override
-    @µIntercepted
+    @MicroIntercepted
     public String bothAnnotated() {
         return TestBean.super.bothAnnotated();
     }

--- a/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestMicronautBean.java
+++ b/integrations/micronaut/cdi/src/test/java/io/helidon/integrations/micronaut/cdi/TestMicronautBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
There were a few classes with utf-8 character in their names causing issues on operating systems that do not support them.
Renamed (these tests were not intended to test support for UTF-8 file names)
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>