### PR TITLE
Fix lock condition in initalization when building native image.

### DIFF
--- a/microprofile/cdi/src/main/resources/META-INF/native-image/io.helidon.microprofile.cdi/helidon-microprofile-cdi/native-image.properties
+++ b/microprofile/cdi/src/main/resources/META-INF/native-image/io.helidon.microprofile.cdi/helidon-microprofile-cdi/native-image.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 # We need "report-unsupported-elements-at-runtime" - there is no fine grained control of this switch
 Args=--initialize-at-build-time \
+     --initialize-at-build-time=io.helidon.microprofile.cdi.BuildTimeInitializer \
      --initialize-at-run-time=org.jboss.weld.probe.Resource \
      --initialize-at-run-time=org.jboss.weld.probe.Resource$14 \
      --report-unsupported-elements-at-runtime

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@ import io.helidon.microprofile.cdi.HelidonContainer;
  */
 public class ServerImpl implements Server {
     private static final Logger LOGGER = Logger.getLogger(Server.class.getName());
-    // this constant is to ensure we initialize Helidon CDI at build time
-    private static final HelidonContainer CONTAINER = HelidonContainer.instance();
 
     private static final Logger STARTUP_LOGGER = Logger.getLogger("io.helidon.microprofile.startup.server");
 
@@ -45,7 +43,7 @@ public class ServerImpl implements Server {
 
     ServerImpl(Builder builder) {
         this.container = (SeContainer) CDI.current();
-        LOGGER.finest(() -> "Container context id: " + CONTAINER.context().id());
+        LOGGER.finest(() -> "Container context id: " + HelidonContainer.instance().context().id());
 
         InetAddress listenHost;
         if (null == builder.host()) {


### PR DESCRIPTION
The class `BuildTimeInitializer` is initalized automatically, no need to reference it from `ServerImpl`

When using GraalVM for java 17, this resulted in a deadlock (probably some change in thread model of class initialization in GraalVM dev build.
