### PR TITLE
Optimize concurrent gauges to use a shared current-time-in-minutes for all instances which use the system clock

### DIFF
--- a/metrics/metrics/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/HelidonConcurrentGaugeTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  * Class HelidonConcurrentGaugeTest.
@@ -135,6 +136,14 @@ public class HelidonConcurrentGaugeTest {
         System.out.println("Verifying max and min from last minute ...");
         assertThat(formatErrorOutput("checking max"), gauge.getMax(), is(5L));
         assertThat(formatErrorOutput("checking min"), gauge.getMin(), is(-5L));
+    }
+
+    @Test
+    void checkSharedCurrentTimeMinute() {
+        HelidonConcurrentGauge g1 = HelidonConcurrentGauge.create("application", meta, Clock.system());
+        HelidonConcurrentGauge g2 = HelidonConcurrentGauge.create("application", meta, Clock.system());
+
+        assertThat("Current minute AtomicLong from ConcurrentGauge", g1.currentMinuteRef(), is(sameInstance(g2.currentMinuteRef())));
     }
 
     private void ensureSecondsInMinute() throws InterruptedException {


### PR DESCRIPTION
Resolves #3398 

Earlier changes added a `PeriodicExecutor` which is used in metrics to optimize updates to current-time-in-seconds values.

This PR adds the use of `PeriodicExecutor` by the `ConcurrentGauge`  implementation which relies on a current-time-in-minutes value.

In real apps, virtually all `ConcurrentGauges` will use the system clock which means they can all share the same current-time-in-minutes value, which further means we can enroll only a single updater with `PeriodicExecutor`. 

This PR adds that optimization to `ConcurrentGauge` while preserving the existing behavior (which updates the current-time-in-minutes on each metric update) if a given instance _does not_ use the system clock.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>