### PR TITLE
Fix Prometheus formatting errors 

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricImpl.java
@@ -297,7 +297,7 @@ abstract class MetricImpl implements HelidonMetric {
             boolean withHelpType,
             String typeName,
             Derived derived) {
-        appendPrometheusElement(sb, name.units(), () -> name.nameStatUnits(statName), withHelpType, typeName, derived.value(),
+        appendPrometheusElement(sb, name, () -> name.nameStatUnits(statName), withHelpType, typeName, derived.value(),
                 derived.sample());
     }
 
@@ -307,12 +307,12 @@ abstract class MetricImpl implements HelidonMetric {
             boolean withHelpType,
             String typeName,
             Sample.Labeled sample) {
-        appendPrometheusElement(sb, name.units(), () -> name.nameStatUnits(statName), withHelpType, typeName, sample.value(),
+        appendPrometheusElement(sb, name, () -> name.nameStatUnits(statName), withHelpType, typeName, sample.value(),
                 sample);
     }
 
     private void appendPrometheusElement(StringBuilder sb,
-            Units units,
+            PrometheusName name,
             Supplier<String> nameToUse,
             boolean withHelpType,
             String typeName,
@@ -321,11 +321,11 @@ abstract class MetricImpl implements HelidonMetric {
         if (withHelpType) {
             prometheusType(sb, nameToUse.get(), typeName);
         }
-        Object convertedValue = units.convert(value);
-        sb.append(nameToUse.get())
+        Object convertedValue = name.units().convert(value);
+        sb.append(nameToUse.get() + name.prometheusTags())
                 .append(" ")
                 .append(convertedValue)
-                .append(prometheusExemplar(sample, units))
+                .append(prometheusExemplar(sample, name.units()))
                 .append("\n");
     }
 

--- a/metrics/metrics/src/main/java/io/helidon/metrics/PrometheusName.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/PrometheusName.java
@@ -79,7 +79,7 @@ class PrometheusName {
      * @return name with stat name with units
      */
     String nameStatUnits(String statName) {
-        return nameStat(statName) + "_" + prometheusUnit;
+        return nameStat(statName) + (prometheusUnit.isBlank() ? "" :  "_" + prometheusUnit);
     }
 
     String nameStat(String statName) {

--- a/metrics/metrics/src/test/java/io/helidon/metrics/MetricsCustomMatchers.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/MetricsCustomMatchers.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Custom Hamcrest matchers used in metrics tests.
+ */
+class MetricsCustomMatchers {
+
+    /**
+     * A group of matchers dealing with map contents.
+     */
+    static abstract class MapContains extends TypeSafeMatcher<Map<?, ?>> {
+
+        static All all(Map<?, ?> targetValues) {
+            return new All(targetValues);
+        }
+
+        static None none(Map<?, ?> targetValues) {
+            return new None(targetValues);
+        }
+
+        private final Map<?, ?> targetValues;
+        private final String descriptionLabel;
+
+        MapContains(Map<?, ?> targetValues, String descriptionLabel) {
+            this.targetValues = targetValues;
+            this.descriptionLabel = descriptionLabel;
+        }
+
+        protected Map<?, ?> targetValues() {
+            return targetValues;
+        }
+
+        protected Predicate<Map.Entry<?, ?>> entryChecker(Map<?, ?> candidateMap) {
+            return (Map.Entry<?, ?> expectedEntry) -> candidateMap.containsKey(expectedEntry.getKey())
+                    && candidateMap.get(expectedEntry.getKey())
+                    .equals(expectedEntry.getValue());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("tags containing ")
+                    .appendText(descriptionLabel)
+                    .appendText(" of ")
+                    .appendText(targetValues.toString());
+        }
+
+        /**
+         * Matcher for checking that all key/value pairs in the target values appear in the candidate map.
+         */
+        static class All extends MapContains {
+
+            All(Map<?, ?> targetValues) {
+                super(targetValues, "all");
+            }
+
+            @Override
+            protected boolean matchesSafely(Map<?, ?> candidateMap) {
+                return targetValues().entrySet()
+                        .stream()
+                        .allMatch(entryChecker(candidateMap));
+            }
+        }
+
+        static class None extends MapContains {
+
+            None(Map<?, ?> targetValues) {
+                super(targetValues, "none");
+            }
+
+            @Override
+            protected boolean matchesSafely(Map<?, ?> candidateMap) {
+                return targetValues().entrySet()
+                        .stream()
+                        .noneMatch(entryChecker(candidateMap));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #3451 

Two errors in Prometheus output:
1. Tags were omitted from histogram output.
2. A trailing underscore appeared in metrics names when the metric had no units.

The fixes for these are relatively straightforward. Most of the coding changes are for testing.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>