### PR TITLE
OIDC logout

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -40,6 +40,7 @@ public class SetCookie {
     private final String path;
     private final boolean secure;
     private final boolean httpOnly;
+    private final SameSite sameSite;
 
     private SetCookie(Builder builder) {
         this.name = builder.name;
@@ -50,6 +51,7 @@ public class SetCookie {
         this.path = builder.path;
         this.secure = builder.secure;
         this.httpOnly = builder.httpOnly;
+        this.sameSite = builder.sameSite;
     }
 
     /**
@@ -191,6 +193,11 @@ public class SetCookie {
         if (httpOnly) {
             result.append(PARAM_SEPARATOR);
             result.append("HttpOnly");
+        }
+        if (sameSite != null) {
+            result.append(PARAM_SEPARATOR);
+            result.append("SameSite=");
+            result.append(sameSite.text());
         }
         return result.toString();
     }

--- a/common/http/src/main/java/io/helidon/common/http/SetCookie.java
+++ b/common/http/src/main/java/io/helidon/common/http/SetCookie.java
@@ -207,6 +207,7 @@ public class SetCookie {
         private String path;
         private boolean secure = false;
         private boolean httpOnly = false;
+        private SameSite sameSite;
 
         private Builder(String name, String value) {
             Objects.requireNonNull(name, "Parameter 'name' is null!");
@@ -316,6 +317,56 @@ public class SetCookie {
         public Builder httpOnly(boolean httpOnly) {
             this.httpOnly = httpOnly;
             return this;
+        }
+
+        /**
+         * The {@code SameSite} cookie parameter.
+         *
+         * @param sameSite same site type to use
+         * @return updated builder
+         */
+        public Builder sameSite(SameSite sameSite) {
+            this.sameSite = sameSite;
+            return this;
+        }
+    }
+
+    /**
+     * The SameSite attribute of the Set-Cookie HTTP response header allows you to declare if your cookie should be restricted
+     * to a first-party or same-site context.
+     */
+    public enum SameSite {
+        /**
+         * Cookies are not sent on normal cross-site subrequests (for example to load images or frames into a third party site)
+         * , but are sent when a user is navigating to the origin site (i.e., when following a link).
+         *
+         * This is the default cookie value if SameSite has not been explicitly specified in recent browser versions
+         */
+        LAX("Lax"),
+        /**
+         * Cookies will only be sent in a first-party context and not be sent along with requests initiated by third party
+         * websites.
+         */
+        STRICT("Strict"),
+        /**
+         * Cookies will be sent in all contexts, i.e. in responses to both first-party and cross-origin requests. If
+         * SameSite=None is set, the cookie Secure attribute must also be set (or the cookie will be blocked).
+         */
+        NONE("None");
+
+        private final String text;
+
+        SameSite(String text) {
+            this.text = text;
+        }
+
+        /**
+         * Text to write to the same site cookie param.
+         *
+         * @return text to send in cookie
+         */
+        public String text() {
+            return text;
         }
     }
 }

--- a/docs-internal/oidc.md
+++ b/docs-internal/oidc.md
@@ -1,0 +1,19 @@
+OIDC
+----
+
+New Open ID Connect features in Helidon.
+
+# OIDC Logout
+The capability to logout requires two pieces of information:
+1. The token (JWT) that we usually have in a cookie or in a header
+2. The ID token, that we get when obtaining JWT using the code flow 
+
+As we need both, we need to store both of these tokens in a cookie (or get them from a header).
+This also requires encrypting these tokens, as the ID token is not public information.
+
+To achieve this, we need
+
+1. either configuration of encryption as part of OIDC configuration,
+ or use `Security` instance registered in global context (and named encryption/decryption configured).
+2. support for encrypted JWT and capability to encrypt existing JWT ourselves
+

--- a/examples/security/idcs-login/README.md
+++ b/examples/security/idcs-login/README.md
@@ -17,12 +17,14 @@ Edit application.yaml for IdcsMain.java or OidcConfig variable definition for Id
     1. Create two resources called `first_scope` and `second_scope`
     2. Primary Audience = `http://localhost:7987/"`   (ensure there is a trailing /)
 3. Within **Client Configuration**
-   1.  Register a client
-   2.  Allowed Grant Types = Client Credentials,JWT Assertion, Refresh Token, Authorization Code
-   3.  Check "Allow non-HTTPS URLs"
-   4.  Set ReDirect URL to `http://localhost:7987/oidc/redirect`
-   5.  Client Type = Confidential
-   6.  Add all Scopes defined in the resources section
+   1. Register a client
+   2. Allowed Grant Types = Client Credentials,JWT Assertion, Refresh Token, Authorization Code
+   3. Check "Allow non-HTTPS URLs"
+   4. Set Redirect URL to `http://localhost:7987/oidc/redirect`
+   5. Client Type = Confidential
+   6. Add all Scopes defined in the resources section
+   7. Set allowed operations to `Introspect`
+   8. Set Post Logout Redirect URL to `http://localhost:7987/loggedout`
 
 Ensure you save and *activate* the application
 
@@ -48,10 +50,7 @@ Try the endpoints:
 
 3. Open http://localhost:7987/rest/profile in your browser. This should present
  you with a response highlighting your logged in role (null) correctly as you are not logged in
-4. Navigate to `http://localhost:7987/jersey` this should
-   1. Redirect you to the OIDCS login console to authenticate yourself, once done
-   2. Redirects you back to the application and should display your users credentials/IDCS information
-5. Executing `http://localhost:7987/jersey` displays the user details from IDCS
+4. Open `http://localhost:7987/oidc/logout` in your browser. This will log you out from your IDCS and Helidon sessions
 
 ## Calling Sample from Postman
 

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -91,6 +91,10 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>

--- a/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
+++ b/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,8 @@ public final class IdcsMain {
                             .flatMap(SecurityContext::user)
                             .map(Subject::toString)
                             .orElse("Security context is null"));
-                });
+                })
+                .get("/loggedout", (req, res) -> res.send("You have been logged out"));
 
         theServer = WebServer.create(routing, config.get("server"));
 

--- a/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
+++ b/examples/security/idcs-login/src/main/java/io/helidon/security/examples/idcs/IdcsMain.java
@@ -19,6 +19,7 @@ package io.helidon.security.examples.idcs;
 import java.util.Optional;
 
 import io.helidon.common.LogConfig;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.http.MediaType;
 import io.helidon.config.Config;
 import io.helidon.security.Security;
@@ -57,6 +58,8 @@ public final class IdcsMain {
         Config config = buildConfig();
 
         Security security = Security.create(config.get("security"));
+        // this is needed for proper encryption/decryption of cookies
+        Contexts.globalContext().register(security);
 
         Routing.Builder routing = Routing.builder()
                 .register(WebSecurity.create(security, config.get("security")))

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ security:
       # support for non-public signature JWK (and maybe other IDCS specific handling)
       server-type: "idcs"
       logout-enabled: true
+      post-logout-uri: "http://localhost:7987/loggedout"
   - idcs-role-mapper:
       multitenant: false
       oidc-config:
@@ -51,7 +52,6 @@ security:
         client-id: "${security.properties.idcs-client-id}"
         client-secret: "${security.properties.idcs-client-secret}"
         identity-uri: "${security.properties.idcs-uri}"
-        logout-enabled: "true"
   web-server:
     # protected paths on the web server - do not include paths served by Jersey, as those are protected directly
     paths:

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ security:
       frontend-uri: "${security.properties.frontend-uri}"
       # support for non-public signature JWK (and maybe other IDCS specific handling)
       server-type: "idcs"
+      logout-enabled: true
   - idcs-role-mapper:
       multitenant: false
       oidc-config:
@@ -50,6 +51,7 @@ security:
         client-id: "${security.properties.idcs-client-id}"
         client-secret: "${security.properties.idcs-client-secret}"
         identity-uri: "${security.properties.idcs-uri}"
+        logout-enabled: "true"
   web-server:
     # protected paths on the web server - do not include paths served by Jersey, as those are protected directly
     paths:

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -31,6 +31,7 @@ security:
   - abac:
     # Adds ABAC Provider - it does not require any configuration
   - oidc:
+      audience: "https://idcs-f936fc684541496a8b004edb789d59e1.identity.pint.oc9qadev.com:443"
       client-id: "${security.properties.idcs-client-id}"
       client-secret: "${security.properties.idcs-client-secret}"
       identity-uri: "${security.properties.idcs-uri}"
@@ -56,6 +57,6 @@ security:
         methods: ["get"]
         authenticate: true
         roles-allowed: ["my_admins"]
-#        abac:
-#          scopes: ["first_scope", "second_scope"]
+        abac:
+          scopes: ["first_scope", "second_scope"]
 

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -57,6 +57,6 @@ security:
         methods: ["get"]
         authenticate: true
         roles-allowed: ["my_admins"]
-        abac:
-          scopes: ["first_scope", "second_scope"]
+#        abac:
+#          scopes: ["first_scope", "second_scope"]
 

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -56,6 +56,6 @@ security:
         methods: ["get"]
         authenticate: true
         roles-allowed: ["my_admins"]
-        abac:
-          scopes: ["first_scope", "second_scope"]
+#        abac:
+#          scopes: ["first_scope", "second_scope"]
 

--- a/examples/security/idcs-login/src/main/resources/logging.properties
+++ b/examples/security/idcs-login/src/main/resources/logging.properties
@@ -21,4 +21,5 @@ java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$
 
 .level=INFO
 AUDIT.level=FINEST
-io.helidon.security.providers.oidc.level=FINEST
+io.helidon.security.level=FINEST
+

--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -25,6 +25,11 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -32,7 +37,9 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +56,7 @@ import javax.json.JsonReaderFactory;
 
 import io.helidon.common.Errors;
 import io.helidon.common.configurable.Resource;
+import io.helidon.common.http.Http;
 import io.helidon.common.pki.KeyConfig;
 import io.helidon.config.Config;
 import io.helidon.security.AuthenticationResponse;
@@ -64,10 +72,14 @@ import io.helidon.security.SecurityException;
 import io.helidon.security.SecurityResponse;
 import io.helidon.security.Subject;
 import io.helidon.security.SubjectType;
+import io.helidon.security.jwt.EncryptedJwt;
 import io.helidon.security.jwt.Jwt;
 import io.helidon.security.jwt.JwtException;
+import io.helidon.security.jwt.JwtHeaders;
 import io.helidon.security.jwt.SignedJwt;
+import io.helidon.security.jwt.Validator;
 import io.helidon.security.jwt.jwk.Jwk;
+import io.helidon.security.jwt.jwk.JwkEC;
 import io.helidon.security.jwt.jwk.JwkKeys;
 import io.helidon.security.jwt.jwk.JwkRSA;
 import io.helidon.security.providers.common.OutboundConfig;
@@ -100,6 +112,22 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
      * Configuration key for expected issuer of incoming tokens. Used for validation of JWT.
      */
     public static final String CONFIG_EXPECTED_ISSUER = "mp.jwt.verify.issuer";
+    /**
+     * Configuration key for expected audiences of incoming tokens. Used for validation of JWT.
+     */
+    public static final String CONFIG_EXPECTED_AUDIENCES = "mp.jwt.verify.audiences";
+    /**
+     * Configuration of Cookie property name which contains JWT token.
+     *
+     * This will be ignored unless {@link #CONFIG_JWT_HEADER} is set to {@link Http.Header#COOKIE}.
+     */
+    private static final String CONFIG_COOKIE_PROPERTY_NAME = "mp.jwt.token.cookie";
+    /**
+     * Configuration of the header where the JWT token is set.
+     *
+     * Default value is {@link Http.Header#AUTHORIZATION}.
+     */
+    private static final String CONFIG_JWT_HEADER = "mp.jwt.token.header";
 
     private final boolean optional;
     private final boolean authenticate;
@@ -109,13 +137,17 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
     private final TokenHandler atnTokenHandler;
     private final TokenHandler defaultTokenHandler;
     private final JwkKeys verifyKeys;
-    private final String expectedAudience;
+    private final Set<String> expectedAudiences;
     private final JwkKeys signKeys;
+    private final JwkKeys decryptionKeys;
     private final OutboundConfig outboundConfig;
     private final String issuer;
     private final Jwk defaultJwk;
+    private final Jwk defaultDecryptionJwk;
     private final Map<OutboundTarget, JwtOutboundTarget> targetToJwtConfig = new IdentityHashMap<>();
     private final String expectedIssuer;
+    private final String cookieProperty;
+    private final boolean useCookie;
 
     private JwtAuthProvider(Builder builder) {
         this.optional = builder.optional;
@@ -128,9 +160,13 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
         this.verifyKeys = builder.verifyKeys;
         this.signKeys = builder.signKeys;
         this.issuer = builder.issuer;
-        this.expectedAudience = builder.expectedAudience;
+        this.expectedAudiences = builder.expectedAudiences;
         this.defaultJwk = builder.defaultJwk;
         this.expectedIssuer = builder.expectedIssuer;
+        this.cookieProperty = builder.cookieProperty;
+        this.useCookie = builder.useCookie;
+        this.decryptionKeys = builder.decryptionKeys;
+        this.defaultDecryptionJwk = builder.defaultDecryptionJwk;
 
         if (null == atnTokenHandler) {
             defaultTokenHandler = TokenHandler.builder()
@@ -190,7 +226,12 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
     AuthenticationResponse authenticate(ProviderRequest providerRequest, LoginConfig loginConfig) {
         Optional<String> maybeToken;
         try {
-            maybeToken = atnTokenHandler.extractToken(providerRequest.env().headers());
+            Map<String, List<String>> headers = providerRequest.env().headers();
+            if (useCookie) {
+                maybeToken = findCookie(headers);
+            } else {
+                maybeToken = atnTokenHandler.extractToken(headers);
+            }
         } catch (Exception e) {
             if (optional) {
                 return AuthenticationResponse.abstain();
@@ -201,22 +242,50 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
 
         return maybeToken
                 .map(token -> {
+                    JwtHeaders headers;
                     SignedJwt signedJwt;
                     try {
-                        signedJwt = SignedJwt.parseToken(token);
+                        headers = JwtHeaders.parseToken(token);
+                        if (headers.encryption().isPresent()) {
+                            EncryptedJwt encryptedJwt = EncryptedJwt.parseToken(headers, token);
+                            if (!headers.contentType().map("JWT"::equals).orElse(false)) {
+                                throw new JwtException("Header \"cty\" (content type) must be set to \"JWT\" "
+                                                               + "for encrypted tokens");
+                            }
+                            signedJwt = encryptedJwt.decrypt(decryptionKeys, defaultDecryptionJwk);
+                        } else {
+                            signedJwt = SignedJwt.parseToken(token);
+                        }
                     } catch (Exception e) {
+                        if (LOGGER.isLoggable(Level.FINEST)) {
+                            LOGGER.log(Level.FINEST, "Failed to parse token String into JWT", e);
+                        }
                         //invalid token
                         return AuthenticationResponse.failed("Invalid token", e);
                     }
                     Errors errors = signedJwt.verifySignature(verifyKeys, defaultJwk);
                     if (errors.isValid()) {
                         Jwt jwt = signedJwt.getJwt();
-                        // verify the audience is correct
-                        Errors validate = jwt.validate(expectedIssuer, expectedAudience);
+
+                        List<Validator<Jwt>> validators = new LinkedList<>();
+                        if (expectedIssuer != null) {
+                            // validate issuer
+                            Jwt.addIssuerValidator(validators, expectedIssuer, true);
+                        }
+                        if (expectedAudiences.size() > 0) {
+                            // validate audience(s)
+                            Jwt.addAudienceValidator(validators, expectedAudiences, true);
+                        }
+                        // validate user principal is present
+                        Jwt.addUserPrincipalValidator(validators);
+                        validators.add(Jwt.ExpirationValidator.create(false));
+
+                        Errors validate = jwt.validate(validators);
+
                         if (validate.isValid()) {
                             return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
                         } else {
-                            return AuthenticationResponse.failed("Audience is invalid or missing: " + expectedAudience);
+                            return AuthenticationResponse.failed(errors.toString());
                         }
                     } else {
                         return AuthenticationResponse.failed(errors.toString());
@@ -228,6 +297,27 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                         return AuthenticationResponse.failed("Header not available or in a wrong format");
                     }
                 });
+    }
+
+    private Optional<String> findCookie(Map<String, List<String>> headers) {
+        List<String> cookies = headers.get(Http.Header.COOKIE);
+        if ((null == cookies) || cookies.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (String cookie : cookies) {
+            //a=b; c=d; e=f
+            String[] cookieValues = cookie.split(";");
+            for (String cookieValue : cookieValues) {
+                String trimmed = cookieValue.trim();
+                if (trimmed.startsWith(cookieProperty)) {
+                    //We need to skip = sigh so we need to add +1
+                    return Optional.of(trimmed.substring(cookieProperty.length() + 1));
+                }
+            }
+        }
+
+        return Optional.empty();
     }
 
     Subject buildSubject(Jwt jwt, SignedJwt signedJwt) {
@@ -485,7 +575,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                     .expirationTime(exp)
                     .notBefore(notBefore)
                     .keyId(jwtKid)
-                    .audience(jwtAudience);
+                    .addAudience(jwtAudience);
         }
     }
 
@@ -495,12 +585,20 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
     public static class Builder implements io.helidon.common.Builder<JwtAuthProvider> {
         private static final String CONFIG_PUBLIC_KEY = "mp.jwt.verify.publickey";
         private static final String CONFIG_PUBLIC_KEY_PATH = "mp.jwt.verify.publickey.location";
+        private static final String CONFIG_JWT_DECRYPT_KEY_LOCATION = "mp.jwt.decrypt.key.location";
         private static final String JSON_START_MARK = "{";
         private static final Pattern PUBLIC_KEY_PATTERN = Pattern.compile(
                 "-+BEGIN\\s+.*PUBLIC\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" // Header
                         + "([a-z0-9+/=\\r\\n\\s]+)"                       // Base64 text
                         + "-+END\\s+.*PUBLIC\\s+KEY[^-]*-+",              // Footer
                 Pattern.CASE_INSENSITIVE);
+        private static final Pattern PRIVATE_KEY_PATTERN = Pattern.compile(
+                "-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" // Header
+                        + "([a-z0-9+/=\\r\\n\\s]+)"                        // Base64 text
+                        + "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+",              // Footer
+                Pattern.CASE_INSENSITIVE);
+
+        private final Set<String> expectedAudiences = new HashSet<>();
 
         private String expectedIssuer;
         private boolean optional = false;
@@ -515,12 +613,16 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
         private OutboundConfig outboundConfig;
         private JwkKeys verifyKeys;
         private JwkKeys signKeys;
+        private JwkKeys decryptionKeys;
         private Jwk defaultJwk;
+        private Jwk defaultDecryptionJwk;
         private String defaultKeyId;
         private String issuer;
-        private String expectedAudience;
         private String publicKeyPath;
         private String publicKey;
+        private String cookieProperty = "Bearer";
+        private String decryptKeyLocation;
+        private boolean useCookie = false;
 
         private Builder() {
         }
@@ -548,7 +650,98 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                 }
             }
 
+            if (decryptKeyLocation != null) {
+                decryptionKeys = createDecryptionJwkKeys();
+
+                List<Jwk> keys = decryptionKeys.keys();
+                if (!keys.isEmpty() && keys.get(0).keyId() == null) {
+                    defaultDecryptionJwk = keys.get(0);
+                }
+            }
+
             return new JwtAuthProvider(this);
+        }
+
+        private JwkKeys createDecryptionJwkKeys() {
+            return Optional.of(decryptKeyLocation)
+                    .map(this::loadDecryptionJwkKeysFromLocation)
+                    .get();
+        }
+
+        private JwkKeys loadDecryptionJwkKeysFromLocation(String uri) {
+            return locatePath(uri)
+                    .map(path -> {
+                        try {
+                            return loadPrivateJwkKeys("file " + path, Files.readString(path, UTF_8));
+                        } catch (IOException e) {
+                            throw new SecurityException("Failed to load private key(s) from path: " + path.toAbsolutePath(), e);
+                        }
+                    })
+                    .orElseGet(() -> {
+                        try (InputStream is = locateStream(uri)) {
+                            if (null == is) {
+                                throw new SecurityException("Could not find private key resource for MP JWT-Auth at: " + uri);
+                            }
+                            return getPrivateKeyFromContent(uri, is);
+                        } catch (IOException e) {
+                            throw new SecurityException("Failed to load private key(s) from : " + uri, e);
+                        }
+                    });
+        }
+
+        private JwkKeys getPrivateKeyFromContent(String location, InputStream bufferedInputStream) throws IOException {
+            return loadPrivateJwkKeys(location, new String(bufferedInputStream.readAllBytes(), UTF_8));
+        }
+
+        private JwkKeys loadPrivateJwkKeys(String location, String stringContent) {
+            if (stringContent.isEmpty()) {
+                throw new SecurityException("Cannot load public key from " + location + ", as its content is empty");
+            }
+            Matcher m = PRIVATE_KEY_PATTERN.matcher(stringContent);
+            if (m.find()) {
+                return loadPlainPrivateKey(stringContent);
+            } else if (stringContent.startsWith(JSON_START_MARK)) {
+                return loadPrivateKeyJWK(stringContent);
+            } else {
+                return loadPrivateKeyJWKBase64(stringContent);
+            }
+        }
+
+        private JwkKeys loadPlainPrivateKey(String stringContent) {
+            PrivateKey privateKey = KeyConfig.pemBuilder()
+                    .key(Resource.create("private key from PKCS8", stringContent))
+                    .build()
+                    .privateKey()
+                    .orElseThrow(() -> new DeploymentException(
+                            "Failed to load private key from string content"));
+            Jwk jwk;
+            String algorithm = privateKey.getAlgorithm();
+            if ("EC".equals(algorithm)) {
+                jwk = JwkEC.builder()
+                        .privateKey((ECPrivateKey) privateKey)
+                        .build();
+            } else {
+                jwk = JwkRSA.builder()
+                        .privateKey((RSAPrivateKey) privateKey)
+                        .build();
+            }
+            return JwkKeys.builder()
+                    .addKey(jwk)
+                    .build();
+        }
+
+        private JwkKeys loadPrivateKeyJWKBase64(String base64Encoded) {
+            return loadPrivateKeyJWK(new String(Base64.getUrlDecoder().decode(base64Encoded), UTF_8));
+        }
+
+        private JwkKeys loadPrivateKeyJWK(String jwkJson) {
+            if (jwkJson.contains("keys")) {
+                return JwkKeys.builder()
+                        .resource(Resource.create("public key from PKCS8", jwkJson))
+                        .build();
+            }
+            JsonObject jsonObject = JSON.createReader(new StringReader(jwkJson)).readObject();
+            return JwkKeys.builder().addKey(Jwk.create(jsonObject)).build();
         }
 
         private JwkKeys createJwkKeys() {
@@ -656,15 +849,25 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
         }
 
         private JwkKeys loadPlainPublicKey(String stringContent) {
+            PublicKey publicKey = KeyConfig.pemBuilder()
+                    .publicKey(Resource.create("public key from PKCS8", stringContent))
+                    .build()
+                    .publicKey()
+                    .orElseThrow(() -> new DeploymentException(
+                            "Failed to load public key from string content"));
+            Jwk jwk;
+            String algorithm = publicKey.getAlgorithm();
+            if ("EC".equals(algorithm)) {
+                jwk = JwkEC.builder()
+                        .publicKey((ECPublicKey) publicKey)
+                        .build();
+            } else {
+                jwk = JwkRSA.builder()
+                        .publicKey((RSAPublicKey) publicKey)
+                        .build();
+            }
             return JwkKeys.builder()
-                    .addKey(JwkRSA.builder()
-                                    .publicKey((RSAPublicKey) KeyConfig.pemBuilder()
-                                            .publicKey(Resource.create("public key from PKCS8", stringContent))
-                                            .build()
-                                            .publicKey()
-                                            .orElseThrow(() -> new DeploymentException(
-                                                    "Failed to load public key from string content")))
-                                    .build())
+                    .addKey(jwk)
                     .build();
         }
 
@@ -880,6 +1083,10 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
             mpConfig.getOptionalValue(CONFIG_PUBLIC_KEY, String.class).ifPresent(this::publicKey);
             mpConfig.getOptionalValue(CONFIG_PUBLIC_KEY_PATH, String.class).ifPresent(this::publicKeyPath);
             mpConfig.getOptionalValue(CONFIG_EXPECTED_ISSUER, String.class).ifPresent(this::expectedIssuer);
+            mpConfig.getOptionalValue(CONFIG_EXPECTED_AUDIENCES, String[].class).map(List::of).ifPresent(this::expectedAudiences);
+            mpConfig.getOptionalValue(CONFIG_COOKIE_PROPERTY_NAME, String.class).ifPresent(this::cookieProperty);
+            mpConfig.getOptionalValue(CONFIG_JWT_HEADER, String.class).ifPresent(this::jwtHeader);
+            mpConfig.getOptionalValue(CONFIG_JWT_DECRYPT_KEY_LOCATION, String.class).ifPresent(this::decryptKeyLocation);
 
             if (null == publicKey && null == publicKeyPath) {
                 // this is a fix for incomplete TCK tests
@@ -893,6 +1100,34 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                 });
             }
 
+            return this;
+        }
+
+        /**
+         * @param header header name which should be used
+         * @return updated builder instance
+         */
+        public Builder jwtHeader(String header) {
+            if (Http.Header.COOKIE.equals(header)) {
+                useCookie = true;
+            } else {
+                useCookie = false;
+                atnTokenHandler = TokenHandler.builder()
+                        .tokenHeader(header)
+                        .tokenPrefix("bearer ")
+                        .build();
+            }
+            return this;
+        }
+
+        /**
+         * Specific cookie property name where we should search for JWT property.
+         *
+         * @param cookieProperty cookie property name
+         * @return updated builder instance
+         */
+        public Builder cookieProperty(String cookieProperty) {
+            this.cookieProperty = cookieProperty;
             return this;
         }
 
@@ -912,9 +1147,44 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
          *
          * @param audience audience string
          * @return updated builder instance
+         * @deprecated use {@link #addExpectedAudience(String)} instead
          */
+        @Deprecated(forRemoval = true, since = "2.4.0")
         public Builder expectedAudience(String audience) {
-            this.expectedAudience = audience;
+            return addExpectedAudience(audience);
+        }
+
+        /**
+         * Add an audience expected in inbound JWTs.
+         *
+         * @param audience audience string
+         * @return updated builder instance
+         */
+        public Builder addExpectedAudience(String audience) {
+            this.expectedAudiences.add(audience);
+            return this;
+        }
+
+        /**
+         * Replace expected audiences with the content of the provided collection.
+         *
+         * @param audiences expected audiences to use
+         * @return updated builder instance
+         */
+        public Builder expectedAudiences(Collection<String> audiences) {
+            this.expectedAudiences.clear();
+            this.expectedAudiences.addAll(audiences);
+            return this;
+        }
+
+        /**
+         * Private key to decryption of encrypted claims.
+         *
+         * @param decryptKeyLocation private key location
+         * @return updated builder instance
+         */
+        public Builder decryptKeyLocation(String decryptKeyLocation) {
+            this.decryptKeyLocation = decryptKeyLocation;
             return this;
         }
 
@@ -928,7 +1198,6 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
 
         private void outbound(Config config) {
             config.get("jwt-issuer").asString().ifPresent(this::issuer);
-
 
             // jwk is optional, we may be propagating existing token
             config.get("jwk.resource").as(Resource::create).ifPresent(this::signJwk);

--- a/security/jwt/etc/spotbugs/exclude.xml
+++ b/security/jwt/etc/spotbugs/exclude.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+              xmlns="https://github.com/spotbugs/filter/3.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!--
+    Initialization vector is not static.
+    -->
+    <Match>
+        <Class name="io.helidon.security.jwt.EncryptedJwt$AesAlgorithm"/>
+        <Method name="createParameterSpec" />
+        <Bug pattern="STATIC_IV" />
+    </Match>
+</FindBugsFilter>

--- a/security/jwt/pom.xml
+++ b/security/jwt/pom.xml
@@ -33,6 +33,10 @@
         Implementation of JWT and JWK to be used in other modules.
     </description>
 
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.common</groupId>

--- a/security/jwt/src/main/java/io/helidon/security/jwt/EncryptedJwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/EncryptedJwt.java
@@ -1,0 +1,851 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.json.Json;
+import javax.json.JsonReaderFactory;
+
+import io.helidon.common.Errors;
+import io.helidon.security.jwt.jwk.Jwk;
+import io.helidon.security.jwt.jwk.JwkEC;
+import io.helidon.security.jwt.jwk.JwkKeys;
+import io.helidon.security.jwt.jwk.JwkRSA;
+
+/**
+ * The JWT used to transfer content across network - e.g. the base64 parts concatenated with a dot.
+ *
+ * The content of the transferred JWT is encrypted by one of the supported ciphers mentioned here {@link SupportedEncryption}.
+ * Key for the content encryption is randomly generated and encrypted by selected {@link SupportedAlgorithm} algorithm.
+ *
+ * A new key and initialization vector is being generated automatically for each encrypted JWT.
+ */
+public final class EncryptedJwt {
+
+    private static final Map<SupportedAlgorithm, String> RSA_ALGORITHMS;
+    private static final Map<SupportedEncryption, AesAlgorithm> CONTENT_ENCRYPTION;
+
+    private static final Pattern JWE_PATTERN = Pattern
+            .compile("(^[\\S]+)\\.([\\S]+)\\.([\\S]+)\\.([\\S]+)\\.([\\S]+$)");
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
+
+    static {
+        RSA_ALGORITHMS = Map.of(SupportedAlgorithm.RSA_OAEP, "RSA/ECB/OAEPWithSHA-1AndMGF1Padding",
+                                SupportedAlgorithm.RSA_OAEP_256, "RSA/ECB/OAEPWithSHA-256AndMGF1Padding",
+                                SupportedAlgorithm.RSA1_5, "RSA/ECB/PKCS1Padding");
+
+        CONTENT_ENCRYPTION = Map.of(SupportedEncryption.A128GCM, new AesGcmAlgorithm(128),
+                                    SupportedEncryption.A192GCM, new AesGcmAlgorithm(192),
+                                    SupportedEncryption.A256GCM, new AesGcmAlgorithm(256),
+                                    SupportedEncryption.A128CBC_HS256,
+                                    new AesAlgorithmWithHmac("AES/CBC/PKCS5Padding", 128, 16, "HmacSHA256"),
+                                    SupportedEncryption.A192CBC_HS384,
+                                    new AesAlgorithmWithHmac("AES/CBC/PKCS5Padding", 192, 16, "HmacSHA384"),
+                                    SupportedEncryption.A256CBC_HS512,
+                                    new AesAlgorithmWithHmac("AES/CBC/PKCS5Padding", 256, 16, "HmacSHA512"));
+    }
+
+    private final String token;
+    private final JwtHeaders header;
+    private final byte[] iv;
+    private final byte[] encryptedKey;
+    private final byte[] authTag;
+    private final byte[] encryptedPayload;
+
+    private EncryptedJwt(String token,
+                         JwtHeaders header,
+                         byte[] iv,
+                         byte[] encryptedKey,
+                         byte[] authTag,
+                         byte[] encryptedPayload) {
+        this.token = token;
+        this.header = header;
+        this.iv = iv;
+        this.encryptedKey = encryptedKey;
+        this.authTag = authTag;
+        this.encryptedPayload = encryptedPayload;
+    }
+
+    /**
+     * Builder of the Encrypted JWT.
+     *
+     * @param jwt jwt to be encrypted
+     * @return encrypted jwt builder instance
+     */
+    public static Builder builder(SignedJwt jwt) {
+        return new Builder(jwt);
+    }
+
+    /**
+     * Create new EncryptedJwt.
+     * Content is encrypted by {@link SupportedEncryption#A256GCM} and content encryption key is
+     * encrypted by {@link SupportedAlgorithm#RSA_OAEP} for transportation.
+     *
+     * @param jwt jwt to be encrypted
+     * @param jwk jwk used for content key encryption
+     * @return encrypted jwt instance
+     */
+    public static EncryptedJwt create(SignedJwt jwt, Jwk jwk) {
+        return builder(jwt).jwk(jwk).build();
+    }
+
+    /**
+     * Parse a token received over network. The expected content is
+     * {@code jwe_header_base64.encrypted_content_key_base64.iv_base64.content_base64.authentication_tag_base64} where base64 is
+     * base64 URL encoding.
+     * Use this method if you have previous knowledge of this being an encrypted token.
+     * Use {@link #parseToken(JwtHeaders, String)} if header had to be parsed separately to identify token type.
+     *
+     * This method does NO validation of content at all, only validates that the content is correctly formatted:
+     * <ul>
+     * <li>correct format of string (e.g. base64.base64.base64.base64.base64)</li>
+     * <li>each base64 part is actually base64 URL encoded</li>
+     * <li>header is JSON object</li>
+     * </ul>
+     *
+     * @param token String with the token
+     * @return Encrypted jwt parts
+     * @throws RuntimeException in case of invalid content, see {@link Errors.ErrorMessagesException}
+     */
+    public static EncryptedJwt parseToken(String token) {
+        Errors.Collector collector = Errors.collector();
+
+        Matcher matcher = JWE_PATTERN.matcher(token);
+        if (matcher.matches()) {
+            String headerBase64 = matcher.group(1);
+            String encryptedKeyBase64 = matcher.group(2);
+            String ivBase64 = matcher.group(3);
+            String payloadBase64 = matcher.group(4);
+            String authTagBase64 = matcher.group(5);
+
+            // these all can fail
+            JwtHeaders header = JwtHeaders.parseBase64(headerBase64, collector);
+            return parse(token, collector, header, encryptedKeyBase64, ivBase64, payloadBase64, authTagBase64);
+        } else {
+            throw new JwtException("Not a JWE token: " + token);
+        }
+    }
+
+    /**
+     * Parse a token received over network. The expected content is
+     * {@code jwe_header_base64.encrypted_content_key_base64.iv_base64.content_base64.authentication_tag_base64} where base64 is
+     * base64 URL encoding.
+     * Use this method if you have pre-parsed header, otherwise use {@link #parseToken(String)}.
+     *
+     * This method does NO validation of content at all, only validates that the content is correctly formatted:
+     * <ul>
+     * <li>correct format of string (e.g. base64.base64.base64.base64.base64)</li>
+     * <li>each base64 part is actually base64 URL encoded</li>
+     * <li>header is JSON object</li>
+     * </ul>
+     *
+     * @param header parsed JWT header
+     * @param token String with the token
+     * @return Encrypted jwt parts
+     * @throws RuntimeException in case of invalid content, see {@link Errors.ErrorMessagesException}
+     */
+    public static EncryptedJwt parseToken(JwtHeaders header, String token) {
+        Errors.Collector collector = Errors.collector();
+
+        Matcher matcher = JWE_PATTERN.matcher(token);
+        if (matcher.matches()) {
+            String encryptedKeyBase64 = matcher.group(2);
+            String ivBase64 = matcher.group(3);
+            String payloadBase64 = matcher.group(4);
+            String authTagBase64 = matcher.group(5);
+
+            return parse(token, collector, header, encryptedKeyBase64, ivBase64, payloadBase64, authTagBase64);
+        } else {
+            throw new JwtException("Not a JWE token: " + token);
+        }
+    }
+
+    private static EncryptedJwt parse(String token,
+                                      Errors.Collector collector,
+                                      JwtHeaders header,
+                                      String encryptedKeyBase64,
+                                      String ivBase64,
+                                      String payloadBase64,
+                                      String authTagBase64) {
+        byte[] encryptedKey = decodeBytes(encryptedKeyBase64, collector, "JWE encrypted key");
+        byte[] iv = decodeBytes(ivBase64, collector, "JWE initialization vector");
+        byte[] encryptedPayload = decodeBytes(payloadBase64, collector, "JWE payload");
+        byte[] authTag = decodeBytes(authTagBase64, collector, "JWE authentication tag");
+
+        // if failed, do not continue
+        collector.collect().checkValid();
+
+        return new EncryptedJwt(token, header, iv, encryptedKey, authTag, encryptedPayload);
+    }
+
+    private static byte[] encryptRsa(String algorithm, PublicKey publicKey, byte[] unencryptedKey) {
+        try {
+            Cipher rsaCipher = Cipher.getInstance(algorithm);
+            rsaCipher.init(Cipher.ENCRYPT_MODE, publicKey);
+            return rsaCipher.doFinal(unencryptedKey);
+        } catch (Exception e) {
+            throw new JwtException("Exception during aes key decryption occurred.", e);
+        }
+    }
+
+    private static byte[] decryptRsa(String algorithm, PrivateKey privateKey, byte[] encryptedKey) {
+        try {
+            Cipher rsaCipher = Cipher.getInstance(algorithm);
+            rsaCipher.init(Cipher.DECRYPT_MODE, privateKey);
+            return rsaCipher.doFinal(encryptedKey);
+        } catch (Exception e) {
+            throw new JwtException("Exception during aes key decryption occurred.", e);
+        }
+    }
+
+    private static String encode(String string) {
+        return encode(string.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String encode(byte[] bytes) {
+        return URL_ENCODER.encodeToString(bytes);
+    }
+
+    private static String decode(String base64, Errors.Collector collector, String description) {
+        try {
+            return new String(URL_DECODER.decode(base64), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            collector.fatal(base64, description + " is not a base64 encoded string.");
+            return null;
+        }
+    }
+
+    private static byte[] decodeBytes(String base64, Errors.Collector collector, String description) {
+        try {
+            return URL_DECODER.decode(base64);
+        } catch (Exception e) {
+            collector.fatal(base64, description + " is not a base64 encoded string.");
+            return null;
+        }
+    }
+
+    /**
+     * Decrypt {@link SignedJwt} from the content of the encrypted jwt.
+     * Encrypted JWT needs to have "kid" header specified to be able to determine {@link Jwk} from the
+     * {@link JwkKeys} instance.
+     *
+     * Selected {@link Jwk} needs to have private key set.
+     *
+     * @param jwkKeys   jwk keys
+     * @param collector error collector
+     * @return empty optional if any error has occurred or SignedJwt instance if the decryption and validation was successful
+     */
+    public Optional<SignedJwt> decrypt(JwkKeys jwkKeys, Errors.Collector collector) {
+        return decrypt(jwkKeys, null, collector);
+    }
+
+    /**
+     * Decrypt {@link SignedJwt} from the content of the encrypted jwt.
+     * Provided jwk will be used for content key decryption.
+     *
+     * Provided {@link Jwk} needs to have private key set.
+     *
+     * @param jwk       jwk keys
+     * @param collector error collector
+     * @return empty optional if any error has occurred or SignedJwt instance if the decryption and validation was successful
+     */
+    public Optional<SignedJwt> decrypt(Jwk jwk, Errors.Collector collector) {
+        return decrypt(null, jwk, collector);
+    }
+
+    /**
+     * Decrypt {@link SignedJwt} from the content of the encrypted jwt.
+     * If the kid header is specified among encrypted JWT headers, it will be used to match corresponding key
+     * from the jwkKeys. If no kid is specified, provided default Jwk is used.
+     *
+     * Used {@link Jwk} needs to have private key set.
+     *
+     * @param jwkKeys    jwk keys
+     * @param defaultJwk default jwk
+     * @param collector  error collector
+     * @return empty optional if any error has occurred or SignedJwt instance if the decryption and validation was successful
+     */
+    public Optional<SignedJwt> decrypt(JwkKeys jwkKeys, Jwk defaultJwk, Errors.Collector collector) {
+        String headerBase64 = encode(header.headerJson().toString().getBytes(StandardCharsets.UTF_8));
+        String alg = header.algorithm().orElse(null);
+        String kid = header.keyId().orElse(null);
+        String enc = header.encryption().orElse(null);
+        Jwk jwk = null;
+        String algorithm = null;
+        if (kid != null) {
+            if (jwkKeys != null) {
+                jwk = jwkKeys.forKeyId(kid).orElse(null);
+            } else if (kid.equals(defaultJwk.keyId())) {
+                jwk = defaultJwk;
+            } else {
+                collector.fatal("Could not find JWK for kid: " + kid);
+            }
+        } else {
+            jwk = defaultJwk;
+            if (jwk == null) {
+                collector.fatal("Could not find any suitable JWK.");
+            }
+        }
+
+        if (enc == null) {
+            collector.fatal("Content encryption algorithm not set.");
+        }
+
+        if (alg != null) {
+            try {
+                SupportedAlgorithm supportedAlgorithm = SupportedAlgorithm.getValue(alg);
+                algorithm = RSA_ALGORITHMS.get(supportedAlgorithm);
+            } catch (IllegalArgumentException e) {
+                collector.fatal("Value of the claim alg not supported! alg: " + alg);
+            }
+        } else {
+            collector.fatal("No alg header was present among JWE headers");
+        }
+
+        PrivateKey privateKey = null;
+        Jwk finalJwk = jwk;
+        if (jwk instanceof JwkRSA) {
+            privateKey = ((JwkRSA) jwk).privateKey().orElseGet(() -> {
+                collector.fatal("No private key present in RSA JWK kid: " + finalJwk.keyId());
+                return null;
+            });
+        } else if (jwk instanceof JwkEC) {
+            privateKey = ((JwkEC) jwk).privateKey().orElseGet(() -> {
+                collector.fatal("No private key present in EC JWK kid: " + finalJwk.keyId());
+                return null;
+            });
+        } else if (jwk != null) {
+            collector.fatal("Not supported JWK type: " + jwk.keyType() + ", JWK class: " + jwk.getClass().getName());
+        }
+
+        if (collector.hasFatal()) {
+            return Optional.empty();
+        }
+
+        byte[] decryptedKey = decryptRsa(algorithm, privateKey, encryptedKey);
+        //Base64 headers are used as an aad. This aad has to be in US_ASCII encoding.
+        EncryptionParts encryptionParts = new EncryptionParts(decryptedKey,
+                                                              iv,
+                                                              headerBase64.getBytes(StandardCharsets.US_ASCII),
+                                                              encryptedPayload,
+                                                              authTag);
+        AesAlgorithm aesAlgorithm;
+        try {
+            SupportedEncryption supportedEncryption = SupportedEncryption.getValue(enc);
+            aesAlgorithm = CONTENT_ENCRYPTION.get(supportedEncryption);
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("Unsupported content encryption: " + enc);
+        }
+        String decryptedPayload = new String(aesAlgorithm.decrypt(encryptionParts), StandardCharsets.UTF_8);
+        return Optional.of(SignedJwt.parseToken(decryptedPayload));
+    }
+
+    /**
+     * Encrypted JWT headers.
+     *
+     * @return headers of the encrypted JWT
+     */
+    public JwtHeaders headers() {
+        return header;
+    }
+
+    /**
+     * Encrypted JWT as token.
+     *
+     * @return encrypted jwt token
+     */
+    public String token() {
+        return token;
+    }
+
+    /**
+     * Initialization vector for the encrypted content.
+     *
+     * @return initialization vector
+     */
+    public byte[] iv() {
+        return Arrays.copyOf(iv, iv.length);
+    }
+
+    /**
+     * Encrypted content encryption key.
+     *
+     * @return content encryption key
+     */
+    public byte[] encryptedKey() {
+        return Arrays.copyOf(encryptedKey, encryptedKey.length);
+    }
+
+    /**
+     * Authentication tag of the encrypted content.
+     *
+     * @return authentication tag
+     */
+    public byte[] authTag() {
+        return Arrays.copyOf(authTag, authTag.length);
+    }
+
+    /**
+     * Encrypted content.
+     *
+     * @return encrypted content
+     */
+    public byte[] encryptedPayload() {
+        return Arrays.copyOf(encryptedPayload, encryptedPayload.length);
+    }
+
+    /**
+     * Encrypted JWT builder.
+     */
+    public static class Builder implements io.helidon.common.Builder<EncryptedJwt> {
+
+        private final SignedJwt jwt;
+        private final JwtHeaders.Builder headersBuilder = JwtHeaders.builder();
+        private Jwk jwk;
+        private SupportedAlgorithm algorithm = SupportedAlgorithm.RSA_OAEP;
+        private SupportedEncryption encryption = SupportedEncryption.A256GCM;
+        private JwkKeys jwks;
+        private String kid;
+
+        private Builder(SignedJwt jwt) {
+            this.jwt = Objects.requireNonNull(jwt);
+        }
+
+        /**
+         * {@link JwkKeys} which should be searched for key with specific kid.
+         * This key will be used for content key encryption.
+         *
+         * Selected {@link Jwk} is required to have private key specified otherwise encryption of the content
+         * encryption key will not be possible.
+         *
+         * @param jwkKeys jwk keys
+         * @param kid     searched kid
+         * @return updated builder instance
+         */
+        public Builder jwks(JwkKeys jwkKeys, String kid) {
+            this.jwks = Objects.requireNonNull(jwkKeys);
+            this.kid = Objects.requireNonNull(kid);
+            return this;
+        }
+
+        /**
+         * Specific {@link Jwk} which should be used for content key encryption.
+         *
+         * Specific {@link Jwk} is required to have private key specified otherwise encryption of the content
+         * encryption key will not be possible.
+         *
+         * @param jwk specific jwk
+         * @return updated builder instance
+         */
+        public Builder jwk(Jwk jwk) {
+            this.jwk = Objects.requireNonNull(jwk);
+            return this;
+        }
+
+        /**
+         * Algorithm which should be used as content key encryption.
+         *
+         * @param algorithm content key encryption
+         * @return updated builder instance
+         */
+        public Builder algorithm(SupportedAlgorithm algorithm) {
+            this.algorithm = Objects.requireNonNull(algorithm);
+            return this;
+        }
+
+        /**
+         * Encryption which should be used for content encryption.
+         *
+         * @param encryption content encryption
+         * @return updated builder instance
+         */
+        public Builder encryption(SupportedEncryption encryption) {
+            this.encryption = Objects.requireNonNull(encryption);
+            return this;
+        }
+
+        @Override
+        public EncryptedJwt build() {
+            headersBuilder.algorithm(algorithm.toString());
+            headersBuilder.encryption(encryption.toString());
+            headersBuilder.contentType("JWT");
+            PublicKey publicKey;
+            if (jwk == null && jwks != null) {
+                jwk = jwks.forKeyId(kid)
+                        .orElseThrow(() -> new JwtException("Could not determine which JWK should be used for encryption."));
+                headersBuilder.keyId(kid);
+            }
+            if (jwk == null) {
+                throw new JwtException("No JWK specified for encrypted JWT creation.");
+            }
+            if (jwk instanceof JwkRSA) {
+                publicKey = ((JwkRSA) jwk).publicKey();
+            } else if (jwk instanceof JwkEC) {
+                publicKey = ((JwkEC) jwk).publicKey();
+            } else {
+                throw new JwtException("Unsupported JWK type: " + jwk.keyType());
+            }
+            JwtHeaders headers = headersBuilder.build();
+            StringBuilder tokenBuilder = new StringBuilder();
+            String headersBase64 = encode(headers.headerJson().toString());
+            String rsaCipherType = RSA_ALGORITHMS.get(algorithm);
+            AesAlgorithm contentEncryption = CONTENT_ENCRYPTION.get(encryption);
+            //Base64 headers are used as an aad. This aad has to be in US_ASCII encoding.
+            EncryptionParts encryptionParts = contentEncryption.encrypt(jwt.tokenContent().getBytes(StandardCharsets.UTF_8),
+                                                                        headersBase64.getBytes(StandardCharsets.US_ASCII));
+            byte[] aesKey = encryptionParts.key();
+
+            byte[] encryptedAesKey = encryptRsa(rsaCipherType, publicKey, aesKey);
+            String token = tokenBuilder.append(headersBase64).append(".")
+                    .append(encode(encryptedAesKey)).append(".")
+                    .append(encode(encryptionParts.iv())).append(".")
+                    .append(encode(encryptionParts.encryptedContent())).append(".")
+                    .append(encode(encryptionParts.authTag())).toString();
+            return new EncryptedJwt(token,
+                                    headers,
+                                    encryptionParts.iv,
+                                    encryptedAesKey,
+                                    encryptionParts.authTag(),
+                                    encryptionParts.encryptedContent());
+        }
+
+    }
+
+    /**
+     * Supported RSA cipher for content key encryption.
+     *
+     * This cipher is using private key to decrypt encrypted content key with it.
+     */
+    public enum SupportedAlgorithm {
+
+        /**
+         * RSA-OAEP declares that RSA/ECB/OAEPWithSHA-1AndMGF1Padding cipher will be used for content key encryption.
+         */
+        RSA_OAEP("RSA-OAEP"),
+        /**
+         * RSA-OAEP-256 declares that RSA/ECB/OAEPWithSHA-256AndMGF1Padding cipher will be used for content key encryption.
+         */
+        RSA_OAEP_256("RSA-OAEP-256"),
+        /**
+         * RSA1_5 declares that RSA/ECB/PKCS1Padding cipher will be used for content key encryption.
+         */
+        RSA1_5("RSA1_5");
+
+        private final String algorithmName;
+
+        SupportedAlgorithm(String algorithmName) {
+            this.algorithmName = algorithmName;
+        }
+
+        @Override
+        public String toString() {
+            return algorithmName;
+        }
+
+        static SupportedAlgorithm getValue(String value) {
+            for (SupportedAlgorithm v : values()) {
+                if (v.algorithmName.equalsIgnoreCase(value)) {
+                    return v;
+                }
+            }
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Supported AES cipher for content encryption.
+     */
+    public enum SupportedEncryption {
+
+        /**
+         * Cipher AES/GCM/NoPadding will be used for content encryption and 128 bit key will be generated.
+         */
+        A128GCM("A128GCM"),
+        /**
+         * Cipher AES/GCM/NoPadding will be used for content encryption and 192 bit key will be generated.
+         */
+        A192GCM("A192GCM"),
+        /**
+         * Cipher AES/GCM/NoPadding will be used for content encryption and 256 bit key will be generated.
+         */
+        A256GCM("A256GCM"),
+        /**
+         * Cipher AES/CBC/PKCS5Padding will be used for content encryption and 128 bit key will be generated.
+         * Authentication tag is generated by using HmacSHA256.
+         */
+        A128CBC_HS256("A128CBC-HS256"),
+        /**
+         * Cipher AES/CBC/PKCS5Padding will be used for content encryption and 192 bit key will be generated.
+         * Authentication tag is generated by using HmacSHA384.
+         */
+        A192CBC_HS384("A192CBC-HS384"),
+        /**
+         * Cipher AES/CBC/PKCS5Padding will be used for content encryption and 256 bit key will be generated.
+         * Authentication tag is generated by using HmacSHA512.
+         */
+        A256CBC_HS512("A256CBC-HS512");
+
+        private final String encryptionName;
+
+        SupportedEncryption(String encryptionName) {
+            this.encryptionName = encryptionName;
+        }
+
+        @Override
+        public String toString() {
+            return encryptionName;
+        }
+
+        static SupportedEncryption getValue(String value) {
+            for (SupportedEncryption v : values()) {
+                if (v.encryptionName.equalsIgnoreCase(value)) {
+                    return v;
+                }
+            }
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static class AesAlgorithm {
+
+        private static final SecureRandom RANDOM = new SecureRandom();
+
+        private final String cipher;
+        private final int keySize;
+        private final int ivSize;
+
+        private AesAlgorithm(String cipher, int keySize, int ivSize) {
+            this.cipher = cipher;
+            this.keySize = keySize;
+            this.ivSize = ivSize;
+        }
+
+        EncryptionParts encrypt(byte[] plainContent, byte[] aad) {
+            try {
+                KeyGenerator kgen = KeyGenerator.getInstance("AES");
+                kgen.init(keySize, RANDOM);
+                SecretKey secretKey = kgen.generateKey();
+                byte[] iv = new byte[ivSize];
+                RANDOM.nextBytes(iv);
+                EncryptionParts encryptionParts = new EncryptionParts(secretKey.getEncoded(), iv, aad, null, null);
+                Cipher cipher = Cipher.getInstance(this.cipher);
+                cipher.init(Cipher.ENCRYPT_MODE, secretKey, createParameterSpec(encryptionParts));
+                postCipherConstruct(cipher, encryptionParts);
+                byte[] encryptedContent = cipher.doFinal(plainContent);
+                return new EncryptionParts(secretKey.getEncoded(), iv, aad, encryptedContent, null);
+            } catch (Exception e) {
+                throw new JwtException("Exception during content encryption", e);
+            }
+        }
+
+        byte[] decrypt(EncryptionParts encryptionParts) {
+            try {
+                byte[] key = encryptionParts.key();
+                Cipher cipher = Cipher.getInstance(this.cipher);
+                SecretKey secretKey = new SecretKeySpec(key, "AES");
+                cipher.init(Cipher.DECRYPT_MODE, secretKey, createParameterSpec(encryptionParts));
+                postCipherConstruct(cipher, encryptionParts);
+                byte[] encryptedContent = encryptionParts.encryptedContent();
+                return cipher.doFinal(encryptedContent);
+            } catch (Exception e) {
+                throw new JwtException("Exception during content decryption.", e);
+            }
+        }
+
+        protected void postCipherConstruct(Cipher cipher, EncryptionParts encryptionParts) {
+        }
+
+        protected AlgorithmParameterSpec createParameterSpec(EncryptionParts encryptionParts) {
+            return new IvParameterSpec(encryptionParts.iv());
+        }
+
+    }
+
+    private static class AesAlgorithmWithHmac extends AesAlgorithm {
+
+        private final String hmac;
+
+        private AesAlgorithmWithHmac(String cipher, int keySize, int ivSize, String hmac) {
+            super(cipher, keySize, ivSize);
+            this.hmac = hmac;
+        }
+
+        @Override
+        public EncryptionParts encrypt(byte[] plainContent, byte[] aad) {
+            EncryptionParts encryptionParts = super.encrypt(plainContent, aad);
+            byte[] authTag = sign(encryptionParts);
+            return new EncryptionParts(encryptionParts.key(),
+                                       encryptionParts.iv(),
+                                       encryptionParts.aad(),
+                                       encryptionParts.encryptedContent(),
+                                       authTag);
+        }
+
+        private byte[] sign(EncryptionParts parts) {
+            try {
+                Mac mac = macInstance();
+                mac.init(new SecretKeySpec(parts.key(), "AES"));
+                mac.update(parts.aad());
+                mac.update(parts.encryptedContent());
+                return mac.doFinal();
+            } catch (InvalidKeyException e) {
+                throw new JwtException("Exception occurred while HMAC signature");
+            }
+        }
+
+        @Override
+        public byte[] decrypt(EncryptionParts encryptionParts) {
+            if (!verifySignature(encryptionParts)) {
+                throw new JwtException("HMAC signature does not match");
+            }
+            return super.decrypt(encryptionParts);
+        }
+
+        private boolean verifySignature(EncryptionParts encryptionParts) {
+            try {
+                Mac mac = macInstance();
+                mac.init(new SecretKeySpec(encryptionParts.key(), "AES"));
+                mac.update(encryptionParts.aad());
+                mac.update(encryptionParts.encryptedContent());
+                byte[] authKey = mac.doFinal();
+                return Arrays.equals(authKey, encryptionParts.authTag());
+            } catch (InvalidKeyException e) {
+                throw new JwtException("Exception occurred while HMAC signature.");
+            }
+        }
+
+        private Mac macInstance() {
+            try {
+                return Mac.getInstance(hmac);
+            } catch (NoSuchAlgorithmException e) {
+                throw new JwtException("Could not find MAC instance: " + hmac);
+            }
+        }
+    }
+
+    private static class AesGcmAlgorithm extends AesAlgorithm {
+
+        private AesGcmAlgorithm(int keySize) {
+            super("AES/GCM/NoPadding", keySize, 12);
+        }
+
+        @Override
+        public EncryptionParts encrypt(byte[] plainContent, byte[] aad) {
+            EncryptionParts encryptionParts = super.encrypt(plainContent, aad);
+            byte[] wholeEncryptedContent = encryptionParts.encryptedContent();
+            int length = wholeEncryptedContent.length - 16; //16 is a size of auth tag
+            byte[] encryptedContent = new byte[length];
+            byte[] authTag = new byte[16];
+            System.arraycopy(wholeEncryptedContent, 0, encryptedContent, 0, encryptedContent.length);
+            System.arraycopy(wholeEncryptedContent, length, authTag, 0, authTag.length);
+            return new EncryptionParts(encryptionParts.key(),
+                                       encryptionParts.iv(),
+                                       encryptionParts.aad(),
+                                       encryptedContent,
+                                       authTag);
+        }
+
+        @Override
+        byte[] decrypt(EncryptionParts encryptionParts) {
+            byte[] encryptedPayload = encryptionParts.encryptedContent();
+            byte[] authTag = encryptionParts.authTag();
+            int epl = encryptedPayload.length;
+            int al = authTag.length;
+            byte[] result = new byte[epl + al];
+            System.arraycopy(encryptedPayload, 0, result, 0, epl);
+            System.arraycopy(authTag, 0, result, epl, al);
+            EncryptionParts newEncParts = new EncryptionParts(encryptionParts.key(),
+                                                              encryptionParts.iv(),
+                                                              encryptionParts.aad(),
+                                                              result,
+                                                              authTag);
+            return super.decrypt(newEncParts);
+        }
+
+        @Override
+        protected AlgorithmParameterSpec createParameterSpec(EncryptionParts encryptionParts) {
+            return new GCMParameterSpec(128, encryptionParts.iv());
+        }
+
+        @Override
+        protected void postCipherConstruct(Cipher cipher, EncryptionParts encryptionParts) {
+            cipher.updateAAD(encryptionParts.aad());
+        }
+    }
+
+    private static final class EncryptionParts {
+
+        private final byte[] key;
+        private final byte[] iv;
+        private final byte[] aad;
+        private final byte[] encryptedContent;
+        private final byte[] authTag;
+
+        private EncryptionParts(byte[] key, byte[] iv, byte[] aad, byte[] encryptedContent, byte[] authTag) {
+            this.key = key;
+            this.iv = iv;
+            this.aad = aad;
+            this.encryptedContent = encryptedContent;
+            this.authTag = authTag;
+        }
+
+        public byte[] key() {
+            return key;
+        }
+
+        public byte[] iv() {
+            return iv;
+        }
+
+        public byte[] aad() {
+            return aad;
+        }
+
+        public byte[] encryptedContent() {
+            return encryptedContent;
+        }
+
+        public byte[] authTag() {
+            return authTag;
+        }
+    }
+
+}

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -952,7 +952,12 @@ public class Jwt {
         return validate(validators);
     }
 
-    private static void addUserPrincipalValidator(Collection<Validator<Jwt>> validators) {
+    /**
+     * Adds a validator that makes sure the {@link Jwt#userPrincipal()} is present.
+     *
+     * @param validators validator collection to update
+     */
+    public static void addUserPrincipalValidator(Collection<Validator<Jwt>> validators) {
         validators.add(new UserPrincipalValidator());
     }
 

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
@@ -31,6 +31,9 @@ class JwtClaims {
     private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
     private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
 
+    protected JwtClaims() {
+    }
+
     protected static String decode(String base64, Errors.Collector collector, String description) {
         try {
             return new String(URL_DECODER.decode(base64), StandardCharsets.UTF_8);

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtClaims.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.jwt;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReaderFactory;
+
+import io.helidon.common.Errors;
+
+class JwtClaims {
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+    private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
+
+    protected static String decode(String base64, Errors.Collector collector, String description) {
+        try {
+            return new String(URL_DECODER.decode(base64), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            collector.fatal(base64, description + " is not a base64 encoded string.");
+            return null;
+        }
+    }
+
+    protected static JsonObject parseJson(String jsonString, Errors.Collector collector, String base64, String description) {
+        try {
+            return JSON.createReader(new StringReader(jsonString)).readObject();
+        } catch (Exception e) {
+            collector.fatal(base64, description + " is not a valid JSON object (value is base64 encoded)");
+            return null;
+        }
+    }
+}

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtHeaders.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtHeaders.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.jwt;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonString;
+import javax.json.JsonValue;
+
+import io.helidon.common.Errors;
+import io.helidon.common.GenericType;
+
+/**
+ * Representation of the header section of a JWT.
+ * This can be used to partially parse a token to understand what kind of
+ * processing should be done further, whether {@link io.helidon.security.jwt.SignedJwt}
+ * or {@link io.helidon.security.jwt.EncryptedJwt}.
+ *
+ * @see #parseToken(String)
+ */
+public class JwtHeaders extends JwtClaims {
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    private final Optional<String> algorithm;
+    private final Optional<String> encryption;
+    private final Optional<String> contentType;
+    private final Optional<String> keyId;
+    private final Optional<String> type;
+    // intended for replication into header in encrypted JWT
+    private final Optional<String> subject;
+    private final Optional<String> issuer;
+    private final Optional<List<String>> audience;
+
+    private final Map<String, JsonValue> headerClaims;
+
+    private JwtHeaders(Builder builder) {
+        this.algorithm = Optional.ofNullable(builder.algorithm);
+        this.encryption = Optional.ofNullable(builder.encryption);
+        this.contentType = Optional.ofNullable(builder.contentType);
+        this.keyId = Optional.ofNullable(builder.keyId);
+        this.type = Optional.ofNullable(builder.type);
+        this.subject = Optional.ofNullable(builder.subject);
+        this.issuer = Optional.ofNullable(builder.issuer);
+        this.audience = Optional.ofNullable(builder.audience);
+        this.headerClaims = Map.copyOf(builder.claims);
+    }
+
+    /**
+     * Create a new builder for header claims.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Parse a token to retrieve the JWT header.
+     * This method only cares about the first section of the token, and ignores the rest (even if not valid).
+     * Text before the first dot is considered to be base64 value of the header JSON.
+     *
+     * @param token token, expected to be JWT (encrypted or signed)
+     * @return header parsed from the token
+     * @throws io.helidon.security.jwt.JwtException in case the token is not valid
+     */
+    public static JwtHeaders parseToken(String token) {
+        Errors.Collector collector = Errors.collector();
+
+        int firstDot = token.indexOf('.');
+        if (firstDot < 0) {
+            throw new JwtException("Not a JWT token: " + token);
+        }
+        String headerBase64 = token.substring(0, firstDot);
+        JwtHeaders jwtHeader = parseBase64(headerBase64, collector);
+        collector.collect().checkValid();
+        return jwtHeader;
+    }
+
+    static JwtHeaders parseBase64(String base64, Errors.Collector collector) {
+        String headerJsonString = decode(base64, collector, "JWT header");
+
+        // if failed, do not continue
+        if (collector.hasFatal()) {
+            return null;
+        }
+
+        // this is either a signed JWT or encrypted JWT, first section is always
+        // base64 encoded header
+        JsonObject headerJson = parseJson(headerJsonString, collector, base64, "JWT header");
+
+        // if failed, do not continue
+        if (collector.hasFatal()) {
+            return null;
+        }
+
+        Builder builder = builder();
+
+        builder.fromJson(headerJson);
+
+        collector.collect().checkValid();
+
+        return builder.build();
+    }
+
+    /**
+     * Create a JSON header object.
+     *
+     * @return JsonObject for header
+     */
+    public JsonObject headerJson() {
+        JsonObjectBuilder objectBuilder = JSON.createObjectBuilder();
+        headerClaims.forEach(objectBuilder::add);
+
+        return objectBuilder.build();
+    }
+
+    /**
+     * Get a claim by its name from header.
+     *
+     * @param claim name of a claim
+     * @return claim value if present
+     */
+    public Optional<JsonValue> headerClaim(String claim) {
+        return Optional.ofNullable(headerClaims.get(claim));
+    }
+
+    /**
+     * Algorithm claim.
+     *
+     * @return algorithm or empty if claim is not defined
+     */
+    public Optional<String> algorithm() {
+        return algorithm;
+    }
+
+    /**
+     * Encryption algorithm claim.
+     *
+     * @return algorithm or empty if not encrypted
+     */
+    public Optional<String> encryption() {
+        return encryption;
+    }
+
+    /**
+     * Content type claim.
+     *
+     * @return content type or empty if claim is not defined
+     */
+    public Optional<String> contentType() {
+        return contentType;
+    }
+
+    /**
+     * Key id claim.
+     *
+     * @return key id or empty if claim is not defined
+     */
+    public Optional<String> keyId() {
+        return keyId;
+    }
+
+    /**
+     * Type claim.
+     *
+     * @return type or empty if claim is not defined
+     */
+    public Optional<String> type() {
+        return type;
+    }
+
+    /**
+     * Subject claim.
+     *
+     * @return subject or empty if claim is not defined
+     */
+    public Optional<String> subject() {
+        return subject;
+    }
+
+    /**
+     * Issuer claim.
+     *
+     * @return Issuer or empty if claim is not defined
+     */
+    public Optional<String> issuer() {
+        return issuer;
+    }
+
+    /**
+     * Audience claim.
+     *
+     * @return audience or empty if claim is not defined
+     */
+    public Optional<List<String>> audience() {
+        return audience;
+    }
+
+    /**
+     * Fluent API builder to create JWT Header.
+     */
+    public static class Builder implements io.helidon.common.Builder<JwtHeaders> {
+        private static final GenericType<List<String>> STRING_LIST_TYPE = new GenericType<List<String>>() { };
+        private static final GenericType<String> STRING_TYPE = GenericType.create(String.class);
+
+        private static final Map<String, KnownField<? extends Object>> KNOWN_HEADER_CLAIMS;
+        private static final KnownField<String> TYPE_FIELD = KnownField.create("typ", Builder::type);
+        private static final KnownField<String> ALG_FIELD = KnownField.create("alg", Builder::algorithm);
+        private static final KnownField<String> ENC_FIELD = KnownField.create("enc", Builder::encryption);
+        private static final KnownField<String> CTY_FIELD = KnownField.create("cty", Builder::contentType);
+        private static final KnownField<String> KID_FIELD = KnownField.create("kid", Builder::keyId);
+        private static final KnownField<String> SUB_FIELD = KnownField.create("sub", Builder::headerSubject);
+        private static final KnownField<String> ISS_FIELD = KnownField.create("iss", Builder::headerIssuer);
+        private static final KnownField<List<String>> AUD_FIELD = new KnownField<List<String>>("aud",
+                                                                                               STRING_LIST_TYPE,
+                                                                                               Builder::headerAudience,
+                                                                                               Builder::jsonToStringList);
+
+        static {
+            Map<String, KnownField<? extends Object>> map = new HashMap<>();
+
+            addKnownField(map, TYPE_FIELD);
+            addKnownField(map, ALG_FIELD);
+            addKnownField(map, ENC_FIELD);
+            addKnownField(map, CTY_FIELD);
+            addKnownField(map, KID_FIELD);
+            addKnownField(map, SUB_FIELD);
+            addKnownField(map, ISS_FIELD);
+            addKnownField(map, AUD_FIELD);
+
+            KNOWN_HEADER_CLAIMS = Map.copyOf(map);
+        }
+
+        private final Map<String, JsonValue> claims = new HashMap<>();
+
+        private String type;
+        private String algorithm;
+        private String encryption;
+        private String contentType = "JWT";
+        private String keyId;
+        private String subject;
+        private String issuer;
+        private List<String> audience;
+
+        private Builder() {
+        }
+
+        @Override
+        public JwtHeaders build() {
+            if (audience != null) {
+                // this may be changing throughout the build
+                AUD_FIELD.set(claims, audience);
+            }
+            return new JwtHeaders(this);
+        }
+
+        /**
+         * Add a header claim.
+         *
+         * @param claim name of the claim
+         * @param value claim value, must be of expected type
+         * @return updated builder
+         * @throws java.lang.IllegalArgumentException if a known header (such as {@code iss}, {@code aud}) is set to a non-string
+         *  type
+         */
+        public Builder addHeaderClaim(String claim, Object value) {
+            setFromGeneric(claim, value);
+            this.claims.put(claim, JwtUtil.toJson(value));
+            return this;
+        }
+
+        /**
+         * The "alg" claim is used to define the signature algorithm.
+         * Note that this algorithm should be the same as is supported by
+         * the JWK used to sign (or verify) the JWT.
+         *
+         * @param algorithm algorithm to use, {@link io.helidon.security.jwt.jwk.Jwk#ALG_NONE} for none
+         * @return updated builder instance
+         */
+        public Builder algorithm(String algorithm) {
+            ALG_FIELD.set(claims, algorithm);
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        /**
+         * Encryption algorithm to use.
+         *
+         * @param encryption encryption to use
+         * @return updated builder
+         */
+        public Builder encryption(String encryption) {
+            ENC_FIELD.set(claims, encryption);
+            this.encryption = encryption;
+            return this;
+        }
+
+        /**
+         * This header claim should only be used when nesting or encrypting JWT.
+         * See <a href="https://tools.ietf.org/html/rfc7519#section-5.2">RFC 7519, section 5.2</a>.
+         *
+         * @param contentType content type to use, use "JWT" if nested
+         * @return updated builder instance
+         */
+        public Builder contentType(String contentType) {
+            CTY_FIELD.set(claims, contentType);
+            this.contentType = contentType;
+            return this;
+        }
+
+        /**
+         * Key id to be used to sign/verify this JWT.
+         *
+         * @param keyId key id (pointing to a JWK)
+         * @return updated builder instance
+         */
+        public Builder keyId(String keyId) {
+            KID_FIELD.set(claims, keyId);
+            this.keyId = keyId;
+            return this;
+        }
+
+        /**
+         * Type of this JWT.
+         *
+         * @param type type definition (JWT, JWE)
+         * @return updated builder instance
+         */
+        public Builder type(String type) {
+            TYPE_FIELD.set(claims, type);
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Subject defines the principal this JWT was issued for (e.g. user id).
+         * This configures subject in header claims (usually it is part of payload).
+         *
+         * See <a href="https://tools.ietf.org/html/rfc7519#section-4.1.2">RFC 7519, section 4.1.2</a>.
+         *
+         * @param subject subject of this JWt
+         * @return updated builder instance
+         */
+        public Builder headerSubject(String subject) {
+            SUB_FIELD.set(claims, subject);
+            this.subject = subject;
+            return this;
+        }
+
+        /**
+         * The issuer claim identifies the principal that issued the JWT.
+         * This configures issuer in header claims (usually it is part of payload).
+         *
+         * See <a href="https://tools.ietf.org/html/rfc7519#section-4.1.1">RFC 7519, section 4.1.1</a>.
+         *
+         * @param issuer issuer name or URL
+         * @return updated builder instance
+         */
+        public Builder headerIssuer(String issuer) {
+            ISS_FIELD.set(claims, issuer);
+            this.issuer = issuer;
+            return this;
+        }
+
+        /**
+         * Audience identifies the expected recipients of this JWT (optional).
+         * Multiple audience may be added.
+         * This configures audience in header claims, usually this is defined in payload.
+         *
+         * See <a href="https://tools.ietf.org/html/rfc7519#section-4.1.3">RFC 7519, section 4.1.3</a>.
+         *
+         * @param audience audience of this JWT
+         * @return updated builder instance
+         * @see #headerAudience(java.util.List)
+         */
+        public Builder addHeaderAudience(String audience) {
+            if (this.audience == null) {
+                this.audience = new LinkedList<>();
+            }
+            this.audience.add(audience);
+            return this;
+        }
+
+        /**
+         * Audience identifies the expected recipients of this JWT (optional).
+         * Replaces existing configured audiences.
+         * This configures audience in header claims, usually this is defined in payload.
+         *
+         * See <a href="https://tools.ietf.org/html/rfc7519#section-4.1.3">RFC 7519, section 4.1.3</a>.
+         *
+         * @param audience audience of this JWT
+         * @return updated builder instance
+         */
+        public Builder headerAudience(List<String> audience) {
+            this.audience = new LinkedList<>(audience);
+            return this;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private void setFromGeneric(String claim, Object value) {
+            KnownField knownField = KNOWN_HEADER_CLAIMS.get(claim);
+            if (knownField == null) {
+                return;
+            }
+            if (knownField.supports(value)) {
+                knownField.valueConsumer().accept(this, value);
+            } else {
+                throw new IllegalArgumentException("Claim \"" + claim
+                                                           + " is expected to be of type " + knownField.type
+                                                           + ", but is " + value.getClass().getName());
+            }
+        }
+
+        private static List<String> jsonToStringList(JsonValue jsonValue) {
+            if (jsonValue instanceof JsonString) {
+                return List.of(((JsonString) jsonValue).getString());
+            }
+            if (jsonValue instanceof JsonArray) {
+                JsonArray array = (JsonArray) jsonValue;
+                List<String> result = new LinkedList<>();
+                for (JsonValue value : array) {
+                    result.add(KnownField.jsonToString(value));
+                }
+                return result;
+            }
+            throw new JwtException("Json value should have been a String or an array of Strings, but is " + jsonValue);
+        }
+
+        private static <T extends Object> void addKnownField(Map<String, KnownField<? extends Object>> map,
+                                                             KnownField<T> field) {
+            map.put(field.name, field);
+        }
+
+        void fromJson(JsonObject headerJson) {
+            headerJson.forEach((claim, value) -> {
+                KnownField<?> knownField = KNOWN_HEADER_CLAIMS.get(claim);
+                if (knownField == null) {
+                    addHeaderClaim(claim, value);
+                } else {
+                    knownField.set(this, value);
+                }
+            });
+        }
+    }
+
+    private static final class KnownField<T> {
+        private final String name;
+        private final GenericType<T> type;
+        private final BiConsumer<JwtHeaders.Builder, T> valueConsumer;
+        private final Function<JsonValue, T> fromJson;
+
+        private KnownField(String name,
+                           GenericType<T> type,
+                           BiConsumer<Builder, T> valueConsumer,
+                           Function<JsonValue, T> fromJson) {
+            this.name = name;
+            this.type = type;
+            this.valueConsumer = valueConsumer;
+            this.fromJson = fromJson;
+        }
+
+        static KnownField<String> create(String name, BiConsumer<Builder, String> valueConsumer) {
+            return new KnownField<>(name, Builder.STRING_TYPE, valueConsumer, KnownField::jsonToString);
+        }
+
+        private static String jsonToString(JsonValue jsonValue) {
+            if (jsonValue instanceof JsonString) {
+                return ((JsonString) jsonValue).getString();
+            }
+            throw new JwtException("Json value should have been a String, but is " + jsonValue);
+        }
+
+        BiConsumer<Builder, T> valueConsumer() {
+            return valueConsumer;
+        }
+
+        void set(Map<String, JsonValue> claims, T value) {
+            claims.put(name, JwtUtil.toJson(value));
+        }
+
+        void set(Builder builder, JsonValue value) {
+            valueConsumer.accept(builder, fromJson.apply(value));
+        }
+
+        public boolean supports(Object value) {
+            return type.rawType().isAssignableFrom(value.getClass());
+        }
+    }
+}

--- a/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/JwtUtil.java
@@ -248,7 +248,19 @@ public final class JwtUtil {
         return result;
     }
 
-    private static JsonValue toJson(Object object) {
+    /**
+     * Create a {@link javax.json.JsonValue} from an object.
+     * This will use correct types for known primitives, {@link io.helidon.security.jwt.JwtUtil.Address}
+     * otherwise it uses String value.
+     *
+     * @param object object to create json value from
+     * @return json value
+     */
+    public static JsonValue toJson(Object object) {
+        if (object instanceof JsonValue) {
+            return (JsonValue) object;
+        }
+
         if (object instanceof String) {
             return JSON_PROVIDER.createValue((String) object);
         }

--- a/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkEC.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/jwk/JwkEC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/jwt/src/test/java/io/helidon/security/jwt/EncryptedJwtTest.java
+++ b/security/jwt/src/test/java/io/helidon/security/jwt/EncryptedJwtTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import javax.json.JsonObject;
 
-import io.helidon.common.Errors;
 import io.helidon.common.configurable.Resource;
 import io.helidon.security.jwt.EncryptedJwt.SupportedAlgorithm;
 import io.helidon.security.jwt.jwk.JwkKeys;
@@ -99,13 +98,11 @@ public class EncryptedJwtTest {
         EncryptedJwt encryptedOne = builder(signedJwt).jwks(jwkKeys, "RS_512").build();
         EncryptedJwt encryptedSecond = builder(signedJwt).jwks(jwkKeys, "RS_512").build();
         assertThat(encryptedOne.token(), not(encryptedSecond.token()));
-        Errors.Collector collector = Errors.collector();
+
         EncryptedJwt encryptedJwt = parseToken(encryptedOne.token());
-        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys, collector).get();
-        collector.collect().checkValid();
+        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys);
         EncryptedJwt encryptedJwt2 = parseToken(encryptedSecond.token());
-        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys, collector).get();
-        collector.collect().checkValid();
+        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys);
         assertThat(decryptedOne.headerJson(), is(decryptedTwo.headerJson()));
     }
 
@@ -122,13 +119,12 @@ public class EncryptedJwtTest {
                 .encryption(SupportedEncryption.A128CBC_HS256)
                 .build();
         assertThat(encryptedOne.token(), not(encryptedSecond.token()));
-        Errors.Collector collector = Errors.collector();
+
         EncryptedJwt encryptedJwt = parseToken(encryptedOne.token());
-        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys, collector).get();
-        collector.collect().checkValid();
+        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys);
         EncryptedJwt encryptedJwt2 = parseToken(encryptedSecond.token());
-        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys, collector).get();
-        collector.collect().checkValid();
+        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys);
+
         assertThat(decryptedOne.headerJson(), is(decryptedTwo.headerJson()));
     }
 

--- a/security/jwt/src/test/java/io/helidon/security/jwt/EncryptedJwtTest.java
+++ b/security/jwt/src/test/java/io/helidon/security/jwt/EncryptedJwtTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.jwt;
+
+import java.util.Optional;
+
+import javax.json.JsonObject;
+
+import io.helidon.common.Errors;
+import io.helidon.common.configurable.Resource;
+import io.helidon.security.jwt.EncryptedJwt.SupportedAlgorithm;
+import io.helidon.security.jwt.jwk.JwkKeys;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.security.jwt.EncryptedJwt.SupportedEncryption;
+import static io.helidon.security.jwt.EncryptedJwt.builder;
+import static io.helidon.security.jwt.EncryptedJwt.parseToken;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Encrypted JWT tests.
+ */
+public class EncryptedJwtTest {
+
+    private static JwkKeys jwkKeys;
+    private static SignedJwt signedJwt;
+
+    @BeforeAll
+    public static void init() {
+        jwkKeys = JwkKeys.builder()
+                .resource(Resource.create("jwk_data.json"))
+                .build();
+
+        Jwt jwt = Jwt.builder()
+                .audience("test")
+                .email("unit@test.example")
+                .algorithm("RS256")
+                .keyId("cc34c0a0-bd5a-4a3c-a50d-a2a7db7643df")
+                .issuer("unit-test")
+                .build();
+
+        signedJwt = SignedJwt.sign(jwt, jwkKeys);
+    }
+
+    @Test
+    public void testDefaultHeaderCreation() {
+        String kid = "RS_512";
+        EncryptedJwt encryptedJwt = builder(signedJwt).jwks(jwkKeys, kid).build();
+        JwtHeaders headers = encryptedJwt.headers();
+        assertThat(headers.algorithm(), is(Optional.of(SupportedAlgorithm.RSA_OAEP.toString())));
+        assertThat(headers.encryption(), is(Optional.of(SupportedEncryption.A256GCM.toString())));
+        assertThat(headers.contentType(), is(Optional.of("JWT")));
+        assertThat(headers.keyId(), is(Optional.of(kid)));
+
+        headers = JwtHeaders.parseToken(encryptedJwt.token());
+        assertThat(headers.algorithm(), is(Optional.of(SupportedAlgorithm.RSA_OAEP.toString())));
+        assertThat(headers.encryption(), is(Optional.of(SupportedEncryption.A256GCM.toString())));
+        assertThat(headers.contentType(), is(Optional.of("JWT")));
+        assertThat(headers.keyId(), is(Optional.of(kid)));
+    }
+
+    @Test
+    public void testCustomHeaderCreation() {
+        String kid = "RS_512";
+        SupportedAlgorithm rsaAlgorithm = SupportedAlgorithm.RSA1_5;
+        SupportedEncryption aesAlgorithm = SupportedEncryption.A256CBC_HS512;
+        EncryptedJwt encryptedJwt = builder(signedJwt)
+                .jwks(jwkKeys, kid)
+                .algorithm(rsaAlgorithm)
+                .encryption(aesAlgorithm)
+                .build();
+        JsonObject headers = encryptedJwt.headers().headerJson();
+        assertThat(headers.getString("alg"), is(rsaAlgorithm.toString()));
+        assertThat(headers.getString("enc"), is(aesAlgorithm.toString()));
+        assertThat(headers.getString("cty"), is("JWT"));
+        assertThat(headers.getString("kid"), is(kid));
+    }
+
+    @Test
+    public void testDefaultEncryptAndDecrypt() {
+        EncryptedJwt encryptedOne = builder(signedJwt).jwks(jwkKeys, "RS_512").build();
+        EncryptedJwt encryptedSecond = builder(signedJwt).jwks(jwkKeys, "RS_512").build();
+        assertThat(encryptedOne.token(), not(encryptedSecond.token()));
+        Errors.Collector collector = Errors.collector();
+        EncryptedJwt encryptedJwt = parseToken(encryptedOne.token());
+        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys, collector).get();
+        collector.collect().checkValid();
+        EncryptedJwt encryptedJwt2 = parseToken(encryptedSecond.token());
+        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys, collector).get();
+        collector.collect().checkValid();
+        assertThat(decryptedOne.headerJson(), is(decryptedTwo.headerJson()));
+    }
+
+    @Test
+    public void testCustomEncryptAndDecrypt() {
+        EncryptedJwt encryptedOne = builder(signedJwt)
+                .jwks(jwkKeys, "RS_512")
+                .algorithm(SupportedAlgorithm.RSA1_5)
+                .encryption(SupportedEncryption.A256CBC_HS512)
+                .build();
+        EncryptedJwt encryptedSecond = builder(signedJwt)
+                .jwks(jwkKeys, "RS_512")
+                .algorithm(SupportedAlgorithm.RSA_OAEP_256)
+                .encryption(SupportedEncryption.A128CBC_HS256)
+                .build();
+        assertThat(encryptedOne.token(), not(encryptedSecond.token()));
+        Errors.Collector collector = Errors.collector();
+        EncryptedJwt encryptedJwt = parseToken(encryptedOne.token());
+        SignedJwt decryptedOne = encryptedJwt.decrypt(jwkKeys, collector).get();
+        collector.collect().checkValid();
+        EncryptedJwt encryptedJwt2 = parseToken(encryptedSecond.token());
+        SignedJwt decryptedTwo = encryptedJwt2.decrypt(jwkKeys, collector).get();
+        collector.collect().checkValid();
+        assertThat(decryptedOne.headerJson(), is(decryptedTwo.headerJson()));
+    }
+
+}

--- a/security/providers/oidc-common/pom.xml
+++ b/security/providers/oidc-common/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>helidon-jersey-media-jsonp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-crypto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.bundles</groupId>
             <artifactId>helidon-bundles-config</artifactId>
             <scope>test</scope>

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -306,8 +306,8 @@ public final class OidcConfig {
     private final String redirectUri;
     private final boolean useCookie;
     private final String cookieName;
-    private final String cookieNameToken;
-    private final String cookieNameId;
+//    private final String cookieNameToken;
+//    private final String cookieNameId;
     private final String cookieOptions;
 
     private final boolean useParam;

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -306,7 +306,10 @@ public final class OidcConfig {
     private final String redirectUri;
     private final boolean useCookie;
     private final String cookieName;
+    private final String cookieNameToken;
+    private final String cookieNameId;
     private final String cookieOptions;
+
     private final boolean useParam;
     private final String paramName;
 

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -426,6 +426,9 @@ public final class OidcConfig {
         }
 
         this.tokenCookieHandler = builder.tokenCookieBuilder.build();
+        if (logoutEnabled) {
+            builder.idTokenCookieBuilder.encryptionEnabled(true);
+        }
         this.idTokenCookieHandler = builder.idTokenCookieBuilder.build();
 
         if ((builder.scopeAudience == null) || builder.scopeAudience.trim().isEmpty()) {
@@ -1017,7 +1020,6 @@ public final class OidcConfig {
         private final OidcCookieHandler.Builder tokenCookieBuilder = OidcCookieHandler.builder()
                 .cookieName(DEFAULT_COOKIE_NAME);
         private final OidcCookieHandler.Builder idTokenCookieBuilder = OidcCookieHandler.builder()
-                .encryptionEnabled(true)
                 .cookieName(DEFAULT_COOKIE_NAME + "_2");
 
         private boolean useParam = DEFAULT_PARAM_USE;

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcCookieHandler.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.oidc.common;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.helidon.common.http.SetCookie;
+import io.helidon.common.reactive.Single;
+
+/**
+ * Handler of cookies used in OIDC.
+ */
+public class OidcCookieHandler {
+    private static final Logger LOGGER = Logger.getLogger(OidcCookieHandler.class.getName());
+
+    private final String createCookieOptions;
+    private final List<Consumer<SetCookie.Builder>> removeCookieUpdaters = new LinkedList<>();
+    private final List<Consumer<SetCookie.Builder>> createCookieUpdaters = new LinkedList<>();
+    private final String cookieName;
+    private final String valuePrefix;
+    private final Function<String, Single<String>> encryptFunction;
+    private final Function<String, Single<String>> decryptFunction;
+
+    private OidcCookieHandler(Builder builder) {
+        this.cookieName = builder.cookieName;
+        this.valuePrefix = cookieName + "=";
+
+        // need to copy the values here, so we do not use future values of the builder
+        String path = builder.path;
+        boolean httpOnly = builder.httpOnly;
+        SetCookie.SameSite sameSite = builder.sameSite;
+        String domain = builder.domain;
+        boolean secure = builder.secure;
+        Long maxAge = builder.maxAge;
+
+        removeCookieUpdaters.add(it -> it.path(path));
+        if (httpOnly) {
+            removeCookieUpdaters.add(it -> it.httpOnly(true));
+        }
+        if (sameSite != null) {
+            removeCookieUpdaters.add(it -> it.sameSite(sameSite));
+        }
+        if (domain != null) {
+            removeCookieUpdaters.add(it -> it.domain(domain));
+        }
+        if (secure) {
+            removeCookieUpdaters.add(it -> it.secure(true));
+        }
+        // now we can share the updaters, from this point the two lists diverge
+        createCookieUpdaters.addAll(removeCookieUpdaters);
+
+        if (maxAge != null) {
+            createCookieUpdaters.add(it -> it.maxAge(Duration.ofSeconds(maxAge)));
+        }
+        // set expires to 0 - this removes the cookie from browsers
+        removeCookieUpdaters.add(it -> it.expires(Instant.ofEpochMilli(0)));
+
+        String value = createCookieDirectValue("value").build().toString();
+        int index = value.indexOf(';');
+        if (index < 0) {
+            this.createCookieOptions = "";
+        } else {
+            this.createCookieOptions = value.substring(index);
+        }
+
+        if (builder.encryptionEnabled) {
+            var cookieEncryption = OidcEncryption.create("Cookie(" + cookieName + ")",
+                                                         builder.encryptionName,
+                                                         builder.encryptionPassword);
+            this.encryptFunction = it -> cookieEncryption.encrypt(it.getBytes(StandardCharsets.UTF_8));
+            this.decryptFunction = it -> cookieEncryption.decrypt(it).map(String::new);
+        } else {
+            this.encryptFunction = Single::just;
+            this.decryptFunction = Single::just;
+        }
+
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(() -> "OIDC Create cookie example: " + value);
+            LOGGER.finest(() -> "OIDC Remove cookie example: " + removeCookie().build());
+        }
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * {@link io.helidon.common.http.SetCookie} builder to set a new cookie,
+     * returns a future, as the value may need to be encrypted using a remote service.
+     *
+     * @param value value of the cookie
+     * @return a new builder to configure set cookie configured from OIDC Config
+     */
+    public Single<SetCookie.Builder> createCookie(String value) {
+        return encryptFunction.apply(value)
+                .map(this::createCookieDirectValue);
+    }
+
+    /**
+     * Cookie name.
+     *
+     * @return name of the cookie to use
+     */
+    public String cookieName() {
+        return cookieName;
+    }
+
+    /**
+     * {@link io.helidon.common.http.SetCookie} builder to remove an existing cookie (such as during logout).
+     *
+     * @return a new builder to configure set cookie configured from OIDC Config with expiration set to epoch begin and
+     *  empty value
+     */
+    public SetCookie.Builder removeCookie() {
+        SetCookie.Builder builder = SetCookie.builder(cookieName, "");
+        removeCookieUpdaters.forEach(it -> it.accept(builder));
+        return builder;
+    }
+
+    /**
+     * Locate cookie in a map of headers and return its value.
+     * If the cookie is encrypted, decrypts the cookie value.
+     *
+     * @param headers headers to process
+     * @return cookie value, or empty if the cookie could not be found
+     */
+    public Optional<Single<String>> findCookie(Map<String, List<String>> headers) {
+        Objects.requireNonNull(headers);
+
+        List<String> cookies = headers.get("Cookie");
+        if ((cookies == null) || cookies.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (String cookie : cookies) {
+            //a=b; c=d; e=f
+            String[] cookieValues = cookie.split(";");
+            for (String cookieValue : cookieValues) {
+                String trimmed = cookieValue.trim();
+                if (trimmed.startsWith(valuePrefix)) {
+                    return Optional.of(decrypt(trimmed.substring(valuePrefix.length())));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Decrypt a cipher text into clear text (if encryption is enabled).
+     *
+     * @param cipherText cipher text to decrypt
+     * @return secret
+     */
+    public Single<String> decrypt(String cipherText) {
+        return decryptFunction.apply(cipherText);
+    }
+
+    String createCookieOptions() {
+        return createCookieOptions;
+    }
+
+    String cookieValuePrefix() {
+        return valuePrefix;
+    }
+
+    private SetCookie.Builder createCookieDirectValue(String value) {
+        SetCookie.Builder builder = SetCookie.builder(cookieName, value);
+        createCookieUpdaters.forEach(it -> it.accept(builder));
+        return builder;
+    }
+
+    static class Builder implements io.helidon.common.Builder<OidcCookieHandler> {
+        static final String DEFAULT_PATH = "/";
+        static final boolean DEFAULT_HTTP_ONLY = true;
+        static final boolean DEFAULT_SECURE = false;
+        static final SetCookie.SameSite DEFAULT_SAME_SITE = SetCookie.SameSite.LAX;
+
+        private String path = DEFAULT_PATH;
+        private boolean httpOnly = DEFAULT_HTTP_ONLY;
+        private SetCookie.SameSite sameSite = DEFAULT_SAME_SITE;
+        private String domain;
+        private boolean secure = DEFAULT_SECURE;
+        private Long maxAge;
+        private String cookieName;
+        private String encryptionName;
+        private char[] encryptionPassword;
+        private boolean encryptionEnabled;
+
+        private Builder() {
+        }
+
+        @Override
+        public OidcCookieHandler build() {
+            return new OidcCookieHandler(this);
+        }
+
+        Builder path(String cookiePath) {
+            this.path = cookiePath;
+            return this;
+        }
+
+        Builder httpOnly(boolean cookieHttpOnly) {
+            this.httpOnly = cookieHttpOnly;
+            return this;
+        }
+
+        Builder sameSite(SetCookie.SameSite cookieSameSite) {
+            this.sameSite = cookieSameSite;
+            return this;
+        }
+
+        Builder domain(String cookieDomain) {
+            this.domain = cookieDomain;
+            return this;
+        }
+
+        Builder secure(boolean secure) {
+            this.secure = secure;
+            return this;
+        }
+
+        Builder maxAge(Long maxAge) {
+            this.maxAge = maxAge;
+            return this;
+        }
+
+        Builder cookieName(String cookieName) {
+            this.cookieName = cookieName;
+            return this;
+        }
+
+        public Builder encryptionName(String encryptionName) {
+            this.encryptionName = encryptionName;
+            return this;
+        }
+
+        public Builder encryptionPassword(char[] encryptionPassword) {
+            this.encryptionPassword = encryptionPassword;
+            return this;
+        }
+
+        public Builder encryptionEnabled(Boolean encryptionEnabled) {
+            this.encryptionEnabled = encryptionEnabled;
+            return this;
+        }
+    }
+}

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcEncryption.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.oidc.common;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import io.helidon.common.Base64Value;
+import io.helidon.common.context.Contexts;
+import io.helidon.common.crypto.SymmetricCipher;
+import io.helidon.common.reactive.Single;
+import io.helidon.security.Security;
+import io.helidon.security.spi.EncryptionProvider.EncryptionSupport;
+
+final class OidcEncryption {
+    private static final Logger LOGGER = Logger.getLogger(OidcEncryption.class.getName());
+
+    private OidcEncryption() {
+    }
+
+    static EncryptionSupport create(String type,
+                                    String encryptionConfigurationName,
+                                    char[] encryptionPassword) {
+        EncryptionSupport found = null;
+
+        if (encryptionConfigurationName != null) {
+            found = nameBasedCipher(encryptionConfigurationName);
+        }
+
+        char[] masterPassword = encryptionPassword;
+        if (encryptionPassword == null && found == null) {
+            masterPassword = generateMasterPassword();
+        }
+
+        if (found != null && masterPassword != null) {
+            throw new SecurityException("Cannot define both name based encryption and password based encryption for " + type);
+        }
+
+        return symmetricCipher(masterPassword);
+    }
+
+    private static EncryptionSupport symmetricCipher(char[] masterPassword) {
+        SymmetricCipher cipher = SymmetricCipher.create(masterPassword);
+        return EncryptionSupport.create(
+                bytes -> Single.just(cipher.encrypt(Base64Value.create(bytes)).toBase64()),
+                cipherText -> Single.just(cipher.decrypt(Base64Value.createFromEncoded(cipherText)).toBytes())
+        );
+    }
+
+    private static EncryptionSupport nameBasedCipher(String encryptionConfigurationName) {
+        return EncryptionSupport.create(
+                bytes -> securityFromContext().encrypt(encryptionConfigurationName, bytes),
+                cipherText -> securityFromContext().decrypt(encryptionConfigurationName, cipherText)
+        );
+    }
+
+    private static char[] generateMasterPassword() {
+        Path path = Paths.get(".helidon-oidc-secret");
+        if (!Files.exists(path)) {
+
+            String password = UUID.randomUUID().toString();
+            try {
+                Files.writeString(path, password, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+                Files.setPosixFilePermissions(path, Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+            } catch (IOException e) {
+                throw new SecurityException("Failed to create OIDC secret " + path.toAbsolutePath(), e);
+            }
+            LOGGER.warning("OIDC requires encryption configuration which was not provided. We will generate a password"
+                                   + " that will only work for the current service instance. To disable encryption, use"
+                                   + " cookie-encryption-enabled: false configuration, to configure master password, use"
+                                   + " cookie-encryption-password: my-master-password (must be configured to same value on all"
+                                   + " instances that share the cookie), to configure encryption using security"
+                                   + " (support for vaults), use"
+                                   + " cookie-encryption-name: name (must have corresponding encryption provider and"
+                                   + " configuration with the provided name in security), this also requires Security to be"
+                                   + " registered with current or global Context (this works automatically in Helidon MP)."
+                                   + " This message is logged just once, before generating the master password");
+
+        }
+
+        try {
+            // to be consistent, I always read the content from the file, even when creating it
+            return Files.readString(path, StandardCharsets.UTF_8).toCharArray();
+        } catch (IOException e) {
+            throw new SecurityException("Cannot read OIDC secret file: " + path.toAbsolutePath(), e);
+        }
+    }
+
+    private static Security securityFromContext() {
+        return Contexts.context()
+                .orElseGet(Contexts::globalContext)
+                .get(Security.class)
+                .orElseThrow(() -> new SecurityException("When using encryption configuration name for OIDC,"
+                                                                 + " Security must be registered with current or"
+                                                                 + " global context"));
+    }
+}

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcMetadata.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcMetadata.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.oidc.common;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+
+import io.helidon.common.Errors;
+import io.helidon.webclient.WebClient;
+
+final class OidcMetadata {
+    private static final Logger LOGGER = Logger.getLogger(OidcMetadata.class.getName());
+    private static final String DEFAULT_OIDC_METADATA_URI = "/.well-known/openid-configuration";
+
+    private final JsonObject oidcMetadata;
+    private final URI identityUri;
+
+    private OidcMetadata(Builder builder) {
+        this.oidcMetadata = builder.metadata;
+        this.identityUri = builder.identityUri;
+    }
+
+    URI getOidcEndpoint(Errors.Collector collector,
+                        URI currentValue,
+                        String metaKey,
+                        String defaultUri) {
+
+        // is it explicitly configured?
+        if (currentValue != null) {
+            LOGGER.finest(() -> metaKey + " explicitly configured: " + currentValue);
+            return currentValue;
+        }
+
+        URI foundValue = null;
+
+        // do we have OIDC metadata
+        if (oidcMetadata == null) {
+            // no OIDC metadata, use default
+            if (identityUri == null) {
+                collector.fatal("Identity URI is not defined, cannot provide endpoint for " + metaKey);
+                return null;
+            }
+        } else {
+            // get it from metadata
+            String jsonValue = oidcMetadata.getString(metaKey, null);
+            if (jsonValue != null) {
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest(metaKey + " loaded from well known metadata: " + jsonValue);
+                }
+                foundValue = URI.create(jsonValue);
+            }
+        }
+
+        if (foundValue != null) {
+            return foundValue;
+        }
+
+        // not found in metadata, or metadata does not exist, use default value
+        if (defaultUri == null) {
+            collector.fatal(metaKey + " default URI is not defined and URI was not in OIDC metadata");
+            return null;
+        }
+
+        // safely use default
+        return identityUri.resolve(defaultUri);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    public Optional<String> getString(String key) {
+        if (oidcMetadata == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(oidcMetadata.getString(key, null));
+    }
+
+    static class Builder implements io.helidon.common.Builder<OidcMetadata> {
+        private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
+        private boolean enableRemoteLoad;
+        private JsonObject metadata;
+        private WebClient webClient;
+        private Errors.Collector collector = Errors.collector();
+        private URI identityUri;
+
+        private Builder() {
+        }
+
+        @Override
+        public OidcMetadata build() {
+            if (metadata == null) {
+                if (enableRemoteLoad) {
+                    load();
+                }
+            }
+            return new OidcMetadata(this);
+        }
+
+        Builder remoteEnabled(boolean enableRemoteLoad) {
+            this.enableRemoteLoad = enableRemoteLoad;
+            return this;
+        }
+
+        Builder json(JsonObject jsonObject) {
+            this.metadata = jsonObject;
+            return this;
+        }
+
+        Builder webClient(WebClient webClient) {
+            this.webClient = webClient;
+            return this;
+        }
+
+        Builder collector(Errors.Collector collector) {
+            this.collector = collector;
+            return this;
+        }
+
+        Builder identityUri(URI identityUri) {
+            this.identityUri = identityUri;
+            return this;
+        }
+
+        private void load() {
+            URI wellKnown = identityUri.resolve(DEFAULT_OIDC_METADATA_URI);
+
+            try {
+                this.metadata = webClient.get()
+                        .uri(wellKnown)
+                        .request(JsonObject.class)
+                        .await(Duration.ofSeconds(20));
+
+                LOGGER.finest(() -> "OIDC Metadata loaded from well known URI: " + wellKnown);
+            } catch (Exception e) {
+                collector.fatal(e, "Failed to load metadata: " + e.getClass().getName()
+                        + ": " + e.getMessage()
+                        + " from " + wellKnown);
+            }
+        }
+    }
+}

--- a/security/providers/oidc-common/src/main/java/module-info.java
+++ b/security/providers/oidc-common/src/main/java/module-info.java
@@ -20,16 +20,23 @@
 module io.helidon.security.providers.oidc.common {
     requires java.logging;
 
-    requires io.helidon.security.util;
+    // EncryptionProvider.EncryptionSupport is part of API
+    requires transitive io.helidon.security;
+    // TokenHandler is part of API
+    requires transitive io.helidon.security.util;
+    // WebClient is part of API
+    requires transitive io.helidon.webclient;
+
     requires io.helidon.security.providers.common;
     requires io.helidon.security.jwt;
     requires io.helidon.security.providers.httpauth;
     requires io.helidon.webclient.jaxrs;
-    requires io.helidon.webclient;
     requires io.helidon.webclient.security;
     requires io.helidon.webclient.tracing;
     requires io.helidon.media.jsonp;
+    requires io.helidon.common.crypto;
 
+    // these are deprecated and will be removed in 3.x
     requires jersey.client;
     requires java.ws.rs;
 

--- a/security/providers/oidc-common/src/main/java/module-info.java
+++ b/security/providers/oidc-common/src/main/java/module-info.java
@@ -19,6 +19,7 @@
  */
 module io.helidon.security.providers.oidc.common {
     requires java.logging;
+
     requires io.helidon.security.util;
     requires io.helidon.security.providers.common;
     requires io.helidon.security.jwt;
@@ -28,6 +29,7 @@ module io.helidon.security.providers.oidc.common {
     requires io.helidon.webclient.security;
     requires io.helidon.webclient.tracing;
     requires io.helidon.media.jsonp;
+    requires io.helidon.common.crypto;
 
     requires jersey.client;
     requires java.ws.rs;

--- a/security/providers/oidc-common/src/main/java/module-info.java
+++ b/security/providers/oidc-common/src/main/java/module-info.java
@@ -29,7 +29,6 @@ module io.helidon.security.providers.oidc.common {
     requires io.helidon.webclient.security;
     requires io.helidon.webclient.tracing;
     requires io.helidon.media.jsonp;
-    requires io.helidon.common.crypto;
 
     requires jersey.client;
     requires java.ws.rs;

--- a/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigAbstractTest.java
+++ b/security/providers/oidc-common/src/test/java/io/helidon/security/providers/oidc/common/OidcConfigAbstractTest.java
@@ -63,7 +63,8 @@ abstract class OidcConfigAbstractTest {
                   () -> assertThat("Base scopes to use", config.baseScopes(), is(OidcConfig.DEFAULT_BASE_SCOPES)),
                   () -> assertThat("Cookie value prefix", config.cookieValuePrefix(), is("JSESSIONID=")),
                   () -> assertThat("Cookie name", config.cookieName(), is(OidcConfig.DEFAULT_COOKIE_NAME)),
-                  () -> assertThat("Cookie options", config.cookieOptions(), is(";Path=/;HttpOnly;SameSite=Lax")),
+                  // cookie options should be separated by space as defined by the specification
+                  () -> assertThat("Cookie options", config.cookieOptions(), is("; Path=/; HttpOnly; SameSite=Lax")),
                   () -> assertThat("Audience", config.audience(), is("https://identity.oracle.com")),
                   () -> assertThat("Parameter name", config.paramName(), is("accessToken")),
                   () -> assertThat("Issuer", config.issuer(), nullValue()),

--- a/security/providers/oidc/pom.xml
+++ b/security/providers/oidc/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-crypto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.security</groupId>
             <artifactId>helidon-security</artifactId>
         </dependency>

--- a/security/providers/oidc/src/main/java/module-info.java
+++ b/security/providers/oidc/src/main/java/module-info.java
@@ -20,6 +20,7 @@
 module io.helidon.security.providers.oidc {
     requires io.helidon.config;
     requires io.helidon.common;
+    requires io.helidon.common.crypto;
     requires io.helidon.security;
     requires java.logging;
 

--- a/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
+++ b/tests/integration/native-image/mp-1/src/main/java/io/helidon/tests/integration/nativeimage/mp1/Mp1Main.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -137,6 +138,7 @@ public final class Mp1Main {
                 .issueTime(Instant.now())
                 .userPrincipal("jack")
                 .keyId("SIGNING_KEY")
+                .expirationTime(Instant.now().plus(5, ChronoUnit.MINUTES))
                 .build();
 
         JwkKeys jwkKeys = JwkKeys.builder()


### PR DESCRIPTION
Resolves #3306 

I had to refactor `OidcConfig`, as the `build` method was too long, and the class had too many lines (reported by checkstyle).

New features:
 - customizable name of cookie for token and for id token
 - customizable encryption of token in cookie (disabled by default) and id token in cookie (enabled by default)
 - support for logout (default endpoint is `/oidc/logout` - removes Helidon cookies, redirects to OIDC server to log out)

Logout is disabled by default, as it requires an unsecured "post-logout-uri" to work correctly. Also as encryption is required, users should provide either a master password or a encryption configuration name.
