### PR TITLE
Do not deploy LRA Coordinator server

### DIFF
--- a/lra/coordinator/server/pom.xml
+++ b/lra/coordinator/server/pom.xml
@@ -36,6 +36,9 @@
     <description>Narayana compatible LRA coordinator</description>
 
     <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.sources.skip>true</maven.sources.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
         <mainClass>io.helidon.lra.coordinator.Main</mainClass>
     </properties>
     


### PR DESCRIPTION
` lra/coordinator/server` is an application and should not be deployed.  

Forward port of fix from 2.4.0 release build.