### PR TITLE
New flag to force the use of relative URIs in WebClient 

### DIFF
--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientConfiguration.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientConfiguration.java
@@ -80,6 +80,7 @@ class WebClientConfiguration {
     private final WebClientTls webClientTls;
     private final URI uri;
     private final boolean validateHeaders;
+    private final boolean relativeUris;
 
     /**
      * Creates a new instance of client configuration.
@@ -109,6 +110,7 @@ class WebClientConfiguration {
         this.uri = builder.uri;
         this.keepAlive = builder.keepAlive;
         this.validateHeaders = builder.validateHeaders;
+        this.relativeUris = builder.relativeUris;
     }
 
     /**
@@ -277,6 +279,10 @@ class WebClientConfiguration {
         return validateHeaders;
     }
 
+    boolean relativeUris() {
+        return relativeUris;
+    }
+
     /**
      * A fluent API builder for {@link WebClientConfiguration}.
      */
@@ -306,6 +312,7 @@ class WebClientConfiguration {
         private MessageBodyReaderContext readerContext;
         private MessageBodyWriterContext writerContext;
         private boolean validateHeaders;
+        private boolean relativeUris;
         @SuppressWarnings("unchecked")
         private B me = (B) this;
 
@@ -468,6 +475,18 @@ class WebClientConfiguration {
          */
         public B defaultHeader(String key, List<String> values) {
             clientHeaders.put(key, values);
+            return me;
+        }
+
+        /**
+         * Can be set to {@code true} to force the use of relative URIs in all requests,
+         * regardless of the presence or absence of proxies or no-proxy lists.
+         *
+         * @param relativeUris relative URIs flag
+         * @return updated builder instance
+         */
+        public B relativeUris(boolean relativeUris) {
+            this.relativeUris = relativeUris;
             return me;
         }
 
@@ -655,6 +674,7 @@ class WebClientConfiguration {
                     .map(Proxy.Builder::build)
                     .ifPresent(this::proxy);
             config.get("media-support").as(MediaContext::create).ifPresent(this::mediaContext);
+            config.get("relative-uris").asBoolean().ifPresent(this::relativeUris);
             return me;
         }
 

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
@@ -541,7 +541,7 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
         }
 
         return Single.create(rcs.thenCompose(serviceRequest -> {
-            URI requestUri = relativizeNoProxy(finalUri, proxy);
+            URI requestUri = relativizeNoProxy(finalUri, proxy, configuration.relativeUris());
             requestId = serviceRequest.requestId();
             HttpHeaders headers = toNettyHttpHeaders();
             DefaultHttpRequest request = new DefaultHttpRequest(toNettyHttpVersion(httpVersion),
@@ -677,13 +677,16 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
 
 
     /**
-     * Relativize final URI if no proxy or if host in no-proxy list.
+     * Relativize final URI if no proxy or if host in no-proxy list or if forced via
+     * the {@code relative-uris} config property.
      *
      * @param finalUri the final URI
+     * @param proxy the proxy
+     * @param relativeUris flag to force all URIs to be relative
      * @return possibly converted URI
      */
-    static URI relativizeNoProxy(URI finalUri, Proxy proxy) {
-        if (proxy == Proxy.noProxy() || proxy.noProxyPredicate().apply(finalUri)) {
+    static URI relativizeNoProxy(URI finalUri, Proxy proxy, boolean relativeUris) {
+        if (proxy == Proxy.noProxy() || proxy.noProxyPredicate().apply(finalUri) || relativeUris) {
             String path = finalUri.getRawPath();
             String fragment = finalUri.getRawFragment();
             String query = finalUri.getRawQuery();

--- a/webclient/webclient/src/test/java/io/helidon/webclient/ProxyTest.java
+++ b/webclient/webclient/src/test/java/io/helidon/webclient/ProxyTest.java
@@ -69,13 +69,26 @@ class ProxyTest {
     void testNoProxyHandlingPredicate() {
         Config config = Config.create();
         Proxy proxy = Proxy.create(config.get("proxy"));
-        assertThat(relativizeNoProxy(URI.create("http://localhost/foo"), proxy).toString(),
+        assertThat(relativizeNoProxy(URI.create("http://localhost/foo"), proxy, false).toString(),
                 is("/foo"));
-        assertThat(relativizeNoProxy(URI.create("http://www.localhost/foo"), proxy).toString(),
+        assertThat(relativizeNoProxy(URI.create("http://www.localhost/foo"), proxy, false).toString(),
                 is("http://www.localhost/foo"));
-        assertThat(relativizeNoProxy(URI.create("http://identity.oc9qadev.com/foo/bar"), proxy).toString(),
+        assertThat(relativizeNoProxy(URI.create("http://identity.oc9qadev.com/foo/bar"), proxy, false).toString(),
                 is("/foo/bar"));
-        assertThat(relativizeNoProxy(URI.create("http://identity.oci1234.oc9qadev.com/foo/bar"), proxy).toString(),
+        assertThat(relativizeNoProxy(URI.create("http://identity.oci1234.oc9qadev.com/foo/bar"), proxy, false).toString(),
+                is("/foo/bar"));
+    }
+
+    @Test
+    void testForceRelativeUris() {
+        Config config = Config.create();
+        Proxy proxy = Proxy.create(config.get("proxy"));
+        WebClientConfiguration webConfig = WebClientConfiguration.builder()
+                .config(config.get("force-relative-uris")).build();
+        boolean relativeUris = webConfig.relativeUris();
+        assertThat(relativizeNoProxy(URI.create("http://www.localhost/foo"), proxy, relativeUris).toString(),
+                is("/foo"));
+        assertThat(relativizeNoProxy(URI.create("http://identity.oci.com/foo/bar"), proxy, relativeUris).toString(),
                 is("/foo/bar"));
     }
 

--- a/webclient/webclient/src/test/resources/application.yaml
+++ b/webclient/webclient/src/test/resources/application.yaml
@@ -31,3 +31,6 @@ proxy:
   no-proxy:
     - localhost
     - .oc9qadev.com
+
+force-relative-uris:
+  relative-uris: true


### PR DESCRIPTION
New flag to force the use of relative URIs (paths) on all requests, even if proxies are configured. Default is false. See #3577 for a use case.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>