### PR TITLE
Suppress warning when metrics PeriodicExecutor is stopped multiple times (e.g., during tests)

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/PeriodicExecutor.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/PeriodicExecutor.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,10 +49,20 @@ class PeriodicExecutor {
 
     private static final String STOP_LOG_MESSAGE = "Received stop request in state {0}";
 
+    /**
+     * Current state of the executor.
+     *
+     * Normally, the life cycle is DORMANT -> STARTED -> STOPPED & then JVM exit. Particularly in some testing situations, the
+     * singleton PeriodicExecutor might be reused serially with the life cycle DORMANT -> STARTED -> STOPPED -> STARTED -> ...
+     */
     enum State {
         DORMANT, // never started
         STARTED, // started and still running
-        STOPPED  // stopped
+        STOPPED;  // stopped
+
+        boolean isStartable() {
+            return this != STARTED;
+        }
     }
 
     private static class Enrollment {
@@ -97,18 +108,20 @@ class PeriodicExecutor {
                     interval.toMillis(),
                     interval.toMillis(),
                     TimeUnit.MILLISECONDS);
-        } else if (state == State.DORMANT) {
-            deferredEnrollments.add(new Enrollment(runnable, interval));
         } else {
-            LOGGER.log(Level.WARNING,
-                    "Attempt to enroll when in unexpected state " + state + "; ignored",
-                    new IllegalStateException());
+            deferredEnrollments.add(new Enrollment(runnable, interval));
+            if (state == State.STOPPED) {
+                LOGGER.log(Level.FINE,
+                           "Recording deferred enrollment even though in unexpected state " + State.STOPPED,
+                           new IllegalStateException());
+            }
         }
     }
 
     synchronized void startExecutor() {
-        if (state == State.DORMANT) {
-            LOGGER.log(Level.FINE, "Starting up with " + deferredEnrollments.size() + " deferred enrollments");
+        if (state.isStartable()) {
+            LOGGER.log(Level.FINE, "Starting up with " + deferredEnrollments.size() + " deferred enrollments"
+                    + (state == State.DORMANT ? "" : " even though in state " + State.STOPPED));
             state = State.STARTED;
             currentTimeUpdaterExecutorService = Executors.newSingleThreadScheduledExecutor();
             for (Enrollment deferredEnrollment : deferredEnrollments) {
@@ -138,7 +151,7 @@ class PeriodicExecutor {
                 break;
 
             default:
-                LOGGER.log(Level.WARNING, String.format(
+                LOGGER.log(Level.FINE, String.format(
                         "Unexpected attempt to stop; the expected states are %s but found %s; ignored",
                         Set.of(State.DORMANT, State.STARTED),
                         state),


### PR DESCRIPTION
Resolves #3616 

Change warning message to fine when `PeriodicExecutor` is shut down multiple times. This can happen if multiple `@HelidonTests` run in the same JVM.

This should _not_ happen normally in production servers...the `PeriodicExecutor` stop is triggered when `MetricsSupport` receives notification of server shutdown, and there is typically at most one `MetricsSupport` instance in a server. 

Also, while I was here, I changed `synchronized` methods to use a `Semaphore` instead.