### PR TITLE
3.0 preparation: change sources to Java 17

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven.compiler.release>${maven.compiler.source}</maven.compiler.release>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>

--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.jlink.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.jlink.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -17,7 +17,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-mp/src/main/resources/Dockerfile.native.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.jlink.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.jlink.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -18,7 +18,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
+++ b/archetypes/quickstart-se/src/main/resources/Dockerfile.native.mustache
@@ -1,6 +1,6 @@
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/common/http/src/main/java/io/helidon/common/http/Content.java
+++ b/common/http/src/main/java/io/helidon/common/http/Content.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import io.helidon.common.reactive.Single;
 /**
  * Represents an HTTP entity as a {@link Multi multi} of {@link DataChunk chunks} with specific
  * features.
- * <h3>Default publisher contract</h3>
+ * <h2>Default publisher contract</h2>
  * Default publisher accepts only single subscriber. Other subscribers receives
  * {@link Flow.Subscriber#onError(Throwable) onError()}.
  * <p>
@@ -36,11 +36,11 @@ import io.helidon.common.reactive.Single;
  * method call. Buffer can be reused by network infrastructure as soon as {@code onNext()} method returns.
  * This behavior can be inconvenient yet it helps to provide excellent performance.
  *
- * <h3>Publisher Overwrite.</h3>
+ * <h2>Publisher Overwrite.</h2>
  * It is possible to modify contract of the original publisher by registration of a new publisher using
  * {@link #registerFilter(Function)} method. It can be used to wrap or replace previously registered (or default) publisher.
  *
- * <h3>Entity Readers</h3>
+ * <h2>Entity Readers</h2>
  * It is possible to register function to convert publisher to {@link io.helidon.common.reactive.Single} of a single entity using
  * {@link #registerReader(Class, Reader)} or {@link #registerReader(Predicate, Reader)} methods. It
  * is then possible to use {@link #as(Class)} method to obtain such entity.

--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -569,7 +569,6 @@ public final class MediaType implements AcceptPredicate<MediaType> {
 
     /**
      * Tests if this media type has provided Structured Syntax {@code suffix} (RFC 6839).
-     * <p>
      *
      * @param suffix Suffix with or without '+' prefix. If null or empty then returns {@code true} if this media type
      *               has ANY suffix.

--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ import io.helidon.config.spi.MergingStrategy;
 import io.helidon.config.spi.OverrideSource;
 
 /**
- * <h1>Configuration</h1>
+ * <h2>Configuration</h2>
  * Immutable tree-structured configuration.
- * <h2>Loading Configuration</h2>
+ * <h3>Loading Configuration</h3>
  * Load the default configuration using the {@link Config#create} method.
  * <pre>{@code
  * Config config = Config.create();
@@ -95,7 +95,7 @@ import io.helidon.config.spi.OverrideSource;
  * </tr>
  * </table>
  *
- * <h2>Navigating in a Configuration Tree</h2>
+ * <h3>Navigating in a Configuration Tree</h3>
  * Each loaded configuration is a tree of {@code Config} objects. The
  * application can access an arbitrary node in the tree by passing its
  * fully-qualified name to {@link Config#get}:
@@ -146,8 +146,8 @@ import io.helidon.config.spi.OverrideSource;
  * <p>
  * To get node value, use {@link #as(Class)} to access this config node as a {@link ConfigValue}
  *
- * <h2>Converting Configuration Values to Types</h2>
- * <h3>Explicit Conversion by the Application</h3>
+ * <h3>Converting Configuration Values to Types</h3>
+ * <h4>Explicit Conversion by the Application</h4>
  * The interpretation of a configuration node, including what datatype to use,
  * is up to the application. To interpret a node's value as a type other than
  * {@code String} the application can invoke one of these convenience methods:
@@ -231,8 +231,8 @@ import io.helidon.config.spi.OverrideSource;
  * that can handle classes that fulfill some requirements (see documentation), such as a public constructor,
  * static "create(Config)" method etc.
  *
- * <h2><a id="multipleSources">Handling Multiple Configuration
- * Sources</a></h2>
+ * <h3><a id="multipleSources">Handling Multiple Configuration
+ * Sources</a></h3>
  * A {@code Config} instance, including the default {@code Config} returned by
  * {@link Config#create}, might be associated with multiple {@link ConfigSource}s. The
  * config system merges these together so that values from config sources with higher priority have

--- a/config/config/src/main/java/io/helidon/config/ValueResolvingFilter.java
+++ b/config/config/src/main/java/io/helidon/config/ValueResolvingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import io.helidon.config.spi.ConfigFilter;
  * will be resolved as:
  * <pre>
  * {@code message = "Hello Joachim!"}</pre>
- * <h1>How to Activate This Filter</h1>
+ * <h2>How to Activate This Filter</h2>
  * Use any of the following techniques to create a {@code ValueResolvingFilter} and
  * use it for config look-ups.
  * <ol>
@@ -62,7 +62,7 @@ import io.helidon.config.spi.ConfigFilter;
  * every {@code Config.Builder} automatically.
  * </li>
  * </ol>
- * <h2>Handling Missing References</h2>
+ * <h3>Handling Missing References</h3>
  * By default, references to tokens that are not present <em>do not</em> cause
  * retrievals to fail. You can customize this behavior in several ways.
  * <ol>

--- a/config/config/src/main/java/io/helidon/config/spi/PollingStrategy.java
+++ b/config/config/src/main/java/io/helidon/config/spi/PollingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,6 @@ import io.helidon.config.PollingStrategies;
  *      seconds</td>
  *  </tr>
  * </table>
- * <p>
  * </li>
  * <li>{@code class} - fully-qualified class name of a custom polling strategy
  * implementation or a builder class that implements a {@code build()} method
@@ -79,7 +78,7 @@ import io.helidon.config.PollingStrategies;
  * For a given config source use either {@code type} or {@code class} to
  * indicate a polling strategy but not both. If both appear the config system
  * ignores the {@code class} setting.
- * <h3>Meta-configuration Support for Custom Polling Strategies</h3>
+ * <h2>Meta-configuration Support for Custom Polling Strategies</h2>
  * To support settings in meta-configuration, a custom polling strategy must
  * be capable of processing the meta configuration provided to
  * {@link io.helidon.config.spi.PollingStrategyProvider#create(String, io.helidon.config.Config)}

--- a/docs/shared/common_prereqs/common_prereqs.adoc
+++ b/docs/shared/common_prereqs/common_prereqs.adoc
@@ -30,7 +30,7 @@
 // tag::common-prereqs-table-contents[]
 
 |A Helidon MP Application | You can use your own application or use the https://helidon.io/docs/v2/#/mp/guides/02_quickstart[Helidon MP Quickstart] to create a sample application.
-|https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}11] (http://jdk.java.net[Open{nbsp}JDK{nbsp}11]) |Helidon requires Java 11+.
+|https://www.oracle.com/technetwork/java/javase/downloads[Java{nbsp}SE{nbsp}17] (http://jdk.java.net[Open{nbsp}JDK{nbsp}17]) |Helidon requires Java 17+.
 |https://maven.apache.org/download.cgi[Maven 3.6.1+]|Helidon requires Maven 3.6.1+.
 |https://docs.docker.com/install/[Docker 18.09+]|You need Docker if you
 want to build and deploy Docker containers.

--- a/etc/dockerfiles/Dockerfile.jdk17-graalvm
+++ b/etc/dockerfiles/Dockerfile.jdk17-graalvm
@@ -23,7 +23,7 @@ RUN set -x \
     && apt-get -y install curl
 
 RUN curl -O -L \
-    https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-amd64-21.3.0.tar.gz && \
+    https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java17-linux-amd64-21.3.0.tar.gz && \
     tar -xvzf graalvm-*.tar.gz && \
     rm graalvm-*.tar.gz && \
     mv graalvm-* graalvm && \

--- a/etc/dockerfiles/Dockerfile.jdk17-graalvm-maven
+++ b/etc/dockerfiles/Dockerfile.jdk17-graalvm-maven
@@ -30,7 +30,7 @@ RUN set -x && \
 
 RUN echo "done!"
 
-FROM helidon/jdk11-graalvm:21.3.0
+FROM helidon/jdk17-graalvm:21.3.0
 
 COPY --from=build /build/maven /usr/share/maven
 RUN ln -s /usr/share/maven/bin/mvn /bin/

--- a/etc/dockerfiles/build.sh
+++ b/etc/dockerfiles/build.sh
@@ -60,10 +60,10 @@ readonly MY_DIR=$(cd $(dirname -- "${SCRIPT_PATH}") ; pwd -P)
 
 readonly GRAALVM_VERSION=21.3.0
 
-docker build -f ${MY_DIR}/Dockerfile.jdk11-graalvm -t helidon/jdk11-graalvm:${GRAALVM_VERSION} ${MY_DIR}
-docker build -f ${MY_DIR}/Dockerfile.jdk11-graalvm-maven -t helidon/jdk11-graalvm-maven:${GRAALVM_VERSION} ${MY_DIR}
+docker build -f ${MY_DIR}/Dockerfile.jdk17-graalvm -t helidon/jdk17-graalvm:${GRAALVM_VERSION} ${MY_DIR}
+docker build -f ${MY_DIR}/Dockerfile.jdk17-graalvm-maven -t helidon/jdk17-graalvm-maven:${GRAALVM_VERSION} ${MY_DIR}
 
 if [ "${PUSH}" = "true" ] ; then
-    docker push helidon/jdk11-graalvm:${GRAALVM_VERSION}
-    docker push helidon/jdk11-graalvm-maven:${GRAALVM_VERSION}
+    docker push helidon/jdk17-graalvm:${GRAALVM_VERSION}
+    docker push helidon/jdk17-graalvm-maven:${GRAALVM_VERSION}
 fi

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -71,6 +71,8 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.showDateTime=true"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS"
+        # Needed for archetype engine plugin
+        MAVEN_OPTS="${MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED"
         export MAVEN_OPTS
         export PATH="/tools/apache-maven-3.6.3/bin:${JAVA_HOME}/bin:/tools/node-v12/bin:${PATH}"
         if [ -n "${GITHUB_SSH_KEY}" ] ; then

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -47,7 +47,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
     . ${WS_DIR}/etc/scripts/includes/error_handlers.sh
 
     if [ -z "${GRAALVM_HOME}" ]; then
-        export GRAALVM_HOME="/tools/graalvm-ce-java11-21.3.0"
+        export GRAALVM_HOME="/tools/graalvm-ce-java17-21.3.0"
     fi
 
     require_env() {
@@ -67,7 +67,7 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
 
     if [ -n "${JENKINS_HOME}" ] ; then
         export PIPELINE="true"
-        export JAVA_HOME="/tools/jdk-11.0.12"
+        export JAVA_HOME="/tools/jdk-17"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.showDateTime=true"
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS"

--- a/etc/scripts/includes/pipeline-env.sh
+++ b/etc/scripts/includes/pipeline-env.sh
@@ -73,6 +73,8 @@ if [ -z "${__PIPELINE_ENV_INCLUDED__}" ]; then
         MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS"
         # Needed for archetype engine plugin
         MAVEN_OPTS="${MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED"
+        # Needed for generating site
+        MAVEN_OPTS="${MAVEN_OPTS} --add-opens=java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED"
         export MAVEN_OPTS
         export PATH="/tools/apache-maven-3.6.3/bin:${JAVA_HOME}/bin:/tools/node-v12/bin:${PATH}"
         if [ -n "${GITHUB_SSH_KEY}" ] ; then

--- a/examples/employee-app/Dockerfile
+++ b/examples/employee-app/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/grpc/opentracing/Dockerfile
+++ b/examples/grpc/opentracing/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -38,7 +38,7 @@ RUN mvn -f opentracing/pom.xml package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/cdi/datasource-hikaricp/Dockerfile
+++ b/examples/integrations/cdi/datasource-hikaricp/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/cdi/jedis/Dockerfile
+++ b/examples/integrations/cdi/jedis/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/cdi/oci-objectstorage/Dockerfile
+++ b/examples/integrations/cdi/oci-objectstorage/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/integrations/neo4j/neo4j-mp/Dockerfile.native
+++ b/examples/integrations/neo4j/neo4j-mp/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile.jlink
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/integrations/neo4j/neo4j-se/Dockerfile.native
+++ b/examples/integrations/neo4j/neo4j-se/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:20.2.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/messaging/README.md
+++ b/examples/messaging/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 * Docker
-* Java 11+
+* Java 17+
 
 ### Test Kafka server
 To make examples easily runnable, 

--- a/examples/messaging/docker/kafka/Dockerfile.kafka
+++ b/examples/messaging/docker/kafka/Dockerfile.kafka
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:11-jre-slim-buster
+FROM openjdk:17-jdk-slim-buster
 
 ENV VERSION=2.7.0
 ENV SCALA_VERSION=2.13

--- a/examples/messaging/jms-websocket-mp/README.md
+++ b/examples/messaging/jms-websocket-mp/README.md
@@ -1,7 +1,7 @@
 # Helidon Messaging with JMS Example
 
 ## Prerequisites
-* Java 11+ 
+* Java 17+ 
 * Docker
 * [ActiveMQ server](../README.md) running on `localhost:61616`
 

--- a/examples/messaging/jms-websocket-se/README.md
+++ b/examples/messaging/jms-websocket-se/README.md
@@ -1,7 +1,7 @@
 # Helidon Messaging with JMS Example
 
 ## Prerequisites
-* Java 11+ 
+* Java 17+ 
 * Docker
 * [ActiveMQ server](../README.md) running on `localhost:61616`
 

--- a/examples/messaging/kafka-websocket-mp/README.md
+++ b/examples/messaging/kafka-websocket-mp/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 * Docker
-* Java 11+ 
+* Java 17+ 
 * [Kafka bootstrap server](../README.md) running on `localhost:9092`
 
 ## Build & Run

--- a/examples/messaging/kafka-websocket-se/README.md
+++ b/examples/messaging/kafka-websocket-se/README.md
@@ -1,7 +1,7 @@
 # Helidon Messaging with Kafka Examples
 
 ## Prerequisites
-* Java 11+ 
+* Java 17+ 
 * Docker
 * [Kafka bootstrap server](../README.md) running on `localhost:9092`
 

--- a/examples/messaging/oracle-aq-websocket-mp/README.md
+++ b/examples/messaging/oracle-aq-websocket-mp/README.md
@@ -1,7 +1,7 @@
 # Helidon Messaging with Oracle AQ Example
 
 ## Prerequisites
-* Java 11+ 
+* Java 17+ 
 * Docker
 * [Oracle database](../README.md) running on `localhost:1521`
 

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-mp/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-quickstart-se/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/pom.xml
@@ -29,7 +29,7 @@
         <helidon.version>3.0.0-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.microprofile.cdi.Main</mainClass>
 
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven.site.skip>true</maven.site.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.jlink
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6.3-jdk-11-slim as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/Dockerfile.native
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM helidon/jdk11-graalvm-maven:21.3.0 as build
+FROM helidon/jdk17-graalvm-maven:21.3.0 as build
 
 WORKDIR /helidon
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -29,7 +29,7 @@
         <helidon.version>3.0.0-SNAPSHOT</helidon.version>
         <mainClass>io.helidon.examples.quickstart.se.Main</mainClass>
 
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven.site.skip>true</maven.site.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/security/idcs-login/pom.xml
+++ b/examples/security/idcs-login/pom.xml
@@ -91,10 +91,6 @@
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
             <scope>runtime</scope>

--- a/examples/todo-app/backend/Dockerfile
+++ b/examples/todo-app/backend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -32,7 +32,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
+++ b/examples/todo-app/backend/src/test/java/io/helidon/demo/todos/backend/BackendTests.java
@@ -40,12 +40,14 @@ import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @HelidonTest
 @Configuration(useExisting = true)
+@Disabled("3.0.0-JAKARTA")
 class BackendTests {
 
     private final static String CASSANDRA_HOST = "127.0.0.1";

--- a/examples/todo-app/frontend/Dockerfile
+++ b/examples/todo-app/frontend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -39,7 +39,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/translator-app/backend/Dockerfile
+++ b/examples/translator-app/backend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/translator-app/frontend/Dockerfile
+++ b/examples/translator-app/frontend/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -Dmaven.test.skip
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/examples/webserver/opentracing/Dockerfile
+++ b/examples/webserver/opentracing/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 
 # 1st stage, build the app
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon
 
@@ -33,7 +33,7 @@ RUN mvn package -DskipTests
 RUN echo "done!"
 
 # 2nd stage, build the runtime image
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 # Copy the binary built in the 1st stage

--- a/lra/coordinator/server/Dockerfile
+++ b/lra/coordinator/server/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM maven:3.6-jdk-11 as build
+FROM maven:3.6.3-openjdk-17-slim as build
 
 WORKDIR /helidon    
 ARG HELIDON_BRANCH=master
@@ -49,7 +49,7 @@ RUN mvn install -pl :helidon-lra-coordinator-server -am -DskipTests
 
 RUN echo "Helidon LRA Coordinator build successfully fished"
 
-FROM openjdk:11-jre-slim
+FROM openjdk:17-jdk-slim
 WORKDIR /helidon
 
 COPY --from=build /helidon/lra/coordinator/server/target/helidon-lra-coordinator-server.jar ./

--- a/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/Main.java
+++ b/microprofile/cdi/src/main/java/io/helidon/microprofile/cdi/Main.java
@@ -26,8 +26,8 @@ import javax.enterprise.inject.spi.CDI;
  * This is the "master" main class of Helidon MP.
  * You can boot the Helidon MP instance using this class if you want do not need to modify
  * anything using builders.
- * <h1>Startup</h1>
- * <h2>Configuration</h2>
+ * <h2>Startup</h2>
+ * <h3>Configuration</h3>
  * <p>
  * If this method is used, the following approach is taken for configuration:
  * <ul>
@@ -36,7 +36,7 @@ import javax.enterprise.inject.spi.CDI;
  *      <li>If there are any MicroProfile config sources, these will be added</li>
  *      <li>If there are any {@code META-INF/microprofile-config.properties} files on the classpath, these will be added</li>
  * </ul>
- * <h2>Logging</h2>
+ * <h3>Logging</h3>
  * Helidon uses Java Util Logging. You can configure logging using:
  * <ul>
  *     <li>A system property {@code java.util.logging.config.class}</li>

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * <h1>Helidon MP CORS Support</h1>
+ * <h2>Helidon MP CORS Support</h2>
  * Adding the Helidon MP CORS module to your application enables CORS support automatically, implementing the configuration in
  * the {@value io.helidon.microprofile.cors.CrossOriginFilter#CORS_CONFIG_KEY} section of your MicroProfile configuration.
  * <p>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -18,6 +18,7 @@ package io.helidon.microprofile.metrics;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
@@ -176,14 +177,18 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
      * @param <E> type of element
      * @deprecated This method is made public to migrate from metrics1 to metrics2 for gRPC, this should be refactored
      */
+    @SuppressWarnings("rawtypes")
     @Deprecated
     public static <E extends Member & AnnotatedElement>
     void registerMetric(E element, Class<?> clazz, LookupResult<? extends Annotation> lookupResult) {
         Executable executable;
         if (element instanceof AnnotatedCallable) {
            executable = (Executable) ((AnnotatedCallable<?>) element).getJavaMember();
-        } else if (element instanceof Executable) {
-            executable = (Executable) element;
+        } else if (element instanceof Constructor) {
+            // code checking instanceof Executable and casting to it would not compile on Java17
+            executable = (Constructor) element;
+        } else if (element instanceof Method) {
+            executable = (Method) element;
         } else {
             throw new IllegalArgumentException("Element must be an AnnotatedCallable or Executable but was "
                     + element.getClass().getName());

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <description>Java libraries for writing microservices</description>
 
     <properties>
+        <version.java>17</version.java>
+
         <doclint>all</doclint>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -207,9 +209,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.plugin.compiler}</version>
                     <configuration>
-                        <source>11</source>
-                        <target>11</target>
-                        <release>11</release>
+                        <source>${version.java}</source>
+                        <target>${version.java}</target>
+                        <release>${version.java}</release>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                         <compilerArgs>
                             <arg>-Xlint:unchecked</arg>
@@ -225,7 +227,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${version.plugin.javadoc}</version>
                     <configuration>
-                        <source>11</source>
+                        <source>${version.java}</source>
                         <failOnError>true</failOnError>
                         <!-- we are not interested in each file that is generated -->
                         <quiet>true</quiet>
@@ -343,9 +345,7 @@
                         </offlineLinks>
                         <additionalJOptions combine.children="append">
                             <additionalJOption>-J-Dhttp.agent=maven-javadoc-plugin</additionalJOption>
-                            <additionalJOption>--add-exports=java.base/sun.security.util=io.helidon.common.pki
-                            </additionalJOption>
-                            <!--<additionalJOption>- -frames</additionalJOption>-->
+                            <additionalJOption>--add-exports=java.base/sun.security.util=io.helidon.common.pki</additionalJOption>
                         </additionalJOptions>
                         <additionalOptions>
                             <!--<additionalOption> - -add-stylesheet ${top.parent.basedir}/etc/helidon-javadoc.css</additionalOption>-->
@@ -1184,58 +1184,6 @@ helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,he
             </modules>
         </profile>
         <profile>
-          <id>jdk9-javadoc</id>
-          <!-- https://maven.apache.org/guides/introduction/introduction-to-profiles.html#Details_on_profile_activation -->
-          <!-- AND semantics; see https://issues.apache.org/jira/browse/MNG-4565 -->
-            <activation>
-              <jdk>[9,10)</jdk>
-              <property>
-                  <name>!jdkToolchainVersion</name>
-              </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalJOptions>
-                                    <!-- https://bugs.openjdk.java.net/browse/JDK-8184969 -->
-                                    <JOption>-Xold</JOption>
-                                </additionalJOptions>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-          <id>jdk9-toolchain-javadoc</id>
-            <activation>
-              <property>
-                <name>jdkToolchainVersion</name>
-                <value>9</value>
-              </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalJOptions combine.children="append">
-                                    <!-- https://bugs.openjdk.java.net/browse/JDK-8184969 -->
-                                    <JOption>-Xold</JOption>
-                                </additionalJOptions>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>sources</id>
             <build>
                 <plugins>
@@ -1551,7 +1499,7 @@ helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,he
         <profile>
             <id>loom</id>
             <activation>
-                <jdk>16-loom</jdk>
+                <jdk>18-loom</jdk>
             </activation>
             <build>
                 <pluginManagement>
@@ -1560,17 +1508,17 @@ helidon-parent,helidon-dependencies,helidon-bom,helidon-se,helidon-mp,io.grpc,he
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
-                                <source>16</source>
-                                <target>16</target>
-                                <release>16</release>
+                                <source>18</source>
+                                <target>18</target>
+                                <release>18</release>
                             </configuration>
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-javadoc-plugin</artifactId>
                             <configuration>
-                                <source>16</source>
-                                <release>16</release>
+                                <source>18</source>
+                                <release>18</release>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -204,7 +204,6 @@ public class Security {
 
     /**
      * Creates new instance based on configuration values.
-     * <p>
      *
      * @param config Config instance located on security configuration ("providers" is an expected child)
      * @return new instance.
@@ -218,7 +217,6 @@ public class Security {
 
     /**
      * Creates new instance based on configuration values.
-     * <p>
      *
      * @param config Config instance located on security configuration ("providers" is an expected child)
      * @return new instance.

--- a/security/security/src/main/java/io/helidon/security/package-info.java
+++ b/security/security/src/main/java/io/helidon/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * <h1>Security</h1>
+ * <h2>Security</h2>
  *
  * Supports security for web (and possibly other) resources including:
  * <ul>
@@ -30,7 +30,7 @@
  * Various security aspects are pluggable, using {@link io.helidon.security.spi.SecurityProvider providers}
  * to extend functionality.
  *
- * <h2>Bootstrapping</h2>
+ * <h3>Bootstrapping</h3>
  *
  * You have two way to do things with security - either load it from configuration or create a fully configured instance
  * using a builder. Both approaches should allow the same behavior.

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/package-info.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
  */
 
 /**
- * <h1>Helidon SE CORS Support</h1>
+ * <h2>Helidon SE CORS Support</h2>
  * <p>
  * Use {@link io.helidon.webserver.cors.CorsSupport} and its {@link io.helidon.webserver.cors.CorsSupport.Builder} to add CORS
  * handling to resources in your application.
  * <p>
  * Because Helidon SE does not use annotation processing to identify endpoints, you need to provide the CORS information for
  * your application another way. You can use Helidon configuration, the Helidon CORS API, or a combination.
- * <h2>Configuration</h2>
- * <h3>Format</h3>
+ * <h3>Configuration</h3>
+ * <h4>Format</h4>
  * CORS configuration looks like this:
  * <pre>
  * enabled: true    # the default
@@ -34,7 +34,7 @@
  * allow-credentials: true
  * max-age: -1
  * </pre>
- * <h3>Finding and applying CORS configuration</h3>
+ * <h4>Finding and applying CORS configuration</h4>
  * Although Helidon prescribes the CORS config format, you can put it wherever you want in your application's configuration
  * file. Your application code will retrieve the CORS config from its location within your configuration and then use that
  * config node to prepare CORS support for your app.
@@ -72,7 +72,7 @@
  * This sets up more restrictive CORS behavior for more sensitive HTTP methods ({@code PUT} for example) and more liberal CORS
  * behavior for {@code GET}.
  *
- * <h2>The Helidon CORS API</h2>
+ * <h3>The Helidon CORS API</h3>
  * You can define your application's CORS behavior programmatically -- together with configuration if you want -- by:
  * <ul>
  *     <li>creating a {@link io.helidon.webserver.cors.CrossOriginConfig.Builder} instance,</li>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/PathMatcher.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/PathMatcher.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * <p>Matched URI path is always <b>decoded</b>, <b>{@link java.net.URI#normalize() normalized}</b> and
  * with <b>removed single ended slash</b> (if any).
  *
- * <h3><a id="pattern">Web Server Path Pattern</a></h3>
+ * <h2><a id="pattern">Web Server Path Pattern</a></h2>
  * While user can implement this interface to implement any specific needs the primary construction method is
  * {@link #create(String)} factory method. The method accepts <i>Web Server Path Pattern</i> format.
  *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import io.helidon.common.http.MediaType;
  * The handler to be used for matching requests is passed as parameter to
  * {@link #thenApply(Handler)} and the handler to be used for requests that do not
  * match can be specified using {@link ConditionalHandler#otherwise(Handler) }.
- * <h3>Examples</h3>
+ * <h2>Examples</h2>
  * <p>
  * Invoke a {@link Handler} only when the request contains a header name {@code foo}
  * and accepts {@code text/plain}, otherwise return a response with {@code 404} code.

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ResponseHeaders.java
@@ -36,7 +36,7 @@ import io.helidon.common.reactive.Single;
  * Extends {@link Parameters} interface by adding HTTP response headers oriented constants and convenient methods.
  * Use constants located in {@link io.helidon.common.http.Http.Header} as standard header names.
  *
- * <h3>Lifecycle</h3>
+ * <h2>Lifecycle</h2>
  * Headers can be muted until {@link #send() send} to the client. It is also possible to register a '{@link #beforeSend(Consumer)
  * before send}' function which can made 'last minute mutation'.
  * <p>

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerResponse.java
@@ -39,7 +39,7 @@ import io.helidon.media.common.MessageBodyWriters;
 /**
  * Represents HTTP Response.
  *
- * <h3>Lifecycle</h3>
+ * <h2>Lifecycle</h2>
  * HTTP response is send to the client in two or more steps (chunks). First contains {@link #status() HTTP status code}
  * and {@link ResponseHeaders headers}. First part can be send explicitly by calling {@link ResponseHeaders#send()}
  * method or implicitly by sending a first part of the the response content. As soon as first part is send it become immutable -
@@ -161,7 +161,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
     /**
      * Send a message and close the response.
      *
-     * <h3>Marshalling</h3>
+     * <h4>Marshalling</h4>
      * Data are marshaled using default or {@link #registerWriter(Class, Function) registered} {@code writer} to the format
      * of {@link ByteBuffer} {@link Publisher Publisher}. The last registered compatible writer is used.
      * <p>
@@ -173,7 +173,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      *     <li>{@link java.io.File}</li>
      * </ul>
      *
-     * <h3>Blocking</h3>
+     * <h4>Blocking</h4>
      * The method blocks only during marshalling. It means until {@code registered writer} produce a {@code Publisher} and
      * subscribe HTTP IO implementation on it. If the thread is used for publishing is up to HTTP IO and generated Publisher
      * implementations. Use returned {@link io.helidon.common.reactive.Single} to monitor and react on finished sending process.
@@ -203,7 +203,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * A single {@link Subscription Subscriber} subscribes to the provided {@link Publisher Publisher} during
      * the method execution.
      *
-     * <h3>Blocking</h3>
+     * <h4>Blocking</h4>
      * If the thread is used for publishing is up to HTTP IO and generated Publisher
      * implementations. Use returned {@link io.helidon.common.reactive.Single} to monitor and react on finished sending process.
      *
@@ -221,7 +221,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * A single {@link Subscription Subscriber} subscribes to the provided {@link Publisher Publisher} during
      * the method execution.
      *
-     * <h3>Blocking</h3>
+     * <h4>Blocking</h4>
      * If the thread is used for publishing is up to HTTP IO and generated Publisher
      * implementations. Use returned {@link io.helidon.common.reactive.Single} to monitor and react on finished sending process.
      *

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebServer.java
@@ -422,6 +422,12 @@ public interface WebServer {
             return result;
         }
 
+        /**
+         * Configure the transport to be used by this server.
+         *
+         * @param transport transport to use
+         * @return updated builder instance
+         */
         public Builder transport(Transport transport) {
             configurationBuilder.transport(transport);
             return this;


### PR DESCRIPTION
Source and target are now `17`.
All graalvm related artifacts changed to 17.
(docker images for graalvm are pushed).
Required javadoc fixes.