### PR TITLE
Checkstyle upgrade

### DIFF
--- a/config/config/src/main/java/io/helidon/config/Config.java
+++ b/config/config/src/main/java/io/helidon/config/Config.java
@@ -922,6 +922,12 @@ public interface Config {
         @Override
         String toString();
 
+        /**
+         * Create a child key to the current key.
+         *
+         * @param key child key (relative to current key)
+         * @return a new resolved key
+         */
         Key child(Key key);
 
         /**

--- a/config/config/src/main/java/io/helidon/config/spi/ChangeWatcher.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ChangeWatcher.java
@@ -81,6 +81,15 @@ public interface ChangeWatcher<T> {
          */
         ChangeEventType type();
 
+        /**
+         * Create a new change event.
+         *
+         * @param target target of the change
+         * @param type event type
+         * @param instant time the event occurred
+         * @param <T> type of the target
+         * @return a new typed change event
+         */
         static <T> ChangeEvent<T> create(T target, ChangeEventType type, Instant instant) {
             return new ChangeEvent<>() {
                 @Override
@@ -105,6 +114,14 @@ public interface ChangeWatcher<T> {
             };
         }
 
+        /**
+         * Create a new change event that occurred right now.
+         *
+         * @param target target of the change
+         * @param type event type
+         * @param <T> type of the target
+         * @return a new typed change event
+         */
         static <T> ChangeEvent<T> create(T target, ChangeEventType type) {
             return create(target, type, Instant.now());
         }

--- a/config/config/src/main/java/io/helidon/config/spi/ConfigContent.java
+++ b/config/config/src/main/java/io/helidon/config/spi/ConfigContent.java
@@ -63,6 +63,9 @@ public interface ConfigContent {
          */
         OverrideSource.OverrideData data();
 
+        /**
+         * Fluent API builder for {@link io.helidon.config.spi.ConfigContent}.
+         */
         class Builder extends ConfigContent.Builder<Builder> implements io.helidon.common.Builder<Builder, OverrideContent> {
             // override data
             private OverrideSource.OverrideData data;

--- a/config/config/src/main/java/io/helidon/config/spi/PollableSource.java
+++ b/config/config/src/main/java/io/helidon/config/spi/PollableSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,20 @@ public interface PollableSource<S> {
      * @see io.helidon.config.AbstractConfigSource
      */
     interface Builder<T extends Builder<T>> {
+        /**
+         * Configure the polling strategy to use.
+         *
+         * @param pollingStrategy polling strategy
+         * @return updated builder
+         */
         T pollingStrategy(PollingStrategy pollingStrategy);
 
+        /**
+         * Configure the polling strategy to use.
+         *
+         * @param pollingStrategy supplier of polling strategy (such as its builder)
+         * @return updated builder
+         */
         default T pollingStrategy(Supplier<? extends PollingStrategy> pollingStrategy) {
             return pollingStrategy(pollingStrategy.get());
         }

--- a/config/object-mapping/src/main/java/io/helidon/config/objectmapping/Value.java
+++ b/config/object-mapping/src/main/java/io/helidon/config/objectmapping/Value.java
@@ -237,6 +237,9 @@ public @interface Value {
      * Class that represents not-set default values.
      */
     interface None extends Supplier<Void> {
+        /**
+         * Value to use when a {@code null} value should be the default.
+         */
         String VALUE = "io.helidon.config:default=null";
 
         @Override

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/ConnectionPool.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/ConnectionPool.java
@@ -157,6 +157,12 @@ public interface ConnectionPool {
                     .collect(Collectors.toList());
         }
 
+        /**
+         * Update builder from configuration.
+         *
+         * @param config configuration
+         * @return updated builder
+         */
         public Builder config(Config config) {
             Map<String, String> poolConfig = config.detach().asMap().get();
             poolConfig.forEach((key, value) -> {
@@ -182,21 +188,45 @@ public interface ConnectionPool {
             return this;
         }
 
+        /**
+         * Connection pool URL string.
+         *
+         * @param url connection pool string to use
+         * @return updated builder
+         */
         public Builder url(String url) {
             this.url = url;
             return this;
         }
 
+        /**
+         * Connection pool username.
+         *
+         * @param username username to use
+         * @return updated builder
+         */
         public Builder username(String username) {
             this.username = username;
             return this;
         }
 
+        /**
+         * Connection pool password.
+         *
+         * @param password password to use
+         * @return updated builder
+         */
         public Builder password(String password) {
             this.password = password;
             return this;
         }
 
+        /**
+         * Configure connection pool properties.
+         *
+         * @param properties properties to use
+         * @return updated builder
+         */
         public Builder properties(Properties properties) {
             this.properties = properties;
             return this;

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -111,7 +111,7 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="scope" value="protected"/>
+            <property name="accessModifiers" value="public, protected"/>
             <property name="validateThrows" value="false"/>
         </module>
         <module name="MissingJavadocMethod">

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -370,6 +370,11 @@ public interface Retry extends FtHandler {
             }
         }
 
+        /**
+         * A new fluent API builder to configure instances of {@link io.helidon.faulttolerance.Retry}.
+         *
+         * @return a new builder
+         */
         public static Builder builder() {
             return new Builder();
         }

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcServerConfiguration.java
@@ -169,7 +169,13 @@ public interface GrpcServerConfiguration {
         private Builder() {
         }
 
-        public GrpcServerConfiguration.Builder config(Config config) {
+        /**
+         * Update the builder from configuration.
+         *
+         * @param config configuration instance
+         * @return updated builder
+         */
+        public Builder config(Config config) {
             if (config == null) {
                 return this;
             }
@@ -220,7 +226,8 @@ public interface GrpcServerConfiguration {
         }
 
         /**
-         * Sets an <a href="http://opentracing.io">opentracing.io</a> tracer. (Default is {@link GlobalTracer}.)
+         * Sets an <a href="http://opentracing.io">opentracing.io</a> tracer.
+         * (Default is {@link GlobalTracer}.)
          *
          * @param tracer a tracer to set
          * @return an updated builder
@@ -286,6 +293,11 @@ public interface GrpcServerConfiguration {
             return port;
         }
 
+        /**
+         * Current Helidon {@link io.helidon.common.context.Context}.
+         *
+         * @return current context
+         */
         public Context context() {
             return context;
         }

--- a/grpc/server/src/main/java/module-info.java
+++ b/grpc/server/src/main/java/module-info.java
@@ -37,4 +37,5 @@ module io.helidon.grpc.server {
     requires java.logging;
 
     requires jakarta.inject;
+    requires io.opentracing.util;
 }

--- a/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetricsRx.java
+++ b/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetricsRx.java
@@ -127,16 +127,38 @@ public interface OciMetricsRx {
             return this;
         }
 
+        /**
+         * Replace host prefix.
+         * Changing host prefix may be a breaking change. This API is designed to work with
+         * {@link #API_HOST_PREFIX}.
+         *
+         * @param prefix prefix to use
+         * @return updated builder
+         */
         public Builder hostPrefix(String prefix) {
             this.hostPrefix = prefix;
             return this;
         }
 
+        /**
+         * Replace endpoint to be invoked when contacting OCI.
+         *
+         * @param endpoint endpoint to use
+         * @return updated builder
+         */
         public Builder endpoint(String endpoint) {
             this.endpoint = endpoint;
             return this;
         }
 
+        /**
+         * Configure API version to use.
+         * API version is part of the request URI. Changing API version is potentially breaking,
+         *  as this API is designed to work with a specific version (see {@link #API_VERSION}).
+         *
+         * @param apiVersion version of the API to use
+         * @return updated builder
+         */
         public Builder apiVersion(String apiVersion) {
             this.apiVersion = apiVersion;
             return this;
@@ -153,6 +175,12 @@ public interface OciMetricsRx {
             return this;
         }
 
+        /**
+         * Configure REST API to use.
+         *
+         * @param restApi OCI rest API
+         * @return updated builder
+         */
         public Builder restApi(OciRestApi restApi) {
             this.restApi = restApi;
             return this;

--- a/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVaultRx.java
+++ b/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVaultRx.java
@@ -228,62 +228,145 @@ public interface OciVaultRx {
             return this;
         }
 
+        /**
+         * Replace Vault host prefix.
+         * Changing host prefix may be a breaking change. This API is designed to work with
+         * {@link #VAULTS_HOST_PREFIX}.
+         *
+         * @param vaultPrefix prefix to use
+         * @return updated builder
+         */
         public Builder vaultPrefix(String vaultPrefix) {
             this.vaultPrefix = vaultPrefix;
             return this;
         }
 
+        /**
+         * Replace retrieval host prefix.
+         * Changing host prefix may be a breaking change. This API is designed to work with
+         * {@link #RETRIEVAL_HOST_PREFIX}.
+         *
+         * @param retrievalHostPrefix prefix to use
+         * @return updated builder
+         */
         public Builder retrievalPrefix(String retrievalHostPrefix) {
             this.retrievalPrefix = retrievalHostPrefix;
             return this;
         }
 
+        /**
+         * Vault endpoint.
+         *
+         * @param vaultEndpoint valut endpoint
+         * @return updated builder
+         */
         public Builder vaultEndpoint(String vaultEndpoint) {
             this.vaultEndpoint = vaultEndpoint;
             return this;
         }
 
+        /**
+         * Endpoint to retrieve secrets from.
+         *
+         * @param retrievalEndpoint endpoint
+         * @return updated builder
+         */
         public Builder retrievalEndpoint(String retrievalEndpoint) {
             this.retrievalEndpoint = retrievalEndpoint;
             return this;
         }
 
+        /**
+         * Replace KMS host prefix.
+         * Changing host prefix may be a breaking change. This API is designed to work with
+         * {@link #KMS_HOST_PREFIX}.
+         *
+         * @param kmsPrefix prefix to use
+         * @return updated builder
+         */
         public Builder kmsPrefix(String kmsPrefix) {
             this.kmsPrefix = kmsPrefix;
             return this;
         }
 
+        /**
+         * KMS endpoint.
+         *
+         * @param kmsEndpoint KMS endpoint
+         * @return updated builder
+         */
         public Builder kmsEndpoint(String kmsEndpoint) {
             this.kmsEndpoint = kmsEndpoint;
             return this;
         }
 
+        /**
+         * Endpoint format to use.
+         * Default is {@link #OCI_ENDPOINT_FORMAT}.
+         *
+         * @param endpointFormat endpoint format to use
+         * @return updated builder
+         */
         public Builder vaultEndpointFormat(String endpointFormat) {
             this.vaultEndpointFormat = endpointFormat;
             return this;
         }
 
+        /**
+         * Configure API version to use.
+         * API version is part of the request URI. Changing API version is potentially breaking,
+         *  as this API is designed to work with a specific version (see {@link #SECRET_API_VERSION}).
+         *
+         * @param apiVersion version of the API to use
+         * @return updated builder
+         */
         @ConfiguredOption(key = "vault.secret-api-version")
         public Builder secretApiVersion(String apiVersion) {
             this.secretApiVersion = apiVersion;
             return this;
         }
 
+        /**
+         * Configure bundle API version to use.
+         * API version is part of the request URI. Changing API version is potentially breaking,
+         *  as this API is designed to work with a specific version (see {@link #SECRET_BUNDLE_API_VERSION}).
+         *
+         * @param apiVersion version of the API to use
+         * @return updated builder
+         */
         public Builder secretBundleApiVersion(String apiVersion) {
             this.secretBundleApiVersion = apiVersion;
             return this;
         }
 
+        /**
+         * Configure the cryptographic endpoint.
+         *
+         * @param address endpoint for crypto operations
+         * @return updated builder
+         */
         public Builder cryptographicEndpoint(String address) {
             this.cryptographicEndpoint = address;
             return this;
         }
 
+        /**
+         * Configure the management endpoint.
+         *
+         * @param managementEndpoint management endpoint
+         * @return updated builder
+         */
         public Builder managementEndpoint(String managementEndpoint) {
             this.managementEndpoint = managementEndpoint;
             return this;
         }
 
+        /**
+         * Configure REST API to use.
+         *
+         * @param restApi OCI rest API
+         * @return updated builder
+         */
         @ConfiguredOption(key = "scheme", type = String.class, value = "https", description = "Scheme to use to "
                 + "connect to cloud")
         @ConfiguredOption(key = "domain", type = String.class, value = "oraclecloud.com", description = "Cloud domain")

--- a/integrations/vault/vault/src/main/java/io/helidon/integrations/vault/Vault.java
+++ b/integrations/vault/vault/src/main/java/io/helidon/integrations/vault/Vault.java
@@ -242,31 +242,68 @@ public interface Vault {
             return this;
         }
 
+        /**
+         * Base namespace to use when invoking Vault operations.
+         *
+         * @param baseNamespace base namespace
+         * @return updated builder
+         */
         public Builder baseNamespace(String baseNamespace) {
             this.baseNamespace = baseNamespace;
             return this;
         }
 
+        /**
+         * Vault address (if configured).
+         *
+         * @return vault address
+         */
         public Optional<String> address() {
             return Optional.ofNullable(address);
         }
 
+        /**
+         * Token (if configured).
+         *
+         * @return token
+         */
         public Optional<String> token() {
             return Optional.ofNullable(token);
         }
 
+        /**
+         * Base namespace (if configured).
+         *
+         * @return namespace to use
+         */
         public Optional<String> baseNamespace() {
             return Optional.ofNullable(baseNamespace);
         }
 
+        /**
+         * Configured fault tolerance handler.
+         *
+         * @return FT Handler
+         */
         public FtHandler ftHandler() {
             return faultTolerance;
         }
 
+        /**
+         * Current config.
+         *
+         * @return config instance
+         */
         public Config config() {
             return config;
         }
 
+        /**
+         * Update to web client setup.
+         * Used by authentication methods
+         *
+         * @return web client updater
+         */
         public Consumer<WebClient.Builder> webClientUpdater() {
             return webClientUpdater;
         }

--- a/messaging/connectors/jms/src/main/java/io/helidon/messaging/connectors/jms/JmsMessage.java
+++ b/messaging/connectors/jms/src/main/java/io/helidon/messaging/connectors/jms/JmsMessage.java
@@ -429,6 +429,14 @@ public interface JmsMessage<PAYLOAD> extends Message<PAYLOAD> {
             }
         }
 
+        /**
+         * Helper method to use a lambda that throws a checked exception.
+         *
+         * @param p payload
+         * @param session session
+         * @return a new message
+         * @throws JMSException as thrown by underlying API
+         */
         jakarta.jms.Message applyThrows(PAYLOAD p, Session session) throws JMSException;
     }
 

--- a/metrics/api/src/main/java/io/helidon/metrics/api/KeyPerformanceIndicatorMetricsSettings.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/KeyPerformanceIndicatorMetricsSettings.java
@@ -136,7 +136,13 @@ public interface KeyPerformanceIndicatorMetricsSettings {
         long LONG_RUNNING_REQUESTS_THRESHOLD_MS_DEFAULT = 10 * 1000; // 10 seconds
 
         // The following constants are used in JavaDoc.
+        /**
+         * Prefix of configuration keys.
+         */
         String CONFIG_KEY_PREFIX = "metrics." + KEY_PERFORMANCE_INDICATORS_CONFIG_KEY;
+        /**
+         * Configuration key for long-running requests extended configuration.
+         */
         String QUALIFIED_LONG_RUNNING_REQUESTS_THRESHOLD_CONFIG_KEY =
                 LONG_RUNNING_REQUESTS_CONFIG_KEY + "." + KEY_PERFORMANCE_INDICATORS_EXTENDED_CONFIG_KEY;
 
@@ -176,8 +182,17 @@ public interface KeyPerformanceIndicatorMetricsSettings {
          */
         KeyPerformanceIndicatorMetricsSettings build();
 
+        /**
+         * Whether extended KPIs are enabled.
+         * @return {@code true} if extended
+         */
         boolean isExtended();
 
+        /**
+         * Threshold (in milliseconds) for long-running requests.
+         *
+         * @return threshold in milliseconds
+         */
         long longRunningRequestThresholdMs();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.lib.arquillian-weld-embedded>3.0.0.Final</version.lib.arquillian-weld-embedded>
         <version.lib.asciidoctor.diagram>1.5.4.1</version.lib.asciidoctor.diagram>
         <version.lib.asm>6.0</version.lib.asm>
-        <version.lib.checkstyle>8.29</version.lib.checkstyle>
+        <version.lib.checkstyle>9.1</version.lib.checkstyle>
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
         <version.lib.jboss-logging-annotations>2.2.1.Final</version.lib.jboss-logging-annotations>
@@ -90,7 +90,7 @@
         <version.plugin.archetype-packaging>3.1.2</version.plugin.archetype-packaging>
         <version.plugin.archetype>3.1.2</version.plugin.archetype>
         <version.plugin.build-helper>1.12</version.plugin.build-helper>
-        <version.plugin.checkstyle>3.1.0</version.plugin.checkstyle>
+        <version.plugin.checkstyle>3.1.2</version.plugin.checkstyle>
         <version.plugin.compiler>3.8.1</version.plugin.compiler>
         <version.plugin.dependency>3.1.2</version.plugin.dependency>
         <version.plugin.directory>0.3.1</version.plugin.directory>

--- a/security/security/src/main/java/io/helidon/security/spi/AuditProvider.java
+++ b/security/security/src/main/java/io/helidon/security/spi/AuditProvider.java
@@ -162,6 +162,12 @@ public interface AuditProvider extends SecurityProvider {
             }
         }
 
+        /**
+         * Check if the stack element is an actual Helidon Security class.
+         *
+         * @param element element to check
+         * @return {@code true} if the class comes from Helidon Security
+         */
         static boolean isSecurityClass(StackWalker.StackFrame element) {
             String className = element.getClassName();
             int last = className.lastIndexOf('.');


### PR DESCRIPTION
Upgrade checkstyle to support `record`.

This upgrade also (finally) correctly enforces javadocs on static methods on interfaces, and public methods on inner public classes. I have fixed all such issues in Helidon sources.
