### PR TITLE
Prepare RegistryFactory lazily to use the most-recently-assigned MetricsSettings

### DIFF
--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -120,6 +120,7 @@
                                 <excludes>
                                     <exclude>**/TestServerWithKeyPerformanceIndicatorMetrics.java</exclude>
                                     <exclude>**/TestExponentiallyDecayingReservoir.java</exclude>
+                                    <exclude>**/TestDisabledEntirely.java</exclude>
                                 </excludes>
                             </configuration>
                         </execution>
@@ -160,6 +161,18 @@
                             <configuration>
                                 <includes>
                                     <include>**/TestExponentiallyDecayingReservoir.java</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- Run in separate invocation to make sure the RegistryFactory is initialized correctly. -->
+                            <id>check-metrics-entirely-disabled</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/TestDisabledEntirely.java</include>
                                 </includes>
                             </configuration>
                         </execution>

--- a/metrics/metrics/src/test/java/io/helidon/metrics/TestDisabledEntirely.java
+++ b/metrics/metrics/src/test/java/io/helidon/metrics/TestDisabledEntirely.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.metrics;
+
+import io.helidon.metrics.api.MetricsSettings;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+class TestDisabledEntirely {
+
+    @Test
+    void testDisabledCompletely() {
+        MetricsSettings metricsSettings = MetricsSettings.builder()
+                .enabled(false)
+                .build();
+
+        io.helidon.metrics.api.RegistryFactory registryFactory =
+                io.helidon.metrics.api.RegistryFactory.getInstance(metricsSettings);
+
+        assertThat("Disabled RegistryFactory impl class",
+                   registryFactory,
+                   not(instanceOf(io.helidon.metrics.RegistryFactory.class)));
+    }
+}

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -74,6 +74,7 @@ import io.helidon.common.Errors;
 import io.helidon.common.context.Contexts;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
+import io.helidon.config.mp.MpConfig;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.metrics.serviceapi.MetricsSupport;
@@ -619,19 +620,16 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
                 Object adv,
                 BeanManager bm,
                 ServerCdiExtension server) {
-        Set<String> vendorMetricsAdded = new HashSet<>();
-        Config config = ((Config) ConfigProvider.getConfig()).get("metrics");
-
-        // Update the registry factory with the runtime config.
-        RegistryFactory.getInstance(MetricsSettings.create(config));
+        Routing.Builder defaultRouting = super.registerService(adv, bm, server);
+        MetricsSupport metricsSupport = serviceSupport();
 
         registerMetricsForAnnotatedSites();
         registerProducers(bm);
 
-        Routing.Builder defaultRouting = super.registerService(adv, bm, server);
-        MetricsSupport metricsSupport = serviceSupport();
-
+        Set<String> vendorMetricsAdded = new HashSet<>();
         vendorMetricsAdded.add("@default");
+
+        Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(MetricsSettings.Builder.METRICS_CONFIG_KEY);
 
         // now we may have additional sockets we want to add vendor metrics to
         config.get("vendor-metrics-routings")

--- a/microprofile/metrics/src/main/java/module-info.java
+++ b/microprofile/metrics/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module io.helidon.microprofile.metrics {
 
     requires transitive microprofile.config.api;
     requires microprofile.metrics.api;
-
+    requires io.helidon.config.mp;
 
     exports io.helidon.microprofile.metrics;
 


### PR DESCRIPTION
Resolves #3653 

The prior  implementation used a static initializer to create a `RegistryFactory` using default `MetricsSettings` (which would imply that metrics would be enabled). Even though subsequent `RegistryFactory#getInstance(MetricsSettings)` calls would correctly communicate if metrics had been disabled, by this time the full-featured registry had already been created and saved as the singleton instance. That would mean we would lose some of the efficiency of the minimal metrics implementation when metrics is configured as disabled.

This PR changes the code to lazily create the singleton on first retrieval, using the latest `MetricsSettings` passed to `RegistryFactory#getInstance()`.