### PR TITLE
Fix some remaining problems with disabling metrics, mostly deferring access to RegistryFactory

### DIFF
--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
@@ -17,8 +17,9 @@ package io.helidon.dbclient.metrics.jdbc;
 
 import java.util.logging.Logger;
 
+import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -40,11 +41,11 @@ public class DropwizardMetricsListener implements MetricRegistryListener {
 
     private final String prefix;
     // Helidon metrics registry
-    private final MetricRegistry registry;
+    private final LazyValue<MetricRegistry> registry = LazyValue.create(
+            () -> RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR));
 
     private DropwizardMetricsListener(String prefix) {
         this.prefix = prefix;
-        this.registry = RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR);
     }
 
     static MetricRegistryListener create(Config config) {
@@ -54,61 +55,61 @@ public class DropwizardMetricsListener implements MetricRegistryListener {
     @Override
     public void onGaugeAdded(String name, Gauge<?> gauge) {
         LOGGER.finest(() -> String.format("Gauge added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsGauge<>(gauge));
+        registry.get().register(prefix + name, new JdbcMetricsGauge<>(gauge));
     }
 
     @Override
     public void onGaugeRemoved(String name) {
         LOGGER.finest(() -> String.format("Gauge removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onCounterAdded(String name, Counter counter) {
         LOGGER.finest(() -> String.format("Counter added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsCounter(counter));
+        registry.get().register(prefix + name, new JdbcMetricsCounter(counter));
     }
 
     @Override
     public void onCounterRemoved(String name) {
         LOGGER.finest(() -> String.format("Counter removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onHistogramAdded(String name, Histogram histogram) {
         LOGGER.finest(() -> String.format("Histogram added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsHistogram(histogram));
+        registry.get().register(prefix + name, new JdbcMetricsHistogram(histogram));
     }
 
     @Override
     public void onHistogramRemoved(String name) {
         LOGGER.finest(() -> String.format("Histogram removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onMeterAdded(String name, Meter meter) {
         LOGGER.finest(() -> String.format("Meter added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsMeter(meter));
+        registry.get().register(prefix + name, new JdbcMetricsMeter(meter));
     }
 
     @Override
     public void onMeterRemoved(String name) {
         LOGGER.finest(() -> String.format("Meter removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onTimerAdded(String name, Timer timer) {
         LOGGER.finest(() -> String.format("Timer added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsTimer(timer));
+        registry.get().register(prefix + name, new JdbcMetricsTimer(timer));
     }
 
     @Override
     public void onTimerRemoved(String name) {
         LOGGER.finest(() -> String.format("Timer removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
 }

--- a/dbclient/metrics/pom.xml
+++ b/dbclient/metrics/pom.xml
@@ -37,11 +37,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.dbclient</groupId>
             <artifactId>helidon-dbclient-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/dbclient/metrics/src/main/java/module-info.java
+++ b/dbclient/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbclient/metrics/src/main/java/module-info.java
+++ b/dbclient/metrics/src/main/java/module-info.java
@@ -23,7 +23,7 @@ import io.helidon.dbclient.spi.DbClientServiceProvider;
 module io.helidon.dbclient.metrics {
     requires java.logging;
     requires io.helidon.dbclient;
-    requires io.helidon.metrics;
+    requires io.helidon.metrics.api;
     requires io.helidon.dbclient.common;
 
     exports io.helidon.dbclient.metrics;

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -42,8 +42,13 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grpc/metrics/src/main/java/module-info.java
+++ b/grpc/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/metrics/src/main/java/module-info.java
+++ b/grpc/metrics/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.helidon.grpc.metrics {
     requires transitive io.helidon.grpc.core;
     requires static io.helidon.grpc.client;
     requires static io.helidon.grpc.server;
-    requires transitive io.helidon.metrics;
+    requires transitive io.helidon.metrics.api;
 
     requires microprofile.metrics.api;
 }

--- a/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
+++ b/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
@@ -18,6 +18,7 @@ package io.helidon.grpc.metrics;
 
 import java.util.Map;
 
+import io.helidon.common.LazyValue;
 import io.helidon.grpc.server.GrpcService;
 import io.helidon.grpc.server.MethodDescriptor;
 import io.helidon.grpc.server.ServiceDescriptor;
@@ -70,9 +71,9 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class GrpcMetricsInterceptorIT {
 
-    private static MetricRegistry vendorRegistry;
+    private static LazyValue<MetricRegistry> vendorRegistry;
 
-    private static MetricRegistry appRegistry;
+    private static LazyValue<MetricRegistry> appRegistry;
 
     private static Meter vendorMeter;
 
@@ -85,7 +86,7 @@ public class GrpcMetricsInterceptorIT {
 
         vendorRegistry = GrpcMetrics.VENDOR_REGISTRY;
         appRegistry = GrpcMetrics.APP_REGISTRY;
-        vendorMeter = vendorRegistry.meter(GrpcMetrics.GRPC_METER);
+        vendorMeter = vendorRegistry.get().meter(GrpcMetrics.GRPC_METER);
     }
 
     @BeforeEach
@@ -108,7 +109,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.testCounted");
+        Counter appCounter = appRegistry.get().counter("Foo.testCounted");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -127,7 +128,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Histogram appHistogram = appRegistry.histogram("Foo.barHistogram");
+        Histogram appHistogram = appRegistry.get().histogram("Foo.barHistogram");
 
         assertVendorMetrics();
         assertThat(appHistogram.getCount(), is(1L));
@@ -146,7 +147,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Meter appMeter = appRegistry.meter("Foo.barMetered");
+        Meter appMeter = appRegistry.get().meter("Foo.barMetered");
 
         assertVendorMetrics();
         assertThat(appMeter.getCount(), is(1L));
@@ -165,7 +166,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Timer appTimer = appRegistry.timer("Foo.barTimed");
+        Timer appTimer = appRegistry.get().timer("Foo.barTimed");
 
         assertVendorMetrics();
         assertThat(appTimer.getCount(), is(1L));
@@ -184,7 +185,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        SimpleTimer appSimpleTimer = appRegistry.simpleTimer("Foo.barSimplyTimed");
+        SimpleTimer appSimpleTimer = appRegistry.get().simpleTimer("Foo.barSimplyTimed");
 
         assertVendorMetrics();
         assertThat(appSimpleTimer.getCount(), is(1L));
@@ -203,7 +204,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        ConcurrentGauge appConcurrentGauge = appRegistry.concurrentGauge("Foo.barConcurrentGauge");
+        ConcurrentGauge appConcurrentGauge = appRegistry.get().concurrentGauge("Foo.barConcurrentGauge");
 
         assertVendorMetrics();
         assertThat(appConcurrentGauge.getCount(), is(1L));
@@ -224,7 +225,7 @@ public class GrpcMetricsInterceptorIT {
         call.close(Status.OK, new Metadata());
 
         Map<MetricID, Metric> matchingMetrics =
-                appRegistry.getMetrics().entrySet().stream()
+                appRegistry.get().getMetrics().entrySet().stream()
                         .filter(entry -> entry.getKey().getName().equals("Foo.barTags"))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -258,7 +259,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.barDesc");
+        Counter appCounter = appRegistry.get().counter("Foo.barDesc");
 
         assertVendorMetrics();
         assertThat(appCounter.toString(), containsString("description='foo'"));
@@ -277,7 +278,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.barUnits");
+        Counter appCounter = appRegistry.get().counter("Foo.barUnits");
 
         assertVendorMetrics();
         assertThat(appCounter.toString(), containsString("unit='bits'"));
@@ -297,7 +298,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("My.Service.bar");
+        Counter appCounter = appRegistry.get().counter("My.Service.bar");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -316,7 +317,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("overridden");
+        Counter appCounter = appRegistry.get().counter("overridden");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -356,7 +357,7 @@ public class GrpcMetricsInterceptorIT {
     }
 
     private void assertVendorMetrics() {
-        Meter meter = vendorRegistry.meter(GrpcMetrics.GRPC_METER);
+        Meter meter = vendorRegistry.get().meter(GrpcMetrics.GRPC_METER);
 
         assertThat(meter.getCount(), is(vendorMeterCount + 1));
     }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
@@ -112,6 +112,11 @@ class NoOpMetricImpl extends AbstractMetric implements NoOpMetric {
             return new NoOpGaugeImpl<>(registryType, metadata, metric);
         }
 
+        static <S /* extends Number */> NoOpGaugeImpl<S> create(String registryType, Metadata metadata) {
+            // TODO uncomment above once MP metrics enforces the Number restriction
+            return new NoOpGaugeImpl<>(registryType, metadata, () -> null);
+        }
+
         private NoOpGaugeImpl(String registryType, Metadata metadata, Gauge<T> metric) {
             super(registryType, metadata);
             value = metric::getValue;

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricRegistry.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricRegistry.java
@@ -30,9 +30,8 @@ import org.eclipse.microprofile.metrics.MetricType;
 class NoOpMetricRegistry extends AbstractRegistry<NoOpMetric> {
 
     private static final Map<MetricType, BiFunction<String, Metadata, NoOpMetric>> NO_OP_METRIC_FACTORIES =
-            // Omit gauge because creating a gauge requires an existing delegate instance.
-            // These factory methods do not use delegates.
             Map.of(MetricType.COUNTER, NoOpMetricImpl.NoOpCounterImpl::create,
+                   MetricType.GAUGE, NoOpMetricImpl.NoOpGaugeImpl::create,
                    MetricType.HISTOGRAM, NoOpMetricImpl.NoOpHistogramImpl::create,
                    MetricType.METERED, NoOpMetricImpl.NoOpMeterImpl::create,
                    MetricType.TIMER, NoOpMetricImpl.NoOpTimerImpl::create,

--- a/metrics/api/src/main/java/io/helidon/metrics/api/RegistryFactoryManager.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/RegistryFactoryManager.java
@@ -65,7 +65,8 @@ class RegistryFactoryManager {
     private static final RegistryFactoryProvider NO_OP_FACTORY_PROVIDER = (metricsSettings) -> NoOpRegistryFactory.create();
 
     // Might be changed via getInstance(MetricsSettings).
-    private static MetricsSettings metricsSettings = MetricsSettings.create();
+    private static MetricsSettings metricsSettings = MetricsSettings.create(
+            Config.create().get(MetricsSettings.Builder.METRICS_CONFIG_KEY));
 
     // Instance managed and returned by the {@link getInstance} methods. Use the latest-provided metrics settings.
     private static final LazyValue<RegistryFactory> INSTANCE = LazyValue.create(() -> create(metricsSettings));

--- a/metrics/jaeger/pom.xml
+++ b/metrics/jaeger/pom.xml
@@ -30,12 +30,17 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
             <version>${version.lib.jaegertracing}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/metrics/jaeger/src/main/java/io/helidon/metrics/jaeger/HelidonJaegerMetricsFactory.java
+++ b/metrics/jaeger/src/main/java/io/helidon/metrics/jaeger/HelidonJaegerMetricsFactory.java
@@ -19,7 +19,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.common.LazyValue;
+import io.helidon.metrics.api.RegistryFactory;
 
 import io.jaegertracing.internal.metrics.Counter;
 import io.jaegertracing.internal.metrics.Gauge;
@@ -37,8 +38,8 @@ import org.eclipse.microprofile.metrics.Tag;
  */
 public class HelidonJaegerMetricsFactory implements MetricsFactory {
 
-    private final MetricRegistry vendorRegistry = RegistryFactory.getInstance()
-            .getRegistry(MetricRegistry.Type.VENDOR);
+    private final LazyValue<MetricRegistry> vendorRegistry = LazyValue.create(() -> RegistryFactory.getInstance()
+            .getRegistry(MetricRegistry.Type.VENDOR));
 
     @Override
     public Counter createCounter(String name, Map<String, String> jaegerTags) {
@@ -49,7 +50,7 @@ public class HelidonJaegerMetricsFactory implements MetricsFactory {
                     jaegerTags,
                     MetricType.COUNTER,
                     MetricUnits.NONE,
-                    vendorRegistry::counter);
+                    HelidonJaegerMetricsFactory.this::counter);
 
             @Override
             public void inc(long delta) {
@@ -67,7 +68,7 @@ public class HelidonJaegerMetricsFactory implements MetricsFactory {
                     jaegerTags,
                     MetricType.TIMER,
                     MetricUnits.MICROSECONDS,
-                    vendorRegistry::timer);
+                    HelidonJaegerMetricsFactory.this::timer);
 
             @Override
             public void durationMicros(long time) {
@@ -84,7 +85,7 @@ public class HelidonJaegerMetricsFactory implements MetricsFactory {
 
             {
                 Metadata metadata = metadata(name, MetricType.GAUGE, MetricUnits.NONE);
-                vendorRegistry.register(metadata,
+                vendorRegistry.get().register(metadata,
                         gauge,
                         convertTags(jaegerTags));
             }
@@ -94,6 +95,14 @@ public class HelidonJaegerMetricsFactory implements MetricsFactory {
                 gauge.update(amount);
             }
         };
+    }
+
+    private org.eclipse.microprofile.metrics.Counter counter(Metadata metadata, Tag[] tags) {
+        return vendorRegistry.get().counter(metadata, tags);
+    }
+
+    private org.eclipse.microprofile.metrics.Timer timer(Metadata metadata, Tag[] tags) {
+        return vendorRegistry.get().timer(metadata, tags);
     }
 
     private static class JaegerGauge implements org.eclipse.microprofile.metrics.Gauge<Long> {

--- a/metrics/jaeger/src/main/java/module-info.java
+++ b/metrics/jaeger/src/main/java/module-info.java
@@ -20,7 +20,8 @@
 module io.helidon.metrics.jaeger {
 
     requires java.logging;
-    requires io.helidon.metrics;
+    requires io.helidon.common;
+    requires io.helidon.metrics.api;
     requires jaeger.core;
 
     provides io.jaegertracing.spi.MetricsFactory with io.helidon.metrics.jaeger.HelidonJaegerMetricsFactory;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -27,8 +27,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
 import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.spi.AfterDeploymentValidation;
 import javax.enterprise.inject.spi.AnnotatedConstructor;
 import javax.enterprise.inject.spi.AnnotatedField;
 import javax.enterprise.inject.spi.AnnotatedMethod;
@@ -56,6 +57,8 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.glassfish.jersey.process.internal.RequestScope;
+
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * Class FaultToleranceExtension.
@@ -232,9 +235,12 @@ public class FaultToleranceExtension implements Extension {
     /**
      * Registers metrics for all FT methods and init executors.
      *
-     * @param validation Event information.
+     * This registration must occur after the metrics extension has observed the event and prepared the registry factory.
+     *
+     * @param event Event information.
      */
-    void registerMetricsAndInitExecutors(@Observes AfterDeploymentValidation validation) {
+    void registerMetricsAndInitExecutors(@Observes @Priority(LIBRARY_BEFORE + 10 + 5) @Initialized(ApplicationScoped.class)
+                                                 Object event) {
         if (FaultToleranceMetrics.enabled()) {
             getRegisteredMethods().stream().forEach(beanMethod -> {
                 final Method method = beanMethod.method();

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -103,6 +103,7 @@
                                 <exclude>**/HelloWorldAsyncResponseTest.java</exclude>
                                 <exclude>**/TestExtendedKPIMetrics.java</exclude>
                                 <exclude>**/TestMetricsOnOwnSocket.java</exclude>
+                                <exclude>**/TestDisabledMetrics.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -117,6 +118,18 @@
                                 <include>**/HelloWorldAsyncResponseTest.java</include>
                                 <include>**/TestExtendedKPIMetrics.java</include>
                                 <include>**/TestMetricsOnOwnSocket.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run in separate invocation to disable all metrics -->
+                        <id>test-with-metrics-disabled</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestDisabledMetrics.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -78,7 +78,6 @@ import io.helidon.config.mp.MpConfig;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.metrics.serviceapi.MetricsSupport;
-import io.helidon.microprofile.cdi.RuntimeStart;
 import io.helidon.microprofile.metrics.MetricAnnotationInfo.RegistrationPrep;
 import io.helidon.microprofile.metrics.MetricUtil.LookupResult;
 import io.helidon.microprofile.server.ServerCdiExtension;

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -320,9 +320,6 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
     void before(@Observes BeforeBeanDiscovery discovery) {
         LOGGER.log(Level.FINE, () -> "Before bean discovery " + discovery);
 
-        // Initialize our implementation
-        RegistryProducer.clearApplicationRegistry();
-
         // Register beans manually with annotated type identifiers that are deliberately the same as those used by the container
         // during bean discovery to avoid accidental duplicate registration in odd packaging scenarios.
         discovery.addAnnotatedType(RegistryProducer.class, RegistryProducer.class.getName());
@@ -583,10 +580,6 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
         syntheticSimpleTimersToRegister.addAll(methodsWithSyntheticSimpleTimer.get(clazz));
     }
 
-    private void runtimeStart(@Observes @RuntimeStart Object event) {
-        registerSyntheticSimpleTimerMetrics();
-    }
-
     private void registerSyntheticSimpleTimerMetrics() {
         syntheticSimpleTimersToRegister.forEach(this::registerAndSaveSyntheticSimpleTimer);
         if (LOGGER.isLoggable(Level.FINE)) {
@@ -623,7 +616,12 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
         Routing.Builder defaultRouting = super.registerService(adv, bm, server);
         MetricsSupport metricsSupport = serviceSupport();
 
+        // Initialize our implementation
+        RegistryProducer.clearApplicationRegistry();
+
         registerMetricsForAnnotatedSites();
+        registerAnnotatedGauges(bm);
+        registerSyntheticSimpleTimerMetrics();
         registerProducers(bm);
 
         Set<String> vendorMetricsAdded = new HashSet<>();
@@ -728,9 +726,11 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
         }
     }
 
-    private void registerAnnotatedGauges(@Observes AfterDeploymentValidation adv, BeanManager bm) {
+    private void registerAnnotatedGauges(BeanManager bm) {
         LOGGER.log(Level.FINE, () -> "registerGauges");
         MetricRegistry registry = getMetricRegistry();
+
+        List<Exception> gaugeProblems = new ArrayList<>();
 
         annotatedGaugeSites.entrySet().forEach(gaugeSite -> {
             LOGGER.log(Level.FINE, () -> "gaugeSite " + gaugeSite.toString());
@@ -754,14 +754,18 @@ public class MetricsCdiExtension extends HelidonRestCdiExtension<MetricsSupport>
                 LOGGER.log(Level.FINE, () -> String.format("Registering gauge with metadata %s", md.toString()));
                 registry.register(md, dg, gaugeID.getTagsAsList().toArray(new Tag[0]));
             } catch (Throwable t) {
-                adv.addDeploymentProblem(new IllegalArgumentException("Error processing @Gauge "
-                                                                              + "annotation on " + site
-                        .getJavaMember().getDeclaringClass().getName()
-                                                                              + ":" + site.getJavaMember()
-                        .getName(), t));
+                gaugeProblems.add(new IllegalArgumentException(
+                        String.format("Error processing @Gauge annotation on %s#%s: %s",
+                                      site.getJavaMember().getDeclaringClass().getName(),
+                                      site.getJavaMember().getName(),
+                                      t.getMessage()),
+                        t));
             }
         });
 
+        if (!gaugeProblems.isEmpty()) {
+            throw new RuntimeException("Could not process one or more @Gauge annotations" + gaugeProblems);
+        }
         annotatedGaugeSites.clear();
     }
 

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDisabledMetrics.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDisabledMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "metrics.enabled", value = "false")
+@AddBean(GaugedBean.class)
+class TestDisabledMetrics {
+
+    @Test
+    void ensureRegistryFactoryIsMinimal() {
+        // Invoking getInstance() should retrieve the factory previously initialized as disabled.
+        RegistryFactory rf = RegistryFactory.getInstance();
+        assertThat("RegistryFactory type", rf, not(instanceOf(io.helidon.metrics.RegistryFactory.class)));
+    }
+}


### PR DESCRIPTION
Resolves #3653 

When metrics are disabled via config, we want to give the code a chance to set the `MetricsSettings` used for the `RegistryFactory` accordingly before the `RegistryFactory` is used by other Helidon code.

This PR fixes a few remaining issues with that.

The commits are grouped roughly by the affected area to simply reviews.
