### PR TITLE
Fix some remaining problems with disabling metrics, mostly deferring access to RegistryFactory (3.0)

### DIFF
--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/DropwizardMetricsListener.java
@@ -17,8 +17,9 @@ package io.helidon.dbclient.metrics.jdbc;
 
 import java.util.logging.Logger;
 
+import io.helidon.common.LazyValue;
 import io.helidon.config.Config;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -40,11 +41,11 @@ public class DropwizardMetricsListener implements MetricRegistryListener {
 
     private final String prefix;
     // Helidon metrics registry
-    private final MetricRegistry registry;
+    private final LazyValue<MetricRegistry> registry = LazyValue.create(
+            () -> RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR));
 
     private DropwizardMetricsListener(String prefix) {
         this.prefix = prefix;
-        this.registry = RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR);
     }
 
     static MetricRegistryListener create(Config config) {
@@ -54,61 +55,61 @@ public class DropwizardMetricsListener implements MetricRegistryListener {
     @Override
     public void onGaugeAdded(String name, Gauge<?> gauge) {
         LOGGER.finest(() -> String.format("Gauge added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsGauge<>(gauge));
+        registry.get().register(prefix + name, new JdbcMetricsGauge<>(gauge));
     }
 
     @Override
     public void onGaugeRemoved(String name) {
         LOGGER.finest(() -> String.format("Gauge removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onCounterAdded(String name, Counter counter) {
         LOGGER.finest(() -> String.format("Counter added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsCounter(counter));
+        registry.get().register(prefix + name, new JdbcMetricsCounter(counter));
     }
 
     @Override
     public void onCounterRemoved(String name) {
         LOGGER.finest(() -> String.format("Counter removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onHistogramAdded(String name, Histogram histogram) {
         LOGGER.finest(() -> String.format("Histogram added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsHistogram(histogram));
+        registry.get().register(prefix + name, new JdbcMetricsHistogram(histogram));
     }
 
     @Override
     public void onHistogramRemoved(String name) {
         LOGGER.finest(() -> String.format("Histogram removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onMeterAdded(String name, Meter meter) {
         LOGGER.finest(() -> String.format("Meter added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsMeter(meter));
+        registry.get().register(prefix + name, new JdbcMetricsMeter(meter));
     }
 
     @Override
     public void onMeterRemoved(String name) {
         LOGGER.finest(() -> String.format("Meter removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
     @Override
     public void onTimerAdded(String name, Timer timer) {
         LOGGER.finest(() -> String.format("Timer added: %s", name));
-        registry.register(prefix + name, new JdbcMetricsTimer(timer));
+        registry.get().register(prefix + name, new JdbcMetricsTimer(timer));
     }
 
     @Override
     public void onTimerRemoved(String name) {
         LOGGER.finest(() -> String.format("Timer removed: %s", name));
-        registry.remove(prefix + name);
+        registry.get().remove(prefix + name);
     }
 
 }

--- a/dbclient/metrics/pom.xml
+++ b/dbclient/metrics/pom.xml
@@ -37,11 +37,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.dbclient</groupId>
             <artifactId>helidon-dbclient-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/dbclient/metrics/src/main/java/module-info.java
+++ b/dbclient/metrics/src/main/java/module-info.java
@@ -23,7 +23,7 @@ import io.helidon.dbclient.spi.DbClientServiceProvider;
 module io.helidon.dbclient.metrics {
     requires java.logging;
     requires io.helidon.dbclient;
-    requires io.helidon.metrics;
+    requires io.helidon.metrics.api;
     requires io.helidon.dbclient.common;
 
     exports io.helidon.dbclient.metrics;

--- a/grpc/metrics/pom.xml
+++ b/grpc/metrics/pom.xml
@@ -42,8 +42,13 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -21,11 +21,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.common.LazyValue;
 import io.helidon.grpc.core.GrpcHelper;
 import io.helidon.grpc.core.InterceptorPriorities;
 import io.helidon.grpc.server.MethodDescriptor;
 import io.helidon.grpc.server.ServiceDescriptor;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 
 import io.grpc.Context;
 import io.grpc.ForwardingServerCall;
@@ -57,14 +58,14 @@ public class GrpcMetrics
     /**
      * The registry of vendor metrics.
      */
-    static final MetricRegistry VENDOR_REGISTRY =
-            RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR);
+    static final LazyValue<MetricRegistry> VENDOR_REGISTRY = LazyValue.create(() ->
+            RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.VENDOR));
 
     /**
      * The registry of application metrics.
      */
-    static final MetricRegistry APP_REGISTRY =
-            RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.APPLICATION);
+    static final LazyValue<MetricRegistry> APP_REGISTRY = LazyValue.create(() ->
+            RegistryFactory.getInstance().getRegistry(MetricRegistry.Type.APPLICATION));
 
     static final org.eclipse.microprofile.metrics.Metadata GRPC_METER = org.eclipse.microprofile.metrics.Metadata
             .builder()
@@ -261,27 +262,27 @@ public class GrpcMetrics
 
         switch (type) {
             case COUNTER:
-                serverCall = new CountedServerCall<>(APP_REGISTRY.counter(
+                serverCall = new CountedServerCall<>(APP_REGISTRY.get().counter(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case METERED:
-                serverCall = new MeteredServerCall<>(APP_REGISTRY.meter(
+                serverCall = new MeteredServerCall<>(APP_REGISTRY.get().meter(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case HISTOGRAM:
-                serverCall = new HistogramServerCall<>(APP_REGISTRY.histogram(
+                serverCall = new HistogramServerCall<>(APP_REGISTRY.get().histogram(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case TIMER:
-                serverCall = new TimedServerCall<>(APP_REGISTRY.timer(
+                serverCall = new TimedServerCall<>(APP_REGISTRY.get().timer(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case SIMPLE_TIMER:
-                serverCall = new SimplyTimedServerCall<>(APP_REGISTRY.simpleTimer(
+                serverCall = new SimplyTimedServerCall<>(APP_REGISTRY.get().simpleTimer(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case CONCURRENT_GAUGE:
-                serverCall = new ConcurrentGaugeServerCall<>(APP_REGISTRY.concurrentGauge(
+                serverCall = new ConcurrentGaugeServerCall<>(APP_REGISTRY.get().concurrentGauge(
                         rules.metadata(service, methodName), rules.toTags()), call);
                 break;
             case GAUGE:
@@ -290,7 +291,7 @@ public class GrpcMetrics
                 serverCall = call;
         }
 
-        serverCall = new MeteredServerCall<>(VENDOR_REGISTRY.meter(GRPC_METER), serverCall);
+        serverCall = new MeteredServerCall<>(VENDOR_REGISTRY.get().meter(GRPC_METER), serverCall);
 
         return next.startCall(serverCall, headers);
     }

--- a/grpc/metrics/src/main/java/module-info.java
+++ b/grpc/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grpc/metrics/src/main/java/module-info.java
+++ b/grpc/metrics/src/main/java/module-info.java
@@ -23,7 +23,7 @@ module io.helidon.grpc.metrics {
     requires transitive io.helidon.grpc.core;
     requires static io.helidon.grpc.client;
     requires static io.helidon.grpc.server;
-    requires transitive io.helidon.metrics;
+    requires transitive io.helidon.metrics.api;
 
     requires microprofile.metrics.api;
 }

--- a/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
+++ b/grpc/metrics/src/test/java/io/helidon/grpc/metrics/GrpcMetricsInterceptorIT.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.helidon.common.LazyValue;
 import io.helidon.grpc.server.GrpcService;
 import io.helidon.grpc.server.MethodDescriptor;
 import io.helidon.grpc.server.ServiceDescriptor;
@@ -69,9 +70,9 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("unchecked")
 public class GrpcMetricsInterceptorIT {
 
-    private static MetricRegistry vendorRegistry;
+    private static LazyValue<MetricRegistry> vendorRegistry;
 
-    private static MetricRegistry appRegistry;
+    private static LazyValue<MetricRegistry> appRegistry;
 
     private static Meter vendorMeter;
 
@@ -84,7 +85,7 @@ public class GrpcMetricsInterceptorIT {
 
         vendorRegistry = GrpcMetrics.VENDOR_REGISTRY;
         appRegistry = GrpcMetrics.APP_REGISTRY;
-        vendorMeter = vendorRegistry.meter(GrpcMetrics.GRPC_METER);
+        vendorMeter = vendorRegistry.get().meter(GrpcMetrics.GRPC_METER);
     }
 
     @BeforeEach
@@ -107,7 +108,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.testCounted");
+        Counter appCounter = appRegistry.get().counter("Foo.testCounted");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -126,7 +127,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Histogram appHistogram = appRegistry.histogram("Foo.barHistogram");
+        Histogram appHistogram = appRegistry.get().histogram("Foo.barHistogram");
 
         assertVendorMetrics();
         assertThat(appHistogram.getCount(), is(1L));
@@ -145,7 +146,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Meter appMeter = appRegistry.meter("Foo.barMetered");
+        Meter appMeter = appRegistry.get().meter("Foo.barMetered");
 
         assertVendorMetrics();
         assertThat(appMeter.getCount(), is(1L));
@@ -164,7 +165,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Timer appTimer = appRegistry.timer("Foo.barTimed");
+        Timer appTimer = appRegistry.get().timer("Foo.barTimed");
 
         assertVendorMetrics();
         assertThat(appTimer.getCount(), is(1L));
@@ -183,7 +184,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        SimpleTimer appSimpleTimer = appRegistry.simpleTimer("Foo.barSimplyTimed");
+        SimpleTimer appSimpleTimer = appRegistry.get().simpleTimer("Foo.barSimplyTimed");
 
         assertVendorMetrics();
         assertThat(appSimpleTimer.getCount(), is(1L));
@@ -202,7 +203,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        ConcurrentGauge appConcurrentGauge = appRegistry.concurrentGauge("Foo.barConcurrentGauge");
+        ConcurrentGauge appConcurrentGauge = appRegistry.get().concurrentGauge("Foo.barConcurrentGauge");
 
         assertVendorMetrics();
         assertThat(appConcurrentGauge.getCount(), is(1L));
@@ -223,7 +224,7 @@ public class GrpcMetricsInterceptorIT {
         call.close(Status.OK, new Metadata());
 
         Map<MetricID, Metric> matchingMetrics =
-                appRegistry.getMetrics().entrySet().stream()
+                appRegistry.get().getMetrics().entrySet().stream()
                         .filter(entry -> entry.getKey().getName().equals("Foo.barTags"))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -257,7 +258,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.barDesc");
+        Counter appCounter = appRegistry.get().counter("Foo.barDesc");
 
         assertVendorMetrics();
         assertThat(appCounter.toString(), containsString("description='foo'"));
@@ -276,7 +277,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("Foo.barUnits");
+        Counter appCounter = appRegistry.get().counter("Foo.barUnits");
 
         assertVendorMetrics();
         assertThat(appCounter.toString(), containsString("unit='bits'"));
@@ -296,7 +297,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("My.Service.bar");
+        Counter appCounter = appRegistry.get().counter("My.Service.bar");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -315,7 +316,7 @@ public class GrpcMetricsInterceptorIT {
 
         call.close(Status.OK, new Metadata());
 
-        Counter appCounter = appRegistry.counter("overridden");
+        Counter appCounter = appRegistry.get().counter("overridden");
 
         assertVendorMetrics();
         assertThat(appCounter.getCount(), is(1L));
@@ -355,7 +356,7 @@ public class GrpcMetricsInterceptorIT {
     }
 
     private void assertVendorMetrics() {
-        Meter meter = vendorRegistry.meter(GrpcMetrics.GRPC_METER);
+        Meter meter = vendorRegistry.get().meter(GrpcMetrics.GRPC_METER);
 
         assertThat(meter.getCount(), is(vendorMeterCount + 1));
     }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
@@ -111,6 +111,11 @@ class NoOpMetricImpl extends AbstractMetric implements NoOpMetric {
             return new NoOpGaugeImpl<>(registryType, metadata, metric);
         }
 
+        static <S /* extends Number */> NoOpGaugeImpl<S> create(String registryType, Metadata metadata) {
+            // TODO uncomment above once MP metrics enforces the Number restriction
+            return new NoOpGaugeImpl<>(registryType, metadata, () -> null);
+        }
+
         private NoOpGaugeImpl(String registryType, Metadata metadata, Gauge<T> metric) {
             super(registryType, metadata);
             value = metric::getValue;

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricRegistry.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricRegistry.java
@@ -30,9 +30,8 @@ import org.eclipse.microprofile.metrics.MetricType;
 class NoOpMetricRegistry extends AbstractRegistry<NoOpMetric> {
 
     private static final Map<MetricType, BiFunction<String, Metadata, NoOpMetric>> NO_OP_METRIC_FACTORIES =
-            // Omit gauge because creating a gauge requires an existing delegate instance.
-            // These factory methods do not use delegates.
             Map.of(MetricType.COUNTER, NoOpMetricImpl.NoOpCounterImpl::create,
+                   MetricType.GAUGE, NoOpMetricImpl.NoOpGaugeImpl::create,
                    MetricType.HISTOGRAM, NoOpMetricImpl.NoOpHistogramImpl::create,
                    MetricType.METERED, NoOpMetricImpl.NoOpMeterImpl::create,
                    MetricType.TIMER, NoOpMetricImpl.NoOpTimerImpl::create,

--- a/metrics/jaeger/pom.xml
+++ b/metrics/jaeger/pom.xml
@@ -30,12 +30,17 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
             <version>${version.lib.jaegertracing}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.bundles</groupId>

--- a/metrics/jaeger/src/main/java/module-info.java
+++ b/metrics/jaeger/src/main/java/module-info.java
@@ -19,7 +19,8 @@
 module io.helidon.metrics.jaeger {
 
     requires java.logging;
-    requires io.helidon.metrics;
+    requires io.helidon.common;
+    requires io.helidon.metrics.api;
     requires jaeger.core;
 
     provides io.jaegertracing.spi.MetricsFactory with io.helidon.metrics.jaeger.HelidonJaegerMetricsFactory;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -32,8 +32,9 @@ import io.helidon.config.mp.MpConfig;
 import io.helidon.faulttolerance.FaultTolerance;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedConstructor;
 import jakarta.enterprise.inject.spi.AnnotatedField;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
@@ -55,6 +56,8 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.glassfish.jersey.process.internal.RequestScope;
+
+import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * Class FaultToleranceExtension.
@@ -231,9 +234,10 @@ public class FaultToleranceExtension implements Extension {
     /**
      * Validates annotations.
      *
-     * @param validation Event information.
+     * @param event Event information.
      */
-    void validateAnnotations(@Observes AfterDeploymentValidation validation) {
+    void validateAnnotations(@Observes @Priority(LIBRARY_BEFORE + 10 + 5) @Initialized(ApplicationScoped.class)
+                                     Object event) {
         if (FaultToleranceMetrics.enabled()) {
             getRegisteredMethods().stream().forEach(beanMethod -> {
                 final Method method = beanMethod.method();

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -56,8 +56,6 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.glassfish.jersey.process.internal.RequestScope;
 
-import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
-
 /**
  * Class FaultToleranceExtension.
  */

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -32,9 +32,8 @@ import io.helidon.config.mp.MpConfig;
 import io.helidon.faulttolerance.FaultTolerance;
 
 import jakarta.annotation.Priority;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedConstructor;
 import jakarta.enterprise.inject.spi.AnnotatedField;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -32,8 +32,9 @@ import io.helidon.config.mp.MpConfig;
 import io.helidon.faulttolerance.FaultTolerance;
 
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedConstructor;
 import jakarta.enterprise.inject.spi.AnnotatedField;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
@@ -55,6 +56,8 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.glassfish.jersey.process.internal.RequestScope;
+
+import static jakarta.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
 
 /**
  * Class FaultToleranceExtension.

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -103,6 +103,7 @@
                                 <exclude>**/HelloWorldAsyncResponseTest.java</exclude>
                                 <exclude>**/TestExtendedKPIMetrics.java</exclude>
                                 <exclude>**/TestMetricsOnOwnSocket.java</exclude>
+                                <exclude>**/TestDisabledMetrics.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -117,6 +118,18 @@
                                 <include>**/HelloWorldAsyncResponseTest.java</include>
                                 <include>**/TestExtendedKPIMetrics.java</include>
                                 <include>**/TestMetricsOnOwnSocket.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Run in separate invocation to disable all metrics -->
+                        <id>test-with-metrics-disabled</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/TestDisabledMetrics.java</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
+++ b/microprofile/metrics/src/main/java/io/helidon/microprofile/metrics/MetricsCdiExtension.java
@@ -48,7 +48,6 @@ import io.helidon.config.mp.MpConfig;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.metrics.serviceapi.MetricsSupport;
-import io.helidon.microprofile.cdi.RuntimeStart;
 import io.helidon.microprofile.metrics.MetricAnnotationInfo.RegistrationPrep;
 import io.helidon.microprofile.metrics.MetricUtil.LookupResult;
 import io.helidon.microprofile.server.ServerCdiExtension;

--- a/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDisabledMetrics.java
+++ b/microprofile/metrics/src/test/java/io/helidon/microprofile/metrics/TestDisabledMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.metrics;
+
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+@HelidonTest
+@AddConfig(key = "metrics.enabled", value = "false")
+@AddBean(GaugedBean.class)
+class TestDisabledMetrics {
+
+    @Test
+    void ensureRegistryFactoryIsMinimal() {
+        // Invoking getInstance() should retrieve the factory previously initialized as disabled.
+        RegistryFactory rf = RegistryFactory.getInstance();
+        assertThat("RegistryFactory type", rf, not(instanceOf(io.helidon.metrics.RegistryFactory.class)));
+    }
+}


### PR DESCRIPTION
Resolves #3660 

When metrics are disabled via config, we want to give the code a chance to set the MetricsSettings used for the RegistryFactory accordingly before the RegistryFactory is used by other Helidon code.

This PR fixes a few remaining issues with that.

The commits are grouped roughly by the affected area to simply reviews.