### PR TITLE
TestNG support (#3263)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -1105,6 +1105,11 @@
             <dependency>
                 <groupId>io.helidon.microprofile.tests</groupId>
                 <artifactId>helidon-microprofile-tests-junit5</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.microprofile.tests</groupId>
+                <artifactId>helidon-microprofile-tests-testng</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <!-- Logging -->

--- a/docs/mp/testing/02_testing_ng.adoc
+++ b/docs/mp/testing/02_testing_ng.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+    Copyright (c) 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -16,28 +16,28 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Testing with JUnit5
+= Testing with Test NG
 :h1Prefix: MP
-:pagename: testing
-:description: Helidon Testing with JUnit5
-:keywords: helidon, mp, test, testing, junit
-:feature-name: Testing with JUnit
+:pagename: testing_ng
+:description: Helidon Testing with TestNG
+:keywords: helidon, mp, test, testing, testng
+:feature-name: Testing with TestNG
 :common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 
-Helidon provides built-in test support for CDI testing in JUnit5.
+Helidon provides built-in test support for CDI testing in TestNG.
 
 include::{common-deps-page-prefix-inc}[tag=maven-dependency]
 [source,xml]
 ----
 <dependency>
     <groupId>io.helidon.microprofile.tests</groupId>
-    <artifactId>helidon-microprofile-tests-junit5</artifactId>
+    <artifactId>helidon-microprofile-tests-testng</artifactId>
     <scope>test</scope>
 </dependency>
 ----
 
 == Usage - default
-A test can be annotated with `io.helidon.microprofile.tests.junit5.HelidonTest` annotation to mark it as a
+A test can be annotated with `io.helidon.microprofile.tests.testng.HelidonTest` annotation to mark it as a
 CDI test. This annotation will start the CDI container before any test method is invoked, and stop it after
 the last method is invoked. This annotation also enables injection into the test class itself.
 
@@ -48,13 +48,13 @@ If you declare `@AddBean` on both abstract class and implementation class, both 
 
 In addition to this simplification, the following annotations are supported:
 
-- `io.helidon.microprofile.tests.junit5.AddBean` - to add one or more beans to the container
+- `io.helidon.microprofile.tests.testng.AddBean` - to add one or more beans to the container
         (if not part of a bean archive, or when discovery is disabled)
-- `io.helidon.microprofile.tests.junit5.AddExtension` - to add one or more CDI extensions to the container
+- `io.helidon.microprofile.tests.testng.AddExtension` - to add one or more CDI extensions to the container
         (if not added through service loader, or when discovery is disabled)
-- `io.helidon.microprofile.tests.junit5.AddConfig` - to add one or more configuration properties to MicroProfile config
+- `io.helidon.microprofile.tests.testng.AddConfig` - to add one or more configuration properties to MicroProfile config
         without the need of creating a `microprofile-config.properties` file
-- `io.helidon.microprofile.tests.junit5.DisableDiscovery` - to disable automated discovery of beans and extensions
+- `io.helidon.microprofile.tests.testng.DisableDiscovery` - to disable automated discovery of beans and extensions
 
 [source,java]
 .Code sample
@@ -86,7 +86,7 @@ This will change the behavior as follows:
 - A new CDI container is created for each test method invocation
 - annotations to add config, beans and extension can be added for each method in addition to the class
 - you cannot inject fields or constructor parameters of the test class itself (as a single instance is shared by more containers)
-- you can add `SeContainer` as a method parameter of any test method and you will get the current container
+
 
 == Usage - configuration
 In addition to the `@AddConfig` annotation, you can also use
@@ -103,13 +103,5 @@ startup to the test class instantiation (which is too late, as the method source
 *If you want to use method sources that use CDI with repeatable tests, please do not use `@Configuration(useExisting=true)`*
 
 == Usage - added parameters and injection types
-The following types are available for injection (when a single CDI container is used per test class):
 
-- `WebTarget` - a JAX-RS client's target configured for the current hostname and port when `helidon-micorprofile-server` is on
-        the classpath
-
-The following types are available as method parameters (in any type of Helidon tests):
-
-- `WebTarget` - a JAX-RS client's target configured for the current hostname and port when `helidon-micorprofile-server` is on
-        the classpath
-- `SeContainer` - the current container instance
+Test method parameters are currently not supported.

--- a/microprofile/tests/pom.xml
+++ b/microprofile/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@
         <module>arquillian</module>
         <module>junit5</module>
         <module>junit5-tests</module>
+        <module>testng</module>
+        <module>testng-tests</module>
     </modules>
 
     <profiles>

--- a/microprofile/tests/testng-tests/pom.xml
+++ b/microprofile/tests/testng-tests/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <artifactId>tests-project</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-microprofile-tests-testng-tests</artifactId>
+    <name>Helidon Microprofile Tests TestNG unit tests</name>
+
+    <description>
+        Test for TestNG integration to prevent cyclic dependencies,
+        so the module can be used in MP config implementation
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/AbstractTest.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/AbstractTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddConfig(key = "key", value = "value")
+abstract class AbstractTest {
+
+    @Inject
+    @ConfigProperty(name = "key")
+    private String key;
+
+    @Test
+    void testKey() {
+        assertThat(key, is("value"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestAddBean.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestAddBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static io.helidon.microprofile.tests.testng.TestDefaults.DEFAULT_VALUE;
+import static io.helidon.microprofile.tests.testng.TestDefaults.PROPERTY_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddBean(TestAddBean.MyBean.class)
+public class TestAddBean {
+
+    @Inject
+    private MyBean myBean;
+
+    @Test
+    void testIt() {
+        assertThat(myBean, notNullValue());
+        assertThat(myBean.configured(), is(DEFAULT_VALUE));
+    }
+
+    static class MyBean {
+        private final String configured;
+
+        @Inject
+        MyBean(@ConfigProperty(name = PROPERTY_NAME, defaultValue = DEFAULT_VALUE) String configured) {
+            this.configured = configured;
+        }
+
+        String configured() {
+            return configured;
+        }
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestChild1.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestChild1.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@AddConfig(key = "key1", value = "value1")
+public class TestChild1 extends AbstractTest {
+
+    @Inject
+    @ConfigProperty(name = "key1")
+    private String childKey;
+
+    @Test
+    void testChildKey() {
+        assertThat(childKey, is("value1"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestChild2.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestChild2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@AddConfig(key = "key2", value = "value2")
+public class TestChild2 extends AbstractTest {
+    @Inject
+    @ConfigProperty(name = "key2")
+    private String childKey;
+
+    @Test
+    void testChildKey() {
+        assertThat(childKey, is("value2"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigSources.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigSources.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@Configuration(configSources = {"testConfigSources.properties", "testConfigSources.yaml"})
+public class TestConfigSources {
+
+    @Inject
+    @ConfigProperty(name = "some.key")
+    private String someKey;
+
+    @Inject
+    @ConfigProperty(name = "another.key")
+    private String anotherKey;
+
+    @Test
+    void testValue() {
+        assertThat(someKey, is("some.value"));
+        assertThat(anotherKey, is("another.value"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigurationCustomProfile.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigurationCustomProfile.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+@HelidonTest
+@Configuration(profile = "custom")
+public class TestConfigurationCustomProfile {
+
+    @Inject
+    @ConfigProperty(name = "mp.config.profile")
+    private String profile;
+
+    @Test
+    void testCustomProfile() {
+        assertThat(profile, is("custom"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigurationDefaultProfile.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestConfigurationDefaultProfile.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@Configuration
+public class TestConfigurationDefaultProfile {
+
+    @Inject
+    @ConfigProperty(name = "mp.config.profile")
+    private String profile;
+
+    @Test
+    void testProfile() {
+        assertThat(profile, is("test"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestCustomConfig.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestCustomConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.Test;
+
+import static io.helidon.microprofile.tests.testng.TestCustomConfig.PROPERTY_VALUE;
+import static io.helidon.microprofile.tests.testng.TestDefaults.PROPERTY_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddConfig(key = PROPERTY_NAME, value = PROPERTY_VALUE)
+@AddConfig(key = "second-key", value = "test-custom-config-second-value")
+public class TestCustomConfig {
+    static final String PROPERTY_VALUE = "test-custom-config-value";
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Inject
+    @ConfigProperty(name = PROPERTY_NAME, defaultValue = PROPERTY_VALUE)
+    private String shouldExist;
+
+    @Inject
+    @ConfigProperty(name = "second-key", defaultValue = PROPERTY_VALUE)
+    private String anotherValue;
+
+    @Test
+    void testIt() {
+        assertThat(beanManager, notNullValue());
+        assertThat(shouldExist, is(PROPERTY_VALUE));
+        assertThat(anotherValue, is("test-custom-config-second-value"));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestCustomExtension.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestCustomExtension.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddExtension(TestCustomExtension.MyExtension.class)
+public class TestCustomExtension {
+    @Test
+    void testIt() {
+        assertThat("Extension should have been called, as it observes application scope", MyExtension.called, is(true));
+    }
+
+    public static class MyExtension implements Extension {
+        private static volatile boolean called = false;
+
+        void observer(@Observes @Initialized(ApplicationScoped.class) final Object event) {
+            called = true;
+        }
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestDefaults.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestDefaults.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+public class TestDefaults {
+    static final String PROPERTY_NAME = "helidon-junit-extension-test-property";
+    static final String DEFAULT_VALUE = "this-should-not-be-in-config";
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Inject
+    @ConfigProperty(name = PROPERTY_NAME, defaultValue = DEFAULT_VALUE)
+    private String shouldNotExist;
+
+    private static boolean beforeAllCalled;
+    private boolean beforeEachCalled;
+
+    @BeforeClass
+    static void initClass() {
+        beforeAllCalled = true;
+    }
+
+    @BeforeTest
+    void beforeEach() {
+        beforeEachCalled = true;
+    }
+
+    @Test
+    void testIt() {
+        assertThat(beanManager, notNullValue());
+        assertThat(shouldNotExist, is(DEFAULT_VALUE));
+    }
+
+    @Test
+    void testLifecycleMethodsCalled() {
+        // this is to validate we can still use the usual junit methods
+        assertThat("Before all should have been called", beforeAllCalled, is(true));
+        assertThat("Before each should have been called", beforeEachCalled, is(true));
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestNoDiscovery.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestNoDiscovery.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import io.helidon.microprofile.config.ConfigCdiExtension;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test when discovery is disabled.
+ */
+@HelidonTest
+@DisableDiscovery
+@AddBean(TestNoDiscovery.MyBean.class)
+public class TestNoDiscovery {
+    @Inject
+    private MyBean myBean;
+
+    @Test
+    void testIt() {
+        assertThat(myBean, notNullValue());
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                                                          () -> CDI.current().getBeanManager()
+                                                                  .getExtension(ConfigCdiExtension.class));
+    }
+
+    public static class MyBean {
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestPerMethod.java
+++ b/microprofile/tests/testng-tests/src/test/java/io/helidon/microprofile/tests/testng/TestPerMethod.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest(resetPerTest = true)
+public class TestPerMethod {
+    private final static List<SeContainer> ALL_CONTAINERS = new LinkedList<>();
+
+    @Test
+    @AddConfig(key = "key-1", value = "value-1")
+    @AddBean(MyBean.class)
+    public void testWithAdditionalConfig() {
+        String configured = CDI.current()
+                .select(MyBean.class)
+                .get()
+                .configured();
+
+        assertThat(configured, is("value-1"));
+    }
+
+    @Test
+    @AddExtension(MyExtension.class)
+    public void testCustomExtension() {
+        assertThat("Extension should have been called, as it observes application scope", MyExtension.called, is(true));
+    }
+
+    @AfterClass
+    static void validateContainerInstances() {
+        Set<Integer> used = new HashSet<>();
+        try {
+            for (SeContainer container : ALL_CONTAINERS) {
+                if (!used.add(System.identityHashCode(container))) {
+                    Assert.fail("Container instance used twice: " + container);
+                }
+            }
+        } finally {
+            ALL_CONTAINERS.clear();
+        }
+    }
+
+    public static class MyBean {
+        private final String configured;
+
+        @Inject
+        MyBean(@ConfigProperty(name = "key-1") String configured) {
+            this.configured = configured;
+        }
+
+        String configured() {
+            return configured;
+        }
+    }
+
+    public static class MyExtension implements Extension {
+        private static volatile boolean called = false;
+
+        void observer(@Observes @Initialized(ApplicationScoped.class) final Object event) {
+            called = true;
+        }
+    }
+}

--- a/microprofile/tests/testng-tests/src/test/resources/testConfigSources.properties
+++ b/microprofile/tests/testng-tests/src/test/resources/testConfigSources.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+some.key=some.value

--- a/microprofile/tests/testng-tests/src/test/resources/testConfigSources.yaml
+++ b/microprofile/tests/testng-tests/src/test/resources/testConfigSources.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+another:
+  key: "another.value"

--- a/microprofile/tests/testng-tests/test-suite.xml
+++ b/microprofile/tests/testng-tests/test-suite.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<suite name="testNG-tests" verbose="10" configfailurepolicy="continue">
+    <test name="testNG-integration-tests">
+        <packages>
+            <package name="io.helidon.microprofile.tests.testng"/>
+        </packages>
+    </test>
+</suite>

--- a/microprofile/tests/testng/pom.xml
+++ b/microprofile/tests/testng/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tests-project</artifactId>
+        <groupId>io.helidon.microprofile.tests</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.helidon.microprofile.tests</groupId>
+    <artifactId>helidon-microprofile-tests-testng</artifactId>
+    <name>Helidon Microprofile Tests TestNG</name>
+
+    <description>
+        Integration with TestNG to support tests with CDI injection
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.cdi</groupId>
+            <artifactId>helidon-microprofile-cdi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.jersey</groupId>
+            <artifactId>helidon-jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/microprofile/tests/testng/pom.xml
+++ b/microprofile/tests/testng/pom.xml
@@ -32,6 +32,10 @@
         Integration with TestNG to support tests with CDI injection
     </description>
 
+    <properties>
+        <helidon.services.skip>false</helidon.services.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.cdi</groupId>

--- a/microprofile/tests/testng/pom.xml
+++ b/microprofile/tests/testng/pom.xml
@@ -23,8 +23,7 @@
         <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>io.helidon.microprofile.tests</groupId>
+    
     <artifactId>helidon-microprofile-tests-testng</artifactId>
     <name>Helidon Microprofile Tests TestNG</name>
 

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddBean.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddBean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Add a bean.
+ * This is intended for test sources where we do not want to add {@code beans.xml} as this would add
+ * all test classes as beans.
+ * The bean will be added by default with {@link jakarta.enterprise.context.ApplicationScoped}.
+ * The class will be instantiated using CDI and will be available for injection into test classes and other beans.
+ * This annotation can be repeated.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(AddBeans.class)
+public @interface AddBean {
+    /**
+     * Class of the bean.
+     * @return the class of a bean
+     */
+    Class<?> value();
+
+    /**
+     * Scope of the bean.
+     * Only {@link jakarta.inject.Singleton}, {@link jakarta.enterprise.context.ApplicationScoped}
+     *   and {@link jakarta.enterprise.context.RequestScoped} scopes are supported.
+     *
+     * @return scope of the bean
+     */
+    Class<? extends Annotation> scope() default ApplicationScoped.class;
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddBeans.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddBeans.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A repeatable container for {@link AddBean}.
+ * No need to use this annotation, just repeat {@link AddBean} annotation
+ * on test class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface AddBeans {
+    /**
+     * Beans to be added.
+     * @return add bean annotations
+     */
+    AddBean[] value();
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddConfig.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Add a configuration key/value pair to MicroProfile configuration.
+ * This annotation can be repeated.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(AddConfigs.class)
+public @interface AddConfig {
+    /**
+     * Configuration property key.
+     * @return key
+     */
+    String key();
+
+    /**
+     * Configuration property value.
+     * @return value
+     */
+    String value();
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddConfigs.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddConfigs.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A repeatable container for {@link AddConfig}.
+ * No need to use this annotation, just repeat {@link AddConfig} annotation
+ * on test class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface AddConfigs {
+    /**
+     * Configuration properties to be added.
+     *
+     * @return properties
+     */
+    AddConfig[] value();
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddExtension.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.inject.spi.Extension;
+
+/**
+ * Add a CDI extension to the test container.
+ * This annotation can be repeated.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Repeatable(AddExtensions.class)
+public @interface AddExtension {
+    /**
+     * Class of the extension to add. The class must be public.
+     * @return extension class.
+     */
+    Class<? extends Extension> value();
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddExtensions.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/AddExtensions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A repeatable container for {@link AddExtension}.
+ * No need to use this annotation, just repeat {@link AddExtension} annotation
+ * on test class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface AddExtensions {
+    /**
+     * Extensions to be added.
+     * @return extensions
+     */
+    AddExtension[] value();
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/Configuration.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/Configuration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Additional configuration of config itself.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Inherited
+public @interface Configuration {
+    /**
+     * If set to {@code true}, the existing (or default) MicroProfile configuration would be used.
+     * By default uses a configuration constructed using all {@link AddConfig}
+     * annotations and {@link #configSources()}.
+     * When set to false and a {@link org.junit.jupiter.api.BeforeAll} method registers a custom configuration
+     * with {@link org.eclipse.microprofile.config.spi.ConfigProviderResolver}, the result is undefined, though
+     * tests have shown that the registered config may be used (as BeforeAll ordering is undefined by
+     * JUnit, it may be called after our extension)
+     *
+     * @return whether to use existing (or default) configuration, or customized one
+     */
+    boolean useExisting() default false;
+
+    /**
+     * Class path properties config sources to add to configuration of this test class or method.
+     *
+     * @return config sources to add
+     */
+    String[] configSources() default {};
+
+    /**
+     * Configuration profile.
+     *
+     * @return String with default value "test".
+     */
+    String profile() default "test";
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/DisableDiscovery.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/DisableDiscovery.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Whether discovery is automated or disabled. If discovery is desired, do not annotate test
+ * class with this annotation.
+ * <p>
+ * When discovery is enabled, the whole classpath is scanned for bean archives (jar files containing
+ * {@code META-INF/beans.xml}) and all beans and extensions are added automatically.
+ * <p>
+ * When discovery is disabled, CDI would only contain the CDI implementation itself and beans and extensions added
+ * through annotations {@link AddBean} and
+ * {@link AddExtension}
+ *
+ * If discovery is disabled on class level and desired on method level,
+ * the value can be set to {@code false}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Inherited
+public @interface DisableDiscovery {
+    /**
+     * By default if you annotate a class or a method, discovery gets disabled.
+     * If you want to override configuration on method to differ from class, you
+     * can configure the value to {@code false}, effectively enabling discovery.
+     *
+     * @return whether to disable discovery ({@code true}), or enable it ({@code false}). If this
+     * annotation is not present, discovery is enabled
+     */
+    boolean value() default true;
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTest.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation making this test class a CDI bean with support for injection.
+ * <p>
+ * There is no need to provide {@code beans.xml} (actually it is not recommended, as it would combine beans
+ * from all tests), instead use {@link AddBean},
+ * {@link AddExtension}, and {@link AddConfig}
+ * annotations to control the shape of the container.
+ * <p>
+ * To disable automated bean and extension discovery, annotate the class with
+ * {@link DisableDiscovery}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface HelidonTest {
+    /**
+     * By default, CDI container is created once before the class is initialized and shut down
+     * after. All test methods run within the same container.
+     *
+     * If this is set to {@code true}, a container is created per test method invocation.
+     * This restricts the test in the following way:
+     * 1. No injection into fields
+     * 2. No injection into constructor
+     *
+     * @return whether to reset container per test method
+     */
+    boolean resetPerTest() default false;
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTestNGListener.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTestNGListener.java
@@ -135,7 +135,7 @@ public class HelidonTestNGListener implements IClassListener, ITestListener {
         Object[] instances = iTestClass.getInstances(false);
 
         for (Object instance : instances) {
-            injectTestToCDI(instance, iTestClass.getRealClass());
+            injectTestToCdi(instance, iTestClass.getRealClass());
         }
     }
 
@@ -198,7 +198,7 @@ public class HelidonTestNGListener implements IClassListener, ITestListener {
     /*
      * Helper method to inject TestNG initialized classes into CDI Container.
      */
-    private <T> void injectTestToCDI(Object bean, final Class<T> clazz) {
+    private <T> void injectTestToCdi(Object bean, final Class<T> clazz) {
         BeanManager beanManager = CDI.current().getBeanManager();
 
         AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(clazz);

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTestNGListener.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/HelidonTestNGListener.java
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.tests.testng;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.helidon.config.mp.MpConfigSources;
+import io.helidon.config.yaml.mp.YamlMpConfigSource;
+
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+import jakarta.enterprise.inject.spi.InjectionTargetFactory;
+import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+/**
+ * TestNG extension to support Helidon CDI container in tests.
+ */
+public class HelidonTestNGListener implements IClassListener, ITestListener {
+
+    private static final Set<Class<? extends Annotation>> HELIDON_TEST_ANNOTATIONS =
+            Set.of(AddBean.class, AddConfig.class, AddExtension.class, Configuration.class);
+    private static final Map<Class<? extends Annotation>, Annotation> BEAN_DEFINING = new HashMap<>();
+
+    private static final List<String> YAML_SUFFIXES = List.of(".yml", ".yaml");
+
+    static {
+        BEAN_DEFINING.put(ApplicationScoped.class, ApplicationScoped.Literal.INSTANCE);
+        BEAN_DEFINING.put(Singleton.class, ApplicationScoped.Literal.INSTANCE);
+        BEAN_DEFINING.put(RequestScoped.class, RequestScoped.Literal.INSTANCE);
+        BEAN_DEFINING.put(Dependent.class, Dependent.Literal.INSTANCE);
+    }
+
+    private List<AddExtension> classLevelExtensions = new ArrayList<>();
+    private List<AddBean> classLevelBeans = new ArrayList<>();
+    private ConfigMeta classLevelConfigMeta = new ConfigMeta();
+    private boolean classLevelDisableDiscovery = false;
+    private boolean resetPerTest;
+
+    private Class<?> testClass;
+    private ConfigProviderResolver configProviderResolver;
+    private Config config;
+    private SeContainer container;
+
+    @Override
+    public void onBeforeClass(ITestClass iTestClass) {
+
+        testClass = iTestClass.getRealClass();
+
+        AddConfig[] configs = getAnnotations(testClass, AddConfig.class);
+        classLevelConfigMeta.addConfig(configs);
+        classLevelConfigMeta.configuration(testClass.getAnnotation(Configuration.class));
+        configProviderResolver = ConfigProviderResolver.instance();
+
+        AddExtension[] extensions = getAnnotations(testClass, AddExtension.class);
+        classLevelExtensions.addAll(Arrays.asList(extensions));
+
+        AddBean[] beans = getAnnotations(testClass, AddBean.class);
+        classLevelBeans.addAll(Arrays.asList(beans));
+
+        HelidonTest testAnnot = testClass.getAnnotation(HelidonTest.class);
+        if (testAnnot != null) {
+            resetPerTest = testAnnot.resetPerTest();
+        }
+
+        DisableDiscovery discovery = testClass.getAnnotation(DisableDiscovery.class);
+        if (discovery != null) {
+            classLevelDisableDiscovery = discovery.value();
+        }
+
+        if (resetPerTest) {
+            validatePerTest();
+            return;
+        }
+        validatePerClass();
+
+        configure(classLevelConfigMeta);
+
+        if (!classLevelConfigMeta.useExisting) {
+            startContainer(classLevelBeans, classLevelExtensions, classLevelDisableDiscovery);
+        }
+
+        //Injecting Instances to CDI
+        Object[] instances = iTestClass.getInstances(false);
+
+        for (Object instance : instances) {
+            injectTestToCDI(instance, iTestClass.getRealClass());
+        }
+    }
+
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {
+        if (!resetPerTest) {
+            releaseConfig();
+            stopContainer();
+        }
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {
+
+        if (resetPerTest) {
+            Method method = result.getMethod().getConstructorOrMethod().getMethod();
+            AddConfig[] configs = method.getAnnotationsByType(AddConfig.class);
+            ConfigMeta methodLevelConfigMeta = classLevelConfigMeta.nextMethod();
+            methodLevelConfigMeta.addConfig(configs);
+            methodLevelConfigMeta.configuration(method.getAnnotation(Configuration.class));
+
+            configure(methodLevelConfigMeta);
+
+            List<AddExtension> methodLevelExtensions = new ArrayList<>(classLevelExtensions);
+            List<AddBean> methodLevelBeans = new ArrayList<>(classLevelBeans);
+            boolean methodLevelDisableDiscovery = classLevelDisableDiscovery;
+
+            AddExtension[] extensions = method.getAnnotationsByType(AddExtension.class);
+            methodLevelExtensions.addAll(Arrays.asList(extensions));
+
+            AddBean[] beans = method.getAnnotationsByType(AddBean.class);
+            methodLevelBeans.addAll(Arrays.asList(beans));
+
+            DisableDiscovery discovery = method.getAnnotation(DisableDiscovery.class);
+            if (discovery != null) {
+                methodLevelDisableDiscovery = discovery.value();
+            }
+
+            startContainer(methodLevelBeans, methodLevelExtensions, methodLevelDisableDiscovery);
+        }
+    }
+
+    @Override
+    public void onTestFailure(ITestResult iTestResult) {
+        if (resetPerTest) {
+            releaseConfig();
+            stopContainer();
+        }
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult iTestResult) {
+        if (resetPerTest) {
+            releaseConfig();
+            stopContainer();
+        }
+    }
+
+    /*
+     * Helper method to inject TestNG initialized classes into CDI Container.
+     */
+    private <T> void injectTestToCDI(Object bean, final Class<T> clazz) {
+        BeanManager beanManager = CDI.current().getBeanManager();
+
+        AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(clazz);
+        InjectionTargetFactory<T> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        InjectionTarget<T> injectionTarget = injectionTargetFactory.createInjectionTarget(null);
+
+        CreationalContext<T> creationalContext = beanManager.createCreationalContext(null);
+        injectionTarget.inject((T) bean, creationalContext);
+    }
+
+    private void validatePerClass() {
+        Method[] methods = testClass.getMethods();
+        for (Method method : methods) {
+            if (method.getAnnotation(Test.class) != null) {
+                // a test method
+                if (hasHelidonTestAnnotation(method)) {
+                    throw new RuntimeException("When a class is annotated with @HelidonTest, "
+                            + "there is a single CDI container used to invoke all "
+                            + "test methods on the class. Method " + method
+                            + " has an annotation that modifies container behavior.");
+                }
+            }
+        }
+
+        methods = testClass.getDeclaredMethods();
+        for (Method method : methods) {
+            if (method.getAnnotation(Test.class) != null) {
+                // a test method
+                if (hasHelidonTestAnnotation(method)) {
+                    throw new RuntimeException("When a class is annotated with @HelidonTest, "
+                            + "there is a single CDI container used to invoke all "
+                            + "test methods on the class. Method " + method
+                            + " has an annotation that modifies container behavior.");
+                }
+            }
+        }
+
+        Constructor<?>[] declaredConstructors = testClass.getDeclaredConstructors();
+        for (Constructor<?> constructor : declaredConstructors) {
+            if (constructor.getAnnotation(Inject.class) != null) {
+                if (hasHelidonTestAnnotation(constructor)) {
+                    throw new RuntimeException("When a class is annotated with @HelidonTest, "
+                            + "there is a single CDI container used to invoke all "
+                            + "test methods on the class. Do not use @Inject annotation"
+                            + "over constructor. Use it on each field.");
+                }
+            }
+        }
+    }
+
+    private boolean hasHelidonTestAnnotation(AnnotatedElement element) {
+        for (Class<? extends Annotation> aClass : HELIDON_TEST_ANNOTATIONS) {
+            if (element.getAnnotation(aClass) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void validatePerTest() {
+        Constructor<?>[] constructors = testClass.getConstructors();
+        if (constructors.length > 1) {
+            throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
+                    + " the class must have only a single no-arg constructor");
+        }
+        if (constructors.length == 1) {
+            Constructor<?> c = constructors[0];
+            if (c.getParameterCount() > 0) {
+                throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
+                        + " the class must have a no-arg constructor");
+            }
+        }
+
+        Field[] fields = testClass.getFields();
+        for (Field field : fields) {
+            if (field.getAnnotation(Inject.class) != null) {
+                throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
+                        + " injection into fields or constructor is not supported, as each"
+                        + " test method uses a different CDI container. Field " + field
+                        + " is annotated with @Inject");
+            }
+        }
+
+        fields = testClass.getDeclaredFields();
+        for (Field field : fields) {
+            if (field.getAnnotation(Inject.class) != null) {
+                throw new RuntimeException("When a class is annotated with @HelidonTest(resetPerTest=true),"
+                        + " injection into fields or constructor is not supported, as each"
+                        + " test method uses a different CDI container. Field " + field
+                        + " is annotated with @Inject");
+            }
+        }
+    }
+
+    private void configure(ConfigMeta configMeta) {
+        if (config != null) {
+            configProviderResolver.releaseConfig(config);
+        }
+        if (!configMeta.useExisting) {
+            // only create a custom configuration if not provided by test method/class
+            // prepare configuration
+            ConfigBuilder builder = configProviderResolver.getBuilder();
+
+            configMeta.additionalSources.forEach(it -> {
+                // If not using a YAML extension, assume properties file
+                String fileName = it.trim();
+                if (YAML_SUFFIXES.stream().anyMatch(fileName::endsWith)) {
+                    builder.withSources(YamlMpConfigSource.classPath(it).toArray(new ConfigSource[0]));
+                } else {
+                    builder.withSources(MpConfigSources.classPath(it).toArray(new ConfigSource[0]));
+                }
+            });
+            config = builder
+                    .withSources(MpConfigSources.create(configMeta.additionalKeys))
+                    .addDefaultSources()
+                    .addDiscoveredSources()
+                    .addDiscoveredConverters()
+                    .build();
+            configProviderResolver.registerConfig(config, Thread.currentThread().getContextClassLoader());
+        }
+    }
+
+    private void releaseConfig() {
+        if (configProviderResolver != null && config != null) {
+            configProviderResolver.releaseConfig(config);
+            config = null;
+
+            classLevelExtensions = new ArrayList<>();
+            classLevelBeans = new ArrayList<>();
+            classLevelConfigMeta = new ConfigMeta();
+            classLevelDisableDiscovery = false;
+            configProviderResolver = ConfigProviderResolver.instance();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void startContainer(List<AddBean> beanAnnotations,
+                                List<AddExtension> extensionAnnotations,
+                                boolean disableDiscovery) {
+
+        // now let's prepare the CDI bootstrapping
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance();
+
+        if (disableDiscovery) {
+            initializer.disableDiscovery();
+        }
+
+        initializer.addExtensions(new AddBeansExtension(testClass, beanAnnotations));
+
+        for (AddExtension addExtension : extensionAnnotations) {
+            var extensionClass = addExtension.value();
+            if (Modifier.isPublic(extensionClass.getModifiers())) {
+                initializer.addExtensions(addExtension.value());
+            } else {
+                throw new IllegalArgumentException("Extension classes must be public, but " + extensionClass
+                        .getName() + " is not");
+            }
+        }
+
+        container = initializer.initialize();
+    }
+
+    private void stopContainer() {
+        if (container != null) {
+            container.close();
+            container = null;
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private <T extends Annotation> T[] getAnnotations(Class<?> testClass, Class<T> annotClass) {
+        // inherited does not help, as it only returns annot from superclass if
+        // child has none
+        T[] directAnnotations = testClass.getAnnotationsByType(annotClass);
+
+        List<T> allAnnotations = new ArrayList<>(List.of(directAnnotations));
+
+        Class<?> superClass = testClass.getSuperclass();
+        while (superClass != null) {
+            directAnnotations = superClass.getAnnotationsByType(annotClass);
+            allAnnotations.addAll(List.of(directAnnotations));
+            superClass = superClass.getSuperclass();
+        }
+
+        Object result = Array.newInstance(annotClass, allAnnotations.size());
+        for (int i = 0; i < allAnnotations.size(); i++) {
+            Array.set(result, i, allAnnotations.get(i));
+        }
+
+        return (T[]) result;
+    }
+
+    // this is not registered as a bean - we manually register an instance
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    private static class AddBeansExtension implements Extension {
+        private final Class<?> testClass;
+        private final List<AddBean> addBeans;
+
+        private AddBeansExtension(Class<?> testClass, List<AddBean> addBeans) {
+            this.testClass = testClass;
+            this.addBeans = addBeans;
+        }
+
+        @SuppressWarnings("unchecked")
+        void registerOtherBeans(@Observes AfterBeanDiscovery event) {
+            Client client = ClientBuilder.newClient();
+
+            event.addBean()
+                    .addType(jakarta.ws.rs.client.WebTarget.class)
+                    .scope(ApplicationScoped.class)
+                    .createWith(context -> {
+                        try {
+                            Class<? extends Extension> extClass = (Class<? extends Extension>) Class
+                                    .forName("io.helidon.microprofile.server.ServerCdiExtension");
+                            Extension extension = CDI.current().getBeanManager().getExtension(extClass);
+                            Method m = extension.getClass().getMethod("port");
+                            int port = (int) m.invoke(extension);
+                            String uri = "http://localhost:" + port;
+                            return client.target(uri);
+                        } catch (ReflectiveOperationException e) {
+                            return client.target("http://localhost:7001");
+                        }
+                    });
+        }
+
+        void registerAddedBeans(@Observes BeforeBeanDiscovery event) {
+            event.addAnnotatedType(testClass, "testng-" + testClass.getName())
+                    .add(ApplicationScoped.Literal.INSTANCE);
+
+            for (AddBean addBean : addBeans) {
+                Annotation scope;
+                Class<? extends Annotation> definedScope = addBean.scope();
+
+                scope = BEAN_DEFINING.get(definedScope);
+
+                if (scope == null) {
+                    throw new IllegalStateException(
+                            "Only on of " + BEAN_DEFINING.keySet() + " scopes are allowed in tests. Scope "
+                                    + definedScope.getName() + " is not allowed for bean " + addBean.value().getName());
+                }
+
+                AnnotatedTypeConfigurator<?> configurator = event
+                        .addAnnotatedType(addBean.value(), "testng-" + addBean.value().getName());
+                if (!hasBda(addBean.value())) {
+                    configurator.add(scope);
+                }
+            }
+        }
+
+        private boolean hasBda(Class<?> value) {
+            // does it have bean defining annotation?
+            for (Class<? extends Annotation> aClass : BEAN_DEFINING.keySet()) {
+                if (value.getAnnotation(aClass) != null) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static final class ConfigMeta {
+        private final Map<String, String> additionalKeys = new HashMap<>();
+        private final List<String> additionalSources = new ArrayList<>();
+        private boolean useExisting;
+        private String profile;
+
+        private ConfigMeta() {
+            // to allow SeContainerInitializer (forbidden by default because of native image)
+            additionalKeys.put("mp.initializer.allow", "true");
+            additionalKeys.put("mp.initializer.no-warn", "true");
+            // to run on random port
+            additionalKeys.put("server.port", "0");
+            // higher ordinal then all the defaults, system props and environment variables
+            additionalKeys.putIfAbsent(ConfigSource.CONFIG_ORDINAL, "1000");
+            // profile
+            additionalKeys.put("mp.config.profile", "test");
+        }
+
+        private void addConfig(AddConfig[] configs) {
+            for (AddConfig config : configs) {
+                additionalKeys.put(config.key(), config.value());
+            }
+        }
+
+        private void configuration(Configuration config) {
+            if (config == null) {
+                return;
+            }
+            useExisting = config.useExisting();
+            profile = config.profile();
+            additionalSources.addAll(List.of(config.configSources()));
+            //set additional key for profile
+            additionalKeys.put("mp.config.profile", profile);
+        }
+
+        ConfigMeta nextMethod() {
+            ConfigMeta methodMeta = new ConfigMeta();
+
+            methodMeta.additionalKeys.putAll(this.additionalKeys);
+            methodMeta.additionalSources.addAll(this.additionalSources);
+            methodMeta.useExisting = this.useExisting;
+            methodMeta.profile = this.profile;
+
+            return methodMeta;
+        }
+    }
+}

--- a/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/package-info.java
+++ b/microprofile/tests/testng/src/main/java/io/helidon/microprofile/tests/testng/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TestNG extension to run CDI tests.
+ *
+ */
+package io.helidon.microprofile.tests.testng;

--- a/microprofile/tests/testng/src/main/java/module-info.java
+++ b/microprofile/tests/testng/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TestNG extension module to run CDI tests.
+ */
+module io.helidon.microprofile.tests.testng {
+    requires io.helidon.microprofile.cdi;
+    requires io.helidon.config.mp;
+    requires io.helidon.config.yaml.mp;
+    requires org.testng;
+    requires jakarta.cdi;
+    requires jakarta.inject;
+    requires jakarta.ws.rs;
+    requires microprofile.config.api;
+
+    exports io.helidon.microprofile.tests.testng;
+
+    provides org.testng.ITestNGListener with io.helidon.microprofile.tests.testng.HelidonTestNGListener;
+}

--- a/microprofile/tests/testng/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/microprofile/tests/testng/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,1 @@
+io.helidon.microprofile.tests.testng.HelidonTestNGListener

--- a/microprofile/tests/testng/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/microprofile/tests/testng/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,1 +1,0 @@
-io.helidon.microprofile.tests.testng.HelidonTestNGListener

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2016, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@
         <version.lib.shrinkwrap-resolver>3.0.1</version.lib.shrinkwrap-resolver>
         <version.lib.spotbugs-annotations>3.1.12</version.lib.spotbugs-annotations>
         <version.lib.surefire.testng>3.0.0-M5</version.lib.surefire.testng>
-        <version.lib.testng>7.4.0</version.lib.testng>
+        <version.lib.testng>7.5</version.lib.testng>
         <version.lib.zipkin.junit>2.12.5</version.lib.zipkin.junit>
         <version.lib.bedrock>5.0.11</version.lib.bedrock>
         <version.lib.awaitility>3.1.6</version.lib.awaitility>

--- a/pom.xml
+++ b/pom.xml
@@ -1071,6 +1071,12 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${version.lib.testng}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.google.code.findbugs</groupId>
+                            <artifactId>jsr305</artifactId>
+                        </exclusion>
+                    </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.junit</groupId>


### PR DESCRIPTION
This is a Draft PR for TestNG support in Helidon. Following the issue https://github.com/oracle/helidon/issues/3263

This integration provides the same functionality as the JUnit integration.

Currently there is a blocking issue in TestNG not allowing automatic object instantiation. 
https://github.com/cbeust/testng/issues/2676

Thus, it is it is a good idea to wait for release 7.5.0 of TestNG

Update: Using TestNG 7.5.0.