### PR TITLE
Remove SecurityManager and AccessController dependencies in Grpc

### DIFF
--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AbstractServiceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ package io.helidon.microprofile.grpc.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -153,16 +151,11 @@ public abstract class AbstractServiceBuilder {
      */
     protected List<Method> getAllDeclaredMethods(Class<?> clazz) {
         List<Method> result = new LinkedList<>();
-
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            Class current = clazz;
-            while (current != Object.class && current != null) {
-                result.addAll(Arrays.asList(current.getDeclaredMethods()));
-                current = current.getSuperclass();
-            }
-            return null;
-        });
-
+        Class current = clazz;
+        while (current != Object.class && current != null) {
+            result.addAll(Arrays.asList(current.getDeclaredMethods()));
+            current = current.getSuperclass();
+        }
         return result;
     }
 

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethod.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -395,7 +394,7 @@ public class AnnotatedMethod implements AnnotatedElement {
             return null;
         }
 
-        declaredMethod = AccessController.doPrivileged(ModelHelper.findMethodOnClassPA(declaringClass, declaredMethod));
+        declaredMethod = ModelHelper.findMethodOnClass(declaringClass, declaredMethod);
         if (declaredMethod == null) {
             return null;
         }

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethodList.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/AnnotatedMethodList.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.grpc.core;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -254,7 +253,7 @@ public class AnnotatedMethodList implements Iterable<AnnotatedMethod> {
     private static List<Method> allDeclaredMethods(Class<?> c) {
         List<Method> l = new ArrayList<>();
         while (c != null && c != Object.class) {
-            l.addAll(AccessController.doPrivileged(ModelHelper.getDeclaredMethodsPA(c)));
+            l.addAll(ModelHelper.getDeclaredMethods(c));
             c = c.getSuperclass();
         }
         return l;

--- a/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ModelHelper.java
+++ b/microprofile/grpc/core/src/main/java/io/helidon/microprofile/grpc/core/ModelHelper.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -90,56 +89,45 @@ public final class ModelHelper {
     }
 
     /**
-     * Get privileged action to obtain methods declared on given class.
-     * If run using security manager, the returned privileged action
-     * must be invoked within a doPrivileged block.
+     * Get collection of methods declared on given class.
      *
      * @param clazz class for which to get the declared methods.
-     * @return privileged action to obtain methods declared on the {@code clazz} class.
-     * @see java.security.AccessController#doPrivileged(java.security.PrivilegedAction)
+     * @return methods declared on the {@code clazz} class.
      */
-    public static PrivilegedAction<Collection<? extends Method>> getDeclaredMethodsPA(final Class<?> clazz) {
-        return () -> Arrays.asList(clazz.getDeclaredMethods());
+    public static Collection<? extends Method> getDeclaredMethods(final Class<?> clazz) {
+        return Arrays.asList(clazz.getDeclaredMethods());
     }
 
     /**
-     * Get privileged action to find a method on a class given an existing method.
-     * If run using security manager, the returned privileged action
-     * must be invoked within a doPrivileged block.
-     * <p>
-     * If there exists a public method on the class that has the same name
-     * and parameters as the existing method then that public method is
-     * returned from the action.
+     * Find a method in a class. If there exists a public method on the class
+     * that has the same name and parameters then that public method is
+     * returned.
      * <p>
      * Otherwise, if there exists a public method on the class that has
-     * the same name and the same number of parameters as the existing method,
+     * the same name and the same number of parameters,
      * and each generic parameter type, in order, of the public method is equal
-     * to the generic parameter type, in the same order, of the existing method
-     * or is an instance of {@link TypeVariable} then that public method is
-     * returned from the action.
+     * to the generic parameter type, in the same order or is an instance of
+     * {@link TypeVariable} then that public method is returned.
      *
      * @param cls the class to search for a public method
      * @param m the method to find
-     * @return privileged action to return public method found.
-     * @see java.security.AccessController#doPrivileged(java.security.PrivilegedAction)
+     * @return public method found.
      */
-    public static PrivilegedAction<Method> findMethodOnClassPA(final Class<?> cls, final Method m) {
-        return () -> {
-            try {
-                return cls.getMethod(m.getName(), m.getParameterTypes());
-            } catch (final NoSuchMethodException e) {
-                for (final Method method : cls.getMethods()) {
-                    if (method.getName().equals(m.getName())
-                            && method.getParameterTypes().length == m.getParameterTypes().length) {
-                        if (compareParameterTypes(m.getGenericParameterTypes(),
-                                method.getGenericParameterTypes())) {
-                            return method;
-                        }
+    public static Method findMethodOnClass(final Class<?> cls, final Method m) {
+        try {
+            return cls.getMethod(m.getName(), m.getParameterTypes());
+        } catch (final NoSuchMethodException e) {
+            for (final Method method : cls.getMethods()) {
+                if (method.getName().equals(m.getName())
+                        && method.getParameterTypes().length == m.getParameterTypes().length) {
+                    if (compareParameterTypes(m.getGenericParameterTypes(),
+                            method.getGenericParameterTypes())) {
+                        return method;
                     }
                 }
-                return null;
             }
-        };
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Remove SecurityManager and AccessController dependencies. This commit updates public methods and it is technically backward incompatible. Follow up to PR #3440 in which it was decided that these changes would go only in 3.0.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>