### PR TITLE
Support MP OpenAPI 3.0

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -81,7 +81,7 @@
         <version.lib.jakarta.validation-api>3.0.0</version.lib.jakarta.validation-api>
         <version.lib.jakarta.websockets-api>2.0.0</version.lib.jakarta.websockets-api>
         <version.lib.jakarta.xml.bind-api>3.0.1</version.lib.jakarta.xml.bind-api>
-        <version.lib.jandex>2.3.1.Final</version.lib.jandex>
+        <version.lib.jandex>2.4.1.Final</version.lib.jandex>
         <version.lib.jaxb-core>3.0.2</version.lib.jaxb-core>
         <version.lib.jaxb-impl>3.0.2</version.lib.jaxb-impl>
         <version.lib.jboss.classfilewriter>1.2.5.Final</version.lib.jboss.classfilewriter>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -137,7 +137,7 @@
         <version.lib.postgresql>42.2.18</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>1.7.32</version.lib.slf4j>
-        <version.lib.smallrye-openapi>2.1.15</version.lib.smallrye-openapi>
+        <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.27</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.1</version.lib.typesafe-config>
         <version.lib.tyrus>2.0.1</version.lib.tyrus>

--- a/docs/mp/openapi/01_openapi.adoc
+++ b/docs/mp/openapi/01_openapi.adoc
@@ -178,7 +178,7 @@ link:{mp-openapi-spec}#configuration[configuration section] of the MicroProfile
 OpenAPI spec.
 
 == Accessing the OpenAPI document
-Now your Helidon MP application will automatially respond to an additional endpoint --
+Now your Helidon MP application will automatically respond to an additional endpoint --
  `/openapi` -- and it will return the OpenAPI document describing the endpoints
 in your application.
 
@@ -187,5 +187,5 @@ There is not yet an adopted IANA YAML media type, but a proposed one specificall
 for OpenAPI documents that has some support is `application/vnd.oai.openapi`.
 That is what Helidon returns, by default.
 
-A client can specify `Accept:` as either `application/vnd.oai.openapi+json` or `application/json`
-to request JSON.
+In addition a client can specify the HTTP header `Accept:` as either `application/vnd.oai.openapi+json` or `application/json`
+to request JSON. Alternatively, the client can pass the query parameter `format` as either `JSON` or `YAML` to receive `application/json` or `application/vnd.oai.openapi` (YAML) output, respectively.

--- a/docs/se/openapi/01_openapi.adoc
+++ b/docs/se/openapi/01_openapi.adoc
@@ -152,6 +152,7 @@ those described in the MicroProfile OpenAPI spec, two of which were mentioned ab
 servers for given paths
 |`openapi.servers.operation` |Prefix for config properties specifying alternative
 servers for given operations
+|`openapi.schema` |Prefix for config properties defining the schema for a class
 |===
 For more information on what these settings do consult the MicroProfile OpenAPI spec.
 
@@ -182,5 +183,5 @@ There is not yet an adopted IANA YAML media type, but a proposed one specificall
 for OpenAPI documents that has some support is `application/vnd.oai.openapi`.
 That is what Helidon returns, by default.
 
-In addition a client can specify `Accept:` as either `application/vnd.oai.openapi+json` or `application/json`
-to request JSON.
+In addition a client can specify the HTTP header `Accept:` as either `application/vnd.oai.openapi+json` or `application/json`
+to request JSON. Alternatively, the client can pass the query parameter `format` as either `JSON` or `YAML` to receive `application/json` or `application/vnd.oai.openapi` (YAML) output, respectively.

--- a/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
+++ b/examples/quickstarts/helidon-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("3.0.0-JAKARTA") // OpenAPI: Caused by: java.lang.NoSuchMethodError:
-        // 'java.util.List org.jboss.jandex.ClassInfo.unsortedFields()'
 class MainTest {
     private static Server server;
 

--- a/examples/quickstarts/helidon-standalone-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-mp/src/test/java/io/helidon/examples/quickstart/mp/MainTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled("3.0.0-JAKARTA") // OpenAPI: Caused by: java.lang.NoSuchMethodError:
-        // 'java.util.List org.jboss.jandex.ClassInfo.unsortedFields()'
 class MainTest {
     private static Server server;
 

--- a/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
+++ b/microprofile/openapi/src/main/java/io/helidon/microprofile/openapi/MPOpenAPIBuilder.java
@@ -68,10 +68,6 @@ public final class MPOpenAPIBuilder extends OpenAPISupport.Builder<MPOpenAPIBuil
 
     private Config mpConfig;
 
-    protected MPOpenAPIBuilder() {
-        super(MPOpenAPIBuilder.class);
-    }
-
     @Override
     public OpenApiConfig openAPIConfig() {
         return openAPIConfig;

--- a/microprofile/tests/tck/tck-openapi/pom.xml
+++ b/microprofile/tests/tck/tck-openapi/pom.xml
@@ -30,11 +30,6 @@
     <artifactId>tck-openapi</artifactId>
     <name>Helidon Microprofile Tests TCK OpenAPI</name>
 
-    <properties>
-        <!-- 3.0.0-JAKARTA -->
-        <skipTests>true</skipTests>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.helidon.microprofile.tests</groupId>
@@ -70,6 +65,24 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            RestAssured xml-path, used by the TCK, requires the javax flavor of JAX-B, so add the API and impl.
+        -->
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openapi/src/main/java/io/helidon/openapi/CustomConstructor.java
+++ b/openapi/src/main/java/io/helidon/openapi/CustomConstructor.java
@@ -16,9 +16,9 @@
 package io.helidon.openapi;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,56 +40,141 @@ import org.yaml.snakeyaml.nodes.SequenceNode;
 import org.yaml.snakeyaml.nodes.Tag;
 
 /**
- * Specialized SnakeYAML constructor for modifying {@code Node} objects for OpenAPI types that extend {@code Map} to adjust the
- * type of the child nodes of such nodes.
+ * Specialized SnakeYAML constructor for modifying {@code Node} objects for OpenAPI types needing special attention.
  * <p>
- * Several MicroProfile OpenAPI interfaces extend {@code Map}. For example, {@code Paths} extends {@code Map
- * <String, PathItem>} and {@code SecurityRequirement} extends {@code Map<String, List<String>>}. When SnakeYAML builds the node
- * corresponding to one of these types, it correctly creates each child node as a {@code MappingNode} but it assigns those
- * child nodes a type of {@code Object} instead of the mapped type -- {@code PathItem} in the example above.
- * </p>
- * <p>
- * This class customizes the preparation of the node tree in these situations by setting the types for the child nodes explicitly
- * to the corresponding child type. In OpenAPI 1.1.2 there are two situations, depending on whether the mapped-to type is a
- * {@code List} or not.
- * </p>
- * <p>
- * The MicroProfile OpenAPI 2.0 versions of the interfaces no longer use this construct of an interface extending {@code Map}, so
- * ideally we can remove this workaround when we adopt 2.0.
+ *     Several MP OpenAPI types resemble maps with strings for keys and various child types as values. Such interfaces
+ *     expose an {@code addX} method, where X is the child type (e.g., {@link Paths} exposes {@link Paths#addPathItem}.
+ *     SnakeYAML parsing, left to itself, would incorrectly attempt to use the string keys as property names in converting OpenAPI
+ *     documents to and from the in-memory POJO model. To prevent that, this custom constructor takes over the job of
+ *     creating these parent instances and populating the children from the SnakeYAML node graph.
  * </p>
  */
 final class CustomConstructor extends Constructor {
 
-    // maps OpenAPI interfaces which extend Map<?, type> to the mapped-to type where that mapped-to type is NOT List
-    private static final Map<Class<?>, Class<?>> CHILD_MAP_TYPES = new HashMap<>();
+    // OpenAPI interfaces which resemble Map<?, type>, linked to info used to prepare the type description for that type where
+    // the mapped-to type is NOT a list. For typing reasons (in ExpandedTypeDescription$MapLikeTypeDescription#create)
+    // we provide type-specific factory functions as part of the type metadata here where we can specify the actual parent
+    // and child types.
+    static final Map<Class<?>, ChildMapType<?, ?>> CHILD_MAP_TYPES = Map.of(
+            APIResponses.class, new ChildMapType<>(APIResponses.class,
+                                                   APIResponse.class,
+                                                   APIResponses::addAPIResponse,
+                                                   impl -> ExpandedTypeDescription.MapLikeTypeDescription.create(
+                                                           APIResponses.class,
+                                                           impl,
+                                                           APIResponse.class,
+                                                           APIResponses::addAPIResponse)),
+            Callback.class, new ChildMapType<>(Callback.class,
+                                               PathItem.class,
+                                               Callback::addPathItem,
+                                               impl -> ExpandedTypeDescription.MapLikeTypeDescription.create(
+                                                       Callback.class,
+                                                       impl,
+                                                       PathItem.class,
+                                                       Callback::addPathItem)),
+            Content.class, new ChildMapType<>(Content.class,
+                                              MediaType.class,
+                                              Content::addMediaType,
+                                              impl -> ExpandedTypeDescription.MapLikeTypeDescription.create(
+                                                      Content.class,
+                                                      impl,
+                                                      MediaType.class,
+                                                      Content::addMediaType)),
+            Paths.class, new ChildMapType<>(Paths.class,
+                                            PathItem.class,
+                                            Paths::addPathItem,
+                                            impl -> ExpandedTypeDescription.MapLikeTypeDescription.create(
+                                                    Paths.class,
+                                                    impl,
+                                                    PathItem.class,
+                                                    Paths::addPathItem)));
 
-    // maps OpenAPI interfaces which extend Map<?, List<type>> to the type that appears in the list
-    private static final Map<Class<?>, Class<?>> CHILD_MAP_OF_LIST_TYPES = new HashMap<>();
+    // OpenAPI interfaces which resemble Map<?, List<type>>, linked to info used to prepare the type description for that type
+    // where the mapped-to type IS a list.
+    static final Map<Class<?>, ChildMapListType<?, ?>> CHILD_MAP_OF_LIST_TYPES = Map.of(
+            SecurityRequirement.class, new ChildMapListType<>(SecurityRequirement.class,
+                                                              String.class,
+                                                              SecurityRequirement::addScheme,
+                                                              SecurityRequirement::addScheme,
+                                                              SecurityRequirement::addScheme,
+                                                              impl -> ExpandedTypeDescription.ListMapLikeTypeDescription.create(
+                                                                      SecurityRequirement.class,
+                                                                      impl,
+                                                                      String.class,
+                                                                      SecurityRequirement::addScheme,
+                                                                      SecurityRequirement::addScheme,
+                                                                      SecurityRequirement::addScheme)));
+
+    /**
+     * Adds a single named child to the parent.
+     *
+     * @param <P> parent type
+     * @param <C> child type
+     */
+    @FunctionalInterface
+    interface ChildAdder<P, C> {
+        Object addChild(P parent, String name, C child);
+    }
+
+    /**
+     * Adds a list of children to the parent.
+     *
+     * @param <P> parent type
+     * @param <C> child type
+     */
+    @FunctionalInterface
+    interface ChildListAdder<P, C> {
+        Object addChildren(P parent, String name, List<C> children);
+    }
+
+    /**
+     * Adds a valueless child name to the parent.
+     *
+     * @param <P> parent type
+     */
+    @FunctionalInterface
+    interface ChildNameAdder<P> {
+        P addChild(P parent, String name);
+    }
+
+    /**
+     * Type information about a map-resembling interface.
+     *
+     * @param <P> parent type
+     * @param <C> child type
+     */
+    record ChildMapType<P, C>(Class<P> parentType,
+                              Class<C> childType,
+                              ChildAdder<P, C> childAdder,
+                              Function<Class<?>, ExpandedTypeDescription.MapLikeTypeDescription<P, C>> typeDescriptionFactory) { }
+
+    /**
+     * Type information about a map-resembling interface in which a child can have 0, 1, or more values i.e., the child is
+     * a list).
+     *
+     * @param <P> parent type
+     * @param <C> child type
+     */
+    record ChildMapListType<P, C>(
+            Class<P> parentType,
+            Class<C> childType,
+            ChildAdder<P, C> childAdder,
+            ChildListAdder<P, C> childListAdder,
+            ChildNameAdder<P> childNameAdder,
+            Function<Class<?>, ExpandedTypeDescription.ListMapLikeTypeDescription<P, C>> typeDescriptionFunction) { }
 
     private static final Logger LOGGER = Logger.getLogger(CustomConstructor.class.getName());
 
-    static {
-        CHILD_MAP_TYPES.put(Paths.class, PathItem.class);
-        CHILD_MAP_TYPES.put(Callback.class, PathItem.class);
-        CHILD_MAP_TYPES.put(Content.class, MediaType.class);
-        CHILD_MAP_TYPES.put(APIResponses.class, APIResponse.class);
-        /*
-        TODO 3.0.0-JAKARTA
-        CHILD_MAP_TYPES.put(ServerVariables.class, ServerVariable.class);
-        CHILD_MAP_TYPES.put(Scopes.class, String.class);
-        */
-        CHILD_MAP_OF_LIST_TYPES.put(SecurityRequirement.class, String.class);
-    }
-
     CustomConstructor(TypeDescription td) {
         super(td);
+        yamlClassConstructors.put(NodeId.mapping, new ConstructMapping());
     }
 
     @Override
     protected void constructMapping2ndStep(MappingNode node, Map<Object, Object> mapping) {
         Class<?> parentType = node.getType();
         if (CHILD_MAP_TYPES.containsKey(parentType)) {
-            Class<?> childType = CHILD_MAP_TYPES.get(parentType);
+            Class<?> childType = CHILD_MAP_TYPES.get(parentType).childType;
             node.getValue().forEach(tuple -> {
                 Node valueNode = tuple.getValueNode();
                 if (valueNode.getType() == Object.class) {
@@ -97,7 +182,7 @@ final class CustomConstructor extends Constructor {
                 }
             });
         } else if (CHILD_MAP_OF_LIST_TYPES.containsKey(parentType)) {
-            Class<?> childType = CHILD_MAP_OF_LIST_TYPES.get(parentType);
+            Class<?> childType = CHILD_MAP_OF_LIST_TYPES.get(parentType).childType;
             node.getValue().forEach(tuple -> {
                 Node valueNode = tuple.getValueNode();
                 if (valueNode.getNodeId() == NodeId.sequence) {
@@ -125,9 +210,35 @@ final class CustomConstructor extends Constructor {
         });
         if (!numericHttpStatusMarks.isEmpty()) {
             LOGGER.log(Level.WARNING,
-                    "Numeric HTTP status value(s) should be quoted. "
-                    + "Please change the following; unquoted numeric values might be rejected in a future release: {0}",
-                    numericHttpStatusMarks);
+                       "Numeric HTTP status value(s) should be quoted. "
+                               + "Please change the following; unquoted numeric values might be rejected in a future release: "
+                               + "{0}",
+                       numericHttpStatusMarks);
+        }
+    }
+
+    /**
+     * Override of SnakeYAML logic which constructs an object from a node.
+     * <p>
+     *     This class makes sure that parent/child relationships that resemble maps are handled correctly and defers to the
+     *     superclass implementation in other cases.
+     * </p>
+     */
+    class ConstructMapping extends Constructor.ConstructMapping {
+
+        @Override
+        public Object construct(Node node) {
+            Class<?> parentType = node.getType();
+            if (CHILD_MAP_TYPES.containsKey(parentType) || CHILD_MAP_OF_LIST_TYPES.containsKey(parentType)) {
+                // Following is inspired by SnakeYAML Constructor$ConstructMapping#construct.
+                MappingNode mappingNode = (MappingNode) node;
+                if (node.isTwoStepsConstruction()) {
+                    return newMap(mappingNode);
+                } else {
+                    return constructMapping(mappingNode);
+                }
+            }
+            return super.construct(node);
         }
     }
 }

--- a/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
+++ b/openapi/src/main/java/io/helidon/openapi/SEOpenAPISupportBuilder.java
@@ -34,10 +34,6 @@ public final class SEOpenAPISupportBuilder extends OpenAPISupport.Builder<SEOpen
 
     private final OpenAPIConfigImpl.Builder apiConfigBuilder = OpenAPIConfigImpl.builder();
 
-    protected SEOpenAPISupportBuilder() {
-        super(SEOpenAPISupportBuilder.class);
-    }
-
     /**
      * Set various builder attributes from the specified openapi {@code Config} object.
      * <p>

--- a/openapi/src/main/java/io/helidon/openapi/Serializer.java
+++ b/openapi/src/main/java/io/helidon/openapi/Serializer.java
@@ -31,6 +31,7 @@ import io.smallrye.openapi.runtime.io.Format;
 import org.eclipse.microprofile.openapi.models.Extensible;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Reference;
+import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -155,9 +156,23 @@ class Serializer {
 
         private NodeTuple doRepresentJavaBeanProperty(Object javaBean, Property property, Object propertyValue, Tag customTag) {
             NodeTuple defaultTuple = super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
-            return (javaBean instanceof Reference) && property.getName().equals("ref")
-                    ? new NodeTuple(representData("$ref"), defaultTuple.getValueNode())
-                    : defaultTuple;
+            if ((javaBean instanceof Reference) && property.getName().equals("ref")) {
+                return new NodeTuple(representData("$ref"), defaultTuple.getValueNode());
+            }
+            if (javaBean instanceof Schema) {
+                /*
+                 * At most one of additionalPropertiesBoolean and additionalPropertiesSchema will return a non-null value.
+                 * Whichever one does (if either), replace the name with "additionalProperties" for output. Skip whatever is
+                 * returned from the deprecated additionalProperties method itself.
+                 */
+                String propertyName = property.getName();
+                if (propertyName.equals("additionalProperties")) {
+                    return null;
+                } else if (propertyName.startsWith("additionalProperties")) {
+                    return new NodeTuple(representData("additionalProperties"), defaultTuple.getValueNode());
+                }
+            }
+            return defaultTuple;
         }
 
         private Object adjustPropertyValue(Object propertyValue) {

--- a/openapi/src/test/java/io/helidon/openapi/OpenAPIConfigTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/OpenAPIConfigTest.java
@@ -16,6 +16,9 @@
 package io.helidon.openapi;
 
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
 
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
@@ -26,7 +29,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 
 /**
  *
@@ -34,6 +39,36 @@ import static org.hamcrest.Matchers.is;
 public class OpenAPIConfigTest {
 
     private final static String TEST_CONFIG_DIR = "src/test/resources";
+
+    private static final List<String> SCHEMA_OVERRIDE_CONTENTS = List.of(
+            "\"name\": \"EpochMillis\"",
+            "\"type\": \"number\",",
+            "\"format\": \"int64\",",
+            "\"description\": \"Milliseconds since January 1, 1970, 00:00:00 GMT\"");
+
+    private static final Map<String, String> SCHEMA_OVERRIDE_VALUES = Map.of(
+            "name", "EpochMillis",
+            "type", "number",
+            "format", "int64",
+            "description", "Milliseconds since January 1, 1970, 00:00:00 GMT");
+
+    private static final String SCHEMA_OVERRIDE_JSON = prepareSchemaOverrideJSON();
+
+    private static final String SCHEMA_OVERRIDE_CONFIG_FQCN = "java.util.Date";
+
+    private static final Map<String, String> SCHEMA_OVERRIDE_CONFIG = Map.of(
+            OpenAPISupport.Builder.CONFIG_KEY
+                    + "."
+                    + OpenAPIConfigImpl.Builder.SCHEMA
+                    + "."
+                    + SCHEMA_OVERRIDE_CONFIG_FQCN,
+            SCHEMA_OVERRIDE_JSON);
+
+    private static String prepareSchemaOverrideJSON() {
+        StringJoiner sj = new StringJoiner(",\n", "{\n", "\n}");
+        SCHEMA_OVERRIDE_VALUES.forEach((key, value) -> sj.add("\"" + key + "\": \"" + value + "\""));
+        return sj.toString();
+    }
 
     public OpenAPIConfigTest() {
     }
@@ -68,5 +103,19 @@ public class OpenAPIConfigTest {
                 .build();
 
         assertThat("scan disable mismatch", openAPIConfig.scanDisable(), is(true));
+    }
+
+    @Test
+    void checkSchemaConfig() {
+        Config config = Config.just(ConfigSources.file(Paths.get(TEST_CONFIG_DIR, "simple.properties").toString()),
+                                    ConfigSources.create(SCHEMA_OVERRIDE_CONFIG));
+        OpenApiConfig openAPIConfig = OpenAPIConfigImpl.builder()
+                .config(config.get(OpenAPISupport.Builder.CONFIG_KEY))
+                .build();
+
+        assertThat("Schema override", openAPIConfig.getSchemas(), hasKey(SCHEMA_OVERRIDE_CONFIG_FQCN));
+        assertThat("Schema override value for " + SCHEMA_OVERRIDE_CONFIG_FQCN,
+                   openAPIConfig.getSchemas().get(SCHEMA_OVERRIDE_CONFIG_FQCN),
+                   is(SCHEMA_OVERRIDE_JSON));
     }
 }

--- a/openapi/src/test/java/io/helidon/openapi/ParserTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ParserTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Paths;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -31,7 +30,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Disabled("3.0.0-JAKARTA")
 class ParserTest {
 
     private static SnakeYAMLParserHelper<ExpandedTypeDescription> helper = OpenAPISupport.helper();

--- a/openapi/src/test/java/io/helidon/openapi/SerializerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/SerializerTest.java
@@ -33,7 +33,6 @@ import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -43,7 +42,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@Disabled("3.0.0-JAKARTA")
 class SerializerTest {
 
     private static SnakeYAMLParserHelper<ExpandedTypeDescription> helper;

--- a/openapi/src/test/java/io/helidon/openapi/ServerModelReaderTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerModelReaderTest.java
@@ -29,7 +29,6 @@ import jakarta.json.JsonStructure;
 import jakarta.json.JsonValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,12 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Makes sure that the app-supplied model reader participates in constructing
  * the OpenAPI model.
  */
-@Disabled("3.0.0-JAKARTA")
 public class ServerModelReaderTest {
 
     private static final String SIMPLE_PROPS_PATH = "/openapi";
 
-    private static final OpenAPISupport.Builder OPENAPI_SUPPORT_BUILDER =
+    private static final OpenAPISupport.Builder<?> OPENAPI_SUPPORT_BUILDER =
         OpenAPISupport.builderSE()
                 .config(Config.create(ConfigSources.classpath("simple.properties")).get(OpenAPISupport.Builder.CONFIG_KEY));
 

--- a/openapi/src/test/java/io/helidon/openapi/ServerTest.java
+++ b/openapi/src/test/java/io/helidon/openapi/ServerTest.java
@@ -27,7 +27,6 @@ import io.helidon.webserver.WebServer;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Starts a server with the default OpenAPI endpoint to test a static OpenAPI
  * document file in various ways.
  */
-@Disabled("3.0.0-JAKARTA")
 public class ServerTest {
 
     private static WebServer greetingWebServer;
@@ -149,11 +147,24 @@ public class ServerTest {
      * response
      */
     @Test
-    public void checkExplicitResponseMediaType() throws Exception {
+    public void checkExplicitResponseMediaTypeViaHeaders() throws Exception {
         connectAndConsumePayload(MediaType.APPLICATION_OPENAPI_YAML);
         connectAndConsumePayload(MediaType.APPLICATION_YAML);
         connectAndConsumePayload(MediaType.APPLICATION_OPENAPI_JSON);
         connectAndConsumePayload(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void checkExplicitResponseMediaTypeViaQueryParameter() throws Exception {
+        TestUtil.connectAndConsumePayload(greetingWebServer.port(),
+                                          GREETING_PATH,
+                                          "format=JSON",
+                                          MediaType.APPLICATION_JSON);
+
+        TestUtil.connectAndConsumePayload(greetingWebServer.port(),
+                                          GREETING_PATH,
+                                          "format=YAML",
+                                          MediaType.APPLICATION_OPENAPI_YAML);
     }
 
     /**

--- a/openapi/src/test/java/io/helidon/openapi/TestAdditionalProperties.java
+++ b/openapi/src/test/java/io/helidon/openapi/TestAdditionalProperties.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.openapi;
+
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+import io.smallrye.openapi.runtime.io.Format;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class TestAdditionalProperties {
+
+    private static SnakeYAMLParserHelper<ExpandedTypeDescription> helper = OpenAPISupport.helper();
+
+
+    @Test
+    void checkParsingBooleanAdditionalProperties() throws IOException {
+        OpenAPI openAPI = ParserTest.parse(helper, "/withBooleanAddlProps.yml", OpenAPISupport.OpenAPIMediaType.YAML);
+        Schema itemSchema = openAPI.getComponents().getSchemas().get("item");
+
+        Schema additionalPropertiesSchema = itemSchema.getAdditionalPropertiesSchema();
+        Boolean additionalPropertiesBoolean = itemSchema.getAdditionalPropertiesBoolean();
+
+        assertThat("Additional properties as schema", additionalPropertiesSchema, is(nullValue()));
+        assertThat("Additional properties as boolean", additionalPropertiesBoolean, is(notNullValue()));
+        assertThat("Additional properties value", additionalPropertiesBoolean.booleanValue(), is(false));
+    }
+
+    @Test
+    void checkParsingSchemaAdditionalProperties() throws IOException {
+        OpenAPI openAPI = ParserTest.parse(helper, "/withSchemaAddlProps.yml", OpenAPISupport.OpenAPIMediaType.YAML);
+        Schema itemSchema = openAPI.getComponents().getSchemas().get("item");
+
+        Schema additionalPropertiesSchema = itemSchema.getAdditionalPropertiesSchema();
+        Boolean additionalPropertiesBoolean = itemSchema.getAdditionalPropertiesBoolean();
+
+        assertThat("Additional properties as boolean", additionalPropertiesBoolean, is(nullValue()));
+        assertThat("Additional properties as schema", additionalPropertiesSchema, is(notNullValue()));
+
+        Map<String, Schema> additionalProperties = additionalPropertiesSchema.getProperties();
+        assertThat("Additional property 'code'", additionalProperties, hasKey("code"));
+        assertThat("Additional property 'text'", additionalProperties, hasKey("text"));
+    }
+
+    @Test
+    void checkWritingSchemaAdditionalProperties() throws IOException {
+        OpenAPI openAPI = ParserTest.parse(helper, "/withSchemaAddlProps.yml", OpenAPISupport.OpenAPIMediaType.YAML);
+        String document = formatModel(openAPI);
+
+        /*
+         * Expected output (although the
+               additionalProperties:
+        type: object
+        properties:
+          code:
+            type: integer
+          text:
+            type: string
+         */
+        Yaml yaml = new Yaml();
+        Map<String, Object> model = yaml.load(document);
+        Map<String, ?> item = asMap(model, "components", "schemas", "item");
+
+        Object additionalProperties = item.get("additionalProperties");
+
+        assertThat("Additional properties node type", additionalProperties, is(instanceOf(Map.class)));
+
+    }
+
+    private static Map<String, ?> asMap(Map<String, ?> map, String... keys) {
+        Map<String, ?> m = map;
+        for (String key : keys) {
+            m = (Map<String, ?>) m.get(key);
+        }
+        return m;
+    }
+
+    @Test
+    void checkWritingBooleanAdditionalProperties() throws IOException {
+        OpenAPI openAPI = ParserTest.parse(helper, "/withBooleanAddlProps.yml", OpenAPISupport.OpenAPIMediaType.YAML);
+        String document = formatModel(openAPI);
+
+        /*
+         * Expected output: additionalProperties: false
+         */
+
+        assertThat("Formatted OpenAPI document matches expected pattern",
+                   document, containsString("additionalProperties: false"));
+    }
+
+    private String formatModel(OpenAPI model) {
+        StringWriter sw = new StringWriter();
+        Map<Class<?>, ExpandedTypeDescription> implsToTypes = OpenAPISupport.buildImplsToTypes(helper);
+        Serializer.serialize(helper.types(), implsToTypes, model, Format.YAML, sw);
+        return sw.toString();
+    }
+}

--- a/openapi/src/test/java/io/helidon/openapi/TestCors.java
+++ b/openapi/src/test/java/io/helidon/openapi/TestCors.java
@@ -23,14 +23,12 @@ import io.helidon.config.Config;
 import io.helidon.webserver.WebServer;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.openapi.ServerTest.GREETING_OPENAPI_SUPPORT_BUILDER;
 import static io.helidon.openapi.ServerTest.TIME_OPENAPI_SUPPORT_BUILDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("3.0.0-JAKARTA")
 public class TestCors {
 
     private static WebServer greetingWebServer;

--- a/openapi/src/test/java/io/helidon/openapi/TestUtil.java
+++ b/openapi/src/test/java/io/helidon/openapi/TestUtil.java
@@ -317,7 +317,6 @@ public class TestUtil {
         URL url = new URL("http://localhost:" + port + path + "?" + queryParameter);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod(method);
-        System.out.println("Connectiong: " + method + " " + url);
         return conn;
     }
 

--- a/openapi/src/test/resources/withBooleanAddlProps.yml
+++ b/openapi/src/test/resources/withBooleanAddlProps.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+openapi: 3.1.0
+
+info:
+  title: Some service
+  version: 0.1.0
+
+components:
+  schemas:
+    item:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: Get items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/item'

--- a/openapi/src/test/resources/withSchemaAddlProps.yml
+++ b/openapi/src/test/resources/withSchemaAddlProps.yml
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+openapi: 3.1.0
+
+info:
+  title: Some service
+  version: 0.1.0
+
+components:
+  schemas:
+    item:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          code:
+            type: integer
+          text:
+            type: string
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: Get items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/item'


### PR DESCRIPTION
Resolves #2638 
Resolves #3638 

Adopt MP OpenAPI 3.0.

The changes are segregated by commit with explanatory comments with each.

