### PR TITLE
Allow compression to be enabled together with HTTP/2 (helidon-2.x)

### DIFF
--- a/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
+++ b/tests/apps/bookstore/bookstore-se/src/main/java/io/helidon/tests/apps/bookstore/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public final class Main {
      * @return the created {@link WebServer} instance
      */
     static WebServer startServer() {
-        return startServer(false, false);
+        return startServer(false, false, false);
     }
 
     /**
@@ -76,7 +76,7 @@ public final class Main {
      * @param http2 Enable http2 support.
      * @return the created {@link WebServer} instance
      */
-    static WebServer startServer(boolean ssl, boolean http2) {
+    static WebServer startServer(boolean ssl, boolean http2, boolean compression) {
         // load logging configuration
         LogConfig.configureRuntime();
 
@@ -89,12 +89,14 @@ public final class Main {
                 .update(it -> configureJsonSupport(it, config))
                 .update(it -> configureSsl(it, ssl))
                 .update(it -> configureHttp2(it, http2))
+                .enableCompression(compression)
                 .build();
 
         // Start the server and print some info.
         server.start().thenAccept(ws -> {
             String url = (ssl ? "https" : "http") + "://localhost:" + ws.port() + SERVICE_PATH;
-            System.out.println("WEB server is up! " + url + " [ssl=" + ssl + ", http2=" + http2 + "]");
+            System.out.println("WEB server is up! " + url + " [ssl=" + ssl + ", http2=" + http2
+                    + ", compression=" + compression + "]");
         });
 
         // Server threads are not daemon. NO need to block. Just react.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/MainTest.java
@@ -42,7 +42,7 @@ public class MainTest {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        webServer = TestServer.start(false, false);
+        webServer = TestServer.start(false, false, false);
         client = TestServer.newOkHttpClient(false);
     }
 

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/SslTest.java
@@ -39,7 +39,7 @@ public class SslTest {
 
     @BeforeAll
     public static void startServer() throws Exception {
-        webServer = TestServer.start(true, false);
+        webServer = TestServer.start(true, false, false);
         client = TestServer.newOkHttpClient(true);
     }
 

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/TestServer.java
@@ -16,6 +16,9 @@
 
 package io.helidon.tests.apps.bookstore.se;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,12 +30,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
 import io.helidon.webserver.WebServer;
-
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -60,8 +58,8 @@ class TestServer {
         }
     };
 
-    static WebServer start(boolean ssl, boolean http2) throws Exception {
-        WebServer webServer = Main.startServer(ssl, http2);
+    static WebServer start(boolean ssl, boolean http2, boolean compression) throws Exception {
+        WebServer webServer = Main.startServer(ssl, http2, compression);
 
         long timeout = 2000; // 2 seconds should be enough to start the server
         long now = System.currentTimeMillis();
@@ -101,8 +99,15 @@ class TestServer {
     }
 
     static Request.Builder newRequestBuilder(WebServer webServer, String path, boolean ssl) throws Exception {
+        return newRequestBuilder(webServer, path, ssl, false);
+    }
+
+    static Request.Builder newRequestBuilder(WebServer webServer, String path, boolean ssl, boolean compression)
+            throws Exception {
         URL url = new URL((ssl ? "https" : "http") + "://localhost:" + webServer.port() + path);
-        return new Request.Builder().url(url);
+        Request.Builder builder = new Request.Builder().url(url);
+        builder.addHeader("Accept-Encoding", compression ? "gzip" : "none");
+        return builder;
     }
 
     static class LoggingInterceptor implements Interceptor {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/HttpInitializer.java
@@ -200,12 +200,12 @@ class HttpInitializer extends ChannelInitializer<SocketChannel> {
             // Uncomment the following line if you don't want to handle HttpChunks.
             //        p.addLast(new HttpObjectAggregator(1048576));
             p.addLast(new HttpResponseEncoder());
+        }
 
-            // Enable compression via "Accept-Encoding" header if configured
-            if (serverConfig.enableCompression()) {
-                LOGGER.finer(() -> log("Compression negotiation enabled (gzip, deflate)", ch));
-                p.addLast(new HttpContentCompressor());
-            }
+        // Enable compression via "Accept-Encoding" header if configured
+        if (serverConfig.enableCompression()) {
+            LOGGER.finer(() -> log("Compression negotiation enabled (gzip, deflate)", ch));
+            p.addLast(new HttpContentCompressor());
         }
 
         // Helidon's forwarding handler

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ServerConfiguration.java
@@ -798,7 +798,7 @@ public interface ServerConfiguration extends SocketConfiguration {
 
         @Override
         public Builder enableCompression(boolean value) {
-            this.defaultSocketBuilder.enableCompression(true);
+            this.defaultSocketBuilder.enableCompression(value);
             return this;
         }
     }


### PR DESCRIPTION
Allow compression to be enabled together with HTTP/2. Some new tests that show the combination. See #3700.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>