### PR TITLE
Upgrade maven-javadoc-plugin to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.plugin.jacoco>0.8.5</version.plugin.jacoco>
         <version.plugin.jandex>1.1.0</version.plugin.jandex>
         <version.plugin.jar>3.0.2</version.plugin.jar>
-        <version.plugin.javadoc>3.3.0</version.plugin.javadoc>
+        <version.plugin.javadoc>3.3.1</version.plugin.javadoc>
         <version.plugin.jaxb>2.5.0</version.plugin.jaxb>
         <version.plugin.license>1.16</version.plugin.license>
         <version.plugin.os>1.5.0.Final</version.plugin.os>


### PR DESCRIPTION
Fixes `[ERROR] Error fetching link:  target/javadoc-bundle-options. Ignored it.` errors when doing `mvn site`