### PR TITLE
Move scheduling of metrics periodic updater so it is run in MP as well as in SE (2.x)

### DIFF
--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -413,6 +413,8 @@ public final class MetricsSupport extends HelidonRestServiceSupport
             io.helidon.metrics.RegistryFactory fullRF = (io.helidon.metrics.RegistryFactory) rf;
             Registry app = fullRF.getARegistry(MetricRegistry.Type.APPLICATION);
 
+            PeriodicExecutor.start();
+
             // register the metric registry and factory to be available to all
             MetricsContextHandler metricsContextHandler = new MetricsContextHandler(app, rf);
             defaultRules.any(metricsContextHandler);
@@ -469,8 +471,6 @@ public final class MetricsSupport extends HelidonRestServiceSupport
      */
     @Override
     public void update(Routing.Rules rules) {
-        PeriodicExecutor.start();
-
         configureEndpoint(rules, rules);
     }
 


### PR DESCRIPTION
Resolves #3731 

For performance reasons, metrics uses a periodic executor to recalculate the current time in minutes, rather doing so on every update to a time-based metric (e.g., timer, meter). Servers under light load can spare the cycles, while this spares servers under heavy load from repeating the calculation and getting the same result on each update.

This works correctly in SE, but in MP the `MetricsSupport` class is initialized slightly differently and the start-up of the `PeriodicExecutor` was incorrectly skipped.

This PR moves that start-up invocation so that it runs in both SE and MP.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>