### PR TITLE
Handle creation of InjectionManager when parent is a HelidonInjectionManager (helidon-2.x)

### DIFF
--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
@@ -13,29 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-import java.util.Set;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+public class Filter3 implements ContainerResponseFilter {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("filter3", "");
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
@@ -15,10 +15,11 @@
  */
 package io.helidon.tests.functional.multipleapps;
 
+import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
-import java.util.Set;
 
 /**
  * Second application.

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
@@ -13,29 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-import java.util.Set;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
 
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+@ConstrainedTo(RuntimeType.SERVER)
+public class MyFeature implements DynamicFeature {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {
+        featureContext.register(Filter3.class);
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -21,14 +21,12 @@ import javax.json.JsonObject;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import io.helidon.microprofile.tests.junit5.HelidonTest;
 import org.junit.jupiter.api.Test;
 
-import io.helidon.microprofile.server.Server;
-import io.helidon.microprofile.tests.junit5.HelidonTest;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @HelidonTest
 class MainTest {
@@ -62,6 +60,7 @@ class MainTest {
         assertEquals(response.getStatus(), 200);
         assertTrue(response.getHeaders().containsKey("sharedfilter"));
         assertTrue(response.getHeaders().containsKey("filter2"));
+        assertTrue(response.getHeaders().containsKey("filter3"));       // MyFeature
         assertFalse(response.getHeaders().containsKey("filter1"));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
         assertEquals("Hello World 2!", jsonObject.getString("message"),

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -68,6 +68,9 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
             result = new HelidonInjectionManager(forApplication, wrapper.injectionManager, wrapper.application);
             LOGGER.finest(() -> "Creating injection manager " + forApplication + " with shared "
                     + wrapper.injectionManager);
+        } else if (parent instanceof HelidonInjectionManager) {
+            result = (InjectionManager) parent;
+            LOGGER.finest(() -> "Using injection manager " + result);
         } else {
             throw new IllegalStateException("Invalid parent injection manager");
         }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -61,16 +61,16 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
             LOGGER.finest(() -> "Creating injection manager " + result);
         } else if (parent instanceof ImmediateHk2InjectionManager) {        // single JAX-RS app
             result = (InjectionManager) parent;
-            LOGGER.finest(() -> "Using injection manager " + result);
+            LOGGER.finest(() -> "Using injection manager for single app case " + result);
         } else if (parent instanceof InjectionManagerWrapper) {             // multiple JAX-RS apps
             InjectionManagerWrapper wrapper = (InjectionManagerWrapper) parent;
             InjectionManager forApplication = super.create(null);
             result = new HelidonInjectionManager(forApplication, wrapper.injectionManager, wrapper.application);
-            LOGGER.finest(() -> "Creating injection manager " + forApplication + " with shared "
-                    + wrapper.injectionManager);
+            LOGGER.finest(() -> "Creating injection manager for multi app case " + forApplication
+                    + " with shared " + wrapper.injectionManager);
         } else if (parent instanceof HelidonInjectionManager) {
             result = (InjectionManager) parent;
-            LOGGER.finest(() -> "Using injection manager " + result);
+            LOGGER.finest(() -> "Re-using existing Helidon injection manager " + result);
         } else {
             throw new IllegalStateException("Invalid parent injection manager");
         }


### PR DESCRIPTION
Handle creation of InjectionManager when parent is a HelidonInjectionManager which can happen with multiple application subclasses and dynamic features. New test.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>