### PR TITLE
Handle creation of InjectionManager when parent is a HelidonInjectionManager

### DIFF
--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
@@ -13,30 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+public class Filter3 implements ContainerResponseFilter {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        responseContext.getHeaders().add("filter3", "");
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Filter3.java
@@ -16,9 +16,9 @@
 
 package io.helidon.tests.functional.multipleapps;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
 
 public class Filter3 implements ContainerResponseFilter {
 

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
@@ -16,11 +16,11 @@
 
 package io.helidon.tests.functional.multipleapps;
 
-import javax.ws.rs.ConstrainedTo;
-import javax.ws.rs.RuntimeType;
-import javax.ws.rs.container.DynamicFeature;
-import javax.ws.rs.container.ResourceInfo;
-import javax.ws.rs.core.FeatureContext;
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.FeatureContext;
 
 @ConstrainedTo(RuntimeType.SERVER)
 public class MyFeature implements DynamicFeature {

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/MyFeature.java
@@ -13,30 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.core.Application;
-
-/**
- * Second application.
- */
-@ApplicationScoped
-@ApplicationPath("app2")
-public class GreetApplication2 extends Application {
-
-    private static final Filter2 filter2 = new Filter2();
+@ConstrainedTo(RuntimeType.SERVER)
+public class MyFeature implements DynamicFeature {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
-    }
-
-    @Override
-    public Set<Object> getSingletons() {
-        return Set.of(filter2);
+    public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {
+        featureContext.register(Filter3.class);
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -22,6 +22,7 @@ import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +63,7 @@ class MainTest {
         assertEquals(response.getStatus(), 200);
         assertTrue(response.getHeaders().containsKey("sharedfilter"));
         assertTrue(response.getHeaders().containsKey("filter2"));
+        assertTrue(response.getHeaders().containsKey("filter3"));       // MyFeature
         assertFalse(response.getHeaders().containsKey("filter1"));
         JsonObject jsonObject = response.readEntity(JsonObject.class);
         assertEquals("Hello World 2!", jsonObject.getString("message"),

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -60,16 +60,16 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
             LOGGER.finest(() -> "Creating injection manager " + result);
         } else if (parent instanceof ImmediateHk2InjectionManager) {        // single JAX-RS app
             result = (InjectionManager) parent;
-            LOGGER.finest(() -> "Using injection manager " + result);
+            LOGGER.finest(() -> "Using injection manager for single app case " + result);
         } else if (parent instanceof InjectionManagerWrapper) {             // multiple JAX-RS apps
             InjectionManagerWrapper wrapper = (InjectionManagerWrapper) parent;
             InjectionManager forApplication = super.create(null);
             result = new HelidonInjectionManager(forApplication, wrapper.injectionManager, wrapper.application);
-            LOGGER.finest(() -> "Creating injection manager " + forApplication + " with shared "
-                    + wrapper.injectionManager);
+            LOGGER.finest(() -> "Creating injection manager for multi app case " + forApplication
+                    + " with shared " + wrapper.injectionManager);
         } else if (parent instanceof HelidonInjectionManager) {
             result = (InjectionManager) parent;
-            LOGGER.finest(() -> "Using injection manager " + result);
+            LOGGER.finest(() -> "Re-using existing Helidon injection manager " + result);
         } else {
             throw new IllegalStateException("Invalid parent injection manager");
         }

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/HelidonHK2InjectionManagerFactory.java
@@ -67,6 +67,9 @@ public class HelidonHK2InjectionManagerFactory extends Hk2InjectionManagerFactor
             result = new HelidonInjectionManager(forApplication, wrapper.injectionManager, wrapper.application);
             LOGGER.finest(() -> "Creating injection manager " + forApplication + " with shared "
                     + wrapper.injectionManager);
+        } else if (parent instanceof HelidonInjectionManager) {
+            result = (InjectionManager) parent;
+            LOGGER.finest(() -> "Using injection manager " + result);
         } else {
             throw new IllegalStateException("Invalid parent injection manager");
         }


### PR DESCRIPTION
Handle creation of InjectionManager when parent is a HelidonInjectionManager which can happen with multiple application subclasses and dynamic features.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>