### PR TITLE
Ensure all thread pools created by Helidon are named

### DIFF
--- a/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolSupplierTest.java
+++ b/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class ThreadPoolSupplierTest {
 
     @BeforeAll
     static void initClass() {
-        defaultSupplier = ThreadPoolSupplier.create();
+        defaultSupplier = ThreadPoolSupplier.create("test-thread-pool");
         defaultInstance = ensureOurExecutor(defaultSupplier.getThreadPool());
 
         builtSupplier = ThreadPoolSupplier.builder()
@@ -73,7 +73,7 @@ class ThreadPoolSupplierTest {
                 .build();
         builtInstance = ensureOurExecutor(builtSupplier.getThreadPool());
 
-        configuredSupplier = ThreadPoolSupplier.create(Config.create().get("unit.thread-pool"));
+        configuredSupplier = ThreadPoolSupplier.create(Config.create().get("unit.thread-pool"), "test-thread-pool");
         configuredInstance = ensureOurExecutor(configuredSupplier.getThreadPool());
     }
 
@@ -142,7 +142,7 @@ class ThreadPoolSupplierTest {
         try {
             log.addHandler(handler);
             Config config = Config.create(ConfigSources.create(Map.of(thresholdKey, threshold, rateKey, rate)));
-            ExecutorService executor = ThreadPoolSupplier.create(config).get();
+            ExecutorService executor = ThreadPoolSupplier.create(config, "test-thread-pool").get();
             Optional<ThreadPool> asThreadPool = ThreadPool.asThreadPool(executor);
             ThreadPool pool = asThreadPool.orElseThrow(() -> new RuntimeException("not a thread pool"));
             assertThat(pool.getGrowthThreshold(), is(Integer.parseInt(threshold)));

--- a/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcDbClientProviderBuilder.java
+++ b/dbclient/jdbc/src/main/java/io/helidon/dbclient/jdbc/JdbcDbClientProviderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public final class JdbcDbClientProviderBuilder implements DbClientProviderBuilde
             this.mapperManager = MapperManager.create();
         }
         if (null == executorService) {
-            executorService = ThreadPoolSupplier.create();
+            executorService = ThreadPoolSupplier.create("jdbc-dbclient-thread-pool");
         }
         return new JdbcDbClient(this);
     }
@@ -97,7 +97,9 @@ public final class JdbcDbClientProviderBuilder implements DbClientProviderBuilde
                 .ifExists(cfg -> connectionPool(ConnectionPool.create(cfg)));
 
         config.get("statements").as(DbStatements::create).ifPresent(this::statements);
-        config.get("executor-service").as(ThreadPoolSupplier::create).ifPresent(this::executorService);
+        config.get("executor-service")
+                .as(c -> ThreadPoolSupplier.create(c, "jdbc-dbclient-thread-pool"))
+                .ifPresent(this::executorService);
         return this;
     }
 

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/FileService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public final class FileService implements Service {
 
     private static final JsonBuilderFactory JSON_FACTORY = Json.createBuilderFactory(Map.of());
     private final FileStorage storage;
-    private final ExecutorService executor = ThreadPoolSupplier.create().get();
+    private final ExecutorService executor = ThreadPoolSupplier.create("multipart-thread-pool").get();
 
 
     /**

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/FaultTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public final class FaultTolerance {
         CONFIG.set(config);
 
         SCHEDULED_EXECUTOR.set(LazyValue.create(ScheduledThreadPoolSupplier.create(CONFIG.get().get("scheduled-executor"))));
-        EXECUTOR.set(LazyValue.create(ThreadPoolSupplier.create(CONFIG.get().get("executor"))));
+        EXECUTOR.set(LazyValue.create(ThreadPoolSupplier.create(CONFIG.get().get("executor"), "ft-se-thread-pool")));
     }
 
     /**

--- a/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/MpTracingClientRegistrar.java
+++ b/microprofile/tracing/src/main/java/io/helidon/microprofile/tracing/MpTracingClientRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class MpTracingClientRegistrar implements ClientTracingRegistrarProvider 
 
     static {
         Config config = (Config) ConfigProvider.getConfig();
-        EXECUTOR_SERVICE = ThreadPoolSupplier.create(config.get("tracing.executor-service"));
+        EXECUTOR_SERVICE = ThreadPoolSupplier.create(config.get("tracing.executor-service"), "mp-tracing-thread-pool");
     }
 
     @Override

--- a/security/security/src/main/java/io/helidon/security/Security.java
+++ b/security/security/src/main/java/io/helidon/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -576,7 +576,7 @@ public class Security {
         private Tracer tracer;
         private boolean tracingEnabled = true;
         private SecurityTime serverTime = SecurityTime.builder().build();
-        private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create();
+        private Supplier<ExecutorService> executorService = ThreadPoolSupplier.create("security-thread-pool");
         private boolean enabled = true;
 
         private Builder() {
@@ -1175,7 +1175,7 @@ public class Security {
             }
 
             config.get("environment.server-time").as(SecurityTime::create).ifPresent(this::serverTime);
-            executorService(ThreadPoolSupplier.create(config.get("environment.executor-service")));
+            executorService(ThreadPoolSupplier.create(config.get("environment.executor-service"), "security-thread-pool"));
 
             Map<String, SecurityProviderService> configKeyToService = new HashMap<>();
             Map<String, SecurityProviderService> classNameToService = new HashMap<>();

--- a/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
+++ b/tests/apps/bookstore/bookstore-se/src/test/java/io/helidon/tests/apps/bookstore/se/Http2SslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public class Http2SslTest {
 
     @Test
     public void testHelloWorldHttp2SslConcurrent() throws Exception {
-        ExecutorService executor = ThreadPoolSupplier.create().get();
+        ExecutorService executor = ThreadPoolSupplier.create("test-thread-pool").get();
         Request.Builder builder = TestServer.newRequestBuilder(webServer, "/books", true);
         Request getBooks = builder.build();
 

--- a/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JaxRsClient.java
+++ b/webclient/jaxrs/src/main/java/io/helidon/webclient/jaxrs/JaxRsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public final class JaxRsClient {
      * </tr>
      * <tr>
      *     <td>executor</td>
-     *     <td>{@link io.helidon.common.configurable.ThreadPoolSupplier#create(io.helidon.config.Config)}</td>
+     *     <td>{@link io.helidon.common.configurable.ThreadPoolSupplier#create(io.helidon.config.Config, String)}</td>
      *     <td>Default executor service to use for asynchronous operations. For configuration options
      *      of {@code executor}, please refer to
      *      {@link io.helidon.common.configurable.ThreadPoolSupplier.Builder#config(io.helidon.config.Config)}</td>
@@ -59,7 +59,7 @@ public final class JaxRsClient {
      * @param config configuration to use to configure JAX-RS clients defaults
      */
     public static void configureDefaults(Config config) {
-        EXECUTOR_SUPPLIER.set(ThreadPoolSupplier.create(config));
+        EXECUTOR_SUPPLIER.set(ThreadPoolSupplier.create(config, "jaxrs-client-thread-pool"));
     }
 
     /**


### PR DESCRIPTION
This is necessary for debugging and performance analysis of logs. All pools are now named and default names are improved for application-created pools where only a thread name prefix is provided. A couple of methods to create thread pools without naming them are now deprecated. See #3784.