### PR TITLE
Only deactivate request context if it was inactive before migrating it

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -15,13 +15,13 @@
  */
 package io.helidon.microprofile.faulttolerance;
 
-
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.spi.CDI;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.spi.CDI;
 
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.process.internal.RequestContext;

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,29 +114,29 @@ class RequestScopeHelper {
             return () -> requestScope.runInScope(requestContext,
                     (Callable<?>) (() -> {
                         InjectionManager old = WeldRequestScope.actualInjectorManager.get();
-                        BoundRequestContext boundRequestContext = null;
+                        Runnable migrationCleaner = null;
                         try {
-                            boundRequestContext = migrateRequestContext();
+                            migrationCleaner = migrateRequestContext();
                             WeldRequestScope.actualInjectorManager.set(injectionManager);
                             return supplier.get();
                         } catch (Throwable t) {
                             throw t instanceof Exception ? ((Exception) t) : new RuntimeException(t);
                         } finally {
-                            if (boundRequestContext != null) {
-                                boundRequestContext.deactivate();
+                            if (migrationCleaner != null) {
+                                migrationCleaner.run();
                             }
                             WeldRequestScope.actualInjectorManager.set(old);
                         }
                     }));
         } else if (weldManager != null) {         // CDI only
             return () -> {
-                BoundRequestContext boundRequestContext = null;
+                Runnable migrationCleaner = null;
                 try {
-                    boundRequestContext = migrateRequestContext();
+                    migrationCleaner = migrateRequestContext();
                     return supplier.get();
                 } finally {
-                    if (boundRequestContext != null) {
-                        boundRequestContext.deactivate();
+                    if (migrationCleaner != null) {
+                        migrationCleaner.run();
                     }
                 }
             };
@@ -152,19 +152,32 @@ class RequestScopeHelper {
      * if a request scope bean in the original context was not accessed/proxied, it
      * will not be carried over.
      *
-     * @return the request context if not active or {@code null} otherwise
+     * @return runnable that cleans up after migration or {@code null}
      */
-    private BoundRequestContext migrateRequestContext() {
+    private Runnable migrateRequestContext() {
         if (requestScopeInstances != null) {
+            // Access CDI context instance
             BoundRequestContext requestContext = weldManager.instance()
                     .select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
+
+            // Ensure a storage and activate if necessary
             Map<String, Object> requestMap = new HashMap<>();
-            requestContext.associate(requestMap);
+            boolean wasAssociated = requestContext.associate(requestMap);
             requestContext.clearAndSet(requestScopeInstances);
-            if (!requestContext.isActive()) {
+            boolean wasActive = requestContext.isActive();
+            if (!wasActive) {
                 requestContext.activate();
-                return requestContext;
             }
+
+            // Return runnable that properly cleans up after context migration
+            return () -> {
+                if (!wasActive) {
+                    requestContext.deactivate();
+                }
+                if (wasAssociated) {
+                    requestContext.dissociate(requestMap);
+                }
+            };
         }
         return null;
     }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RequestScopeHelper.java
@@ -155,15 +155,13 @@ class RequestScopeHelper {
      * @return the request context if not active or {@code null} otherwise
      */
     private BoundRequestContext migrateRequestContext() {
-        BoundRequestContext requestContext = weldManager.instance()
-                .select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
-        boolean isActive = requestContext.isActive();
-
         if (requestScopeInstances != null) {
+            BoundRequestContext requestContext = weldManager.instance()
+                    .select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
             Map<String, Object> requestMap = new HashMap<>();
             requestContext.associate(requestMap);
             requestContext.clearAndSet(requestScopeInstances);
-            if (!isActive) {
+            if (!requestContext.isActive()) {
                 requestContext.activate();
                 return requestContext;
             }

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/RequestReaderInterceptor.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/RequestReaderInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.hello;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+
+/**
+ * A reader interceptor in request scope.
+ *
+ * @see HelloResource#getHello
+ */
+@Provider
+@RequestScoped
+public class RequestReaderInterceptor implements ReaderInterceptor {
+
+
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException, WebApplicationException {
+        return context.proceed();
+    }
+}

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ResponseWriterInterceptor.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ResponseWriterInterceptor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.hello;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+import javax.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+
+/**
+ * Presence of this interceptor in request scope tests that a request scope is
+ * active after returning from the resource method call while running in a
+ * different thread -- such as a fault tolerance thread.
+ *
+ * @see "https://github.com/oracle/helidon/issues/3804"
+ * @see HelloResource#getHello
+ */
+@Provider
+@RequestScoped
+public class ResponseWriterInterceptor implements WriterInterceptor {
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+        context.proceed();
+    }
+}


### PR DESCRIPTION
Do not eagerly restore a migrated request context in new thread after calling the resource method. Jersey may still need to have the context active for allocation of providers such as writer interceptors. Instead, request context state will be overwritten simply next time the thread is reused and another context migrated. See issue #3810.