### PR TITLE
Ignore "package-lock.json" when full build is done.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ node/
 user.txt
 ObjectStore/
 PutObjectStoreDirHere/
+package-lock.json


### PR DESCRIPTION
Every time a full build is done, file `package-lock.json`  is generated in examples/todo-app/frontend, and always added as a new unversioned file to git commit. 

Adding it to _.gitignore_ will fix this.