### PR TITLE
2.x: Upgrade grpc-java to 1.41.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,10 +56,12 @@
         <version.lib.google-api-client>1.32.2</version.lib.google-api-client>
         <version.lib.google-oauth-client>1.32.1</version.lib.google-oauth-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
+        <version.lib.google-protobuf>3.19.2</version.lib.google-protobuf>
+        <version.lib.google-gson>2.8.9</version.lib.google-gson>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>
-        <version.lib.grpc>1.35.0</version.lib.grpc>
+        <version.lib.grpc>1.43.2</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
@@ -449,6 +451,18 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty</artifactId>
                 <version>${version.lib.grpc}</version>
+            </dependency>
+            <!-- Dependency convergence. Should align with version used by io.grpc -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${version.lib.google-protobuf}</version>
+            </dependency>
+            <!-- Dependency convergence. Should align with version used by io.grpc -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${version.lib.google-gson}</version>
             </dependency>
             <dependency>
               <groupId>io.opentracing.contrib</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,12 +56,12 @@
         <version.lib.google-api-client>1.32.2</version.lib.google-api-client>
         <version.lib.google-oauth-client>1.32.1</version.lib.google-oauth-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
-        <version.lib.google-protobuf>3.19.2</version.lib.google-protobuf>
+        <version.lib.google-protobuf>3.18.2</version.lib.google-protobuf>
         <version.lib.google-gson>2.8.9</version.lib.google-gson>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>
-        <version.lib.grpc>1.43.2</version.lib.grpc>
+        <version.lib.grpc>1.41.2</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.200</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>
@@ -457,12 +457,6 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${version.lib.google-protobuf}</version>
-            </dependency>
-            <!-- Dependency convergence. Should align with version used by io.grpc -->
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${version.lib.google-gson}</version>
             </dependency>
             <dependency>
               <groupId>io.opentracing.contrib</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -57,7 +57,6 @@
         <version.lib.google-oauth-client>1.32.1</version.lib.google-oauth-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
         <version.lib.google-protobuf>3.18.2</version.lib.google-protobuf>
-        <version.lib.google-gson>2.8.9</version.lib.google-gson>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>


### PR DESCRIPTION
In 1.42.0 they removed `CallCredentials2` which we use. So we stick with 1.41 for now.