### PR TITLE
1.x: Upgrade grpc-java to 1.41.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
-        <version.lib.grpc>1.35.0</version.lib.grpc>
+        <version.lib.grpc>1.43.2</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -47,7 +47,7 @@
         <version.lib.etcd4j>2.17.0</version.lib.etcd4j>
         <version.lib.google-api-client>1.30.11</version.lib.google-api-client>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
-        <version.lib.grpc>1.43.2</version.lib.grpc>
+        <version.lib.grpc>1.41.2</version.lib.grpc>
         <version.lib.guava>30.0-jre</version.lib.guava>
         <version.lib.h2>1.4.199</version.lib.h2>
         <version.lib.hamcrest>1.3</version.lib.hamcrest>


### PR DESCRIPTION
In 1.42.0 they removed `CallCredentials2` which we use. So we stick with 1.41 for now.