### PR TITLE
Only deactivate request context if it was inactive before migrating it (master)

### DIFF
--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/RequestReaderInterceptor.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/RequestReaderInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.hello;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.ReaderInterceptor;
+import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import java.io.IOException;
+
+/**
+ * A reader interceptor in request scope.
+ *
+ * @see HelloResource#getHello
+ */
+@Provider
+@RequestScoped
+public class RequestReaderInterceptor implements ReaderInterceptor {
+
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException, WebApplicationException {
+        return context.proceed();
+    }
+}

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ResponseWriterInterceptor.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/ResponseWriterInterceptor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.context.hello;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import java.io.IOException;
+
+/**
+ * Presence of this interceptor in request scope tests that a request scope is
+ * active after returning from the resource method call while running in a
+ * different thread -- such as a fault tolerance thread.
+ *
+ * @see "https://github.com/oracle/helidon/issues/3804"
+ * @see HelloResource#getHello
+ */
+@Provider
+@RequestScoped
+public class ResponseWriterInterceptor implements WriterInterceptor {
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+        context.proceed();
+    }
+}


### PR DESCRIPTION
 Only deactivate request context if it was inactive before migrating it. Better cleanup migration cleanup. Issue #3810.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>