### PR TITLE
Fix wrong connection close

### DIFF
--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
@@ -233,7 +233,8 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
 
     static void removeChannelFromCache(ConnectionIdent key, Channel channel) {
         if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.finest(() -> "Removing from channel cache. Connection ident ->  " + key + ", channel -> " + channel.hashCode());
+            LOGGER.finest(() -> "Removing from channel cache. Connection ident ->  " + key
+                    + ", channel -> " + channel.hashCode());
         }
         CHANNEL_CACHE.get(key).remove(new ChannelRecord(channel));
     }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -207,7 +207,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         lastContent = false;
 
         HttpContent httpContent = (HttpContent) msg;
-        boolean hasRequests = requestContext.hasRequests();
 
         ByteBuf content = httpContent.content();
         if (content.isReadable()) {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -438,6 +438,10 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         LOGGER.fine(log("Response complete: %s", ctx, System.identityHashCode(msg)));
                     }
                 });
+        /*
+        TODO we should only send continue in case the entity is request (e.g. we found a route and user started reading it)
+        This would solve connection close for 404 for requests with entity
+         */
         if (HttpUtil.is100ContinueExpected(request)) {
             send100Continue(ctx, request);
         }

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -350,7 +350,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // If a problem with the request URI, return 400 response
         BareRequestImpl bareRequest;
         try {
-            bareRequest = new BareRequestImpl((HttpRequest) msg,
+            bareRequest = new BareRequestImpl(request,
                                               requestContextRef.publisher(),
                                               webServer,
                                               ctx,
@@ -535,6 +535,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         "");
 
         FullHttpResponse response = toNettyResponse(transportResponse);
+        // we should flush this immediately, as we need the client to send entity
         ctx.writeAndFlush(response);
     }
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -16,7 +16,6 @@
 
 package io.helidon.webserver;
 
-import java.util.concurrent.Flow;
 import java.util.logging.Logger;
 
 import io.helidon.common.context.Context;
@@ -46,7 +45,7 @@ class RequestContext {
         this.scope = scope;
     }
 
-    Flow.Publisher<DataChunk> publisher() {
+    Multi<DataChunk> publisher() {
         return Multi.create(publisher)
                 .peek(something -> emitted = true);
     }
@@ -93,7 +92,7 @@ class RequestContext {
      * @return {@code true} if data was requested and request was not cancelled
      */
     boolean isDataRequested() {
-        return (hasRequests() || hasEmitted()) && !requestCancelled();
+        return (hasRequests() || hasEmitted()) || requestCancelled();
     }
 
     boolean hasEmitted() {

--- a/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/RequestContext.java
@@ -87,6 +87,15 @@ class RequestContext {
         return publisher.hasRequests();
     }
 
+    /**
+     * Has there been a request for content.
+     *
+     * @return {@code true} if data was requested and request was not cancelled
+     */
+    boolean isDataRequested() {
+        return (hasRequests() || hasEmitted()) && !requestCancelled();
+    }
+
     boolean hasEmitted() {
         return emitted;
     }

--- a/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Test support for HTTP 1.1 pipelining.
@@ -67,7 +67,12 @@ public class HttpPipelineTest {
                         .put("/", (req, res) -> {
                             counter.set(0);
                             log("put server");
-                            res.send();
+                            req.content()
+                                    .as(String.class)
+                                    .forSingle(it -> {
+                                        log("put: " + it);
+                                        res.send();
+                                    });
                         })
                         .get("/", (req, res) -> {
                             log("get server");
@@ -99,8 +104,8 @@ public class HttpPipelineTest {
     public void testPipelining() throws Exception {
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             s.request(Http.Method.PUT, "/");        // reset server
-            s.request(Http.Method.GET, "/");        // request_0
-            s.request(Http.Method.GET, "/");        // request_1
+            s.request(Http.Method.GET, null);        // request_0
+            s.request(Http.Method.GET, null);        // request_1
             log("put client");
             String reset = s.receive();
             assertThat(reset, notNullValue());

--- a/webserver/webserver/src/test/java/io/helidon/webserver/KeepAliveTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/KeepAliveTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.webserver;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.reactive.Multi;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KeepAliveTest {
+    private static WebServer server;
+    private static WebClient webClient;
+
+    @BeforeAll
+    static void setUp() {
+        LogConfig.configureRuntime();
+        server = WebServer.builder()
+                .routing(Routing.builder()
+                                 .register("/close", rules -> rules.any((req, res) -> {
+                                     req.content().forEach(dataChunk -> {
+                                         // consume only first from two chunks
+                                         dataChunk.release();
+                                         throw new RuntimeException("BOOM!");
+                                     }).exceptionally(res::send);
+                                 }))
+                                 .register("/plain", rules -> rules.any((req, res) -> {
+                                     req.content()
+                                             .forEach(DataChunk::release)
+                                             .onComplete(res::send)
+                                             .ignoreElement();
+                                 }))
+                                 .build())
+                .build();
+        server.start().await();
+        String serverUrl = "http://localhost:" + server.port();
+        webClient = WebClient.builder()
+                .baseUri(serverUrl)
+                .keepAlive(true)
+                .build();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        server.shutdown();
+    }
+
+    @RepeatedTest(100)
+    void closeWithKeepAliveUnconsumedRequest() {
+        testCall(webClient, true, "/close", 500, HttpHeaderValues.CLOSE);
+    }
+
+    @RepeatedTest(100)
+    void sendWithoutKeepAlive() {
+        testCall(webClient, false, "/plain", 200, null);
+    }
+
+    @RepeatedTest(100)
+    void sendWithKeepAlive() {
+        testCall(webClient, true, "/plain", 200, HttpHeaderValues.KEEP_ALIVE);
+    }
+
+    private static void testCall(WebClient webClient,
+                                 boolean keepAlive,
+                                 String path,
+                                 int expectedStatus,
+                                 AsciiString expectedConnectionHeader) {
+        WebClientResponse res = null;
+        try {
+            res = webClient
+                    .put()
+                    .keepAlive(keepAlive)
+                    .path(path)
+                    .submit(Multi.just("first", "second")
+                                    .map(String::getBytes)
+                                    .map(ByteBuffer::wrap)
+                                    .map(bb -> DataChunk.create(true, true, bb))
+                    )
+                    .await(5, TimeUnit.MINUTES);
+
+            assertEquals(expectedStatus, res.status().code());
+            if (expectedConnectionHeader != null) {
+                assertThat(res.headers().toMap(), hasEntry(HttpHeaderNames.CONNECTION.toString(), List.of(expectedConnectionHeader.toString())));
+            } else {
+                assertThat(res.headers().toMap(), not(hasKey(HttpHeaderNames.CONNECTION.toString())));
+            }
+            res.content().forEach(DataChunk::release);
+        } finally {
+            Optional.ofNullable(res).ifPresent(WebClientResponse::close);
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,7 +307,7 @@ public class PlainTest {
     }
 
     @Test
-    public void getWithIllegalSmallEnoughPayloadDoesntCauseConnectionClose() throws Exception {
+    public void getWithIllegalSmallEnoughPayloadDoesCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -315,12 +315,12 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("9\nIt works!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsOpen(s);
+            SocketHttpClient.assertConnectionIsClosed(s);
         }
     }
 
     @Test
-    public void unconsumedSmallPostDataDoesNotCauseConnectionClose() throws Exception {
+    public void unconsumedSmallPostDataDoesCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -329,7 +329,7 @@ public class PlainTest {
             System.out.println(received);
             // assert
             assertThat(entityFromResponse(received, true), is("15\nPayload not consumed!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsOpen(s);
+            SocketHttpClient.assertConnectionIsClosed(s);
         }
     }
 
@@ -360,7 +360,7 @@ public class PlainTest {
     }
 
     @Test
-    public void errorHandlerWithGetPayloadDoesNotCauseConnectionClose() throws Exception {
+    public void errorHandlerWithGetPayloadDoesCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -368,12 +368,12 @@ public class PlainTest {
 
             // assert
             assertThat(s.receive(), startsWith("HTTP/1.1 500 Internal Server Error\n"));
-            SocketHttpClient.assertConnectionIsOpen(s);
+            SocketHttpClient.assertConnectionIsClosed(s);
         }
     }
 
     @Test
-    public void errorHandlerWithPostDataDoesNotCauseConnectionClose() throws Exception {
+    public void errorHandlerWithPostDataDoesCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -381,7 +381,7 @@ public class PlainTest {
 
             // assert
             assertThat(s.receive(), startsWith("HTTP/1.1 500 Internal Server Error\n"));
-            SocketHttpClient.assertConnectionIsOpen(s);
+            SocketHttpClient.assertConnectionIsClosed(s);
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -256,7 +256,7 @@ public class PlainTest {
     }
 
     @Test
-    public void getWithLargePayloadCausesConnectionClose() throws Exception {
+    public void getWithLargePayloadDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -264,7 +264,7 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("9\nIt works!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
@@ -295,19 +295,19 @@ public class PlainTest {
     }
 
     @Test
-    public void deferredGetWithLargePayloadCausesConnectionClose() throws Exception {
+    public void deferredGetWithLargePayloadDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
             s.request(Http.Method.GET, "/deferred", SocketHttpClient.longData(100_000).toString());
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("d\nI'm deferred!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void getWithIllegalSmallEnoughPayloadDoesCauseConnectionClose() throws Exception {
+    public void getWithIllegalSmallEnoughPayloadDoesntCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -315,12 +315,12 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("9\nIt works!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void unconsumedSmallPostDataDoesCauseConnectionClose() throws Exception {
+    public void unconsumedSmallPostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -329,12 +329,12 @@ public class PlainTest {
             System.out.println(received);
             // assert
             assertThat(entityFromResponse(received, true), is("15\nPayload not consumed!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void unconsumedLargePostDataCausesConnectionClose() throws Exception {
+    public void unconsumedLargePostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -342,12 +342,12 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("15\nPayload not consumed!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void unconsumedDeferredLargePostDataCausesConnectionClose() throws Exception {
+    public void unconsumedDeferredLargePostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -355,12 +355,12 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("d\nI'm deferred!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void errorHandlerWithGetPayloadDoesCauseConnectionClose() throws Exception {
+    public void errorHandlerWithGetPayloadDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -368,12 +368,12 @@ public class PlainTest {
 
             // assert
             assertThat(s.receive(), startsWith("HTTP/1.1 500 Internal Server Error\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void errorHandlerWithPostDataDoesCauseConnectionClose() throws Exception {
+    public void errorHandlerWithPostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -381,7 +381,7 @@ public class PlainTest {
 
             // assert
             assertThat(s.receive(), startsWith("HTTP/1.1 500 Internal Server Error\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
@@ -19,8 +19,6 @@ package io.helidon.webserver;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -37,9 +35,7 @@ import org.junit.jupiter.api.RepeatedTest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ReqEntityAnalyzedTest {
     private static final Duration TIME_OUT = Duration.ofSeconds(5);
@@ -93,14 +89,15 @@ public class ReqEntityAnalyzedTest {
 
             assertThat(webClientResponse.status(), is(Http.Status.OK_200));
 
-            webClientResponse.content().as(String.class)
-                    .forSingle(s -> assertEquals("Server:0Server:1Server:2", s, "Wrong response!"))
+            String response = webClientResponse.content()
+                    .as(String.class)
                     .await(TIME_OUT);
 
-        } catch (CompletionException e) {
-            fail(e);
+            assertThat(response, is("Server:0Server:1Server:2"));
         } finally {
-            Optional.ofNullable(webClientResponse).ifPresent(WebClientResponse::close);
+            if (webClientResponse != null) {
+                webClientResponse.close();
+            }
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.Http;
 import io.helidon.common.reactive.Multi;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientResponse;
@@ -34,6 +35,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -87,6 +90,8 @@ public class ReqEntityAnalyzedTest {
                     .submit(payload)
                     .onError(Throwable::printStackTrace)
                     .await(TIME_OUT);
+
+            assertThat(webClientResponse.status(), is(Http.Status.OK_200));
 
             webClientResponse.content().as(String.class)
                     .forSingle(s -> assertEquals("Server:0Server:1Server:2", s, "Wrong response!"))

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
@@ -94,6 +94,12 @@ public class ReqEntityAnalyzedTest {
                     .await(TIME_OUT);
 
             assertThat(response, is("Server:0Server:1Server:2"));
+        } catch (Exception e) {
+            // this is expected - we do not support parallel read of entity
+            if (e.getMessage().contains("reset by the host")) {
+                return;
+            }
+            throw e;
         } finally {
             if (webClientResponse != null) {
                 webClientResponse.close();

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class SocketHttpClient implements AutoCloseable {
      */
     public SocketHttpClient(WebServer webServer) throws IOException {
         socket = new Socket("localhost", webServer.port());
+        socket.setSoTimeout(10000);
     }
 
     /**


### PR DESCRIPTION
Resolves #3829 

Entity is consumed for any request that completed and did not subscribe (including JAX-RS).
We were consuming the entity anyway at a later stage (when we already did a connection close). For connection:close cases, entity is ignored if not consumed.

This keeps original handling and improved it even for requests with more than one chunk in request entity, while simplifying the code.


Signed-off-by: Tomas Langer <tomas.langer@oracle.com>