### PR TITLE
Do not create close listener handlers for every new request

### DIFF
--- a/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientHandler.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientHandler.java
@@ -231,7 +231,7 @@ class NettyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
         super.channelInactive(ctx);
         // Connection closed without last HTTP content received. Some server problem
         // so we need to fail the publisher and report an exception.
-        if (!responseCloser.isClosed()) {
+        if (publisher != null && !responseCloser.isClosed()) {
             WebClientException exception = new WebClientException("Connection reset by the host");
             publisher.fail(exception);
         }

--- a/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientHandler.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/NettyClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,16 +154,6 @@ class NettyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
                 }
             }
 
-            channel.closeFuture()
-                    .addListener(f -> {
-                        // Connection closed without last HTTP content received. Some server problem
-                        // so we need to fail the publisher and report an exception.
-                        if (!responseCloser.isClosed()) {
-                            WebClientException exception = new WebClientException("Connection reset by the host");
-                            publisher.fail(exception);
-                        }
-                    });
-
             requestConfiguration.cookieManager().put(requestConfiguration.requestURI(),
                                                      clientResponse.headers().toMap());
 
@@ -233,6 +223,17 @@ class NettyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
             } else {
                 responseCloser.close();
             }
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        super.channelInactive(ctx);
+        // Connection closed without last HTTP content received. Some server problem
+        // so we need to fail the publisher and report an exception.
+        if (!responseCloser.isClosed()) {
+            WebClientException exception = new WebClientException("Connection reset by the host");
+            publisher.fail(exception);
         }
     }
 


### PR DESCRIPTION
Do not create listener handlers for every new request resulting in a memory leak. Use using channelInactive() instead. Issue #3850.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>