### PR TITLE
Fix wrong connection close (#3830)

### DIFF
--- a/microprofile/tests/tck/tck-jwt-auth/tck-base-suite.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/tck-base-suite.xml
@@ -37,38 +37,42 @@
                 <exclude name="excludes"/>
             </run>
         </groups>
+        <packages>
+            <package name="org.eclipse.microprofile.jwt.tck.*">
+                <!-- Optional, we do not support those-->
+                <exclude name="org.eclipse.microprofile.jwt.tck.container.servlet"/>
+                <exclude name="org.eclipse.microprofile.jwt.tck.container.ejb"/>
+                <exclude name="org.eclipse.microprofile.jwt.tck.container.jacc"/>
+            </package>
+        </packages>
         <classes>
-            <class name="org.eclipse.microprofile.jwt.tck.util.TokenUtilsTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.UnsecuredPingTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RequiredClaimsTest"/>
-            <!-- TODO expects injection into custom claims that are NOT JsonValue
-            https://github.com/eclipse/microprofile-jwt-auth/issues/117
-            -->
-            <!--<class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ClaimValueInjectionTest"/>-->
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.JsonValueInjectionTest"/>
-            <!-- TODO expects injection into custom claims that are NOT JsonValue
-            https://github.com/eclipse/microprofile-jwt-auth/issues/117
-            -->
-            <!--<class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.ProviderInjectionTest"/>-->
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.InvalidTokenTest"/>
-            <!-- TODO https://github.com/eclipse/microprofile-jwt-auth/issues/116 -->
-            <!--<class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrimitiveInjectionTest"/>-->
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.PrincipalInjectionTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKSLocationTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsBase64JWKTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsFileLocationURLTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationNoIssTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssNoValidationBadIssTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationTest"/>
-            <class name="org.eclipse.microprofile.jwt.tck.config.IssValidationFailTest"/>
+            <!-- TODO expects server to be running before security is configured
+           https://github.com/eclipse/microprofile-jwt-auth/issues/118
+           -->
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsPEMLocationURLTest">
+                <methods>
+                    <exclude name="validateLocationUrlContents"/>
+                    <exclude name="testKeyAsLocationUrl"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.jwt.tck.config.PublicKeyAsJWKLocationURLTest">
+                <methods>
+                    <exclude name="validateLocationUrlContents"/>
+                    <exclude name="testKeyAsLocationUrl"/>
+                </methods>
+            </class>
+
+            <!-- Optional, we do not support those-->
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest">
+                <methods>
+                    <exclude name="testNeedsGroup1Mapping"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.RolesAllowedTest">
+                <methods>
+                    <exclude name="testNeedsGroup1Mapping"/>
+                </methods>
+            </class>
         </classes>
     </test>
 </suite>

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClientRequestBuilderImpl.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.helidon.common.GenericType;
@@ -204,15 +205,19 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
             for (ChannelRecord channelRecord : channels) {
                 Channel channel = channelRecord.channel;
                 if (channel.isOpen() && channel.attr(IN_USE).get().compareAndSet(false, true)) {
-                    LOGGER.finest(() -> "Reusing -> " + channel.hashCode());
-                    LOGGER.finest(() -> "Setting in use -> true");
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.finest(() -> "Reusing -> " + channel.hashCode() + ", settting in use -> true");
+                    }
                     return channelRecord.channelFuture;
                 }
-                LOGGER.finest(() -> "Not accepted -> " + channel.hashCode());
-                LOGGER.finest(() -> "Open -> " + channel.isOpen());
-                LOGGER.finest(() -> "In use -> " + channel.attr(IN_USE).get());
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest(() -> "Not accepted -> " + channel.hashCode() + ", open -> "
+                            + channel.isOpen() + ", in use -> " + channel.attr(IN_USE).get());
+                }
             }
-            LOGGER.finest(() -> "New connection to -> " + connectionIdent);
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.finest(() -> "New connection to -> " + connectionIdent);
+            }
             URI uri = connectionIdent.base;
             ChannelFuture connect = bootstrap.connect(uri.getHost(), uri.getPort());
             Channel channel = connect.channel();
@@ -225,9 +230,10 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
     }
 
     static void removeChannelFromCache(ConnectionIdent key, Channel channel) {
-        LOGGER.finest(() -> "Removing from channel cache.");
-        LOGGER.finest(() -> "Connection ident -> " + key);
-        LOGGER.finest(() -> "Channel -> " + channel.hashCode());
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest(() -> "Removing from channel cache. Connection ident ->  " + key
+                    + ", channel -> " + channel.hashCode());
+        }
         CHANNEL_CACHE.get(key).remove(new ChannelRecord(channel));
     }
 
@@ -578,8 +584,10 @@ class WebClientRequestBuilderImpl implements WebClientRequestBuilder {
                     : bootstrap.connect(finalUri.getHost(), finalUri.getPort());
 
             channelFuture.addListener((ChannelFutureListener) future -> {
-                LOGGER.finest(() -> "(client reqID: " + requestId + ") "
-                        + "Channel hashcode -> " + channelFuture.channel().hashCode());
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.finest(() -> "(client reqID: " + requestId + ") "
+                            + "Channel hashcode -> " + channelFuture.channel().hashCode());
+                }
                 channelFuture.channel().attr(REQUEST).set(clientRequest);
                 channelFuture.channel().attr(RESPONSE_RECEIVED).set(false);
                 channelFuture.channel().attr(RECEIVED).set(responseReceived);

--- a/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/ForwardingHandler.java
@@ -98,7 +98,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     private CompletableFuture<ChannelFutureListener> requestEntityAnalyzed;
     private CompletableFuture<?> prevRequestFuture;
     private boolean lastContent;
-    private boolean hadContentAlready;
 
     ForwardingHandler(Routing routing,
                       NettyWebServer webServer,
@@ -120,7 +119,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
     private void reset() {
         lastContent = false;
-        hadContentAlready = false;
         isWebSocketUpgrade = false;
         actualPayloadSize = 0L;
         ignorePayload = false;
@@ -263,19 +261,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             // this is here to handle the case when the content is not readable but we didn't
             // exceptionally complete the publisher and close the connection
             throw new IllegalStateException("It is not expected to not have readable content.");
-        } else if (!requestContext.hasRequests()
-                && HttpUtil.isKeepAlive(requestContext.request())
-                && !requestEntityAnalyzed.isDone()) {
-            if (hadContentAlready) {
-                LOGGER.finest(() -> "More than one unhandled content present. Closing the connection.");
-                requestEntityAnalyzed.complete(ChannelFutureListener.CLOSE);
-            } else {
-                //We are checking the unhandled entity, but we cannot be sure if connection should be closed or not.
-                //Next content has to be checked if it is last chunk. If not close connection.
-                hadContentAlready = true;
-                LOGGER.finest(() -> "Requesting the next chunk to determine if the connection should be closed.");
-                ctx.channel().read();
-            }
         }
     }
 
@@ -290,7 +275,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
     @SuppressWarnings("checkstyle:methodlength")
     private boolean channelReadHttpRequest(ChannelHandlerContext ctx, Context requestScope, Object msg) {
-        hadContentAlready = false;
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine(log("Received HttpRequest: %s. Remote address: %s. Scope id: %s",
                                   ctx,
@@ -353,7 +337,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             }
 
             if (publisher.hasRequests()) {
-                LOGGER.finest(() -> log("Requesting next chunks from Netty", ctx));
+                LOGGER.finest(() -> log("Requesting next (%d, %d) chunks from Netty", ctx, n, demand));
                 ctx.channel().read();
             } else {
                 LOGGER.finest(() -> log("No hook action required", ctx));
@@ -366,7 +350,12 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         // If a problem with the request URI, return 400 response
         BareRequestImpl bareRequest;
         try {
-            bareRequest = new BareRequestImpl((HttpRequest) msg, publisher, webServer, ctx, sslEngine, requestId);
+            bareRequest = new BareRequestImpl(request,
+                                              requestContextRef.publisher(),
+                                              webServer,
+                                              ctx,
+                                              sslEngine,
+                                              requestId);
         } catch (IllegalArgumentException e) {
             send400BadRequest(ctx, request, e);
             return true;
@@ -376,9 +365,19 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             LOGGER.finest(log("Request id: %s", ctx, bareRequest.requestId()));
         }
 
+        String contentLength = request.headers().get(HttpHeaderNames.CONTENT_LENGTH);
+
+        if ("0".equals(contentLength)
+                || (contentLength == null
+                             && !"upgrade".equalsIgnoreCase(request.headers().get(HttpHeaderNames.CONNECTION))
+                             && !"chunked".equalsIgnoreCase(request.headers().get(HttpHeaderNames.TRANSFER_ENCODING))
+                             && !"multipart/byteranges".equalsIgnoreCase(request.headers().get(HttpHeaderNames.CONTENT_TYPE)))) {
+            // no entity
+            requestContextRef.complete();
+        }
+
         // If context length is greater than maximum allowed, return 413 response
         if (maxPayloadSize >= 0) {
-            String contentLength = request.headers().get(Http.Header.CONTENT_LENGTH);
             if (contentLength != null) {
                 try {
                     long value = Long.parseLong(contentLength);
@@ -439,6 +438,10 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         LOGGER.fine(log("Response complete: %s", ctx, System.identityHashCode(msg)));
                     }
                 });
+        /*
+        TODO we should only send continue in case the entity is request (e.g. we found a route and user started reading it)
+        This would solve connection close for 404 for requests with entity
+         */
         if (HttpUtil.is100ContinueExpected(request)) {
             send100Continue(ctx, request);
         }
@@ -536,7 +539,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         "");
 
         FullHttpResponse response = toNettyResponse(transportResponse);
-        ctx.write(response);
+        // we should flush this immediately, as we need the client to send entity
+        ctx.writeAndFlush(response);
     }
 
     /**
@@ -555,6 +559,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         t);
 
         FullHttpResponse response = toNettyResponse(handlerResponse);
+        // 400 -> close connection
+        response.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
 
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
@@ -575,6 +581,8 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                         "");
 
         FullHttpResponse response = toNettyResponse(transportResponse);
+        // too big entity -> close connection
+        response.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
 
         ctx.writeAndFlush(response)
                 .addListener(future -> ctx.close());
@@ -596,7 +604,6 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
 
         HttpHeaders nettyHeaders = response.headers();
         headers.forEach(nettyHeaders::add);
-        nettyHeaders.add(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         return response;
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/HttpPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,12 @@ public class HttpPipelineTest {
                         .put("/", (req, res) -> {
                             counter.set(0);
                             log("put server");
-                            res.send();
+                            req.content()
+                                    .as(String.class)
+                                    .forSingle(it -> {
+                                        log("put: " + it);
+                                        res.send();
+                                    });
                         })
                         .get("/", (req, res) -> {
                             log("get server");
@@ -99,8 +104,8 @@ public class HttpPipelineTest {
     public void testPipelining() throws Exception {
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             s.request(Http.Method.PUT, "/");        // reset server
-            s.request(Http.Method.GET, "/");        // request_0
-            s.request(Http.Method.GET, "/");        // request_1
+            s.request(Http.Method.GET, null);        // request_0
+            s.request(Http.Method.GET, null);        // request_1
             log("put client");
             String reset = s.receive();
             assertThat(reset, notNullValue());

--- a/webserver/webserver/src/test/java/io/helidon/webserver/KeepAliveTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/KeepAliveTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.webserver;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.reactive.Multi;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+public class KeepAliveTest {
+    private static WebServer server;
+    private static WebClient webClient;
+
+    @BeforeAll
+    static void setUp() {
+        LogConfig.configureRuntime();
+        server = WebServer.builder()
+                .routing(Routing.builder()
+                                 .register("/close", rules -> rules.any((req, res) -> {
+                                     req.content().forEach(dataChunk -> {
+                                         // consume only first from two chunks
+                                         dataChunk.release();
+                                         throw new RuntimeException("BOOM!");
+                                     }).exceptionally(res::send);
+                                 }))
+                                 .register("/plain", rules -> rules.any((req, res) -> {
+                                     req.content()
+                                             .forEach(DataChunk::release)
+                                             .onComplete(res::send)
+                                             .ignoreElement();
+                                 }))
+                                 .build())
+                .build();
+        server.start().await();
+        String serverUrl = "http://localhost:" + server.port();
+        webClient = WebClient.builder()
+                .baseUri(serverUrl)
+                .keepAlive(true)
+                .build();
+
+    }
+
+    @AfterAll
+    static void afterAll() {
+        server.shutdown();
+    }
+
+    @RepeatedTest(100)
+    void closeWithKeepAliveUnconsumedRequest() {
+        testCall(webClient, true, "/close", 500, HttpHeaderValues.CLOSE, true);
+    }
+
+    @RepeatedTest(100)
+    void sendWithoutKeepAlive() {
+        testCall(webClient, false, "/plain", 200, null, false);
+    }
+
+    @RepeatedTest(100)
+    void sendWithKeepAlive() {
+        testCall(webClient, true, "/plain", 200, HttpHeaderValues.KEEP_ALIVE, false);
+    }
+
+    private static void testCall(WebClient webClient,
+                                 boolean keepAlive,
+                                 String path,
+                                 int expectedStatus,
+                                 AsciiString expectedConnectionHeader,
+                                 boolean ignoreConnectionClose) {
+        WebClientResponse res = null;
+        try {
+            res = webClient
+                    .put()
+                    .keepAlive(keepAlive)
+                    .path(path)
+                    .submit(Multi.interval(10, TimeUnit.MILLISECONDS, Executors.newSingleThreadScheduledExecutor())
+                                    .limit(2)
+                                    .map(l -> "msg_"+ l)
+                                    .map(String::getBytes)
+                                    .map(ByteBuffer::wrap)
+                                    .map(bb -> DataChunk.create(true, true, bb))
+                    )
+                    .await(Duration.ofMinutes(5));
+
+            assertThat(res.status().code(), is(expectedStatus));
+            if (expectedConnectionHeader != null) {
+                assertThat(res.headers().toMap(),
+                           hasEntry(HttpHeaderNames.CONNECTION.toString(), List.of(expectedConnectionHeader.toString())));
+            } else {
+                assertThat(res.headers().toMap(), not(hasKey(HttpHeaderNames.CONNECTION.toString())));
+            }
+            res.content().forEach(DataChunk::release);
+        } catch (CompletionException e) {
+            if (ignoreConnectionClose && e.getMessage().contains("Connection reset")) {
+                // this is an expected (intermittent) result - due to a natural race (between us writing the request
+                // data and server responding), we may either get a response
+                // or the socket may be closed for writing (the reset comes from an attempt to write entity to a closed
+                // socket)
+                return;
+            }
+            throw e;
+        } finally {
+            Optional.ofNullable(res).ifPresent(WebClientResponse::close);
+        }
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/PlainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -256,7 +256,7 @@ public class PlainTest {
     }
 
     @Test
-    public void getWithLargePayloadCausesConnectionClose() throws Exception {
+    public void getWithLargePayloadDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -264,7 +264,7 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("9\nIt works!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
@@ -295,14 +295,14 @@ public class PlainTest {
     }
 
     @Test
-    public void deferredGetWithLargePayloadCausesConnectionClose() throws Exception {
+    public void deferredGetWithLargePayloadDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
             s.request(Http.Method.GET, "/deferred", SocketHttpClient.longData(100_000).toString());
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("d\nI'm deferred!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
@@ -334,7 +334,7 @@ public class PlainTest {
     }
 
     @Test
-    public void unconsumedLargePostDataCausesConnectionClose() throws Exception {
+    public void unconsumedLargePostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -342,12 +342,12 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("15\nPayload not consumed!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 
     @Test
-    public void unconsumedDeferredLargePostDataCausesConnectionClose() throws Exception {
+    public void unconsumedDeferredLargePostDataDoesNotCauseConnectionClose() throws Exception {
         // open
         try (SocketHttpClient s = new SocketHttpClient(webServer)) {
             // get
@@ -355,7 +355,7 @@ public class PlainTest {
 
             // assert
             assertThat(entityFromResponse(s.receive(), true), is("d\nI'm deferred!\n0\n\n"));
-            SocketHttpClient.assertConnectionIsClosed(s);
+            SocketHttpClient.assertConnectionIsOpen(s);
         }
     }
 

--- a/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/ReqEntityAnalyzedTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.webserver;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.common.http.DataChunk;
+import io.helidon.common.http.Http;
+import io.helidon.common.reactive.Multi;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReqEntityAnalyzedTest {
+    private static final Duration TIME_OUT = Duration.ofSeconds(5);
+    static final ExecutorService exec = Executors.newFixedThreadPool(3);
+    private static WebServer server;
+    private static WebClient webClient;
+
+    @BeforeAll
+    static void beforeAll() {
+        server = WebServer.builder()
+                .routing(Routing.builder()
+                        .register("/test", rules -> rules.put((req, res) -> {
+                            req.content()
+                                    .observeOn(exec)
+                                    .forEach(DataChunk::release);
+                            res.send(
+                                    Multi.range(0, 3)
+                                            .observeOn(exec)
+                                            .map(i -> "Server:" + i)
+                                            .map(String::getBytes)
+                                            .map(DataChunk::create)
+                            );
+                        }))
+                        .build())
+                .build();
+        server.start().await(TIME_OUT);
+
+        webClient = WebClient.builder()
+                .keepAlive(true)
+                .baseUri("http://localhost:" + server.port())
+                .build();
+    }
+
+    @RepeatedTest(100)
+    void webClient() {
+        testCall(webClient, Multi.range(0, 3)
+                .map(integer -> "Client:" + integer)
+                .map(String::getBytes)
+                .map(bytes -> DataChunk.create(true, ByteBuffer.wrap(bytes))));
+    }
+
+    private void testCall(WebClient webClient, Multi<DataChunk> payload) {
+        WebClientResponse webClientResponse = null;
+        try {
+            webClientResponse = webClient
+                    .put()
+                    .path("/test")
+                    .submit(payload)
+                    .onError(Throwable::printStackTrace)
+                    .await(TIME_OUT);
+
+            assertThat(webClientResponse.status(), is(Http.Status.OK_200));
+
+            String response = webClientResponse.content()
+                    .as(String.class)
+                    .await(TIME_OUT);
+
+            assertThat(response, is("Server:0Server:1Server:2"));
+        } catch (Exception e) {
+            // this is expected - we do not support parallel read of entity
+            if (e.getMessage().contains("reset by the host")) {
+                return;
+            }
+            throw e;
+        } finally {
+            if (webClientResponse != null) {
+                webClientResponse.close();
+            }
+        }
+    }
+
+    @AfterAll
+    static void afterAll() throws InterruptedException {
+        server.shutdown();
+        exec.shutdownNow();
+        assertTrue(exec.awaitTermination(TIME_OUT.toMillis(), TimeUnit.MILLISECONDS));
+    }
+
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/utils/SocketHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class SocketHttpClient implements AutoCloseable {
      */
     public SocketHttpClient(WebServer webServer) throws IOException {
         socket = new Socket("localhost", webServer.port());
+        socket.setSoTimeout(10000);
     }
 
     /**


### PR DESCRIPTION
Forward port to master.

* Fix wrong connection close
* Reduced logging overhead. Small improvements of tests.
* Consume request entity on valid responses.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

(cherry picked from commit 2a1dd6b7d7b8d0f29fbb33f08ff063c90de27434)