### PR TITLE
Use resource /instance/canonicalRegionName to get region

### DIFF
--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigInstancePrincipal.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigInstancePrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -569,7 +569,7 @@ public class OciConfigInstancePrincipal implements OciConfigProvider {
 
             // returns string, such as eu-frankfurt-1
             return webClient.get()
-                            .path("/instance/region")
+                            .path("/instance/canonicalRegionName")
                             .request(String.class)
                             .await(10, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Use resource /instance/canonicalRegionName to get region and construct auth URL. Using /instance/region is only compatible in certain regions and does not yield a canonical name. See https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>