### PR TITLE
Upgrade dependency-check to 6.5.3 and cleanup suppressions

### DIFF
--- a/etc/dependency-check-suppression.xml
+++ b/etc/dependency-check-suppression.xml
@@ -2,47 +2,14 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 <!-- For information see https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
 
-<!-- Applies to Processing:Processing -->
-<suppress>
-   <notes><![CDATA[
-   file name: jsonp-jaxrs-1.1.6.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.glassfish/jsonp\-jaxrs@.*$</packageUrl>
-   <cpe>cpe:/a:processing:processing</cpe>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.json-api-1.1.6.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.json/jakarta\.json\-api@.*$</packageUrl>
-   <cpe>cpe:/a:processing:processing</cpe>
-</suppress>
-
-<!-- This CVE is against the etcd server. We ship a Java client -->
+<!-- This CVE is against the etcd server. We ship a Java client
+-->
 <suppress>
    <notes><![CDATA[
    file name: etcd4j-2.17.0.jar
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/org\.mousio/etcd4j@.*$</packageUrl>
    <cpe>cpe:/a:etcd:etcd</cpe>
-</suppress>
-
-<!-- This CVE is against the Java Websocket project.  Not the Jakarta WebSocket API.
-     See https://github.com/TooTallNate/Java-WebSocket/security/advisories/GHSA-gw55-jm4h-x339
--->
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.websocket-api-1.1.2.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.websocket/jakarta\.websocket\-api@.*$</packageUrl>
-   <cpe>cpe:/a:java-websocket_project:java-websocket</cpe>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: javax.websocket-api-1.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/javax\.websocket/javax\.websocket\-api@.*$</packageUrl>
-   <cpe>cpe:/a:java-websocket_project:java-websocket</cpe>
 </suppress>
 
 <!-- GraalVM -->
@@ -169,19 +136,6 @@
    <cve>CVE-2022-21366</cve>
 </suppress>
 
-
-<!-- junit 4 -->
-<!-- This CVE is fixed in junit 4.13.1 and only applies when using Java 1.6
-     or earlier. We use version 4.13.1 and require Java 11 or above
-     so this CVE does not apply -->
-<suppress>
-   <notes><![CDATA[
-   file name: junit-4.13.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/junit/junit@.*$</packageUrl>
-   <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
-</suppress>
-
 <!-- grpc -->
 <!-- This was applying the version of opentracing-grpc to grpc
      which triggered CVEs for older versions of grpc and grpc-js
@@ -194,20 +148,8 @@
    <cpe>cpe:/a:grpc:grpc</cpe>
 </suppress>
 
-<!-- Apache HttpClient / Google HTTP Client -->
-<!-- This was associating the Google HTTP client version number to Apache HttpClient generating a false positive for
-     an Apache HttpClient CVE for versions 4.5.12 and earlier (we use 4.5.13 in Helidon).
--->
-<suppress>
-   <notes><![CDATA[
-   file name: google-http-client-apache-v2-1.40.1.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/com\.google\.http\-client/google\-http\-client\-apache\-v2@.*$</packageUrl>
-   <cve>CVE-2020-13956</cve>
-</suppress>
 
-
-<!-- This CVE is against Neo4j through 3.4.18. We use Neo4j 4.2.4
+<!-- This CVE is against Neo4j through 3.4.18. We use Neo4j 4.x
      Helidon's Neo4j integration triggered a false positive due to it's 
      version being < 3.4.18
 -->
@@ -219,28 +161,6 @@
    <cve>CVE-2021-34371</cve>
 </suppress>
 
-<!-- The Neo4j java driver contains a shaded copy of a couple of Netty artifacts.
-     This CVE is against netty-codec-http2 which is not included in the Neo4j driver.
--->
-<suppress>
-   <notes><![CDATA[
-   file name: neo4j-java-driver-4.2.4.jar (shaded: io.netty:netty-transport:4.1.60.Final)
-   ]]></notes>
-   <filePath regex="true">.*/neo4j\-java\-driver\-4\.2\.4\.jar.*</filePath>
-   <cve>CVE-2021-21409</cve>
-</suppress>
-
-<!-- This CVE was fixed in the EL implementations com.sun.el:el-ri:3.0.4 and org.glassfish:jakarta.el:3.0.4
-     which we have upgraded to. But the scan triggers a false positive on the API: jakarta.el:jakarta.el-api:3.0.3 -->
-<suppress>
-   <notes><![CDATA[
-   file name: jakarta.el-api-3.0.3.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/jakarta\.el/jakarta\.el\-api@.*$</packageUrl>
-   <cve>CVE-2021-28170</cve>
-</suppress>
-
-
 <!-- These files are being detected as an old version of Netty and raises false positives for
      a number of old Netty CVEs.
 -->
@@ -250,38 +170,6 @@
    ]]></notes>
    <packageUrl regex="true">^pkg:maven/io\.netty\.incubator/netty\-incubator\-transport\-native\-io_uring@.*$</packageUrl>
    <cpe>cpe:/a:netty:netty</cpe>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: netty-tcnative-classes-2.0.46.Final.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
-   <cpe>cpe:/a:netty:netty</cpe>
-</suppress>
-
-<!-- These are old CVEs related to config components of Eclipse IDE and Jenkins. They are generating
-     false positive for MicroProfile Config
--->
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-config-api-3.0-RC5.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile\-config\-api@.*$</packageUrl>
-   <cve>CVE-2008-7271</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-config-api-3.0-RC5.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile\-config\-api@.*$</packageUrl>
-   <cve>CVE-2010-4647</cve>
-</suppress>
-<suppress>
-   <notes><![CDATA[
-   file name: microprofile-config-api-3.0-RC5.jar
-   ]]></notes>
-   <packageUrl regex="true">^pkg:maven/org\.eclipse\.microprofile\.config/microprofile\-config\-api@.*$</packageUrl>
-   <cve>CVE-2018-1000413</cve>
 </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.plugin.source>3.0.1</version.plugin.source>
         <version.plugin.spotbugs>4.4.2.2</version.plugin.spotbugs>
         <version.plugin.findsecbugs>1.11.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>6.0.2</version.plugin.dependency-check>
+        <version.plugin.dependency-check>6.5.3</version.plugin.dependency-check>
         <version.plugin.surefire>3.0.0-M5</version.plugin.surefire>
         <version.plugin.toolchains>1.1</version.plugin.toolchains>
         <version.plugin.version-plugin>2.3</version.plugin.version-plugin>


### PR DESCRIPTION
Upgrades the version `dependency-check-maven` and removes suppressions that arelonger needed because either: the false positive was fixed in `dependency-check-maven` or upgrading our dependencies removed the false-positive trigger.