### PR TITLE
WIP: Search for @Path annotations in base classes 

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/JaxRsCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.helidon.microprofile.server;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -69,8 +70,8 @@ public class JaxRsCdiExtension implements Extension {
     }
 
     private void collectResourceClasses(@Observes ProcessManagedBean<?> processManagedBean) {
-        if (processManagedBean.getAnnotated().isAnnotationPresent(Path.class)) {
-            Class<?> resourceClass = processManagedBean.getAnnotatedBeanClass().getJavaClass();
+        Class<?> resourceClass = processManagedBean.getAnnotatedBeanClass().getJavaClass();
+        if (hasAnnotation(resourceClass, Path.class)) {
             if (resourceClass.isInterface()) {
                 // we are only interested in classes - interface is most likely a REST client API
                 return;
@@ -316,5 +317,19 @@ public class JaxRsCdiExtension implements Extension {
             throw new IllegalStateException("You are attempting to modify applications in JAX-RS after they were registered "
                                                     + "with the server");
         }
+    }
+
+    /**
+     * Checks presence of annotation on class or any of its superclasses.
+     *
+     * @param clazz the class
+     * @param annotation the annotation
+     * @return outcome of test
+     */
+    private static boolean hasAnnotation(Class<?> clazz, Class<? extends Annotation> annotation) {
+        if (clazz == null || clazz == Object.class) {
+            return false;
+        }
+        return clazz.isAnnotationPresent(annotation) || hasAnnotation(clazz.getSuperclass(), annotation);
     }
 }

--- a/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/BookResource.java
+++ b/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/BookResource.java
@@ -16,9 +16,6 @@
 
 package io.helidon.tests.apps.bookstore.mp;
 
-import io.helidon.tests.apps.bookstore.common.Book;
-import io.helidon.tests.apps.bookstore.common.BookStore;
-
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -33,9 +30,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Collection;
 
-@Path("/books")
+import io.helidon.tests.apps.bookstore.common.Book;
+import io.helidon.tests.apps.bookstore.common.BookStore;
+
+/**
+ * The {@link Path} annotation is inherited from the base class. Note that a
+ * CDI scope annotation such as {@code @RequestScoped} is required given that
+ * discovery mode for this application is annotated.
+ */
 @RequestScoped
-public class BookResource {
+public class BookResource extends BookResourceBase {
 
     private final BookStore bookStore;
 

--- a/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/BookResourceBase.java
+++ b/tests/apps/bookstore/bookstore-mp/src/main/java/io/helidon/tests/apps/bookstore/mp/BookResourceBase.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.apps.bookstore.mp;
+
+import javax.ws.rs.Path;
+
+/**
+ * This class exists only to verify inheritance of {@link Path} to subclass
+ * in this application. This is an extension to the JAX-RS spec supported
+ * by Jersey.
+ */
+@Path("/books")
+public abstract class BookResourceBase {
+}


### PR DESCRIPTION
Search for @Path annotations in base classes when collecting REST resources. Inheritance of these annotations is supported by Jersey and used by some Open API/Swagger code generators.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>