### PR TITLE
Fixed builder created from configuration in OutboundTargetDefinition

### DIFF
--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -318,22 +318,19 @@ public final class OutboundTargetDefinition {
          * @return updated builder instance
          */
         public Builder config(Config config) {
-            Builder builder = new Builder();
-
-            // mandatory
-            builder.keyId(config.get("key-id").asString().get());
-            config.get("header").asString().map(HttpSignHeader::valueOf).ifPresent(builder::header);
-            config.get("sign-headers").as(SignedHeadersConfig::create).ifPresent(builder::signedHeaders);
-            config.get("private-key").as(KeyConfig::create).ifPresent(builder::privateKeyConfig);
-            config.get("hmac.secret").asString().ifPresent(builder::hmacSecret);
+            this.keyId(config.get("key-id").asString().get());      // mandatory
+            config.get("header").asString().map(HttpSignHeader::valueOf).ifPresent(this::header);
+            config.get("sign-headers").as(SignedHeadersConfig::create).ifPresent(this::signedHeaders);
+            config.get("private-key").as(KeyConfig::create).ifPresent(this::privateKeyConfig);
+            config.get("hmac.secret").asString().ifPresent(this::hmacSecret);
 
             // last, as we configure defaults based on configuration
-            config.get("algorithm").asString().ifPresent(builder::algorithm);
+            config.get("algorithm").asString().ifPresent(this::algorithm);
 
             // backward compatibility with previous Helidon versions
             config.get("backward-compatible-eol").asBoolean().ifPresent(this::backwardCompatibleEol);
 
-            return builder;
+            return this;
         }
 
         /**

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OutboundTargetDefinitionTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OutboundTargetDefinitionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.httpsign;
+
+import io.helidon.config.Config;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OutboundTargetDefinitionTest {
+
+    private static final String OUTBOUND_SIGNATURE_KEY = "security.providers.0.http-signatures.outbound.0.signature";
+
+    @Test
+    public void testBuilderFromConfig() {
+        Config config = Config.create();
+        OutboundTargetDefinition.Builder builder =
+                OutboundTargetDefinition.builder(config.get(OUTBOUND_SIGNATURE_KEY));
+        OutboundTargetDefinition d = builder.build();
+        assertThat(d.keyId(), is("rsa-key-12345"));
+        assertThat(d.header(), is(HttpSignHeader.SIGNATURE));
+        assertThat(d.keyConfig().isPresent(), is(true));
+        assertThat(d.signedHeadersConfig(), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
Fixed builder from configuration. Update builder instance instead of creating a new builder. New test.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>