### PR TITLE
Compare origin URLs based on protocol, host and port in CORS

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -719,7 +719,7 @@ class CorsSupportHelper<Q, R> {
                             if (n < 0) {
                                 return false;
                             }
-                            i += n;
+                            j += n;
                             state = CompareState.TRAILING;
                         } else if (c1 != c2) {
                             return false;

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_MAX_AGE
 import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_REQUEST_HEADERS;
 import static io.helidon.webserver.cors.CrossOriginConfig.ACCESS_CONTROL_REQUEST_METHOD;
 import static io.helidon.webserver.cors.LogHelper.DECISION_LEVEL;
+import static java.lang.Character.isDigit;
 
 /**
  * Centralizes internal logic common to both SE and MP CORS support for processing requests and preparing responses.
@@ -432,7 +433,7 @@ class CorsSupportHelper<Q, R> {
         // If enabled but not whitelisted, deny request
         List<String> allowedOrigins = Arrays.asList(crossOriginConfig.allowOrigins());
         Optional<String> originOpt = requestAdapter.firstHeader(ORIGIN);
-        if (!allowedOrigins.contains("*") && !contains(originOpt, allowedOrigins, String::equals)) {
+        if (!allowedOrigins.contains("*") && !contains(originOpt, allowedOrigins, CorsSupportHelper::compareOrigins)) {
             return Optional.of(forbid(requestAdapter,
                     responseAdapter,
                     ORIGIN_NOT_IN_ALLOWED_LIST,
@@ -513,7 +514,7 @@ class CorsSupportHelper<Q, R> {
 
         // If enabled but not whitelisted, deny request
         List<String> allowedOrigins = Arrays.asList(crossOrigin.allowOrigins());
-        if (!allowedOrigins.contains("*") && !contains(originOpt, allowedOrigins, String::equals)) {
+        if (!allowedOrigins.contains("*") && !contains(originOpt, allowedOrigins, CorsSupportHelper::compareOrigins)) {
             return forbid(requestAdapter,
                     responseAdapter,
                     ORIGIN_NOT_IN_ALLOWED_LIST,
@@ -609,6 +610,127 @@ class CorsSupportHelper<Q, R> {
             }
         }
         return false;
+    }
+
+    /**
+     * Extract character at index {@code n} or return {@code '/'} if index is out
+     * of range.
+     *
+     * @param s the string
+     * @param n the index
+     * @param length the string length
+     * @return char at index or {@code '/'}.
+     */
+    static char charAt(String s, int n, int length) {
+        return n < length ? s.charAt(n) : '/';
+    }
+
+    /**
+     * Compare states in {@link #compareOrigins}.
+     */
+    enum CompareState {
+        PROTOCOL, HOST, TRAILING
+    }
+
+    /**
+     * Fast compare of two origins on protocol, host and port but ignoring paths.
+     * Handles default ports 80 and 443 for http and https respectively. Comparison will
+     * fail if origins are malformed.
+     *
+     * @param url1 first URL
+     * @param url2 second URL
+     * @return outcome of test
+     */
+    static Boolean compareOrigins(String url1, String url2) {
+        boolean isHttps = false;
+        int length1 = url1.length();
+        int length2 = url2.length();
+        CompareState state = CompareState.PROTOCOL;
+
+        try {
+            for (int i = 0, j = 0; i < length1 || j < length2; i++, j++) {
+                char c1 = charAt(url1, i, length1);
+                char c2 = charAt(url2, j, length2);
+
+                switch (state) {
+                    case PROTOCOL:
+                        if (c1 != c2) {
+                            return false;
+                        }
+                        if (c1 == ':') {
+                            isHttps = (i == 5);
+                            // Match "//"
+                            if (url1.charAt(i + 1) != url2.charAt(j + 1)
+                                    || url1.charAt(i + 2) != url2.charAt(j + 2)) {
+                                return false;
+                            }
+                            i += 2; j += 2;
+                            state = CompareState.HOST;
+                        }
+                        break;
+                    case HOST:
+                        if (c1 == ':') {
+                            // Handle default port in url2
+                            if (c2 != ':') {
+                                if (isHttps) {
+                                    // Default port must be "443"
+                                    if (url1.charAt(i + 1) != '4'
+                                            || url1.charAt(i + 2) != '4'
+                                            || url1.charAt(i + 3) != '3'
+                                            || isDigit(charAt(url1, i + 4, length1))) {
+                                        return false;
+                                    }
+                                    i += 3;
+                                } else {
+                                    // Default port must be "80"
+                                    if (url1.charAt(i + 1) != '8'
+                                            || url1.charAt(i + 2) != '0'
+                                            || isDigit(charAt(url1, i + 3, length1))) {
+                                        return false;
+                                    }
+                                    i += 2;
+                                }
+                                state = CompareState.TRAILING;
+                            }
+                        } else if (c2 == ':') {
+                            // Handle default port in url1
+                            if (isHttps) {
+                                // Default port must be "443"
+                                if (url2.charAt(j + 1) != '4'
+                                        || url2.charAt(j + 2) != '4'
+                                        || url2.charAt(j + 3) != '3'
+                                        || isDigit(charAt(url2, j + 4, length2))) {
+                                    return false;
+                                }
+                                j += 3;
+                            } else {
+                                // Default port must be "80"
+                                if (url2.charAt(j + 1) != '8'
+                                        || url2.charAt(j + 2) != '0'
+                                        || isDigit(charAt(url2, j + 3, length2))) {
+                                    return false;
+                                }
+                                j += 2;
+                            }
+                            state = CompareState.TRAILING;
+                        } else if (c1 != c2) {
+                            return false;
+                        } else if (c1 == '/' || (i == length1 - 1 && j == length2 - 1)) {
+                            state = CompareState.TRAILING;
+                        }
+                        break;
+                    case TRAILING:
+                        // Ignore trailing characters
+                        break;
+                    default:
+                        throw new IllegalStateException("Unknown state");
+                }
+            }
+        } catch (IndexOutOfBoundsException e) {
+            return false;
+        }
+
+        return state == CompareState.TRAILING;
     }
 
     /**

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -660,8 +660,10 @@ class CorsSupportHelper<Q, R> {
                         if (c1 == ':') {
                             isHttps = (i == 5);
                             // Match "//"
-                            if (url1.charAt(i + 1) != url2.charAt(j + 1)
-                                    || url1.charAt(i + 2) != url2.charAt(j + 2)) {
+                            if (url1.charAt(i + 1) != '/'
+                                    || url1.charAt(i + 2) != '/'
+                                    || url2.charAt(j + 1) != '/'
+                                    || url2.charAt(j + 2) != '/') {
                                 return false;
                             }
                             i += 2;

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/CorsSupportHelper.java
@@ -664,7 +664,8 @@ class CorsSupportHelper<Q, R> {
                                     || url1.charAt(i + 2) != url2.charAt(j + 2)) {
                                 return false;
                             }
-                            i += 2; j += 2;
+                            i += 2;
+                            j += 2;
                             state = CompareState.HOST;
                         }
                         break;

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
@@ -70,6 +70,9 @@ public class CompareOriginsTest {
         assertThat(compareOrigins("http://localhost/", "http://remotehost/"), is(false));
         assertThat(compareOrigins("https://localhost:443/", "https://remotehost/"), is(false));
         assertThat(compareOrigins("https://localhost/", "https://remotehost:443/"), is(false));
+        assertThat(compareOrigins("http://localhost", "https://localhost"), is(false));
+        assertThat(compareOrigins("http://localhost/", "http://localhost:443/"), is(false));
+        assertThat(compareOrigins("https://localhost/", "https://localhost:80/"), is(false));
     }
 
     @Test
@@ -77,6 +80,8 @@ public class CompareOriginsTest {
         assertThat(compareOrigins("foo", "foo"), is(false));
         assertThat(compareOrigins("http://", "http://"), is(false));
         assertThat(compareOrigins("http://localhost", "http://"), is(false));
+        assertThat(compareOrigins("http://localhost", "pttp://"), is(false));
+        assertThat(compareOrigins("", ""), is(false));
     }
 
 }

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.webserver.cors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static io.helidon.webserver.cors.CorsSupportHelper.compareOrigins;
+
+public class CompareOriginsTest {
+
+    @Test
+    void compareOriginSimpleTest() {
+        assertThat(compareOrigins("http://localhost", "http://localhost"), is(true));
+        assertThat(compareOrigins("http://localhost/", "http://localhost/"), is(true));
+        assertThat(compareOrigins("http://localhost/foo", "http://localhost/foo"), is(true));
+        assertThat(compareOrigins("http://localhost/foo", "http://localhost/bar"), is(true));
+        assertThat(compareOrigins("http://localhost:8080", "http://localhost:8080"), is(true));
+        assertThat(compareOrigins("http://localhost:8080/", "http://localhost:8080/"), is(true));
+        assertThat(compareOrigins("http://localhost:8080/foo", "http://localhost:8080/foo"), is(true));
+        assertThat(compareOrigins("http://localhost:8080/foo", "http://localhost:8080/bar"), is(true));
+    }
+
+    @Test
+    void compareOriginComplexTest() {
+        assertThat(compareOrigins("http://localhost", "http://localhost:80/foo"), is(true));
+        assertThat(compareOrigins("http://localhost/", "http://localhost:80/bar"), is(true));
+        assertThat(compareOrigins("https://localhost", "https://localhost:443/foo/bar/baz"), is(true));
+        assertThat(compareOrigins("http://localhost/", "http://localhost:80/foo/bar/baz"), is(true));
+    }
+
+    @Test
+    void compareOriginsPortsTest() {
+        assertThat(compareOrigins("http://localhost:80", "http://localhost"), is(true));
+        assertThat(compareOrigins("http://localhost", "http://localhost:80"), is(true));
+        assertThat(compareOrigins("https://localhost:443", "https://localhost"), is(true));
+        assertThat(compareOrigins("https://localhost", "https://localhost:443"), is(true));
+        assertThat(compareOrigins("http://localhost:80/", "http://localhost/"), is(true));
+        assertThat(compareOrigins("http://localhost/", "http://localhost:80/"), is(true));
+        assertThat(compareOrigins("https://localhost:443/", "https://localhost/"), is(true));
+        assertThat(compareOrigins("https://localhost/", "https://localhost:443/"), is(true));
+    }
+
+    @Test
+    void compareOriginsNegativeTest() {
+        assertThat(compareOrigins("http://localhost:8080", "http://localhost"), is(false));
+        assertThat(compareOrigins("http://localhost", "http://localhost:8080"), is(false));
+        assertThat(compareOrigins("https://localhost:443", "http://localhost"), is(false));
+        assertThat(compareOrigins("http://localhost", "https://localhost:443"), is(false));
+        assertThat(compareOrigins("http://localhost", "http://remotehost/"), is(false));
+        assertThat(compareOrigins("http://localhost/", "http://remotehost/"), is(false));
+        assertThat(compareOrigins("https://localhost:443/", "https://remotehost/"), is(false));
+        assertThat(compareOrigins("https://localhost/", "https://remotehost:443/"), is(false));
+    }
+
+    @Test
+    void compareOriginsMalformedTest() {
+        assertThat(compareOrigins("foo", "foo"), is(false));
+        assertThat(compareOrigins("http://", "http://"), is(false));
+        assertThat(compareOrigins("http://localhost", "http://"), is(false));
+    }
+
+}

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CompareOriginsTest.java
@@ -42,6 +42,10 @@ public class CompareOriginsTest {
         assertThat(compareOrigins("http://localhost/", "http://localhost:80/bar"), is(true));
         assertThat(compareOrigins("https://localhost", "https://localhost:443/foo/bar/baz"), is(true));
         assertThat(compareOrigins("http://localhost/", "http://localhost:80/foo/bar/baz"), is(true));
+        assertThat(compareOrigins("http://localhost:80/foo", "http://localhost"), is(true));
+        assertThat(compareOrigins("http://localhost:80/bar", "http://localhost/"), is(true));
+        assertThat(compareOrigins("https://localhost:443/foo/bar/baz", "https://localhost"), is(true));
+        assertThat(compareOrigins("http://localhost:80/foo/bar/baz", "http://localhost/"), is(true));
     }
 
     @Test


### PR DESCRIPTION
Compare origin URLs based on protocol, host and port (including default ports) and ignoring any trailing paths.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>