### PR TITLE
Add check for misplaced @CrossOrigin annotation; improve request-time performance

### DIFF
--- a/docs/mp/cors/02_using-cors.adoc
+++ b/docs/mp/cors/02_using-cors.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -75,10 +75,18 @@ To add CORS support to your Helidon MP application:
 == Adding CORS Support to Your Helidon MP Application
 Adding CORS behavior to your Helidon MP application involves two simple changes to your application code:
 
-. For each resource and subresource in each resource class, make sure you have a Java method annotated with
-`@OPTIONS` and with the correct `@Path`. Create these methods for each resource if you do not already have them.
+. For each resource and subresource in each resource class--in other words, for each path your resource class supports--make sure you have a Java method annotated with
+`@OPTIONS` and with the correct `@Path`. Create these methods for each resource (for each path) if you do not already have them.
 . To each of those methods, add a `@CrossOrigin` annotation that describes the cross-origin sharing you want
 for that resource.
+
+[NOTE]
+.Using @CrossOrigin Correctly
+====
+Use the `@CrossOrigin` annotation _only_ on methods which also have the `@OPTIONS` annotation. Remember that the `@CrossOrigin` settings apply to a given path and therefore to all Java resource methods which share that path.
+
+Helidon MP aborts the server start-up if a resource method other than an `@OPTIONS` method has the `@CrossOrigin` annotation.
+====
 
 The Helidon MP CORS implementation automatically uses the `@CrossOrigin` annotation you add to each `@OPTIONS` method to
 enforce cross-origin sharing behavior for the resource identified by that method's `@Path` annotation.

--- a/docs/mp/cors/02_using-cors.adoc
+++ b/docs/mp/cors/02_using-cors.adoc
@@ -73,11 +73,14 @@ To add CORS support to your Helidon MP application:
 
 
 == Adding CORS Support to Your Helidon MP Application
-Adding CORS behavior to your Helidon MP application involves two simple changes to your application code:
+Adding CORS behavior to your Helidon MP application involves three simple steps:
 
-. For each resource and subresource in each resource class--in other words, for each path your resource class supports--make sure you have a Java method annotated with
+For reach resource class in your application:
+
+. Identify the resources and subresources--in other words, the paths--supported in each.
+. For each of those resources and subresources make sure you have a Java method annotated with
 `@OPTIONS` and with the correct `@Path`. Create these methods for each resource (for each path) if you do not already have them.
-. To each of those methods, add a `@CrossOrigin` annotation that describes the cross-origin sharing you want
+. To each of those `@OPTIONS` methods add a `@CrossOrigin` annotation that describes the cross-origin sharing you want
 for that resource.
 
 [NOTE]

--- a/microprofile/cors/pom.xml
+++ b/microprofile/cors/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -55,6 +55,14 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-cors</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsCdiExtension.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsCdiExtension.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.cors;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.ProcessManagedBean;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.Path;
+
+import io.helidon.config.Config;
+import io.helidon.config.mp.MpConfig;
+import io.helidon.webserver.cors.CrossOriginConfig;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
+
+/**
+ * CDI extension for processing CORS-annotated types.
+ * <p>
+ *     Pre-computes the {@link CrossOriginConfig} for each method which should have one and makes sure that the
+ *     {@link CrossOrigin} annotation appears only on methods which also have {@code OPTIONS}.
+ * </p>
+ */
+public class CorsCdiExtension implements Extension {
+
+    /**
+     * Key used for retrieving CORS-related configuration from MP configuration.
+     */
+    public static final String CORS_CONFIG_KEY = "cors";
+
+    private Supplier<Optional<CrossOriginConfig>> supplierOfCrossOriginConfigFromAnnotation;
+
+    private CorsSupportMp corsSupportMp;
+
+    private final Set<AnnotatedType<?>> annotatedTypes = new HashSet<>();
+    private final Set<Method> methodsWithCrossOriginIncorrectlyUsed = new HashSet<>();
+    private final Map<Method, CrossOriginConfig> corsConfigs = new HashMap<>();
+
+    void recordCrossOrigin(@Observes @WithAnnotations(CrossOrigin.class) ProcessAnnotatedType<?> pat) {
+        annotatedTypes.add(pat.getAnnotatedType());
+    }
+
+    void processManagedBean(@Observes ProcessManagedBean<?> pmb) {
+        if (annotatedTypes.contains(pmb.getAnnotatedBeanClass())) {
+            pmb.getAnnotatedBeanClass().getMethods().forEach(am -> {
+                Method method = am.getJavaMember();
+                if (am.isAnnotationPresent(CrossOrigin.class) && !am.isAnnotationPresent(OPTIONS.class)) {
+                    methodsWithCrossOriginIncorrectlyUsed.add(method);
+                } else {
+                    crossOriginConfigFromAnnotationOnAssociatedMethod(method)
+                            .ifPresent(crossOriginConfig -> corsConfigs.put(method,
+                                                                            crossOriginConfig));
+                }
+            });
+        }
+    }
+
+    void recordSupplierOfCrossOriginConfigFromAnnotation(Supplier<Optional<CrossOriginConfig>> supplier) {
+        supplierOfCrossOriginConfigFromAnnotation = supplier;
+    }
+
+    void ready(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object adv) {
+
+        if (!methodsWithCrossOriginIncorrectlyUsed.isEmpty()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s annotation is valid only on @OPTIONS methods; found incorrectly on the following methods:%n%s",
+                            CrossOrigin.class.getSimpleName(),
+                            methodsWithCrossOriginIncorrectlyUsed));
+        }
+
+        Config corsConfig = MpConfig.toHelidonConfig(ConfigProvider.getConfig()).get(CORS_CONFIG_KEY);
+
+        CorsSupportMp.Builder corsBuilder = CorsSupportMp.builder();
+        corsConfig.ifExists(corsBuilder::mappedConfig);
+        corsSupportMp = corsBuilder
+                .secondaryLookupSupplier(this::deferringSecondaryLookupSupplier)
+                .build();
+    }
+
+    Optional<CrossOriginConfig> crossOriginConfig(Method method) {
+        return Optional.ofNullable(corsConfigs.get(method));
+    }
+
+    CorsSupportMp corsSupportMp() {
+        return corsSupportMp;
+    }
+
+    private Optional<CrossOriginConfig> deferringSecondaryLookupSupplier() {
+        /*
+         * The CrossOriginFilter instance is not created yet when this extension is initialized, but only the
+         * filter knows the active resource method which this code uses to look up the correct CORS config.
+         * To work around that, we register a deferring supplier with the CorsMpSupport.Builder (in the @Initialized observer).
+         * When the filter is instantiated, it registers its own supplier with this extension. The deferring supplier
+         * invokes the filter's supplier, which the filter has registered by the time we need it.
+         */
+        return supplierOfCrossOriginConfigFromAnnotation.get();
+    }
+
+    private Optional<CrossOriginConfig> crossOriginConfigFromAnnotationOnAssociatedMethod(Method resourceMethod) {
+
+        /*
+         * Only @OPTIONS methods should bear the @CrossOrigin annotation, but the annotation on such methods applies to
+         * all methods sharing the same path.
+         */
+        Class<?> resourceClass = resourceMethod.getDeclaringClass();
+
+        CrossOrigin corsAnnot;
+        OPTIONS optsAnnot = resourceMethod.getAnnotation(OPTIONS.class);
+        Path pathAnnot = resourceMethod.getAnnotation(Path.class);
+        if (optsAnnot != null) {
+            corsAnnot = resourceMethod.getAnnotation(CrossOrigin.class);
+        } else {
+            // Find the @OPTIONS method with the same path as the resource method, if any. That one might have a
+            // @CrossOrigin annotation which applies to the resource method.
+            Optional<Method> optionsMethod = Arrays.stream(resourceClass.getDeclaredMethods())
+                    .filter(m -> {
+                        OPTIONS optsAnnot2 = m.getAnnotation(OPTIONS.class);
+                        Path pathAnnot2 = m.getAnnotation(Path.class);
+                        if (optsAnnot2 != null) {
+                            if (pathAnnot != null) {
+                                return pathAnnot2 != null && pathAnnot.value()
+                                        .equals(pathAnnot2.value());
+                            }
+                            return pathAnnot2 == null;
+                        }
+                        return false;
+                    })
+                    .findFirst();
+            corsAnnot = optionsMethod.map(m -> m.getAnnotation(CrossOrigin.class))
+                    .orElse(null);
+        }
+        return Optional.ofNullable(corsAnnot == null ? null : annotationToConfig(corsAnnot));
+    }
+
+    private static CrossOriginConfig annotationToConfig(CrossOrigin crossOrigin) {
+        return CrossOriginConfig.builder()
+                .allowOrigins(crossOrigin.value())
+                .allowHeaders(crossOrigin.allowHeaders())
+                .exposeHeaders(crossOrigin.exposeHeaders())
+                .allowMethods(crossOrigin.allowMethods())
+                .allowCredentials(crossOrigin.allowCredentials())
+                .maxAgeSeconds(crossOrigin.maxAge())
+                .build();
+    }
+
+}

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsCdiExtension.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CorsCdiExtension.java
@@ -57,7 +57,7 @@ public class CorsCdiExtension implements Extension {
     /**
      * Key used for retrieving CORS-related configuration from MP configuration.
      */
-    public static final String CORS_CONFIG_KEY = "cors";
+    static final String CORS_CONFIG_KEY = "cors";
 
     private Supplier<Optional<CrossOriginConfig>> supplierOfCrossOriginConfigFromAnnotation;
 

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/CrossOriginFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,10 @@
 
 package io.helidon.microprofile.cors;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Optional;
 
 import javax.annotation.Priority;
-import javax.ws.rs.OPTIONS;
-import javax.ws.rs.Path;
+import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -32,12 +29,9 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
-import io.helidon.config.Config;
 import io.helidon.microprofile.cors.CorsSupportMp.RequestAdapterMp;
 import io.helidon.microprofile.cors.CorsSupportMp.ResponseAdapterMp;
 import io.helidon.webserver.cors.CrossOriginConfig;
-
-import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * Class CrossOriginFilter.
@@ -45,82 +39,30 @@ import org.eclipse.microprofile.config.ConfigProvider;
 @Priority(Priorities.HEADER_DECORATOR)
 class CrossOriginFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
-    /**
-     * Key used for retrieving CORS-related configuration from MP configuration.
-     */
-    public static final String CORS_CONFIG_KEY = "cors";
-
     @Context
     private ResourceInfo resourceInfo;
 
-    private final CorsSupportMp cors;
+    private CorsCdiExtension corsCdiExtension;
 
     CrossOriginFilter() {
-        Config config = (Config) ConfigProvider.getConfig();
-
-        CorsSupportMp.Builder corsBuilder = CorsSupportMp.builder();
-        config.get(CORS_CONFIG_KEY).ifExists(corsBuilder::mappedConfig);
-        cors = corsBuilder
-                .secondaryLookupSupplier(this::crossOriginFromAnnotationSupplier)
-                .build();
+        corsCdiExtension = CDI.current().getBeanManager().getExtension(CorsCdiExtension.class);
+        corsCdiExtension.recordSupplierOfCrossOriginConfigFromAnnotation(this::crossOriginConfigFromAnnotationSupplier);
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        Optional<Response> response = cors.processRequest(new RequestAdapterMp(requestContext), new ResponseAdapterMp());
+        Optional<Response> response = corsCdiExtension.corsSupportMp()
+                .processRequest(new RequestAdapterMp(requestContext), new ResponseAdapterMp());
         response.ifPresent(requestContext::abortWith);
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
-        cors.prepareResponse(new RequestAdapterMp(requestContext), new ResponseAdapterMp(responseContext));
+        corsCdiExtension.corsSupportMp()
+                .prepareResponse(new RequestAdapterMp(requestContext), new ResponseAdapterMp(responseContext));
     }
 
-    Optional<CrossOriginConfig> crossOriginFromAnnotationSupplier() {
-
-        // If not found, inspect resource matched
-        Method resourceMethod = resourceInfo.getResourceMethod();
-        Class<?> resourceClass = resourceInfo.getResourceClass();
-
-        // Not available if matching failed and error response is returned
-        if (resourceClass == null || resourceMethod == null) {
-            return Optional.empty();
-        }
-
-        CrossOrigin corsAnnot;
-        OPTIONS optsAnnot = resourceMethod.getAnnotation(OPTIONS.class);
-        Path pathAnnot = resourceMethod.getAnnotation(Path.class);
-        if (optsAnnot != null) {
-            corsAnnot = resourceMethod.getAnnotation(CrossOrigin.class);
-        } else {
-            Optional<Method> optionsMethod = Arrays.stream(resourceClass.getDeclaredMethods())
-                    .filter(m -> {
-                        OPTIONS optsAnnot2 = m.getAnnotation(OPTIONS.class);
-                        Path pathAnnot2 = m.getAnnotation(Path.class);
-                        if (optsAnnot2 != null) {
-                            if (pathAnnot != null) {
-                                return pathAnnot2 != null && pathAnnot.value()
-                                        .equals(pathAnnot2.value());
-                            }
-                            return pathAnnot2 == null;
-                        }
-                        return false;
-                    })
-                    .findFirst();
-            corsAnnot = optionsMethod.map(m -> m.getAnnotation(CrossOrigin.class))
-                    .orElse(null);
-        }
-        return Optional.ofNullable(corsAnnot == null ? null : annotationToConfig(corsAnnot));
-    }
-
-    private static CrossOriginConfig annotationToConfig(CrossOrigin crossOrigin) {
-        return CrossOriginConfig.builder()
-            .allowOrigins(crossOrigin.value())
-            .allowHeaders(crossOrigin.allowHeaders())
-            .exposeHeaders(crossOrigin.exposeHeaders())
-            .allowMethods(crossOrigin.allowMethods())
-            .allowCredentials(crossOrigin.allowCredentials())
-            .maxAgeSeconds(crossOrigin.maxAge())
-            .build();
+    Optional<CrossOriginConfig> crossOriginConfigFromAnnotationSupplier() {
+        return corsCdiExtension.crossOriginConfig(resourceInfo.getResourceMethod());
     }
 }

--- a/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
+++ b/microprofile/cors/src/main/java/io/helidon/microprofile/cors/package-info.java
@@ -17,7 +17,7 @@
 /**
  * <h1>Helidon MP CORS Support</h1>
  * Adding the Helidon MP CORS module to your application enables CORS support automatically, implementing the configuration in
- * the {@value io.helidon.microprofile.cors.CrossOriginFilter#CORS_CONFIG_KEY} section of your MicroProfile configuration.
+ * the {@value io.helidon.microprofile.cors.CorsCdiExtension#CORS_CONFIG_KEY} section of your MicroProfile configuration.
  * <p>
  * Many MP developers will use the {@link io.helidon.microprofile.cors.CrossOrigin} annotation on the endpoint implementations in
  * their code to set up the CORS behavior, but any values in configuration will override the annotations or set up CORS for

--- a/microprofile/cors/src/main/java/module-info.java
+++ b/microprofile/cors/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ module io.helidon.microprofile.cors {
 
     requires java.ws.rs;
     requires io.helidon.config;
+    requires io.helidon.config.mp;
     requires io.helidon.webserver.cors;
 
     // Following to help with JavaDoc...
@@ -33,8 +34,13 @@ module io.helidon.microprofile.cors {
     requires jersey.common;
     requires microprofile.config.api;
 
+    requires jakarta.enterprise.cdi.api;
+    requires jakarta.interceptor.api;
+
     exports io.helidon.microprofile.cors;
 
     provides org.glassfish.jersey.internal.spi.AutoDiscoverable
             with io.helidon.microprofile.cors.CrossOriginAutoDiscoverable;
+
+    provides javax.enterprise.inject.spi.Extension with io.helidon.microprofile.cors.CorsCdiExtension;
 }

--- a/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestAnnotation.java
+++ b/microprofile/cors/src/test/java/io/helidon/microprofile/cors/TestAnnotation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.microprofile.cors;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestAnnotation {
+
+    private SeContainer seContainer;
+
+    @Test
+    void checkBadAnnotationHandling() {
+
+        SeContainerInitializer initializer = SeContainerInitializer.newInstance();
+        initializer.addBeanClasses(CorsResourceWithBadAnnotation.class);
+
+        try {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+                    seContainer = initializer.initialize());
+            assertThat("Exception error message",
+                       e.getMessage(),
+                       allOf(containsString("annotation is valid only on @OPTIONS methods"),
+                             containsString(CorsResourceWithBadAnnotation.class.getName())));
+
+        } finally {
+            if (seContainer != null) {
+                seContainer.close();
+            }
+        }
+    }
+
+    @RequestScoped
+    @Path("/cors1")
+    static class CorsResourceWithBadAnnotation {
+
+        // The following @CrossOrigin should trigger an error during start-up annotation processing
+        // because it is not on an @OPTIONS method.
+        @CrossOrigin(value = {"http://foo.bar", "http://bar.foo"},
+                     allowMethods = {"PUT"})
+        @PUT
+        @Path("/subpath")
+        public Response put() {
+            return Response.ok().build();
+        }
+
+        @GET
+        public Response get() {
+            return Response.ok().build();
+        }
+
+        @OPTIONS
+        @CrossOrigin(value = {"http://foo.bar", "http://bar.foo"},
+                     allowMethods = {"PUT"})
+        @Path("/subpath")
+        public void optionsForSubpath() {
+        }
+
+        @OPTIONS
+        @CrossOrigin()
+        public void optionsForMainPath() {
+        }
+    }
+}

--- a/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
+++ b/microprofile/cors/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+mp.initializer.allow=true


### PR DESCRIPTION
Resolves #3655 

1. Add a new CDI extension for CORS which does two things:
   a. Aborts start-up with a clear message if any Java method with a `@CrossOrigin` annotation does not also have the `@OPTIONS` annotation. The code previously threw accurate but not-very-helpful exceptions. 
  b. Prepares data structures in observer methods which speed up processing at request time.
2. Refactor the CORS-related JAX-RS filter slightly to delegate to the new CDI extension.
3. Update the MP CORS doc to emphasize proper practice and mention the new start-up failure in case of user error with the `@CrossOrigin` annotation.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>