### PR TITLE
Add HEAD support to health endpoints (2.x)

### DIFF
--- a/docs/mp/health/01_introduction.adoc
+++ b/docs/mp/health/01_introduction.adoc
@@ -87,7 +87,7 @@ provides these endpoints automatically as part of every MP microservice.
 External management tools (or `curl` or browsers) retrieve liveness via `/health/live` and
 readiness via `/health/ready`.
 
-Responses from the health endpoints report `200` (OK) or `503` (service unavailable) depending on the outcome of running the health checks.
+Responses from the health endpoints report `200` (OK), `204` (no content), or `503` (service unavailable) depending on the outcome of running the health checks.
 HTTP `GET` responses include JSON content showing the detailed results of all the health checks which the server executed after receiving the request.
 HTTP `HEAD` requests return only the status with no payload.
 

--- a/docs/mp/health/01_introduction.adoc
+++ b/docs/mp/health/01_introduction.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -86,6 +86,10 @@ provides these endpoints automatically as part of every MP microservice.
 
 External management tools (or `curl` or browsers) retrieve liveness via `/health/live` and
 readiness via `/health/ready`.
+
+Responses from the health endpoints report `200` (OK) or `503` (service unavailable) depending on the outcome of running the health checks.
+HTTP `GET` responses include JSON content showing the detailed results of all the health checks which the server executed after receiving the request.
+HTTP `HEAD` requests return only the status with no payload.
 
 The following table summarizes the two types of health checks in MicroProfile Health.
 

--- a/docs/se/health/01_health.adoc
+++ b/docs/se/health/01_health.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -126,8 +126,8 @@ HealthCheck hc = this::exampleHealthCheck;
 | `500` | An error occurred while reporting the health.
 |=======
 
-The HTTP response also contains a JSON payload that describes the statuses for
- all health checks.
+HTTP `GET` responses include JSON content showing the detailed results of all the health checks which the server executed after receiving the request.
+HTTP `HEAD` requests return only the status with no payload.
 
 [source,java]
 .Create the health support service:

--- a/docs/se/health/01_health.adoc
+++ b/docs/se/health/01_health.adoc
@@ -121,7 +121,8 @@ HealthCheck hc = this::exampleHealthCheck;
 [cols="1,5",role="flex, sm7"]
 .Health status codes
 |=======
-| `200` | The application is healthy.
+| `200` | The application is healthy (with health check details in the response).
+| `204` | The application is healthy (with _no_ health check details in the response).
 | `503` | The application is not healthy.
 | `500` | An error occurred while reporting the health.
 |=======

--- a/health/health/pom.xml
+++ b/health/health/pom.xml
@@ -83,5 +83,10 @@
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,24 +132,47 @@ public final class HealthSupport implements Service {
             return;
         }
         rules.any(webContext, corsEnabledServiceHelper.processor())
-                .get(webContext, this::callAll)
-                .get(webContext + "/live", this::callLiveness)
-                .get(webContext + "/ready", this::callReadiness);
+                .get(webContext, this::getAll)
+                .get(webContext + "/live", this::getLiveness)
+                .get(webContext + "/ready", this::getReadiness)
+                .head(webContext, this::headAll)
+                .head(webContext + "/live", this::headLiveness)
+                .head(webContext + "/ready", this::headReadiness);
     }
 
-    private void callAll(ServerRequest req, ServerResponse res) {
-        invoke(res, allChecks);
+    private void getAll(ServerRequest req, ServerResponse res) {
+        get(res, allChecks);
     }
 
-    private void callLiveness(ServerRequest req, ServerResponse res) {
-        invoke(res, livenessChecks);
+    private void getLiveness(ServerRequest req, ServerResponse res) {
+        get(res, livenessChecks);
     }
 
-    private void callReadiness(ServerRequest req, ServerResponse res) {
-        invoke(res, readinessChecks);
+    private void getReadiness(ServerRequest req, ServerResponse res) {
+        get(res, readinessChecks);
     }
 
-    void invoke(ServerResponse res, List<HealthCheck> healthChecks) {
+    private void headAll(ServerRequest req, ServerResponse res) {
+        head(res, allChecks);
+    }
+
+    private void headLiveness(ServerRequest req, ServerResponse res) {
+        head(res, livenessChecks);
+    }
+
+    private void headReadiness(ServerRequest req, ServerResponse res) {
+        head(res, readinessChecks);
+    }
+
+    private void get(ServerResponse res, List<HealthCheck> healthChecks) {
+        invoke(res, healthChecks, true);
+    }
+
+    private void head(ServerResponse res, List<HealthCheck> healthChecks) {
+        invoke(res, healthChecks, false);
+    }
+
+    void invoke(ServerResponse res, List<HealthCheck> healthChecks, boolean sendDetails) {
         // timeout on the asynchronous execution
         Single<HealthResponse> result = timeout.invoke(() -> async.invoke(() -> callHealthChecks(healthChecks)));
 
@@ -162,9 +185,12 @@ public final class HealthSupport implements Service {
 
         result.thenAccept(hres -> {
             res.status(hres.status());
-            res.send(jsonpWriter.marshall(hres.json));
+            if (sendDetails) {
+                res.send(jsonpWriter.marshall(hres.json));
+            } else {
+                res.send();
+            }
         });
-
     }
 
     HealthResponse callHealthChecks(List<HealthCheck> healthChecks) {

--- a/health/health/src/main/java/io/helidon/health/HealthSupport.java
+++ b/health/health/src/main/java/io/helidon/health/HealthSupport.java
@@ -184,7 +184,11 @@ public final class HealthSupport implements Service {
         });
 
         result.thenAccept(hres -> {
-            res.status(hres.status());
+            int status = hres.status().code();
+            if (status == Http.Status.OK_200.code() && !sendDetails) {
+                status = Http.Status.NO_CONTENT_204.code();
+            }
+            res.status(status);
             if (sendDetails) {
                 res.send(jsonpWriter.marshall(hres.json));
             } else {

--- a/health/health/src/test/java/io/helidon/health/HealthServerTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthServerTest.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonObject;
 
+import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.media.common.MessageBodyReadableContent;
 import io.helidon.media.jsonp.JsonpSupport;
@@ -113,7 +114,8 @@ class HealthServerTest {
                     .request()
                     .await();
 
-            assertThat("health response status", response.status().code(), is(200));
+            int expectedStatus = expectContent ? Http.Status.OK_200.code() : Http.Status.NO_CONTENT_204.code();
+            assertThat("health response status", response.status().code(), is(expectedStatus));
             MessageBodyReadableContent content = response.content();
             String textContent = null;
             try {

--- a/health/health/src/test/java/io/helidon/health/HealthServerTest.java
+++ b/health/health/src/test/java/io/helidon/health/HealthServerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.health;
+
+import java.io.StringReader;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import io.helidon.common.http.MediaType;
+import io.helidon.media.common.MessageBodyReadableContent;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+import io.helidon.webclient.WebClientRequestBuilder;
+import io.helidon.webclient.WebClientResponse;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.Service;
+import io.helidon.webserver.WebServer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+class HealthServerTest {
+
+    private static final Logger LOGGER = Logger.getLogger(HealthServerTest.class.getName());
+
+    private static WebServer webServer;
+
+    private static WebClient webClient;
+
+    @BeforeAll
+    static void startup() throws InterruptedException, ExecutionException, TimeoutException {
+        HealthSupport healthSupport = HealthSupport.builder().build();
+        webServer = startServer(healthSupport);
+        webClient = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port() + "/")
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+    }
+
+    @AfterAll
+    static void shutdown() {
+        shutdownServer(webServer);
+    }
+
+    @Test
+    void testGetAll() {
+        checkResponse(webClient::get, "health", true);
+    }
+
+    @Test
+    void testHeadAll() {
+        checkResponse(webClient::head, "health", false);
+    }
+
+    @Test
+    void testGetLive() {
+        checkResponse(webClient::get, "health/live", true);
+    }
+
+    @Test
+    void testHeadLive() {
+        checkResponse(webClient::head, "health/live", false);
+    }
+
+    @Test
+    void testGetReady() {
+        checkResponse(webClient::get, "health/ready", true);
+    }
+
+    @Test
+    void testHeadReady() {
+        checkResponse(webClient::head, "health/ready", false);
+    }
+
+
+    private static void checkResponse(Supplier<WebClientRequestBuilder> requestFactory,
+                                      String requestPath,
+                                      boolean expectContent) {
+
+        WebClientResponse response = null;
+
+        try {
+            response = requestFactory.get()
+                    .path(requestPath)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .request()
+                    .await();
+
+            assertThat("health response status", response.status().code(), is(200));
+            MessageBodyReadableContent content = response.content();
+            String textContent = null;
+            try {
+                textContent = content.as(String.class).get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+
+            assertThat("content length", textContent.length(), expectContent ? greaterThan(0) : equalTo(0));
+
+            if (expectContent) {
+                JsonObject health = Json.createReader(new StringReader(textContent)).readObject();
+                assertThat("health status", health.getString("status"), is("UP"));
+            }
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    static WebServer startServer(
+            Service... services) throws
+            InterruptedException, ExecutionException, TimeoutException {
+        WebServer result = WebServer.builder(
+                        Routing.builder()
+                                .register(services)
+                                .build())
+                .port(0)
+                .build()
+                .start()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+        LOGGER.log(Level.INFO, "Started server at: https://localhost:{0}", result.port());
+        return result;
+    }
+
+    static void shutdownServer(WebServer server) {
+        server.shutdown();
+    }
+
+}


### PR DESCRIPTION
Resolves #3716 

Adds `HEAD` support to the health endpoints. Responses to `HEAD` include only the status; no payload describing detailed health results.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>