### PR TITLE
Fixed problem supporting config profiles with JSON and HOCON

### DIFF
--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package io.helidon.config.hocon;
 
 import java.io.InputStreamReader;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -61,6 +62,9 @@ public class HoconConfigParser implements ConfigParser {
      * A String constant representing {@value} media type.
      */
     public static final String MEDIA_TYPE_APPLICATION_JSON = "application/json";
+
+    private static final List<String> SUPPORTED_SUFFIXES = List.of("json", "conf");
+
 
     /**
      * Priority of the parser used if registered by {@link io.helidon.config.Config.Builder} automatically.
@@ -116,6 +120,11 @@ public class HoconConfigParser implements ConfigParser {
      */
     public static HoconConfigParserBuilder builder() {
         return new HoconConfigParserBuilder();
+    }
+
+    @Override
+    public List<String> supportedSuffixes() {
+        return SUPPORTED_SUFFIXES;
     }
 
     @Override

--- a/tests/functional/config-profiles/pom.xml
+++ b/tests/functional/config-profiles/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tests.functional</groupId>
+        <artifactId>helidon-tests-functional-project</artifactId>
+        <version>2.4.3-SNAPSHOT</version>
+    </parent>
+    <groupId>io.helidon.tests.functional.configprofile</groupId>
+    <artifactId>helidon-tests-functional-configprofile</artifactId>
+
+    <properties>
+        <mainClass>io.helidon.tests.configprofile.Main</mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.media</groupId>
+            <artifactId>helidon-media-jsonp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-hocon</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>third-party-license-report</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.plugin.surefire}</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <config.profile>dev</config.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prod-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <config.profile>prod</config.profile>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/functional/config-profiles/src/main/java/io/helidon/tests/configprofile/GreetService.java
+++ b/tests/functional/config-profiles/src/main/java/io/helidon/tests/configprofile/GreetService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.configprofile;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.ServerRequest;
+import io.helidon.webserver.ServerResponse;
+import io.helidon.webserver.Service;
+
+public class GreetService implements Service {
+
+    private final AtomicReference<String> greeting = new AtomicReference<>();
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    GreetService(Config config) {
+        greeting.set(config.get("app.greeting").asString().orElse("Ciao"));
+    }
+
+    @Override
+    public void update(Routing.Rules rules) {
+        rules.get("/", this::getDefaultMessageHandler);
+    }
+
+    private void getDefaultMessageHandler(ServerRequest request, ServerResponse response) {
+        sendResponse(response, "World");
+    }
+
+    private void sendResponse(ServerResponse response, String name) {
+        String msg = String.format("%s %s!", greeting.get(), name);
+
+        JsonObject returnObject = JSON.createObjectBuilder()
+                .add("message", msg)
+                .build();
+        response.send(returnObject);
+    }
+}

--- a/tests/functional/config-profiles/src/main/java/io/helidon/tests/configprofile/Main.java
+++ b/tests/functional/config-profiles/src/main/java/io/helidon/tests/configprofile/Main.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.configprofile;
+
+import io.helidon.common.LogConfig;
+import io.helidon.common.reactive.Single;
+import io.helidon.config.Config;
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webserver.Routing;
+import io.helidon.webserver.WebServer;
+
+public final class Main {
+
+    private Main() {
+    }
+
+    public static void main(final String[] args) {
+        startServer();
+    }
+
+    static Single<WebServer> startServer() {
+
+        LogConfig.configureRuntime();
+
+        Config config = Config.create();
+
+        WebServer server = WebServer.builder(createRouting(config))
+                .config(config.get("server"))
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+
+        Single<WebServer> webserver = server.start();
+
+        webserver.thenAccept(ws -> {
+                    System.out.println("WEB server is up! http://localhost:" + ws.port() + "/greet");
+                    ws.whenShutdown().thenRun(() -> System.out.println("WEB server is DOWN. Good bye!"));
+                })
+                .exceptionallyAccept(t -> {
+                    System.err.println("Startup failed: " + t.getMessage());
+                    t.printStackTrace(System.err);
+                });
+
+        return webserver;
+    }
+
+    private static Routing createRouting(Config config) {
+        GreetService greetService = new GreetService(config);
+        return Routing.builder()
+                .register("/greet", greetService)
+                .build();
+    }
+}

--- a/tests/functional/config-profiles/src/main/resources/app-dev.json
+++ b/tests/functional/config-profiles/src/main/resources/app-dev.json
@@ -1,0 +1,9 @@
+{
+  "app": {
+    "greeting": "Hello Dev"
+  },
+  "server": {
+    "port": 8080,
+    "host": "0.0.0.0"
+  }
+}

--- a/tests/functional/config-profiles/src/main/resources/app-prod.yaml
+++ b/tests/functional/config-profiles/src/main/resources/app-prod.yaml
@@ -1,0 +1,7 @@
+
+app:
+  greeting: "Hello Prod"
+
+server:
+  port: 8080
+  host: 0.0.0.0

--- a/tests/functional/config-profiles/src/main/resources/config-profile-dev.json
+++ b/tests/functional/config-profiles/src/main/resources/config-profile-dev.json
@@ -1,0 +1,10 @@
+{
+  "sources": [
+    {
+      "type": "classpath",
+      "properties": {
+        "resource": "app-dev.json"
+      }
+    }
+  ]
+}

--- a/tests/functional/config-profiles/src/main/resources/config-profile-prod.yaml
+++ b/tests/functional/config-profiles/src/main/resources/config-profile-prod.yaml
@@ -1,0 +1,5 @@
+
+sources:
+  - type: "classpath"
+    properties:
+      resource: "app-prod.yaml"

--- a/tests/functional/config-profiles/src/main/resources/logging.properties
+++ b/tests/functional/config-profiles/src/main/resources/logging.properties
@@ -1,0 +1,19 @@
+
+# Example Logging Configuration File
+# For more information see $JAVA_HOME/jre/lib/logging.properties
+
+# Send messages to the console
+handlers=io.helidon.common.HelidonConsoleHandler
+
+# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
+
+# Global logging level. Can be overridden by specific loggers
+.level=INFO
+
+# Component specific log levels
+#io.helidon.webserver.level=INFO
+#io.helidon.config.level=INFO
+#io.helidon.security.level=INFO
+#io.helidon.common.level=INFO
+#io.netty.level=INFO

--- a/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/BaseTest.java
+++ b/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/BaseTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.configprofile;
+
+import java.util.concurrent.TimeUnit;
+
+import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.webclient.WebClient;
+import io.helidon.webserver.WebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class BaseTest {
+
+    private static WebServer webServer;
+    private static WebClient webClient;
+
+    @BeforeAll
+    public static void startTheServer() {
+        webServer = Main.startServer().await();
+
+        webClient = WebClient.builder()
+                .baseUri("http://localhost:" + webServer.port())
+                .addMediaSupport(JsonpSupport.create())
+                .build();
+    }
+
+    @AfterAll
+    public static void stopServer() throws Exception {
+        if (webServer != null) {
+            webServer.shutdown()
+                    .toCompletableFuture()
+                    .get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    public static WebServer webServer() {
+        return webServer;
+    }
+
+    public static WebClient webClient() {
+        return webClient;
+    }
+}

--- a/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/DevTest.java
+++ b/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/DevTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.configprofile;
+
+import javax.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DevTest extends BaseTest {
+
+    /**
+     * This test will only succeed if the 'dev' profile is enabled and the
+     * config files are loaded properly.
+     */
+    @Test
+    @EnabledIfSystemProperty(named = "config.profile", matches = "dev")
+    public void testHelloDevWorld() {
+        JsonObject jsonObject = webClient().get()
+                .path("/greet")
+                .request(JsonObject.class)
+                .await();
+        assertEquals("Hello Dev World!", jsonObject.getString("message"));
+    }
+}

--- a/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/ProdTest.java
+++ b/tests/functional/config-profiles/src/test/java/io/helidon/tests/configprofile/ProdTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.configprofile;
+
+import javax.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProdTest extends BaseTest {
+
+    /**
+     * This test will only succeed if the 'prod' profile is enabled and the
+     * config files are loaded properly.
+     */
+    @Test
+    @EnabledIfSystemProperty(named = "config.profile", matches = "prod")
+    public void testHelloDevWorld() {
+        JsonObject jsonObject = webClient().get()
+                .path("/greet")
+                .request(JsonObject.class)
+                .await();
+        assertEquals("Hello Prod World!", jsonObject.getString("message"));
+    }
+}

--- a/tests/functional/pom.xml
+++ b/tests/functional/pom.xml
@@ -44,5 +44,6 @@
         <module>request-scope-cdi</module>
         <module>jax-rs-multiple-apps</module>
         <module>param-converter-provider</module>
+        <module>config-profiles</module>
     </modules>
 </project>


### PR DESCRIPTION
Fixed problem supporting config profiles with JSON and HOCON. Created new tests that mix JSON/HOCON and YAML and define two different profiles.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>