### PR TITLE
Add discussion of Helidon-specific config settings to MP OpenAPI doc (2.x)

### DIFF
--- a/docs/mp/openapi/01_openapi.adoc
+++ b/docs/mp/openapi/01_openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@
 :feature-name: MicroProfile OpenAPI
 :common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
 :microprofile-bundle: true
+:common-openapi-doc: ../../shared/openapi/openapi-shared.adoc
 
 Easily allow your Helidon MP application to serve an OpenAPI document
 that describes your application's endpoints.
@@ -173,9 +174,13 @@ class name of your class.
 
 === Update your application configuration
 Beyond the two config properties that denote the model reader and filter, Helidon
-MP OpenAPI supports a number of others. These are described in the 
+MP OpenAPI supports a number of other mandated settings. These are described in the
 link:{mp-openapi-spec}#configuration[configuration section] of the MicroProfile 
 OpenAPI spec.
+
+include::{common-openapi-doc}[common-config]
+Assign these settings in `META-INF/microprofile-config.properties`.
+
 
 == Accessing the OpenAPI document
 Now your Helidon MP application will automatially respond to an additional endpoint --

--- a/docs/se/openapi/01_openapi.adoc
+++ b/docs/se/openapi/01_openapi.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 :filter-java: {mp-openapi-prefix}/api/src/main/java/org/eclipse/microprofile/openapi/OASFilter.java
 :feature-name: OpenAPI
 :common-deps-page-prefix-inc: ../../shared/dependencies/common_shared.adoc
+:common-openapi-doc: ../../shared/openapi/openapi-shared.adoc
 
 Easily allow your Helidon SE application to serve an OpenAPI document
 that describes your application's endpoints.
@@ -155,18 +156,7 @@ servers for given operations
 |===
 For more information on what these settings do consult the MicroProfile OpenAPI spec.
 
-Helidon SE also supports additional properties.
-
-.Helidon SE-specific OpenAPI Config Properties
-|===
-|Property |Use
-
-|`openapi.web-context` |Path which serves the OpenAPI document (defaults to `/openapi`)
-|`openapi.static-file` |Full path to the static OpenAPI file (defaults to 
- `META-INF/openapi.yml`,
- `META-INF/openapi.yaml`, or
- `META-INF/openapi.json`)
-|===
+include::{common-openapi-doc}[common-config]
 
 Set these config properties in one of the config sources your app uses so the
 Helidon config system will load them. Often developers use `application.yaml` at the 

--- a/docs/shared/openapi/openapi-shared.adoc
+++ b/docs/shared/openapi/openapi-shared.adoc
@@ -1,0 +1,31 @@
+///////////////////////////////////////////////////////////////////////////////
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+///////////////////////////////////////////////////////////////////////////////
+
+// tag::common-config[]
+Helidon {h1Prefix} also supports additional properties specific to Helidon.
+
+.Helidon-specific OpenAPI Config Properties
+|===
+|Property |Use
+
+|`openapi.web-context` |Path which serves the OpenAPI document (defaults to `/openapi`)
+|`openapi.static-file` |Full path to the static OpenAPI file (defaults to
+`META-INF/openapi.yml`,
+`META-INF/openapi.yaml`, or
+`META-INF/openapi.json`)
+|===


### PR DESCRIPTION
Resolves #3947 

Refactor some common content to a shared file, then refer to it from the SE and MP OpenAPI doc pages.

