### PR TITLE
Fix body part header encoding

### DIFF
--- a/media/multipart/src/main/java/io/helidon/media/multipart/ContentDisposition.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,7 @@ public final class ContentDisposition {
 
     private static final CharMatcher LINEAR_WHITE_SPACE = CharMatcher.anyOf(" \t\r\n");
 
-    private static final CharMatcher QUOTED_TEXT_MATCHER = CharMatcher.ascii()
-            .and(CharMatcher.noneOf("\"\\\r"));
+    private static final CharMatcher QUOTED_TEXT_MATCHER = CharMatcher.noneOf("\"\\\r");
 
     private static final String NAME_PARAMETER = "name";
     private static final String FILENAME_PARAMETER = "filename";

--- a/media/multipart/src/main/java/io/helidon/media/multipart/MimeParser.java
+++ b/media/multipart/src/main/java/io/helidon/media/multipart/MimeParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ final class MimeParser {
     }
 
     private static final Logger LOGGER = Logger.getLogger(MimeParser.class.getName());
-    private static final Charset HEADER_ENCODING = StandardCharsets.ISO_8859_1;
+    private static final Charset HEADER_ENCODING = StandardCharsets.UTF_8;
 
     /**
      * All states.

--- a/media/multipart/src/test/java/io/helidon/media/multipart/ContentDispositionTest.java
+++ b/media/multipart/src/test/java/io/helidon/media/multipart/ContentDispositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,5 +245,17 @@ public class ContentDispositionTest {
                 .modificationDate(zonedDateTime)
                 .build();
         assertThat(cd.toString(), is(equalTo(template)));
+    }
+
+    @Test
+    public void testNonAsciiFilename() {
+        ContentDisposition cd = ContentDisposition.parse("form-data; name=\"file[]\"; filename=\"\u60A8\u597D.txt\"");
+        assertThat(cd.type(), is(equalTo("form-data")));
+        assertThat(cd.name().isPresent(), is(equalTo(true)));
+        assertThat(cd.name().get(), is(equalTo("file[]")));
+        assertThat(cd.filename().isPresent(), is(equalTo(true)));
+        assertThat(cd.filename().get(), is(equalTo("\u60A8\u597D.txt")));
+        assertThat(cd.parameters(), is(notNullValue()));
+        assertThat(cd.parameters().size(), is(equalTo(2)));
     }
 }

--- a/media/multipart/src/test/java/io/helidon/media/multipart/MimeParserTest.java
+++ b/media/multipart/src/test/java/io/helidon/media/multipart/MimeParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -599,6 +599,24 @@ public class MimeParserTest {
     }
 
     @Test
+    public void testHeaderUTF8() {
+        String boundary = "boundary";
+        final byte[] chunk1 = ("--" + boundary + "\n"
+                + "Content-Disposition: form-data; name=\"file[]\"; filename=\"\u60A8\u597D.txt\"\n"
+                + "\n"
+                + "part1\n"
+                + "--" + boundary + "--").getBytes();
+        List<MimePart> parts = parse(boundary, chunk1).parts;
+        assertThat(parts.size(), is(equalTo(1)));
+        MimePart part1 = parts.get(0);
+        assertThat(part1.headers.size(), is(equalTo(1)));
+        assertThat(part1.headers.get("Content-Disposition"),
+                hasItems("form-data; name=\"file[]\"; filename=\"\u60A8\u597D.txt\""));
+        assertThat(part1.content, is(notNullValue()));
+        assertThat(new String(part1.content), is(equalTo("part1")));
+    }
+
+    @Test
     public void testHeaderValueWithWhiteSpacesOnly() {
         String boundary = "boundary";
         final byte[] chunk1 = ("--" + boundary + "\n"
@@ -728,9 +746,9 @@ public class MimeParserTest {
         final MimeParser.ParserEvent lastEvent;
 
         ParserResult(List<MimePart> parts,
-                            Map<String, List<String>> partHeaders,
-                            byte[] partContent,
-                            MimeParser.ParserEvent lastEvent) {
+                     Map<String, List<String>> partHeaders,
+                     byte[] partContent,
+                     MimeParser.ParserEvent lastEvent) {
             this.parts = parts;
             this.partHeaders = partHeaders;
             this.partContent = partContent;


### PR DESCRIPTION
Update MimeParser to decode body part headers with UTF-8 instead of ISO_8859_1
Update ContentDisposition.parse to remove ASCII restriction for quoted tokens.

Fixes #3963