### PR TITLE
Explicit 404 in Jersey no longer calls next()

### DIFF
--- a/tests/integration/mp-gh-3974/pom.xml
+++ b/tests/integration/mp-gh-3974/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-tests-integration</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-3974</artifactId>
+    <name>Helidon Tests Integration MP GH 3974</name>
+    <description>Reproducer for Github issue #3974 - intentional 404 returns default message</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Resource.java
+++ b/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Resource.java
@@ -16,10 +16,10 @@
 
 package io.helidon.tests.integration.gh3974;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
 
 @Path("/")
 public class Gh3974Resource {

--- a/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Resource.java
+++ b/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Resource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh3974;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class Gh3974Resource {
+    @GET
+    @Path("/test1")
+    public Response test1() {
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+
+    @GET
+    @Path("/test2")
+    public Response test2() {
+        return Response.status(Response.Status.NOT_FOUND).entity("").build();
+    }
+
+    @GET
+    @Path("/test3")
+    public Response test3() {
+        return Response.status(Response.Status.NOT_FOUND).entity("NO").build();
+    }
+
+    @GET
+    @Path("/test4")
+    public Response test4() {
+        throw new NotFoundException();
+    }
+
+    @GET
+    @Path("/test5")
+    public Response test5() {
+        throw new NotFoundException("");
+    }
+
+    @GET
+    @Path("/test6")
+    public Response test6() {
+        throw new NotFoundException(Response.status(Response.Status.NOT_FOUND).entity("NO").build());
+    }
+}

--- a/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Test.java
+++ b/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Test.java
@@ -16,13 +16,12 @@
 
 package io.helidon.tests.integration.gh3974;
 
-import javax.inject.Inject;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-
 import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Test.java
+++ b/tests/integration/mp-gh-3974/src/test/java/io/helidon/tests/integration/gh3974/Gh3974Test.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh3974;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+@AddBean(Gh3974Resource.class)
+class Gh3974Test {
+    private final WebTarget target;
+
+    @Inject
+    Gh3974Test(WebTarget target) {
+        this.target = target;
+    }
+
+    @Test
+    void test404() {
+        Response response = target.path("/notthere")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat("Response entity should not be an empty string", response.readEntity(String.class), not(""));
+    }
+
+    @Test
+    void test404NoEntity() {
+        Response response = target.path("/test1")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is(""));
+    }
+
+    @Test
+    void test404EmptyEntity() {
+        Response response = target.path("/test2")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is(""));
+    }
+
+    @Test
+    void test404CustomEntity() {
+        Response response = target.path("/test3")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is("NO"));
+    }
+
+    @Test
+    void test404Exception() {
+        Response response = target.path("/test4")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is(""));
+    }
+
+    @Test
+    void test404ExceptionEmptyString() {
+        Response response = target.path("/test5")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is(""));
+    }
+
+    @Test
+    void test404ExceptionCustomString() {
+        Response response = target.path("/test6")
+                .request()
+                .get();
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(response.readEntity(String.class), is("NO"));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -47,6 +47,7 @@
         <module>mp-gh-2421</module>
         <module>mp-gh-2461</module>
         <module>mp-gh-3246</module>
+        <module>mp-gh-3974</module>
         <module>kafka</module>
         <module>jms</module>
         <module>config</module>

--- a/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
+++ b/webserver/jersey/src/main/java/io/helidon/webserver/jersey/JerseySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -272,13 +272,14 @@ public class JerseySupport implements Service {
 
         private void doAccept(ServerRequest req, ServerResponse res) {
             CompletableFuture<Void> whenHandleFinishes = new CompletableFuture<>();
-            ResponseWriter responseWriter = new ResponseWriter(res, req, whenHandleFinishes);
             ContainerRequest requestContext = new ContainerRequest(baseUri(req),
                                                                    req.absoluteUri(),
                                                                    req.method().name(),
                                                                    new WebServerSecurityContext(),
                                                                    new MapPropertiesDelegate(),
-                                                                    resourceConfig);
+                                                                   resourceConfig);
+            ResponseWriter responseWriter = new ResponseWriter(requestContext, res, req, whenHandleFinishes);
+
             // set headers
             req.headers().toMap().forEach(requestContext::headers);
 


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Fixes #3974  for 3.x