### PR TITLE
Disable paths such as /metrics and /health from tracing (master)

### DIFF
--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
@@ -165,6 +165,10 @@ public abstract class WebTracingConfig {
                     .tracingConfig(TracingConfig.DISABLED)
                     .build());
             addPathConfig(PathTracingConfig.builder()
+                    .path("/health/{+}")
+                    .tracingConfig(TracingConfig.DISABLED)
+                    .build());
+            addPathConfig(PathTracingConfig.builder()
                     .path("/openapi")
                     .tracingConfig(TracingConfig.DISABLED)
                     .build());

--- a/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/WebTracingConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,35 @@ public abstract class WebTracingConfig {
     public static class Builder implements io.helidon.common.Builder<Builder, WebTracingConfig> {
         private final List<PathTracingConfig> pathTracingConfigs = new LinkedList<>();
         private TracingConfig tracedConfig = TracingConfig.ENABLED;
+
+        /**
+         * OpenTracing spec states that certain MP paths need to be disabled by default.
+         * Note that if a user changes the default location of any of these using
+         * web-context's, then they would need to provide these exclusions manually.
+         *
+         * The default path configs below are overridable via configuration. For example,
+         * health could be enabled by setting {@code tracing.paths.0.path=/health} and
+         * {@code tracing.paths.0.enabled=true}.
+         */
+        Builder() {
+            addPathConfig(PathTracingConfig.builder()
+                    .path("/metrics")
+                    .tracingConfig(TracingConfig.DISABLED)
+                    .build());
+            // Simplified matching for base, vendor and application paths
+            addPathConfig(PathTracingConfig.builder()
+                    .path("/metrics/{+}")
+                    .tracingConfig(TracingConfig.DISABLED)
+                    .build());
+            addPathConfig(PathTracingConfig.builder()
+                    .path("/health")
+                    .tracingConfig(TracingConfig.DISABLED)
+                    .build());
+            addPathConfig(PathTracingConfig.builder()
+                    .path("/openapi")
+                    .tracingConfig(TracingConfig.DISABLED)
+                    .build());
+        }
 
         @Override
         public WebTracingConfig build() {

--- a/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.webserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.helidon.tracing.config.TracingConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+class WebTracingConfigTest {
+
+    /**
+     * Tests default exclusions for MP paths such as "/health", etc.
+     */
+    @Test
+    void testDefaultPaths() {
+        // Collect all path configs
+        WebTracingConfig tracingConfig = WebTracingConfig.builder().build();
+        List<PathTracingConfig> pathConfigs = new ArrayList<>();
+        tracingConfig.pathConfigs().forEach(pathConfigs::add);
+
+        // Check list of disabled paths
+        List<String> paths = pathConfigs.stream().map(PathTracingConfig::path).collect(Collectors.toList());
+        assertThat(paths.size(), is(4));
+        assertThat(paths, contains("/metrics", "/metrics/{+}", "/health", "/openapi"));
+
+        // Check they are all disabled
+        long ignored = pathConfigs.stream()
+                .map(PathTracingConfig::tracedConfig)
+                .filter(tc -> tc.equals(TracingConfig.DISABLED))
+                .count();
+        assertThat(ignored, is(4L));
+    }
+
+    /**
+     * Tests a default override where "/health" is enabled.
+     */
+    @Test
+    void testEnableHealth() {
+        // Collect all path configs
+        WebTracingConfig tracingConfig = WebTracingConfig.builder()
+                .addPathConfig(PathTracingConfig.builder()
+                        .path("/health")
+                        .tracingConfig(TracingConfig.ENABLED)
+                        .build())
+                .build();
+        List<PathTracingConfig> pathConfigs = new ArrayList<>();
+        tracingConfig.pathConfigs().forEach(pathConfigs::add);
+
+        // Get list of /health paths
+        List<PathTracingConfig> healthPathConfigs = pathConfigs
+                .stream()
+                .filter(p -> p.path().equals("/health"))
+                .collect(Collectors.toList());
+        assertThat(healthPathConfigs.size(), is(2));
+        assertThat(healthPathConfigs.get(0).path(), is("/health"));
+        assertThat(healthPathConfigs.get(0).tracedConfig(), is(TracingConfig.DISABLED));
+        assertThat(healthPathConfigs.get(1).path(), is("/health"));
+        assertThat(healthPathConfigs.get(1).tracedConfig(), is(TracingConfig.ENABLED));
+    }
+}

--- a/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
+++ b/webserver/webserver/src/test/java/io/helidon/webserver/WebTracingConfigTest.java
@@ -41,41 +41,41 @@ class WebTracingConfigTest {
 
         // Check list of disabled paths
         List<String> paths = pathConfigs.stream().map(PathTracingConfig::path).collect(Collectors.toList());
-        assertThat(paths.size(), is(4));
-        assertThat(paths, contains("/metrics", "/metrics/{+}", "/health", "/openapi"));
+        assertThat(paths.size(), is(5));
+        assertThat(paths, contains("/metrics", "/metrics/{+}", "/health", "/health/{+}", "/openapi"));
 
         // Check they are all disabled
         long ignored = pathConfigs.stream()
                 .map(PathTracingConfig::tracedConfig)
                 .filter(tc -> tc.equals(TracingConfig.DISABLED))
                 .count();
-        assertThat(ignored, is(4L));
+        assertThat(ignored, is(5L));
     }
 
     /**
-     * Tests a default override where "/health" is enabled.
+     * Tests a default override where "/openapi" is enabled.
      */
     @Test
     void testEnableHealth() {
         // Collect all path configs
         WebTracingConfig tracingConfig = WebTracingConfig.builder()
                 .addPathConfig(PathTracingConfig.builder()
-                        .path("/health")
+                        .path("/openapi")
                         .tracingConfig(TracingConfig.ENABLED)
                         .build())
                 .build();
         List<PathTracingConfig> pathConfigs = new ArrayList<>();
         tracingConfig.pathConfigs().forEach(pathConfigs::add);
 
-        // Get list of /health paths
+        // Get list of /openapi paths
         List<PathTracingConfig> healthPathConfigs = pathConfigs
                 .stream()
-                .filter(p -> p.path().equals("/health"))
+                .filter(p -> p.path().equals("/openapi"))
                 .collect(Collectors.toList());
         assertThat(healthPathConfigs.size(), is(2));
-        assertThat(healthPathConfigs.get(0).path(), is("/health"));
+        assertThat(healthPathConfigs.get(0).path(), is("/openapi"));
         assertThat(healthPathConfigs.get(0).tracedConfig(), is(TracingConfig.DISABLED));
-        assertThat(healthPathConfigs.get(1).path(), is("/health"));
+        assertThat(healthPathConfigs.get(1).path(), is("/openapi"));
         assertThat(healthPathConfigs.get(1).tracedConfig(), is(TracingConfig.ENABLED));
     }
 }


### PR DESCRIPTION
This change applies to SE and MP, and it is mandated by the MP OpenTracing API. It will not collect/report by default any traces for "/health", "/health/{+}", "/metrics", "/metrics/{+}" and "/openapi". Any of these can be manually enabled via config. @