### PR TITLE
Improve return type of static builder method to avoid compilation warnings

### DIFF
--- a/security/security/src/main/java/io/helidon/security/Grant.java
+++ b/security/security/src/main/java/io/helidon/security/Grant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,11 @@ public class Grant implements AbacSupport, Principal {
      * Creates a fluent API builder to build new instances of this class.
      *
      * @return builder instance
+     * @param <T> type of builder
      */
-    public static Builder<?> builder() {
-        return new Builder<>();
+    @SuppressWarnings("unchecked")
+    public static <T extends Builder<T>> T builder() {
+        return (T) new Builder<T>();
     }
 
     @Override

--- a/security/security/src/test/java/io/helidon/security/BuilderTest.java
+++ b/security/security/src/test/java/io/helidon/security/BuilderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security;
+
+import org.junit.jupiter.api.Test;
+
+public class BuilderTest {
+
+    /**
+     * Test compatibility of {@code builder()} methods in class hierarchy.
+     */
+    @Test
+    void testBuilder() {
+        testAccept(Grant.builder());
+        testAccept(Role.builder());
+    }
+
+    private static <B extends Grant.Builder<?>> B testAccept(B builder) {
+        return builder;
+    }
+}


### PR DESCRIPTION
Improve return type of static builder method to avoid compilation warnings. Type erasure is backward compatible. Issue #3929.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>