### PR TITLE
Update MediaType parser to handle parameter without value (#3999)

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/MediaType.java
+++ b/common/http/src/main/java/io/helidon/common/http/MediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,23 +325,27 @@ public final class MediaType implements AcceptPredicate<MediaType> {
                 String attribute = tokenizer.consumeToken(TOKEN_MATCHER);
                 tokenizer.consumeCharacter('=');
                 final String value;
-                if ('"' == tokenizer.previewChar()) {
-                    tokenizer.consumeCharacter('"');
-                    StringBuilder valueBuilder = new StringBuilder();
-                    while ('"' != tokenizer.previewChar()) {
-                        if ('\\' == tokenizer.previewChar()) {
-                            tokenizer.consumeCharacter('\\');
-                            valueBuilder.append(tokenizer.consumeCharacter(CharMatcher.ascii()));
-                        } else {
-                            valueBuilder.append(tokenizer.consumeToken(QUOTED_TEXT_MATCHER));
+                if (tokenizer.hasMore()) {
+                    if ('"' == tokenizer.previewChar()) {
+                        tokenizer.consumeCharacter('"');
+                        StringBuilder valueBuilder = new StringBuilder();
+                        while ('"' != tokenizer.previewChar()) {
+                            if ('\\' == tokenizer.previewChar()) {
+                                tokenizer.consumeCharacter('\\');
+                                valueBuilder.append(tokenizer.consumeCharacter(CharMatcher.ascii()));
+                            } else {
+                                valueBuilder.append(tokenizer.consumeToken(QUOTED_TEXT_MATCHER));
+                            }
                         }
+                        value = valueBuilder.toString();
+                        tokenizer.consumeCharacter('"');
+                    } else {
+                        value = tokenizer.consumeTokenIfPresent(TOKEN_MATCHER);
                     }
-                    value = valueBuilder.toString();
-                    tokenizer.consumeCharacter('"');
-                } else {
-                    value = tokenizer.consumeToken(TOKEN_MATCHER);
+                    if (value != null) {
+                        parameters.put(attribute, value);
+                    }
                 }
-                parameters.put(attribute, value);
             }
             return create(type, subtype, parameters);
         } catch (IllegalStateException e) {

--- a/common/http/src/main/java/io/helidon/common/http/Tokenizer.java
+++ b/common/http/src/main/java/io/helidon/common/http/Tokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public final class Tokenizer {
      * position the to next character if matched.
      *
      * @param matcher matcher to use
-     * @return token matched
+     * @return token matched, or {@code null} if not matched
      * @throws IllegalStateException if {@link #hasMore() } returns
      * {@code false}
      */
@@ -54,7 +54,8 @@ public final class Tokenizer {
         checkState(hasMore(), "No more elements!");
         int startPosition = position;
         position = matcher.negate().indexIn(input, startPosition);
-        return hasMore() ? input.substring(startPosition, position)
+        return position == startPosition ? null
+                : hasMore() ? input.substring(startPosition, position)
                 : input.substring(startPosition);
     }
 

--- a/common/http/src/test/java/io/helidon/common/http/MediaTypeTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/MediaTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,12 @@ class MediaTypeTest {
         MediaType mediaType = MediaType.parse("unknown-type/unknown-subtype; option=value1; option=value2");
 
         assertThat(mediaType.parameters(), is(Map.of("option", "value2")));
+    }
+
+    @Test
+    void parseEmptyParameterValue() {
+        assertThat(MediaType.parse("type/subtype; o1=").parameters(), is(Map.of()));
+        assertThat(MediaType.parse("type/subtype; o1=; o2=v2").parameters(), is(Map.of("o2", "v2")));
     }
 
     @Test


### PR DESCRIPTION
Use consumeTokenIfPresent instead of consumeToken
Update consumeTokenIfPresent to return null instead of an empty string when matcher is not matched
Add unit test
