### PR TITLE
Avoid putting SmallRye pom into quickstarts

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -774,9 +774,13 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-open-api</artifactId>
+                <artifactId>smallrye-open-api-core</artifactId>
                 <version>${version.lib.smallrye-openapi}</version>
-                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-jaxrs</artifactId>
+                <version>${version.lib.smallrye-openapi}</version>
             </dependency>
 
             <!-- Microstream related -->

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -123,10 +123,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-open-api-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-open-api-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -141,6 +137,10 @@
                     <artifactId>jackson-dataformat-yaml</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-jaxrs</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.media</groupId>

--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -122,8 +122,11 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-open-api</artifactId>
-            <type>pom</type>
+            <artifactId>smallrye-open-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Resolves #3764 

Remove dep. on the SmallRye OpenAPI pom, replacing it with deps on the core and jaxrs modules.