### PR TITLE
3943 fixed manifest and documentation for Helidon Config Encryption for Helidon 3.x

### DIFF
--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@
                 <configuration>
                     <archive>
                         <manifest>
+                            <addClasspath>true</addClasspath>
                             <mainClass>io.helidon.config.encryption.Main</mainClass>
                         </manifest>
                     </archive>

--- a/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
@@ -52,11 +52,12 @@ public final class Main {
 
     private static void help() {
         System.out.println("To encrypt password using master password to be used in a property file:");
-        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar aes masterPassword secretToEncrypt");
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar "
+                + "aes masterPassword secretToEncrypt");
         System.out.println();
         System.out.println("To encrypt password using public key to be used in a property file:");
-        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar rsa /path/to/pkcs12keystore keystorePassphrase "
-                                   + "publicCertAlias secretToEncrypt");
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar "
+               + "rsa /path/to/pkcs12keystore keystorePassphrase publicCertAlias secretToEncrypt");
     }
 
     enum Algorithm {

--- a/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,10 +52,10 @@ public final class Main {
 
     private static void help() {
         System.out.println("To encrypt password using master password to be used in a property file:");
-        System.out.println("java -jar secure-config-version.jar aes masterPassword secretToEncrypt");
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar aes masterPassword secretToEncrypt");
         System.out.println();
         System.out.println("To encrypt password using public key to be used in a property file:");
-        System.out.println("java -jar secure-config-version.jar rsa /path/to/pkcs12keystore keystorePassphrase "
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar rsa /path/to/pkcs12keystore keystorePassphrase "
                                    + "publicCertAlias secretToEncrypt");
     }
 

--- a/docs/mp/security/03_configuration-secrets.adoc
+++ b/docs/mp/security/03_configuration-secrets.adoc
@@ -91,11 +91,8 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using shared secret `masterPassword`
 ----
-java -jar helidon-config-encryption-X.X.X.jar aes masterPassword secretToEncrypt
+java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar aes masterPassword secretToEncrypt
 ----
-
-NOTE: Ensure that `helidon-config-encryption-X.X.X.jar` and `helidon-common-crypto-X.X.X.jar` are in the same folder.
-
 The tool returns the string to be entered into configuration as the value of a
  property.
 
@@ -126,11 +123,8 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using public certificate in a keystore
 ----
-java -jar helidon-config-encryption-X.X.X.jar Main rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
+java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
 ----
-
-NOTE: Ensure that `helidon-config-encryption-X.X.X.jar` and `helidon-common-crypto-X.X.X.jar` are in the same folder.
-
 
 The tool returns the string to be entered into configuration as the value of a
  property.

--- a/docs/mp/security/03_configuration-secrets.adoc
+++ b/docs/mp/security/03_configuration-secrets.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -91,8 +91,10 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using shared secret `masterPassword`
 ----
-java io.helidon.config.encryption.Main aes masterPassword secretToEncrypt
+java -jar helidon-config-encryption-X.X.X.jar aes masterPassword secretToEncrypt
 ----
+
+NOTE: Ensure that `helidon-config-encryption-X.X.X.jar` and `helidon-common-crypto-X.X.X.jar` are in the same folder.
 
 The tool returns the string to be entered into configuration as the value of a
  property.
@@ -124,8 +126,11 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using public certificate in a keystore
 ----
-java io.helidon.config.encryption Main rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
+java -jar helidon-config-encryption-X.X.X.jar Main rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
 ----
+
+NOTE: Ensure that `helidon-config-encryption-X.X.X.jar` and `helidon-common-crypto-X.X.X.jar` are in the same folder.
+
 
 The tool returns the string to be entered into configuration as the value of a
  property.


### PR DESCRIPTION
The documentation for Helidon Config Encryption pointed to completely wrong  usage.
In this PR, I propose to fix manifest to make the jar useful (include classpath  dependencies) and thus update the documentation.

Resolves #3943 for Helidon 3.x  