### PR TITLE
Deprecated custom OCI integration

### DIFF
--- a/integrations/oci/atp/src/main/java/io/helidon/integrations/oci/atp/OciAutonomousDb.java
+++ b/integrations/oci/atp/src/main/java/io/helidon/integrations/oci/atp/OciAutonomousDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import io.helidon.integrations.common.rest.ApiOptionalResponse;
  * Blocking OCI ATP API.
  * All methods block the current thread. This implementation is not suitable for reactive programming.
  * Use {@link OciAutonomousDbRx} in reactive code.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciAutonomousDb {
     /**
      * Create a blocking ATP integration from its reactive counterpart.

--- a/integrations/oci/atp/src/main/java/io/helidon/integrations/oci/atp/OciAutonomousDbRx.java
+++ b/integrations/oci/atp/src/main/java/io/helidon/integrations/oci/atp/OciAutonomousDbRx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import io.helidon.integrations.oci.connect.OciRestApi;
 
 /**
  * Reactive API for OCI ATP.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciAutonomousDbRx {
     /**
      * Version of ATP API supported by this client.

--- a/integrations/oci/atp/src/main/java/module-info.java
+++ b/integrations/oci/atp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@ import io.helidon.integrations.oci.atp.OciAutonomousDbRx;
  *
  * @see OciAutonomousDb
  * @see OciAutonomousDbRx
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.atp {
     requires transitive java.json;
     requires transitive io.helidon.common.reactive;

--- a/integrations/oci/cdi/src/main/java/io/helidon/integrations/oci/cdi/OciCdiExtension.java
+++ b/integrations/oci/cdi/src/main/java/io/helidon/integrations/oci/cdi/OciCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,9 @@ import io.helidon.microprofile.cdi.RuntimeStart;
  * SPI.
  * This extension also adds support for injection of {@code OciRestApi}, with named instances
  * obtained from configuration.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciCdiExtension implements Extension {
     private final Set<Type> supportedTypes = new HashSet<>();
     private final Set<String> requiredNames = new HashSet<>();

--- a/integrations/oci/cdi/src/main/java/module-info.java
+++ b/integrations/oci/cdi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 /**
  * CDI extension to add support for injection of OCI APIs.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.cdi {
     requires java.logging;
 

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciApiException.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciApiException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,9 @@ import io.helidon.integrations.common.rest.ApiException;
  * This exception is used when the API invocation fails before we receive an HTTP
  * response.
  * {@link io.helidon.integrations.oci.connect.OciRestException} is used otherwise.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciApiException extends ApiException {
     /**
      * Exception without a message and cause.

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigInstancePrincipal.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigInstancePrincipal.java
@@ -71,7 +71,9 @@ import io.helidon.webclient.security.WebClientSecurity;
  * <p>
  * Configuration:
  * <a href="https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/callingservicesfrominstances.htm">OCI Instance Security</a>
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciConfigInstancePrincipal implements OciConfigProvider {
     private static final Logger LOGGER = Logger.getLogger(OciConfigInstancePrincipal.class.getName());
     private static final String DEFAULT_METADATA_SERVICE_URL = "http://169.254.169.254/opc/v2/";

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigProfile.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,9 @@ import io.helidon.config.metadata.ConfiguredOption;
 
 /**
  * OCI configuration required to connect to a service over REST API.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciConfigProfile implements OciConfigProvider {
     private final String userOcid;
     private final String tenancyOcid;

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigProvider.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,9 @@ import io.helidon.common.reactive.Single;
 
 /**
  * Provider of data needed to connect to OCI, and to use its APIs.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciConfigProvider {
     /**
      * Get the current signature data.

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigResourcePrincipal.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciConfigResourcePrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import io.helidon.common.reactive.Single;
  * This is used when running within functions.
  *
  * TODO THIS CLASS IS NOT YET IMPLEMENTED AND WILL THROW AN EXCEPTION
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciConfigResourcePrincipal implements OciConfigProvider {
     private static final String OCI_RESOURCE_PRINCIPAL_VERSION = "OCI_RESOURCE_PRINCIPAL_VERSION";
     private static final String RP_VERSION_2_2 = "2.2";

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRequestBase.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRequestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,9 @@ import io.helidon.integrations.common.rest.ApiJsonRequest;
  * Adds support for {@link #retryToken}.
  *
  * @param <T> type of the request
+ * @deprecated OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public abstract class OciRequestBase<T extends OciRequestBase<T>> extends ApiJsonRequest<T> {
     private static final DateTimeFormatter INSTANT_FORMATTER = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
@@ -96,9 +98,18 @@ public abstract class OciRequestBase<T extends OciRequestBase<T>> extends ApiJso
     }
 
     /**
+     * Endpoint (if configured).
+     *
+     * @return configured endpoint or empty
+     */
+    public Optional<String> endpoint() {
+        return Optional.ofNullable(endpoint);
+    }
+
+    /**
      * Add a timestamp to the JSON. Uses the timestamp as defined in OCI API.
      *
-     * @param name name of the property
+     * @param name    name of the property
      * @param instant instant value
      * @return updated request
      */
@@ -111,15 +122,6 @@ public abstract class OciRequestBase<T extends OciRequestBase<T>> extends ApiJso
             throw new OciApiException("Host prefix must be defined to find correct OCI host.");
         }
         return hostPrefix;
-    }
-
-    /**
-     * Endpoint (if configured).
-     *
-     * @return configured endpoint or empty
-     */
-    public Optional<String> endpoint() {
-        return Optional.ofNullable(endpoint);
     }
 
     Optional<String> retryToken() {

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciResponseParser.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciResponseParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,9 @@ import io.helidon.integrations.common.rest.ApiJsonParser;
 
 /**
  * Utility methods for processing OCI JSON responses.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public abstract class OciResponseParser extends ApiJsonParser {
     private static final DateTimeFormatter INSTANT_PARSER = DateTimeFormatter.ISO_INSTANT;
 

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRestApi.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRestApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,9 @@ import io.helidon.webclient.security.WebClientSecurity;
 /**
  * OCI specific REST API.
  * This class uses HTTP Signatures to sign requests.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciRestApi extends RestApiBase {
     private static final Logger LOGGER = Logger.getLogger(OciRestApi.class.getName());
     private static final HashDigest HASH_DIGEST = HashDigest.create(HashDigest.ALGORITHM_SHA_256);

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRestException.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciRestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ import io.helidon.integrations.common.rest.ApiRestException;
 
 /**
  * Exception used when OCI REST call returned and we have HTTP status and headers, and possibly an entity.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public class OciRestException extends ApiRestException {
     private final String errorCode;
     private final String errorMessage;

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciSignatureData.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/OciSignatureData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ import java.security.interfaces.RSAPrivateKey;
 
 /**
  * Data needed to sign requests.
+ *
+ * @deprecated  OCI SDK insteadw
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciSignatureData {
     /**
      * Key ID to use.

--- a/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/SessionKeys.java
+++ b/integrations/oci/connect/src/main/java/io/helidon/integrations/oci/connect/SessionKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ import java.security.KeyPair;
 
 /**
  * Provider of session keys when using Instance principal security.
+ *
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface SessionKeys {
     /**
      * Create default instance (using RSA).

--- a/integrations/oci/connect/src/main/java/module-info.java
+++ b/integrations/oci/connect/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 /**
  * Classes needed for OCI to connect to service API.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.connect {
     requires java.logging;
 

--- a/integrations/oci/objectstorage-health/src/main/java/module-info.java
+++ b/integrations/oci/objectstorage-health/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 /**
  * OCI Object Storage Health.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.objectstorage.health {
     requires transitive java.json;
     requires transitive io.helidon.common.reactive;

--- a/integrations/oci/objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorage.java
+++ b/integrations/oci/objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import io.helidon.integrations.common.rest.ApiOptionalResponse;
  * Blocking OCI ObjectStorage API.
  * All methods block the current thread. This implementation is not suitable for reactive programming.
  * Use {@link io.helidon.integrations.oci.objectstorage.OciObjectStorageRx} in reactive code.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciObjectStorage {
     /**
      * Create a blocking object storage integration from its reactive counterpart.

--- a/integrations/oci/objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorageRx.java
+++ b/integrations/oci/objectstorage/src/main/java/io/helidon/integrations/oci/objectstorage/OciObjectStorageRx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import io.helidon.integrations.oci.connect.OciRestApi;
 
 /**
  * Reactive API for OCI Object Storage.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciObjectStorageRx {
     /**
      * Version of Secret API supported by this client.

--- a/integrations/oci/objectstorage/src/main/java/module-info.java
+++ b/integrations/oci/objectstorage/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
  *
  * @see io.helidon.integrations.oci.objectstorage.OciObjectStorage
  * @see io.helidon.integrations.oci.objectstorage.OciObjectStorageRx
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.objectstorage {
     requires transitive java.json;
     requires transitive io.helidon.common.reactive;

--- a/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetrics.java
+++ b/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package io.helidon.integrations.oci.telemetry;
 
 /**
  * Blocking APIs for OCI Metrics.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciMetrics {
     /**
      * Create blocking OCI metrics from its reactive counterpart.

--- a/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetricsRx.java
+++ b/integrations/oci/telemetry/src/main/java/io/helidon/integrations/oci/telemetry/OciMetricsRx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,10 @@ import io.helidon.integrations.oci.connect.OciRestApi;
 
 /**
  * Reactive APIs for OCI Metrics.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciMetricsRx {
     /**
      * Version of API supported by this client.

--- a/integrations/oci/telemetry/src/main/java/module-info.java
+++ b/integrations/oci/telemetry/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
  *
  * @see io.helidon.integrations.oci.telemetry.OciMetrics
  * @see io.helidon.integrations.oci.telemetry.OciMetricsRx
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.telemetry {
     requires java.json;
 

--- a/integrations/oci/vault-health/src/main/java/module-info.java
+++ b/integrations/oci/vault-health/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 /**
  * OCI Vault Health.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.vault.health {
     requires java.logging;
     requires io.helidon.integrations.oci.connect;

--- a/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVault.java
+++ b/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ import io.helidon.integrations.common.rest.ApiOptionalResponse;
  * Blocking API to access OCI Vault.
  * All methods block the current thread. This implementation is not suitable for reactive programming.
  * Use {@link io.helidon.integrations.oci.vault.OciVaultRx} in reactive code.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciVault {
     /**
      * Create blocking Vault from its reactive counterpart.

--- a/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVaultRx.java
+++ b/integrations/oci/vault/src/main/java/io/helidon/integrations/oci/vault/OciVaultRx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import io.helidon.integrations.oci.connect.OciRestApi;
 
 /**
  * Reactive APIs for OCI Vault.
+ *
+ * @deprecated use OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 public interface OciVaultRx {
     /**
      * Default endpoint format for KMS.

--- a/integrations/oci/vault/src/main/java/module-info.java
+++ b/integrations/oci/vault/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 /**
  * Integration with OCI Vault REST API including the KMS encryption and digest support.
+ * @deprecated  OCI SDK instead
  */
+@Deprecated(since = "2.5.0", forRemoval = true)
 module io.helidon.integrations.oci.vault {
     requires io.helidon.security;
     requires io.helidon.common.reactive;


### PR DESCRIPTION
Helidon specific OCI integration is discontinued and will be removed in a future major version.
There is a new module that supports OCI SDK in CDI. For SE, `Async` should be used to invoke SDK in a thread pool.

Resolves #3986 

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>