### PR TITLE
2.x: Upgrade Jackson Databind to 2.13.2.1 (BOM 2.13.2.20220324)

### DIFF
--- a/config/git/pom.xml
+++ b/config/git/pom.xml
@@ -93,6 +93,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>${version.lib.junit4}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -70,7 +70,8 @@
         <version.lib.hystrix>1.5.18</version.lib.hystrix>
         <version.lib.inject>1.0</version.lib.inject>
         <version.lib.interceptor-api>1.2.5</version.lib.interceptor-api>
-        <version.lib.jackson>2.12.6</version.lib.jackson>
+        <!-- This is the BOM version for Jackson Databind 2.13.2.1 -->
+        <version.lib.jackson>2.13.2.20220324</version.lib.jackson>
         <version.lib.jaegertracing>1.6.0</version.lib.jaegertracing>
         <version.lib.jandex>2.3.1.Final</version.lib.jandex>
         <version.lib.jaxb-api>2.3.3</version.lib.jaxb-api>
@@ -1259,18 +1260,6 @@
             <!-- END OF Section 2: third party dependencies used by examples -->
 
             <!-- Section 3: transitive dependencies we manage the version of for convergence/upgrade -->
-            <dependency>
-                <!-- Explicitly force jackson-annotations to use proper version; bom doesn't -->
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${version.lib.jackson}</version>
-            </dependency>
-            <dependency>
-                <!-- Jackson BOM manages Junit version. It shouldn't. So we are forced to manage it -->
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.lib.junit4}</version>
-            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-dns</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -91,7 +91,6 @@
         <version.lib.jsonb-api>1.0.2</version.lib.jsonb-api>
         <version.lib.jsonp-api>1.1.6</version.lib.jsonp-api>
         <version.lib.jsonp-impl>1.1.6</version.lib.jsonp-impl>
-        <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.junit>5.7.0</version.lib.junit>
         <version.lib.kafka>2.8.1</version.lib.kafka>
         <version.lib.log4j>2.17.1</version.lib.log4j>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <version.lib.groovy-all>2.4.14</version.lib.groovy-all>
         <!-- Silence javadoc error org.jboss.logging.annotations.Message$Format not found -->
         <version.lib.jboss-logging-annotations>2.2.1.Final</version.lib.jboss-logging-annotations>
+        <version.lib.junit4>4.13.1</version.lib.junit4>
         <version.lib.kafka-junit5>3.2.3</version.lib.kafka-junit5>
         <version.lib.netty.tcnative>2.0.46.Final</version.lib.netty.tcnative>
         <version.lib.restito>0.9.1</version.lib.restito>


### PR DESCRIPTION
Upgrades Jackson Databind to 2.13.2.1 via Jackson bom 2.13.2.20220324

This version of the bom does not have the issues with junit and jackson-annotations versions, so we remove those work-arounds.