### PR TITLE
3943 fixed manifest and documentation for Helidon Config Encryption for Helidon 2.x 

### DIFF
--- a/config/encryption/pom.xml
+++ b/config/encryption/pom.xml
@@ -85,6 +85,7 @@
                 <configuration>
                     <archive>
                         <manifest>
+                            <addClasspath>true</addClasspath>
                             <mainClass>io.helidon.config.encryption.Main</mainClass>
                         </manifest>
                     </archive>

--- a/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
+++ b/config/encryption/src/main/java/io/helidon/config/encryption/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,11 +52,12 @@ public final class Main {
 
     private static void help() {
         System.out.println("To encrypt password using master password to be used in a property file:");
-        System.out.println("java -jar secure-config-version.jar aes masterPassword secretToEncrypt");
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar "
+                + "aes masterPassword secretToEncrypt");
         System.out.println();
         System.out.println("To encrypt password using public key to be used in a property file:");
-        System.out.println("java -jar secure-config-version.jar rsa /path/to/pkcs12keystore keystorePassphrase "
-                                   + "publicCertAlias secretToEncrypt");
+        System.out.println("java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar "
+               + "rsa /path/to/pkcs12keystore keystorePassphrase publicCertAlias secretToEncrypt");
     }
 
     enum Algorithm {

--- a/docs/mp/security/03_configuration-secrets.adoc
+++ b/docs/mp/security/03_configuration-secrets.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -91,9 +91,8 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using shared secret `masterPassword`
 ----
-java io.helidon.config.encryption.Main aes masterPassword secretToEncrypt
+java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar aes masterPassword secretToEncrypt
 ----
-
 The tool returns the string to be entered into configuration as the value of a
  property.
 
@@ -124,7 +123,7 @@ The config encryption filter provides a Main class `io.helidon.config.encryption
 [source,bash]
 .Encrypt secret `secretToEncrypt` using public certificate in a keystore
 ----
-java io.helidon.config.encryption Main rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
+java -jar <path-to-app-libs-dir>/helidon-config-encryption-{helidon-version}.jar rsa /path/to/keystore.p12 keystorePassword publicCertAlias secretToEncrypt
 ----
 
 The tool returns the string to be entered into configuration as the value of a


### PR DESCRIPTION
The documentation for Helidon Config Encryption pointed to completely wrong usage.
In this PR, I propose to fix manifest to make the jar useful (include classpath dependencies) and thus update the documentation.

Resolves https://github.com/oracle/helidon/issues/3943 for Helidon 3.x