### PR TITLE
Update groupIds for metrics/cdi and metrics/metrics in integrations/oci

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1005,12 +1005,12 @@
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.helidon.integrations.oci</groupId>
+                <groupId>io.helidon.integrations.oci.metrics</groupId>
                 <artifactId>helidon-integrations-oci-metrics</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.helidon.integrations.oci</groupId>
+                <groupId>io.helidon.integrations.oci.metrics</groupId>
                 <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -20,11 +20,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.integrations.oci</groupId>
+        <groupId>io.helidon.integrations.oci.metrics</groupId>
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
         <version>2.4.3-SNAPSHOT</version>
     </parent>
-    <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
     <name>Helidon Integrations OCI Metrics CDI</name>
     <description>Helidon Metrics to OCI via CDI</description>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -31,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.integrations.oci</groupId>
+            <groupId>io.helidon.integrations.oci.metrics</groupId>
             <artifactId>helidon-integrations-oci-metrics</artifactId>
         </dependency>
         <dependency>

--- a/integrations/oci/metrics/cdi/pom.xml
+++ b/integrations/oci/metrics/cdi/pom.xml
@@ -24,6 +24,7 @@
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
         <version>2.4.3-SNAPSHOT</version>
     </parent>
+    <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics-cdi</artifactId>
     <name>Helidon Integrations OCI Metrics CDI</name>
     <description>Helidon Metrics to OCI via CDI</description>

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -20,11 +20,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.integrations.oci</groupId>
+        <groupId>io.helidon.integrations.oci.metrics</groupId>
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
         <version>2.4.3-SNAPSHOT</version>
     </parent>
-    <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics</artifactId>
     <name>Helidon Integrations OCI Metrics</name>
     <description>Helidon Metrics to OCI</description>

--- a/integrations/oci/metrics/metrics/pom.xml
+++ b/integrations/oci/metrics/metrics/pom.xml
@@ -24,6 +24,7 @@
         <artifactId>helidon-integrations-oci-metrics-project</artifactId>
         <version>2.4.3-SNAPSHOT</version>
     </parent>
+    <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics</artifactId>
     <name>Helidon Integrations OCI Metrics</name>
     <description>Helidon Metrics to OCI</description>

--- a/integrations/oci/metrics/pom.xml
+++ b/integrations/oci/metrics/pom.xml
@@ -24,6 +24,7 @@
         <artifactId>helidon-integrations-oci-project</artifactId>
         <version>2.4.3-SNAPSHOT</version>
     </parent>
+    <groupId>io.helidon.integrations.oci.metrics</groupId>
     <artifactId>helidon-integrations-oci-metrics-project</artifactId>
     <name>Helidon Integrations OCI Metrics Project</name>
     <description>Helidon Metrics to OCI Project</description>


### PR DESCRIPTION
After checking some patterns in the code, I found that if the structure in the repo is:
```
tech-integration/module/submodule1
tech-integration/module/submodule2
```
that both `submodules` should have a groupId of `io.helidon...tech-integration.module`. Currently, it has only `io.helidon...tech-integration`. So the aim of this fix is to change groupID of `io.helidon.integrations.oci` to `io.helidon.integrations.oci.metrics` in both `metrics` and `cdi` modules under `integrations/oci/metrics` .