### PR TITLE
Fixed dbclient integration tests build issue.

### DIFF
--- a/tests/integration/dbclient/common/pom.xml
+++ b/tests/integration/dbclient/common/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>helidon-dbclient-metrics</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
         </dependency>


### PR DESCRIPTION
This was caused by some refactoring in `helidon-metrics` modules which was not applied to `dbclient` integration tests.

All tests are still passing for
- mysql and postgres in Java VM mode
- mysql in native image mode

Postgres tests in native image mode got broken since last run (2 years ago). This seems to be cause of many failures:
```
[ERROR] io.helidon.tests.integration.dbclient.appl.it.simple.SimpleGetIT.testCreateNamedGetStrStrNamedArgs  Time elapsed: 0.001 s  <<< ERROR!
io.helidon.webclient.WebClientException: Invalid uri http://localhost:-1. Uri.getHost() returned null.
	at io.helidon.tests.integration.dbclient.appl.it.simple.SimpleGetIT.executeTest(SimpleGetIT.java:48)
	at io.helidon.tests.integration.dbclient.appl.it.simple.SimpleGetIT.testCreateNamedGetStrStrNamedArgs(SimpleGetIT.java:62)
```
