### PR TITLE
Fix retention of @Configured 2.x

### DIFF
--- a/config/metadata/src/main/java/io/helidon/config/metadata/Configured.java
+++ b/config/metadata/src/main/java/io/helidon/config/metadata/Configured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,8 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Inherited
-@Retention(RetentionPolicy.SOURCE)
+// the retention must be class, so annotation processing can see this annotation from another module
+@Retention(RetentionPolicy.CLASS)
 public @interface Configured {
     /**
      * Whether this is a root configuration object.


### PR DESCRIPTION
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

We need to find this annotation (`@Configured`) when processing modules that depend on other modules. Source retention was insufficient for this.
For example `helidon-tracing-jaeger` needed to see it on `helidon-tracing` as the builder implements an annotated interface. 
Because this was not seend, auto completion in IDE would not work correctly, as the options from interface were not seen.

Resolves #4114 