### PR TITLE
2.x: Fix deps in jpa examples plus some cleanup

### DIFF
--- a/etc/copyright-exclude.txt
+++ b/etc/copyright-exclude.txt
@@ -34,6 +34,7 @@ jaxb.index
 .p12
 .bin
 .vm
+.sql
 src/main/proto/
 src/test/resources/keystore/
 etc/javadoc/

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -92,17 +92,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Provided-scoped dependencies. -->
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Compile-scoped dependencies. -->
         <dependency>
@@ -123,6 +112,16 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/pokemons/README.md
+++ b/examples/integrations/cdi/pokemons/README.md
@@ -3,7 +3,19 @@
 With Java:
 ```bash
 mvn package
-java -jar target/helidon-integrations-examples-pokemons-jpa.jar
+java -jar target/helidon-integrations-examples-pokemons.jar
+```
+
+## Exercise the application
+
+```
+curl -X GET http://localhost:8080/pokemon
+[{"id":1,"type":12,"name":"Bulbasaur"}, ...]
+
+curl -X GET http://localhost:8080/type
+[{"id":1,"name":"Normal"}, ...]
+
+curl -H "Content-Type: application/json" --request POST --data '{"id":100, "type":1, "name":"Test"}' http://localhost:8080/pokemon
 ```
 
 ---

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -53,6 +53,14 @@
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
@@ -107,17 +115,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Provided-scoped dependencies. -->
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test-scoped dependencies. -->
         <dependency>

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/init_script.sql
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/init_script.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2020 Oracle and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 INSERT INTO POKEMONTYPE VALUES (1, 'Normal');
 INSERT INTO POKEMONTYPE VALUES (2, 'Fighting');
 INSERT INTO POKEMONTYPE VALUES (3, 'Flying');


### PR DESCRIPTION
The pokemons and jpa examples failed to run from the command line due to dependency issues. Fixed the following:

- Changed jpa and jta dependencies to `compile` (from `provided`)
- Removed comment from `init_script.sql` since H2 was trying to parse the comment block as SQL. It skipped it (so test passed) but generated lots of exceptions in log
- Exclude .sql files from copyright check so we are not lured into making mistake again
- README edits