### PR TITLE
3.x Fix deps in jpa examples and do other cleanup

### DIFF
--- a/etc/copyright-exclude.txt
+++ b/etc/copyright-exclude.txt
@@ -24,6 +24,7 @@
 .MD
 .p12
 .txt
+.sql
 jaxb.index
 /MANIFEST.MF
 /README

--- a/examples/integrations/cdi/jpa/pom.xml
+++ b/examples/integrations/cdi/jpa/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -92,17 +92,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Provided-scoped dependencies. -->
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Compile-scoped dependencies. -->
         <dependency>
@@ -123,6 +112,16 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/examples/integrations/cdi/jpa/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/jpa/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 
 -->
 <persistence version="2.2"
-             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
-                                 http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                                 https://jakarta.ee/xml/ns/persistence/persistence_2_2.xsd">
   <persistence-unit name="test" transaction-type="JTA">
     <jta-data-source>test</jta-data-source>
     <class>io.helidon.examples.integrations.cdi.jpa.Greeting</class>

--- a/examples/integrations/cdi/jpa/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/jpa/src/main/resources/META-INF/persistence.xml
@@ -16,11 +16,11 @@
     limitations under the License.
 
 -->
-<persistence version="2.2"
+<persistence version="3.0"
              xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
-                                 https://jakarta.ee/xml/ns/persistence/persistence_2_2.xsd">
+                                 https://jakarta.ee/xml/ns/persistence/persistence_3.0.xsd">
   <persistence-unit name="test" transaction-type="JTA">
     <jta-data-source>test</jta-data-source>
     <class>io.helidon.examples.integrations.cdi.jpa.Greeting</class>

--- a/examples/integrations/cdi/pokemons/README.md
+++ b/examples/integrations/cdi/pokemons/README.md
@@ -6,6 +6,16 @@ mvn package
 java -jar target/helidon-integrations-examples-pokemons-jpa.jar
 ```
 
+## Exercise the application
+
+```
+curl -X GET http://localhost:8080/pokemon
+[{"id":1,"type":12,"name":"Bulbasaur"}, ...]
+curl -X GET http://localhost:8080/type
+[{"id":1,"name":"Normal"}, ...]
+curl -H "Content-Type: application/json" --request POST --data '{"id":100, "type":1, "name":"Test"}' http://localhost:8080/pokemon
+```
+
 ---
 
 Pokémon, and Pokémon character names are trademarks of Nintendo.

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -116,8 +116,13 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>io.helidon.microprofile.bean-validation</groupId>
-            <artifactId>helidon-microprofile-bean-validation</artifactId>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator-cdi</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/examples/integrations/cdi/pokemons/pom.xml
+++ b/examples/integrations/cdi/pokemons/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -53,6 +53,15 @@
             <groupId>jakarta.json.bind</groupId>
             <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+        </dependency>
+
 
         <!-- Runtime-scoped dependencies. -->
         <dependency>
@@ -106,17 +115,10 @@
             <artifactId>microprofile-config-api</artifactId>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Provided-scoped dependencies. -->
         <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.transaction</groupId>
-            <artifactId>jakarta.transaction-api</artifactId>
-            <scope>provided</scope>
+            <groupId>io.helidon.microprofile.bean-validation</groupId>
+            <artifactId>helidon-microprofile-bean-validation</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Test-scoped dependencies. -->

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/init_script.sql
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/init_script.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2020 Oracle and/or its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 INSERT INTO POKEMONTYPE VALUES (1, 'Normal');
 INSERT INTO POKEMONTYPE VALUES (2, 'Fighting');
 INSERT INTO POKEMONTYPE VALUES (3, 'Flying');

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 
 -->
 <persistence version="2.2"
-             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
-                                 http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                                 https://jakarta.eee/xml/ns/persistence/persistence_2_2.xsd">
   <persistence-unit name="test" transaction-type="JTA">
     <jta-data-source>test</jta-data-source>
     <class>io.helidon.examples.integrations.cdi.pokemon.Pokemon</class>

--- a/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
+++ b/examples/integrations/cdi/pokemons/src/main/resources/META-INF/persistence.xml
@@ -16,11 +16,11 @@
     limitations under the License.
 
 -->
-<persistence version="2.2"
+<persistence version="3.0"
              xmlns="https://jakarta.ee/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
-                                 https://jakarta.eee/xml/ns/persistence/persistence_2_2.xsd">
+                                 https://jakarta.eee/xml/ns/persistence/persistence_3.0.xsd">
   <persistence-unit name="test" transaction-type="JTA">
     <jta-data-source>test</jta-data-source>
     <class>io.helidon.examples.integrations.cdi.pokemon.Pokemon</class>


### PR DESCRIPTION
The pokemons and jpa examples failed to run from the command line due to dependency issues. Fixed the following:

- Changed jpa and jta dependencies to `compile` (from `provided`). Added bean validation since hibernate seemed to want that
- Removed comment from `init_script.sql` since H2 was trying to parse the comment block as SQL. It skipped it (so test passed) but generated lots of exceptions in log
- Exclude .sql files from copyright check so we are not lured into making mistake again
- README edits
- Jakarta-fy persistence.xml

