### PR TITLE
Fix JwtProvider wrong error message for Helidon 2.x 

### DIFF
--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
                 if (validate.isValid()) {
                     return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
                 } else {
-                    return failOrAbstain("Audience is invalid or missing: " + expectedAudience);
+                    return failOrAbstain(errors.toString());
                 }
             } else {
                 return failOrAbstain(errors.toString());

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -169,7 +169,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
             Errors errors = signedJwt.verifySignature(verifyKeys, defaultJwk);
             if (errors.isValid()) {
                 Jwt jwt = signedJwt.getJwt();
-                // verify the audience is correct
+                // perform all validations, including expected audience verification
                 Errors validate = jwt.validate(null, expectedAudience);
                 if (validate.isValid()) {
                     return AuthenticationResponse.success(buildSubject(jwt, signedJwt));

--- a/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
+++ b/security/providers/jwt/src/main/java/io/helidon/security/providers/jwt/JwtProvider.java
@@ -174,7 +174,7 @@ public final class JwtProvider extends SynchronousProvider implements Authentica
                 if (validate.isValid()) {
                     return AuthenticationResponse.success(buildSubject(jwt, signedJwt));
                 } else {
-                    return failOrAbstain(errors.toString());
+                    return failOrAbstain(validate.toString());
                 }
             } else {
                 return failOrAbstain(errors.toString());


### PR DESCRIPTION
As agreed with @arjav-desai, the current message is wrong. There is already `Jwt#addAudienceValidator` function, where audience is validated. We can rely on its messages.

Resolves #3912 for Helidon 3.x