### PR TITLE
Abstract decorator class now gets correct proxy name in Weld (3.x)

### DIFF
--- a/microprofile/weld/weld-core-impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/microprofile/weld/weld-core-impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -234,12 +234,16 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
         final String className;
         org.jboss.weld.bean.proxy.ProxyFactory.ProxyNameHolder holder;
         if (typeInfo.getSuperClass() == Object.class) {
-            final StringBuilder name = new StringBuilder();
-
+            // for classes that do not have an enclosing class, we want the super interface to be first
             if (proxiedBeanType.getEnclosingClass() == null) {
+                if (typeInfo.getSuperInterface() == null) {
+                    // abstract decorators fall into this category, let's use the type name
+                    return proxiedBeanType.getName() + PROXY_SUFFIX;
+                }
                 return createProxyName(typeInfo);
             } else {
                 //interface only bean.
+                final StringBuilder name = new StringBuilder();
                 holder = createCompoundProxyName(contextId, bean, typeInfo, name);
             }
         } else {

--- a/tests/integration/mp-gh-4123/pom.xml
+++ b/tests/integration/mp-gh-4123/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-mp-gh-4123</artifactId>
+    <name>Helidon Tests Integration MP GH 4123</name>
+    <description>Reproducer for Github issue #4123 - abstract Decorator class fails with NPE</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.cdi</groupId>
+            <artifactId>helidon-microprofile-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractBean.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractBean.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4123;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ContractBean implements SomeContract {
+    @Override
+    public String message() {
+        return "fromBean";
+    }
+}

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractBean.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractBean.java
@@ -16,7 +16,7 @@
 
 package io.helidon.tests.integration.gh4123;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class ContractBean implements SomeContract {

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractDecorator.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractDecorator.java
@@ -16,9 +16,9 @@
 
 package io.helidon.tests.integration.gh4123;
 
-import javax.decorator.Decorator;
-import javax.decorator.Delegate;
-import javax.inject.Inject;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
 
 @Decorator
 public abstract class ContractDecorator implements SomeContract {

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractDecorator.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/ContractDecorator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4123;
+
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+
+@Decorator
+public abstract class ContractDecorator implements SomeContract {
+    private final SomeContract delegate;
+
+    @Inject
+    public ContractDecorator(
+            @Delegate
+            SomeContract delegate) {
+
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String message() {
+        return "Decorated " + delegate.message();
+    }
+}

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/SomeContract.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/SomeContract.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4123;
+
+public interface SomeContract {
+    String message();
+}

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/UsingBean.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/UsingBean.java
@@ -16,8 +16,8 @@
 
 package io.helidon.tests.integration.gh4123;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class UsingBean {

--- a/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/UsingBean.java
+++ b/tests/integration/mp-gh-4123/src/main/java/io/helidon/tests/integration/gh4123/UsingBean.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4123;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class UsingBean {
+    private final SomeContract contract;
+
+    @Inject
+    public UsingBean(SomeContract contract) {
+        this.contract = contract;
+    }
+
+    public String message() {
+        return contract.message();
+    }
+}

--- a/tests/integration/mp-gh-4123/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/mp-gh-4123/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        bean-discovery-mode="annotated">
+
+    <decorators>
+        <class>io.helidon.tests.integration.gh4123.ContractDecorator</class>
+    </decorators>
+</beans>

--- a/tests/integration/mp-gh-4123/src/test/java/io/helidon/tests/integration/gh4123/Gh4123Test.java
+++ b/tests/integration/mp-gh-4123/src/test/java/io/helidon/tests/integration/gh4123/Gh4123Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4123;
+
+import javax.inject.Inject;
+
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@HelidonTest
+class Gh4123Test {
+    private final SomeContract contract;
+
+    @Inject
+    Gh4123Test(SomeContract contract) {
+        this.contract = contract;
+    }
+
+    @Test
+    void testDecorator() {
+        String value = contract.message();
+
+        assertThat(value, is("Decorated fromBean"));
+    }
+}

--- a/tests/integration/mp-gh-4123/src/test/java/io/helidon/tests/integration/gh4123/Gh4123Test.java
+++ b/tests/integration/mp-gh-4123/src/test/java/io/helidon/tests/integration/gh4123/Gh4123Test.java
@@ -16,10 +16,9 @@
 
 package io.helidon.tests.integration.gh4123;
 
-import javax.inject.Inject;
-
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -48,6 +48,7 @@
         <module>mp-gh-2461</module>
         <module>mp-gh-3246</module>
         <module>mp-gh-3974</module>
+        <module>mp-gh-4123</module>
         <module>kafka</module>
         <module>jms</module>
         <module>config</module>


### PR DESCRIPTION
Forward port of bug fix for #4123 
