### PR TITLE
Support for Hocon inclusion of files without an extension

### DIFF
--- a/config/hocon/src/test/java/io/helidon/config/hocon/IncludeTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/IncludeTest.java
@@ -73,4 +73,23 @@ class IncludeTest {
         assertThat(cpe.getMessage(), is("bogus.conf is missing"));
     }
 
+    @Test
+    void testClasspathIncludesNoExtension() {
+        Config config = Config.create(ClasspathConfigSource.create("conf/application4.conf"));
+
+        String value = config.get("app.greeting").asString().orElse(null);
+
+        assertThat("app.greeting should be loaded from application.conf", value, notNullValue());
+        assertThat(value, is("Hello"));
+
+        value = config.get("server.host").asString().orElse(null);
+
+        assertThat("server.host should be loaded from included.conf", value, notNullValue());
+        assertThat(value, is("localhost"));
+
+        value = config.get("server.port").asString().orElse(null);
+
+        assertThat("server.port should be loaded from sub/included.conf", value, notNullValue());
+        assertThat(value, is("8080"));
+    }
 }

--- a/config/hocon/src/test/resources/conf/application4.conf
+++ b/config/hocon/src/test/resources/conf/application4.conf
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-server {
-  host = "127.0.0.1"
-  port = 8080
+include "sub/included"
+include "included"
+
+app {
+  greeting = "Hello"
 }


### PR DESCRIPTION
Support for Hocon inclusion of files without an extensions. Uses default of '.conf' as stated in spec. Issue #4152.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>