### PR TITLE
2.x: Improve threadNamePrefix defaulting to be more informative

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPoolSupplier.java
@@ -183,7 +183,7 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
         private int keepAliveMinutes = DEFAULT_KEEP_ALIVE_MINUTES;
         private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
         private boolean isDaemon = DEFAULT_IS_DAEMON;
-        private String threadNamePrefix = DEFAULT_THREAD_NAME_PREFIX;
+        private String threadNamePrefix = null;
         private boolean prestart = DEFAULT_PRESTART;
         private int growthThreshold = DEFAULT_GROWTH_THRESHOLD;
         private int growthRate = DEFAULT_GROWTH_RATE;
@@ -198,11 +198,15 @@ public final class ThreadPoolSupplier implements Supplier<ExecutorService> {
         @Override
         public ThreadPoolSupplier build() {
             if (name == null) {
-                if (DEFAULT_THREAD_NAME_PREFIX.equals(threadNamePrefix)) {
+                if (threadNamePrefix == null) {
                     LOGGER.warning("Neither a thread name prefix nor a pool name specified");
+                    threadNamePrefix = DEFAULT_THREAD_NAME_PREFIX;
                 }
                 name = threadNamePrefix + "thread-pool-" + DEFAULT_NAME_COUNTER.incrementAndGet();
+            } else if (threadNamePrefix == null) {
+                threadNamePrefix = DEFAULT_THREAD_NAME_PREFIX + name + "-";
             }
+
             if (rejectionHandler == null) {
                 rejectionHandler = DEFAULT_REJECTION_POLICY;
             }


### PR DESCRIPTION
See #4159 

We previously ensured that all of our thread pools are named. But the thread name prefixes were still "helidon-". This PR  changes the default for  `threadNamePrefix` to be derived from the thread pool name.  So now our threads have names like: 

"helidon-server-14"
"helidon-security-thread-pool-2"