### PR TITLE
Turn off reference substitution in Hocon parser level for lazy resolution of references

### DIFF
--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParser.java
@@ -112,18 +112,6 @@ public class HoconConfigParser implements ConfigParser {
     }
 
     /**
-     * Create a new instance of HOCON config parser using default configuration.
-     *
-     * @param resolvingEnabled whether to resolve references at the parser level
-     * @return a new instance of parser
-     * @see #builder()
-     */
-    public static HoconConfigParser create(boolean resolvingEnabled) {
-        return resolvingEnabled ? builder().enableResolving().build()
-                : builder().disableResolving().build();
-    }
-
-    /**
      * Create a new fluent API builder for a HOCON config parser.
      *
      * @return a new builder instance

--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
@@ -50,19 +50,22 @@ public final class HoconConfigParserBuilder implements Builder<ConfigParser> {
      * Disables HOCON resolving substitutions support. Default is {@code false}.
      *
      * @return modified builder instance
+     * @see #resolvingEnabled
      */
+    @Deprecated(since = "2.5.1", forRemoval = true)
     public HoconConfigParserBuilder disableResolving() {
         resolvingEnabled = false;
         return this;
     }
 
     /**
-     * Enables HOCON resolving substitutions support. Default is {@code false}.
+     * Enables/disables HOCON resolving substitutions support. Default is {@code false}.
      *
+     * @param enabled use to enable or disable substitution
      * @return modified builder instance
      */
-    public HoconConfigParserBuilder enableResolving() {
-        this.resolvingEnabled = true;
+    public HoconConfigParserBuilder resolvingEnabled(boolean enabled) {
+        this.resolvingEnabled = enabled;
         return this;
     }
 

--- a/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
+++ b/config/hocon/src/main/java/io/helidon/config/hocon/HoconConfigParserBuilder.java
@@ -41,18 +41,28 @@ public final class HoconConfigParserBuilder implements Builder<ConfigParser> {
     private HoconConfigIncluder configIncluder;
 
     HoconConfigParserBuilder() {
-        resolvingEnabled = true;
+        resolvingEnabled = false;
         resolveOptions = ConfigResolveOptions.defaults();
         parseOptions = ConfigParseOptions.defaults();
     }
 
     /**
-     * Disables HOCON resolving substitutions support.
+     * Disables HOCON resolving substitutions support. Default is {@code false}.
      *
      * @return modified builder instance
      */
     public HoconConfigParserBuilder disableResolving() {
         resolvingEnabled = false;
+        return this;
+    }
+
+    /**
+     * Enables HOCON resolving substitutions support. Default is {@code false}.
+     *
+     * @return modified builder instance
+     */
+    public HoconConfigParserBuilder enableResolving() {
+        this.resolvingEnabled = true;
         return this;
     }
 

--- a/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
@@ -57,7 +57,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testResolveEnabled() {
-        ConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> ""
                                                + "aaa = 1 \n"
                                                + "bbb = ${aaa} \n"
@@ -73,7 +73,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testResolveEnabledEnvVar() {
-        ConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> "env-var = ${HOCON_TEST_PROPERTY}", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -82,7 +82,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testEmpty() {
-        HoconConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> "", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(0));
@@ -90,7 +90,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testSingleValue() {
-        HoconConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> "aaa = bbb", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -99,7 +99,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testStringListValue() {
-        HoconConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> "aaa = [ bbb, ccc, ddd ]", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -113,7 +113,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testComplexValue() {
-        HoconConfigParser parser = HoconConfigParser.create(true);
+        ConfigParser parser = createResolvingParser();
         ObjectNode node = parser.parse((StringContent) () -> ""
                                                + "aaa =  \"bbb\"\n"
                                                + "arr = [ bbb, 13, true, 3.14159 ] \n"
@@ -355,5 +355,9 @@ public class HoconConfigParserTest {
                     config.get("storagePassphrase").asString().get()
             );
         }
+    }
+
+    private static ConfigParser createResolvingParser() {
+        return HoconConfigParser.builder().resolvingEnabled(true).build();
     }
 }

--- a/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
@@ -38,9 +38,6 @@ import io.helidon.config.spi.ConfigNode.ListNode;
 import io.helidon.config.spi.ConfigNode.ObjectNode;
 import io.helidon.config.spi.ConfigParser;
 import io.helidon.config.spi.ConfigParser.Content;
-import io.helidon.config.spi.ConfigParserException;
-
-import com.typesafe.config.ConfigResolveOptions;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.config.ConfigValues.simpleValue;
@@ -50,11 +47,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.stringContainsInOrder;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link HoconConfigParser}.
@@ -63,7 +57,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testResolveEnabled() {
-        ConfigParser parser = HoconConfigParser.create();
+        ConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> ""
                                                + "aaa = 1 \n"
                                                + "bbb = ${aaa} \n"
@@ -78,28 +72,8 @@ public class HoconConfigParserTest {
     }
 
     @Test
-    public void testResolveDisabled() {
-        ConfigParserException cpe = assertThrows(ConfigParserException.class, () -> {
-            ConfigParser parser = HoconConfigParser.builder().disableResolving().build();
-            parser.parse((StringContent) () -> ""
-                                 + "aaa = 1 \n"
-                                 + "bbb = ${aaa} \n"
-                                 + "ccc = \"${aaa}\" \n"
-                                 + "ddd = ${?zzz}",
-                         it -> Optional.empty());
-        });
-
-        assertThat(cpe.getMessage(),
-                   stringContainsInOrder(List.of(
-                           "Cannot read from source",
-                           "substitution not resolved",
-                           "${aaa}")));
-        assertThat(cpe.getCause(), instanceOf(com.typesafe.config.ConfigException.NotResolved.class));
-    }
-
-    @Test
     public void testResolveEnabledEnvVar() {
-        ConfigParser parser = HoconConfigParser.create();
+        ConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> "env-var = ${HOCON_TEST_PROPERTY}", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -107,25 +81,8 @@ public class HoconConfigParserTest {
     }
 
     @Test
-    public void testResolveEnabledEnvVarDisabled() {
-        ConfigParserException cpe = assertThrows(ConfigParserException.class, () -> {
-            ConfigParser parser = HoconConfigParser.builder()
-                    .resolveOptions(ConfigResolveOptions.noSystem())
-                    .build();
-            parser.parse((StringContent) () -> "env-var = ${HOCON_TEST_PROPERTY}", it -> Optional.empty());
-        });
-
-        assertThat(cpe.getMessage(),
-                   stringContainsInOrder(List.of(
-                           "Cannot read from source",
-                           "not resolve substitution ",
-                           "${HOCON_TEST_PROPERTY}")));
-        assertThat(cpe.getCause(), instanceOf(com.typesafe.config.ConfigException.UnresolvedSubstitution.class));
-    }
-
-    @Test
     public void testEmpty() {
-        HoconConfigParser parser = HoconConfigParser.create();
+        HoconConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> "", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(0));
@@ -133,7 +90,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testSingleValue() {
-        HoconConfigParser parser = HoconConfigParser.create();
+        HoconConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> "aaa = bbb", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -142,7 +99,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testStringListValue() {
-        HoconConfigParser parser = HoconConfigParser.create();
+        HoconConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> "aaa = [ bbb, ccc, ddd ]", it -> Optional.empty());
 
         assertThat(node.entrySet(), hasSize(1));
@@ -156,7 +113,7 @@ public class HoconConfigParserTest {
 
     @Test
     public void testComplexValue() {
-        HoconConfigParser parser = HoconConfigParser.create();
+        HoconConfigParser parser = HoconConfigParser.create(true);
         ObjectNode node = parser.parse((StringContent) () -> ""
                                                + "aaa =  \"bbb\"\n"
                                                + "arr = [ bbb, 13, true, 3.14159 ] \n"

--- a/config/hocon/src/test/java/io/helidon/config/hocon/SubstitutionTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/SubstitutionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import io.helidon.config.ClasspathConfigSource;
+import io.helidon.config.Config;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+class SubstitutionTest {
+
+    @Test
+    void testSubstitution() {
+        Config config = Config.create(
+                ClasspathConfigSource.create("conf/substitution1.conf"),
+                ClasspathConfigSource.create("conf/substitution2.conf"));
+
+        String value = config.get("app1.greeting1").asString().orElse(null);
+        assertThat(value, is("Hello"));
+
+        value = config.get("app1.greeting2").asString().orElse(null);
+        assertThat(value, is("Hello"));
+
+        value = config.get("app2.greeting2").asString().orElse(null);
+        assertThat(value, is("Hello"));
+
+        value = config.get("app2.greeting2").asString().orElse(null);
+        assertThat(value, is("Hello"));
+
+        List<String> list = config.get("app2.greetings").asList(String.class)
+                .orElse(Collections.emptyList());
+        assertThat(list, Matchers.<Collection<String>> allOf(
+                hasSize(2), hasItem(is("Hello"))));
+    }
+}

--- a/config/hocon/src/test/resources/conf/application2.conf
+++ b/config/hocon/src/test/resources/conf/application2.conf
@@ -20,4 +20,3 @@ include "bogus.conf"
 app {
   greeting = "Hello"
 }
-

--- a/config/hocon/src/test/resources/conf/substitution1.conf
+++ b/config/hocon/src/test/resources/conf/substitution1.conf
@@ -14,10 +14,7 @@
 # limitations under the License.
 #
 
-include required("sub/included.conf")
-include "bogus.conf"
-
-app {
-  greeting = "Hello"
+app1 {
+  greeting1 = "Hello"
+  greeting2 = ${app2.greeting1}
 }
-

--- a/config/hocon/src/test/resources/conf/substitution2.conf
+++ b/config/hocon/src/test/resources/conf/substitution2.conf
@@ -14,10 +14,8 @@
 # limitations under the License.
 #
 
-include required("sub/included.conf")
-include "bogus.conf"
-
-app {
-  greeting = "Hello"
+app2 {
+  greeting1 = ${app1.greeting1}
+  greeting2 = ${app1.greeting2}
+  greetings = [ ${app1.greeting1}, ${app2.greeting2} ]
 }
-


### PR DESCRIPTION
Turn off reference resolution/substitution at parser level and leave reference in tree for later resolution in config module. Unfortunately, to avoid depending on parser impl packages, we need to catch an exception for each parsed reference at this time.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>