### PR TITLE
Do not fail when expected audience is null - 2.x backport

### DIFF
--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
+++ b/security/jwt/src/main/java/io/helidon/security/jwt/Jwt.java
@@ -395,7 +395,7 @@ public class Jwt {
      * Add validator of audience to the collection of validators.
      *
      * @param validators collection of validators
-     * @param audience   audience expected to be in the token
+     * @param audience   audience expected to be in the token, never null
      * @param mandatory  whether the audience field is mandatory in the token
      */
     public static void addAudienceValidator(Collection<Validator<Jwt>> validators, String audience, boolean mandatory) {
@@ -917,7 +917,7 @@ public class Jwt {
      * @return errors instance to check for validation result
      */
     public Errors validate(String issuer, String audience) {
-        return validate(issuer, Set.of(audience));
+        return validate(issuer, audience == null ? Set.of() : Set.of(audience));
     }
 
     /**


### PR DESCRIPTION
Do not fail when expected audience is null

Signed-off-by: David Kral <david.k.kral@oracle.com>
(cherry picked from commit 525736c99d75d49fc44384ef8854dc644ebd26dc)