### PR TITLE
Fixed a few problems with Fallback and Multi's (master)

### DIFF
--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Fallback.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Fallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,9 +68,9 @@ public interface Fallback<T> extends FtHandlerTyped<T> {
      * @param <T> type of the result
      * @return a new fallback
      */
-    static <T> Fallback<T> createMulti(Function<Throwable, ? extends CompletionStage<T>> fallback) {
+    static <T> Fallback<T> createMulti(Function<Throwable, ? extends Flow.Publisher<T>> fallback) {
         Builder<T> builder = builder();
-        return builder.fallback(fallback).build();
+        return builder.fallbackMulti(fallback).build();
     }
 
     /**


### PR DESCRIPTION
Fixed a few problems with Fallback and Multi's in SE. Updated Fallback implementation to mimic exception nesting/structure of Single for Multi. Issue https://github.com/oracle/helidon/issues/4155.

Note that the signature of the createMulti method has changed, but seemed incorrect before.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>