### PR TITLE
New AnnotationFinder to handle transitive annotations in FT 

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * Searches for transitive annotations associated with interceptor bindings in
+ * a given Java package. Some of these operations can be expensive, so their
+ * results should be cached.
+ *
+ * For example, a new annotation {@code @TimedRetry} is itself annotated by
+ * {@code @Timeout} and {@code @Retry}, and both need to be found if a method
+ * uses {@code @TimedRetry} instead.
+ */
+public class AnnotationFinder {
+
+    /**
+     * Array of package prefixes we avoid traversing while computing
+     * a transitive closure for an annotation.
+     */
+    private static final String[] SKIP_PACKAGE_PREFIXES = {
+            "java.",
+            "javax.",
+            "jakarta.",
+            "org.microprofile."
+    };
+
+    private final Package pkg;
+
+    private AnnotationFinder(Package pkg) {
+        this.pkg = pkg;
+    }
+
+    /**
+     * Create a find given a Java package.
+     *
+     * @param pkg a package
+     * @return the finder
+     */
+    static AnnotationFinder create(Package pkg) {
+        Objects.requireNonNull(pkg);
+        return new AnnotationFinder(pkg);
+    }
+
+    /**
+     * Searches for transitive annotations starting with a class.
+     *
+     * @param clazz the class
+     * @return set of transitive annotations found
+     */
+    Set<Annotation> findAnnotations(Class<?> clazz) {
+        return findAnnotations(Set.of(clazz.getAnnotations()));
+    }
+
+    /**
+     * Searches for transitive annotations starting with a method.
+     *
+     * @param method the method
+     * @return set of transitive annotations found
+     */
+    Set<Annotation> findAnnotations(Method method) {
+        return findAnnotations(Set.of(method.getAnnotations()));
+    }
+
+    private Set<Annotation> findAnnotations(Set<Annotation> set) {
+        return findAnnotations(set, new HashSet<>(), new HashSet<>(), pkg);
+    }
+
+    /**
+     * Collects a set of transitive annotations in a package. Follows any
+     * annotation that has not been already seen (to avoid infinite loops)
+     * and is of interest.
+     *
+     * @param set set of annotations to start with
+     * @param result set of annotations returned
+     * @param seen set of annotations already processed
+     * @param pkg the package
+     * @return the result set of annotations
+     */
+    private Set<Annotation> findAnnotations(Set<Annotation> set, Set<Annotation> result,
+                                            Set<Annotation> seen, Package pkg) {
+        for (Annotation a1 : set) {
+            Class<? extends Annotation> a1Type = a1.annotationType();
+            if (a1Type.getPackage().equals(pkg)) {
+                result.add(a1);
+            } else if (!seen.contains(a1) && isOfInterest(a1)) {
+                seen.add(a1);
+                Set<Annotation> a1Set = Set.of(a1Type.getAnnotations());
+                findAnnotations(a1Set, result, seen, pkg);
+            }
+        }
+        return result;
+    }
+
+    private static boolean isOfInterest(Annotation a) {
+        if (a.annotationType().isAnnotationPresent(InterceptorBinding.class)) {
+            Optional<String> matches = Stream.of(SKIP_PACKAGE_PREFIXES)
+                    .filter(pp -> a.annotationType().getPackage().getName().startsWith(pp))
+                    .findAny();
+            return matches.isEmpty();
+        }
+        return false;
+    }
+}

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
@@ -85,7 +85,7 @@ public class AnnotationFinder {
         return findAnnotations(Set.of(method.getAnnotations()));
     }
 
-    private Set<Annotation> findAnnotations(Set<Annotation> set) {
+    Set<Annotation> findAnnotations(Set<Annotation> set) {
         return findAnnotations(set, new HashSet<>(), new HashSet<>(), pkg);
     }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
@@ -16,26 +16,25 @@
 
 package io.helidon.microprofile.faulttolerance;
 
-import java.lang.reflect.Method;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
+
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class AsynchronousAntn.
- */
 class AsynchronousAntn extends MethodAntn implements Asynchronous {
 
     /**
      * Constructor.
      *
-     * @param beanClass Bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    AsynchronousAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    AsynchronousAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
@@ -16,24 +16,22 @@
 
 package io.helidon.microprofile.faulttolerance;
 
-import java.lang.reflect.Method;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class BulkheadAntn.
- */
 class BulkheadAntn extends MethodAntn implements Bulkhead {
 
     /**
      * Constructor.
      *
-     * @param beanClass Bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    BulkheadAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    BulkheadAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
@@ -16,25 +16,24 @@
 
 package io.helidon.microprofile.faulttolerance;
 
-import java.lang.reflect.Method;
 import java.time.temporal.ChronoUnit;
+
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class CircuitBreakerAntn.
- */
 class CircuitBreakerAntn extends MethodAntn implements CircuitBreaker {
 
     /**
      * Constructor.
      *
-     * @param beanClass The bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    CircuitBreakerAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    CircuitBreakerAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
@@ -18,24 +18,24 @@ package io.helidon.microprofile.faulttolerance;
 
 import java.lang.reflect.Method;
 
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
+
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class FallbackAntn.
- */
 class FallbackAntn extends MethodAntn implements Fallback {
 
     /**
      * Constructor.
      *
-     * @param beanClass Bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    FallbackAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    FallbackAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -17,7 +17,6 @@
 package io.helidon.microprofile.faulttolerance;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -322,34 +321,17 @@ public class FaultToleranceExtension implements Extension {
      * Determines if a method has any fault tolerance annotationSet. Only {@code @Fallback}
      * is considered if fault tolerance is disabled.
      *
-     * @param beanClass The bean.
-     * @param method The method to check.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The method to check.
      * @return Outcome of test.
      */
-    static boolean isFaultToleranceMethod(Class<?> beanClass, Method method) {
-        return MethodAntn.isAnnotationPresent(beanClass, method, Retry.class)
-                || MethodAntn.isAnnotationPresent(beanClass, method, CircuitBreaker.class)
-                || MethodAntn.isAnnotationPresent(beanClass, method, Bulkhead.class)
-                || MethodAntn.isAnnotationPresent(beanClass, method, Timeout.class)
-                || MethodAntn.isAnnotationPresent(beanClass, method, Asynchronous.class)
-                || MethodAntn.isAnnotationPresent(beanClass, method, Fallback.class);
-    }
-
-    /**
-     * Determines if a method has any fault tolerance annotationSet. Only {@code @Fallback}
-     * is considered if fault tolerance is disabled.
-     *
-     * @param type The annotated type.
-     * @param method The method to check.
-     * @return Outcome of test.
-     */
-    static boolean isFaultToleranceMethod(AnnotatedType<?> type, AnnotatedMethod<?> method) {
-        return MethodAntn.isAnnotationPresent(type, method, Retry.class)
-                || MethodAntn.isAnnotationPresent(type, method, CircuitBreaker.class)
-                || MethodAntn.isAnnotationPresent(type, method, Bulkhead.class)
-                || MethodAntn.isAnnotationPresent(type, method, Timeout.class)
-                || MethodAntn.isAnnotationPresent(type, method, Asynchronous.class)
-                || MethodAntn.isAnnotationPresent(type, method, Fallback.class);
+    static boolean isFaultToleranceMethod(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        return MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Retry.class)
+                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, CircuitBreaker.class)
+                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Bulkhead.class)
+                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Timeout.class)
+                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Asynchronous.class)
+                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Fallback.class);
     }
 
     /**

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
@@ -89,10 +89,6 @@ abstract class MethodAntn {
         return annotatedMethod.getJavaMember();
     }
 
-    AnnotatedMethod<?> annotatedMethod() {
-        return annotatedMethod;
-    }
-
     /**
      * Look up an annotation on the method using instance variables.
      *
@@ -107,26 +103,14 @@ abstract class MethodAntn {
     /**
      * Finds if an annotation is present on a method or its class.
      *
-     * @param beanClass The bean class.
-     * @param method Method to check.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod Method to check.
      * @param annotClass Annotation class.
      * @return Outcome of test.
      */
-    static boolean isAnnotationPresent(Class<?> beanClass, Method method, Class<? extends Annotation> annotClass) {
-        return lookupAnnotation(beanClass, method, annotClass) != null;
-    }
-
-    /**
-     * Finds if an annotation is present on a method or its class.
-     *
-     * @param type The annotated type.
-     * @param method Method to check.
-     * @param annotClass Annotation class.
-     * @return Outcome of test.
-     */
-    static boolean isAnnotationPresent(AnnotatedType<?> type, AnnotatedMethod<?> method,
+    static boolean isAnnotationPresent(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod,
                                        Class<? extends Annotation> annotClass) {
-        return lookupAnnotation(type, method, annotClass) != null;
+        return lookupAnnotation(annotatedType, annotatedMethod, annotClass) != null;
     }
 
     /**
@@ -211,48 +195,6 @@ abstract class MethodAntn {
      * instance of this annotation exist (after computing the transitive closure),
      * one will be returned in an undefined manner.
      *
-     * @param beanClass The bean class.
-     * @param method The method.
-     * @param annotClass The annotation class.
-     * @param <A> Annotation type.
-     * @return The lookup result or {@code null}.
-     */
-    @SuppressWarnings("unchecked")
-    static <A extends Annotation> LookupResult<A> lookupAnnotation(Class<?> beanClass,
-                                                                   Method method,
-                                                                   Class<A> annotClass) {
-        A annotation = (A) getMethodAnnotation(method, annotClass);
-        if (annotation != null) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("Found annotation '" + annotClass.getName()
-                        + "' method '" + method.getName() + "'");
-            }
-            return new LookupResult<>(MatchingType.METHOD, annotation);
-        }
-        annotation = (A) getClassAnnotation(beanClass, annotClass);
-        if (annotation != null) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("Found annotation '" + annotClass.getName()
-                        + "' class '" + method.getDeclaringClass().getName() + "'");
-            }
-            return new LookupResult<>(MatchingType.CLASS, annotation);
-        }
-        annotation = (A) getClassAnnotation(method.getDeclaringClass(), annotClass);
-        if (annotation != null) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine("Found annotation '" + annotClass.getName()
-                        + "' class '" + method.getDeclaringClass().getName() + "'");
-            }
-            return new LookupResult<>(MatchingType.CLASS, annotation);
-        }
-        return null;
-    }
-
-    /**
-     * Returns underlying annotation and info as to how it was found. If more than one
-     * instance of this annotation exist (after computing the transitive closure),
-     * one will be returned in an undefined manner.
-     *
      * @param type The annotated type.
      * @param method The annotated method.
      * @param annotClass The annotation class.
@@ -288,14 +230,6 @@ abstract class MethodAntn {
             return new LookupResult<>(MatchingType.CLASS, annotation);
         }
         return null;
-    }
-
-    private static Annotation getMethodAnnotation(Method m, Class<? extends Annotation> annotClass) {
-        Set<? extends Annotation> set = ANNOTATION_FINDER.findAnnotations(m);
-        return set.stream()
-                .filter(a -> a.annotationType().equals(annotClass))
-                .findFirst()
-                .orElse(null);
     }
 
     private static Annotation getMethodAnnotation(AnnotatedMethod<?> m, Class<? extends Annotation> annotClass) {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -153,7 +153,8 @@ class MethodIntrospector {
      * @return Outcome of test.
      */
     private boolean isAnnotationEnabled(Class<? extends Annotation> clazz) {
-        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(annotatedType, annotatedMethod, clazz);
+        BeanManager bm = CDI.current().getBeanManager();
+        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(annotatedType, annotatedMethod, clazz, bm);
         if (lookupResult == null) {
             return false;       // not present
         }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -18,6 +18,12 @@ package io.helidon.microprofile.faulttolerance;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.Optional;
+
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
 
 import io.helidon.microprofile.faulttolerance.MethodAntn.LookupResult;
 
@@ -31,14 +37,11 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 import static io.helidon.microprofile.faulttolerance.FaultToleranceParameter.getParameter;
 import static io.helidon.microprofile.faulttolerance.MethodAntn.lookupAnnotation;
 
-/**
- * Class MethodIntrospector.
- */
 class MethodIntrospector {
 
-    private final Method method;
+    private final AnnotatedType<?> annotatedType;
 
-    private final Class<?> beanClass;
+    private final AnnotatedMethod<?> annotatedMethod;
 
     private final Retry retry;
 
@@ -55,30 +58,23 @@ class MethodIntrospector {
      *
      * @param method The method to introspect.
      */
+    @SuppressWarnings("unchecked")
     MethodIntrospector(Class<?> beanClass, Method method) {
-        this.beanClass = beanClass;
-        this.method = method;
+        BeanManager bm = CDI.current().getBeanManager();
+        this.annotatedType = bm.createAnnotatedType(beanClass);
+        Optional<AnnotatedMethod<?>> annotatedMethodOptional =
+                (Optional<AnnotatedMethod<?>>) annotatedType.getMethods()
+                        .stream()
+                        .filter(am -> am.getJavaMember().equals(method))
+                        .findFirst();
+        this.annotatedMethod = annotatedMethodOptional.orElseThrow();
 
-        this.retry = isAnnotationEnabled(Retry.class) ? new RetryAntn(beanClass, method) : null;
+        this.retry = isAnnotationEnabled(Retry.class) ? new RetryAntn(annotatedType, annotatedMethod) : null;
         this.circuitBreaker = isAnnotationEnabled(CircuitBreaker.class)
-                ? new CircuitBreakerAntn(beanClass, method) : null;
-        this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(beanClass, method) : null;
-        this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(beanClass, method) : null;
-        this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(beanClass, method) : null;
-    }
-
-    Method method() {
-        return method;
-    }
-
-    /**
-     * Checks if {@code clazz} is assignable from the method's return type.
-     *
-     * @param clazz The class.
-     * @return Outcome of test.
-     */
-    boolean isReturnType(Class<?> clazz) {
-        return clazz.isAssignableFrom(method.getReturnType());
+                ? new CircuitBreakerAntn(annotatedType, annotatedMethod) : null;
+        this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(annotatedType, annotatedMethod) : null;
+        this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(annotatedType, annotatedMethod) : null;
+        this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(annotatedType, annotatedMethod) : null;
     }
 
     /**
@@ -157,7 +153,7 @@ class MethodIntrospector {
      * @return Outcome of test.
      */
     private boolean isAnnotationEnabled(Class<? extends Annotation> clazz) {
-        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(beanClass, method, clazz);
+        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(annotatedType, annotatedMethod, clazz);
         if (lookupResult == null) {
             return false;       // not present
         }
@@ -166,6 +162,7 @@ class MethodIntrospector {
         final String annotationType = clazz.getSimpleName();
 
         // Check if property defined at method level
+        Method method = annotatedMethod.getJavaMember();
         value = getParameter(method.getDeclaringClass().getName(), method.getName(),
                 annotationType, "enabled");
         if (value != null) {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
@@ -16,25 +16,24 @@
 
 package io.helidon.microprofile.faulttolerance;
 
-import java.lang.reflect.Method;
 import java.time.temporal.ChronoUnit;
+
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class RetryAntn.
- */
 class RetryAntn extends MethodAntn implements Retry {
 
     /**
      * Constructor.
      *
-     * @param beanClass Bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    RetryAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    RetryAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
@@ -16,25 +16,24 @@
 
 package io.helidon.microprofile.faulttolerance;
 
-import java.lang.reflect.Method;
 import java.time.temporal.ChronoUnit;
+
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
 
-/**
- * Class TimeoutAntn.
- */
 class TimeoutAntn extends MethodAntn implements Timeout {
 
     /**
      * Constructor.
      *
-     * @param beanClass Bean class.
-     * @param method The method.
+     * @param annotatedType The annotated type.
+     * @param annotatedMethod The annotated method.
      */
-    TimeoutAntn(Class<?> beanClass, Method method) {
-        super(beanClass, method);
+    TimeoutAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedType, annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AnnotationFinderTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AnnotationFinderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AnnotationFinderTest {
+
+    @Test
+    void testAnnotationFinder() throws Exception {
+        Package pkg = Retry.class.getPackage();
+        Method m = TimeoutAnnotBean.class.getMethod("timedRetry");
+        AnnotationFinder finder = AnnotationFinder.create(pkg);
+        Set<Class<? extends Annotation>> transitive = finder.findAnnotations(m)
+                .stream()
+                .map(Annotation::annotationType)
+                .collect(Collectors.toSet());
+        assertThat(transitive, is(Set.of(CircuitBreaker.class, Retry.class, Timeout.class)));
+    }
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AnnotationFinderTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/AnnotationFinderTest.java
@@ -36,7 +36,7 @@ class AnnotationFinderTest {
         Package pkg = Retry.class.getPackage();
         Method m = TimeoutAnnotBean.class.getMethod("timedRetry");
         AnnotationFinder finder = AnnotationFinder.create(pkg);
-        Set<Class<? extends Annotation>> transitive = finder.findAnnotations(m)
+        Set<Class<? extends Annotation>> transitive = finder.findAnnotations(Set.of(m.getAnnotations()), null)
                 .stream()
                 .map(Annotation::annotationType)
                 .collect(Collectors.toSet());

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimedRetry.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimedRetry.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retry(maxRetries = 2)
+@Timeout(value = 1000, unit = ChronoUnit.MILLIS)
+@TimedRetry2        // Need to follow this annotation
+@InterceptorBinding
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Inherited
+public @interface TimedRetry {
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimedRetry2.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimedRetry2.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@CircuitBreaker
+@InterceptorBinding
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Inherited
+public @interface TimedRetry2 {
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimeoutAnnotBean.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimeoutAnnotBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class TimeoutAnnotBean {
+
+    private AtomicInteger invocations = new AtomicInteger(0);
+
+    int getInvocations() {
+        return invocations.get();
+    }
+
+    void reset() {
+        invocations.set(0);
+    }
+
+    @TimedRetry
+    public void timedRetry() throws InterruptedException {
+        invocations.getAndIncrement();
+        FaultToleranceTest.printStatus("TimeoutStereotypeBean::timedRetry()", "failure");
+        Thread.sleep(1500);
+    }
+}

--- a/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimeoutTest.java
+++ b/microprofile/fault-tolerance/src/test/java/io/helidon/microprofile/faulttolerance/TimeoutTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
  */
 @AddBean(TimeoutBean.class)
 @AddBean(TimeoutNoRetryBean.class)
+@AddBean(TimeoutAnnotBean.class)
 class TimeoutTest extends FaultToleranceTest {
 
     @Inject
@@ -43,9 +44,13 @@ class TimeoutTest extends FaultToleranceTest {
     @Inject
     private TimeoutNoRetryBean timeoutNoRetryBean;
 
+    @Inject
+    private TimeoutAnnotBean timeoutAnnotBean;
+
     @Override
     void reset() {
         timeoutBean.reset();
+        timeoutAnnotBean.reset();
     }
 
     @Test
@@ -102,5 +107,11 @@ class TimeoutTest extends FaultToleranceTest {
         } catch (TimeoutException e) {
             assertThat(System.currentTimeMillis() - start, is(greaterThanOrEqualTo(2000L)));
         }
+    }
+
+    @Test
+    void testForceTimeoutAnnot() {
+        assertThrows(TimeoutException.class, timeoutAnnotBean::timedRetry);
+        assertThat(timeoutAnnotBean.getInvocations(), is(3));
     }
 }


### PR DESCRIPTION
New AnnotationFinder to handle transitive annotations in FT used by interceptor bindings. This allows users to define new annotations that are themselves annotated with FT annotations to be used. See new tests and Issue 4171.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>