### PR TITLE
OIDC update to support HTTPS identity provider on plain socket Helidon

### DIFF
--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
@@ -452,6 +452,9 @@ public final class SecurityHandler implements Handler {
                                  atnTracing.findParent().orElse(null));
 
         clientBuilder.explicitProvider(explicitAuthenticator.orElse(null)).submit().thenAccept(response -> {
+            // copy headers to be returned with the current response
+            response.responseHeaders().forEach(res.headers()::put);
+
             switch (response.status()) {
             case SUCCESS:
                 //everything is fine, we can continue with processing

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -308,6 +308,12 @@ import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
  *     <td>&nbsp;</td>
  *     <td>Cross-origin resource sharing settings. See {@link io.helidon.webserver.cors.CrossOriginConfig}.</td>
  * </tr>
+ * <tr>
+ *     <td>{@code force-https-redirects}</td>
+ *     <td>&nbsp;</td>
+ *     <td>Force https for redirects to identity provider.
+ *     This is helpful if you have a frontend SSL or cloud load balancer in front and Helidon is serving plain http.</td>
+ * </tr>
  * </table>
  */
 public final class OidcConfig {
@@ -332,6 +338,7 @@ public final class OidcConfig {
     static final String DEFAULT_ATTEMPT_PARAM = "h_ra";
     static final int DEFAULT_MAX_REDIRECTS = 5;
     static final int DEFAULT_TIMEOUT_SECONDS = 30;
+    static final boolean DEFAULT_FORCE_HTTPS_REDIRECTS = false;
 
     private static final Logger LOGGER = Logger.getLogger(OidcConfig.class.getName());
     private static final JsonReaderFactory JSON = Json.createReaderFactory(Collections.emptyMap());
@@ -374,6 +381,7 @@ public final class OidcConfig {
     private final URI postLogoutUri;
     private final URI logoutEndpointUri;
     private final CrossOriginConfig crossOriginConfig;
+    private final boolean forceHttpsRedirects;
 
     private OidcConfig(Builder builder) {
         this.clientId = builder.clientId;
@@ -406,6 +414,7 @@ public final class OidcConfig {
         this.generalClient = builder.generalClient;
         this.tokenEndpointAuthentication = builder.tokenEndpointAuthentication;
         this.clientTimeout = builder.clientTimeout;
+        this.forceHttpsRedirects = builder.forceHttpsRedirects;
 
         if (tokenEndpointAuthentication == ClientAuthentication.CLIENT_SECRET_POST) {
             // we should only store this if required
@@ -534,6 +543,15 @@ public final class OidcConfig {
      */
     public String redirectUri() {
         return redirectUri;
+    }
+
+    /**
+     * Whether to force https when redirecting to identity provider.
+     *
+     * @return {@code true} to force use of https
+     */
+    public boolean forceHttpsRedirects() {
+        return forceHttpsRedirects;
     }
 
     /**
@@ -1090,6 +1108,7 @@ public final class OidcConfig {
         private Duration clientTimeout = Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS);
         private URI postLogoutUri;
         private CrossOriginConfig crossOriginConfig;
+        private boolean forceHttpsRedirects = DEFAULT_FORCE_HTTPS_REDIRECTS;
 
         @Override
         public OidcConfig build() {
@@ -1292,6 +1311,7 @@ public final class OidcConfig {
             config.get("redirect").asBoolean().ifPresent(this::redirect);
             config.get("redirect-attempt-param").asString().ifPresent(this::redirectAttemptParam);
             config.get("max-redirects").asInt().ifPresent(this::maxRedirects);
+            config.get("force-https-redirects").asBoolean().ifPresent(this::forceHttpsRedirects);
 
             // type of the identity server
             // now uses hardcoded switch - should change to service loader eventually
@@ -1802,6 +1822,19 @@ public final class OidcConfig {
         @ConfiguredOption(key = "cookie-use", value = "true")
         public Builder useCookie(Boolean useCookie) {
             this.useCookie = useCookie;
+            return this;
+        }
+
+        /**
+         * Force HTTPS for redirects to identity provider.
+         * Defaults to {@code false}.
+         *
+         * @param forceHttpsRedirects flag to redirect with https
+         * @return updated builder instance
+         */
+        @ConfiguredOption("false")
+        public Builder forceHttpsRedirects(boolean forceHttpsRedirects) {
+            this.forceHttpsRedirects = forceHttpsRedirects;
             return this;
         }
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -386,7 +386,8 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         for (Map.Entry<String, List<String>> entry : env.headers().entrySet()) {
             if (entry.getKey().equalsIgnoreCase("host") && !entry.getValue().isEmpty()) {
                 String firstHost = entry.getValue().get(0);
-                return oidcConfig.redirectUriWithHost(oidcConfig.forceHttpsRedirects() ? "https" : env.transport() + "://" + firstHost);
+                return oidcConfig.redirectUriWithHost(oidcConfig.forceHttpsRedirects() ? "https" : env.transport()
+                        + "://" + firstHost);
             }
         }
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -386,7 +386,7 @@ public final class OidcProvider implements AuthenticationProvider, OutboundSecur
         for (Map.Entry<String, List<String>> entry : env.headers().entrySet()) {
             if (entry.getKey().equalsIgnoreCase("host") && !entry.getValue().isEmpty()) {
                 String firstHost = entry.getValue().get(0);
-                return oidcConfig.redirectUriWithHost(env.transport() + "://" + firstHost);
+                return oidcConfig.redirectUriWithHost(oidcConfig.forceHttpsRedirects() ? "https" : env.transport() + "://" + firstHost);
             }
         }
 

--- a/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
+++ b/security/providers/oidc/src/main/java/io/helidon/security/providers/oidc/OidcSupport.java
@@ -307,7 +307,7 @@ public final class OidcSupport implements Service {
         path = path.startsWith("/") ? path : "/" + path;
         Optional<String> host = req.headers().first("host");
         if (host.isPresent()) {
-            String scheme = req.isSecure() ? "https" : "http";
+            String scheme = oidcConfig.forceHttpsRedirects() || req.isSecure() ? "https" : "http";
             return scheme + "://" + host.get() + path;
         } else {
             LOGGER.warning("Request without Host header received, yet post logout URI does not define a host");


### PR DESCRIPTION
Related to #3590 

Adds support for https enforcement for IDP redirects.