### PR TITLE
2.x: Remove dependency on helidon-common-reactive from config

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -48,10 +48,6 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.common</groupId>
-            <artifactId>helidon-common-reactive</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-media-type</artifactId>
         </dependency>
         <dependency>

--- a/config/config/src/main/java/module-info.java
+++ b/config/config/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ module io.helidon.config {
     requires transitive java.annotation;
 
     requires transitive io.helidon.common;
-    requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.common.media.type;
 
     requires io.helidon.common.serviceloader;

--- a/dbclient/dbclient/pom.xml
+++ b/dbclient/dbclient/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>helidon-common-mapper</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/dbclient/dbclient/src/main/java/module-info.java
+++ b/dbclient/dbclient/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ module io.helidon.dbclient {
     requires transitive io.helidon.common;
     requires transitive io.helidon.common.context;
     requires transitive io.helidon.common.mapper;
+    requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.common.serviceloader;
 
     exports io.helidon.dbclient;

--- a/fault-tolerance/pom.xml
+++ b/fault-tolerance/pom.xml
@@ -42,6 +42,10 @@
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-configurable</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/fault-tolerance/src/main/java/module-info.java
+++ b/fault-tolerance/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 module io.helidon.faulttolerance {
     requires io.helidon.config;
     requires io.helidon.common.configurable;
+    requires io.helidon.common.reactive;
     requires java.logging;
 
     exports io.helidon.faulttolerance;

--- a/integrations/vault/secrets/database/pom.xml
+++ b/integrations/vault/secrets/database/pom.xml
@@ -35,5 +35,9 @@
             <groupId>io.helidon.integrations.vault</groupId>
             <artifactId>helidon-integrations-vault</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/integrations/vault/secrets/database/src/main/java/module-info.java
+++ b/integrations/vault/secrets/database/src/main/java/module-info.java
@@ -20,7 +20,7 @@
 module io.helidon.integrations.vault.secrets.database {
     requires java.logging;
 
-    requires io.helidon.common.reactive;
+    requires transitive io.helidon.common.reactive;
     requires io.helidon.integrations.vault;
     requires io.helidon.integrations.common.rest;
 

--- a/integrations/vault/secrets/database/src/main/java/module-info.java
+++ b/integrations/vault/secrets/database/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 module io.helidon.integrations.vault.secrets.database {
     requires java.logging;
 
+    requires io.helidon.common.reactive;
     requires io.helidon.integrations.vault;
     requires io.helidon.integrations.common.rest;
 

--- a/integrations/vault/sys/sys/pom.xml
+++ b/integrations/vault/sys/sys/pom.xml
@@ -38,5 +38,9 @@
             <groupId>io.helidon.integrations.vault.auths</groupId>
             <artifactId>helidon-integrations-vault-auths-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/integrations/vault/sys/sys/src/main/java/module-info.java
+++ b/integrations/vault/sys/sys/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 module io.helidon.integrations.vault.sys {
     requires java.logging;
 
+    requires io.helidon.common.reactive;
     requires io.helidon.integrations.vault;
     requires io.helidon.integrations.common.rest;
     requires io.helidon.integrations.vault.auths.common;

--- a/integrations/vault/sys/sys/src/main/java/module-info.java
+++ b/integrations/vault/sys/sys/src/main/java/module-info.java
@@ -23,7 +23,7 @@
 module io.helidon.integrations.vault.sys {
     requires java.logging;
 
-    requires io.helidon.common.reactive;
+    requires transitive io.helidon.common.reactive;
     requires io.helidon.integrations.vault;
     requires io.helidon.integrations.common.rest;
     requires io.helidon.integrations.vault.auths.common;

--- a/messaging/messaging/pom.xml
+++ b/messaging/messaging/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>helidon-common-configurable</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.microprofile.reactive-streams</groupId>
             <artifactId>helidon-microprofile-reactive-streams</artifactId>
             <scope>runtime</scope>

--- a/messaging/messaging/src/main/java/module-info.java
+++ b/messaging/messaging/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ module io.helidon.messaging {
 
     requires io.helidon.common.context;
     requires io.helidon.common.configurable;
+    requires io.helidon.common.reactive;
     requires io.helidon.config.mp;
     requires transitive io.helidon.config;
     requires transitive org.reactivestreams;

--- a/messaging/messaging/src/main/java/module-info.java
+++ b/messaging/messaging/src/main/java/module-info.java
@@ -22,8 +22,8 @@ module io.helidon.messaging {
 
     requires io.helidon.common.context;
     requires io.helidon.common.configurable;
-    requires io.helidon.common.reactive;
     requires io.helidon.config.mp;
+    requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.config;
     requires transitive org.reactivestreams;
     requires transitive microprofile.config.api;

--- a/webclient/webclient/pom.xml
+++ b/webclient/webclient/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>helidon-common-key-util</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>

--- a/webclient/webclient/src/main/java/module-info.java
+++ b/webclient/webclient/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ module io.helidon.webclient {
     requires transitive io.helidon.common;
     requires transitive io.helidon.common.context;
     requires transitive io.helidon.common.http;
+    requires transitive io.helidon.common.reactive;
     requires transitive io.helidon.config;
     requires transitive io.helidon.media.common;
     requires io.helidon.common.pki;


### PR DESCRIPTION
Removes the dependency on `helidon-common-reactive` from `confg` and adjust other modules as needed.

See #4195