### PR TITLE
2.x FT: Make require transitive for helidon common reactive module

### DIFF
--- a/fault-tolerance/src/main/java/module-info.java
+++ b/fault-tolerance/src/main/java/module-info.java
@@ -20,7 +20,7 @@
 module io.helidon.faulttolerance {
     requires io.helidon.config;
     requires io.helidon.common.configurable;
-    requires io.helidon.common.reactive;
+    requires transitive io.helidon.common.reactive;
     requires java.logging;
 
     exports io.helidon.faulttolerance;


### PR DESCRIPTION
Missed this in PR #4225 