### PR TITLE
Fix some test regressions and some code simplifications

### DIFF
--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Bulkhead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public interface Bulkhead extends FtHandler {
         private int limit = DEFAULT_LIMIT;
         private int queueLength = DEFAULT_QUEUE_LENGTH;
         private String name = "Bulkhead-" + System.identityHashCode(this);
+        private boolean cancelSource = true;
 
         private Builder() {
         }
@@ -108,6 +109,18 @@ public interface Bulkhead extends FtHandler {
             return this;
         }
 
+        /**
+         * Policy to cancel any source stage if the value return by {@link Bulkhead#invoke}
+         * is cancelled. Default is {@code true}; mostly used by FT MP to change default.
+         *
+         * @param cancelSource cancel source policy
+         * @return updated builder instance
+         */
+        public Builder cancelSource(boolean cancelSource) {
+            this.cancelSource = cancelSource;
+            return this;
+        }
+
         int limit() {
             return limit;
         }
@@ -122,6 +135,10 @@ public interface Bulkhead extends FtHandler {
 
         String name() {
             return name;
+        }
+
+        boolean cancelSource() {
+            return cancelSource;
         }
     }
 

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/BulkheadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ class BulkheadImpl implements Bulkhead {
     private final Queue<DelayedTask<?>> queue;
     private final Semaphore inProgress;
     private final String name;
+    private final boolean cancelSource;
 
     private final AtomicLong concurrentExecutions = new AtomicLong(0L);
     private final AtomicLong callsAccepted = new AtomicLong(0L);
@@ -47,6 +48,7 @@ class BulkheadImpl implements Bulkhead {
         this.executor = builder.executor();
         this.inProgress = new Semaphore(builder.limit(), true);
         this.name = builder.name();
+        this.cancelSource = builder.cancelSource();
 
         if (builder.queueLength() == 0) {
             queue = new NoQueue();
@@ -62,7 +64,7 @@ class BulkheadImpl implements Bulkhead {
 
     @Override
     public <T> Single<T> invoke(Supplier<? extends CompletionStage<T>> supplier) {
-        return invokeTask(DelayedTask.createSingle(supplier));
+        return invokeTask(DelayedTask.createSingle(supplier, cancelSource));
     }
 
     @Override

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,7 @@ public interface CircuitBreaker extends FtHandler {
         private int volume = 10;
         private LazyValue<? extends ScheduledExecutorService> executor = FaultTolerance.scheduledExecutor();
         private String name = "CircuitBreaker-" + System.identityHashCode(this);
+        private boolean cancelSource = true;
 
         private Builder() {
         }
@@ -242,6 +243,18 @@ public interface CircuitBreaker extends FtHandler {
             return this;
         }
 
+        /**
+         * Policy to cancel any source stage if the value return by {@link CircuitBreaker#invoke}
+         * is cancelled. Default is {@code true}; mostly used by FT MP to change default.
+         *
+         * @param cancelSource cancel source policy
+         * @return updated builder instance
+         */
+        public Builder cancelSource(boolean cancelSource) {
+            this.cancelSource = cancelSource;
+            return this;
+        }
+
         LazyValue<? extends ScheduledExecutorService> executor() {
             return executor;
         }
@@ -272,6 +285,10 @@ public interface CircuitBreaker extends FtHandler {
 
         String name() {
             return name;
+        }
+
+        boolean cancelSource() {
+            return cancelSource;
         }
     }
 }

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/CircuitBreakerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
     private final AtomicReference<ScheduledFuture<Boolean>> schedule = new AtomicReference<>();
     private final ErrorChecker errorChecker;
     private final String name;
+    private final boolean cancelSource;
 
     CircuitBreakerImpl(CircuitBreaker.Builder builder) {
         this.delayMillis = builder.delay().toMillis();
@@ -63,6 +64,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
         this.executor = builder.executor();
         this.errorChecker = ErrorChecker.create(builder.skipOn(), builder.applyOn());
         this.name = builder.name();
+        this.cancelSource = builder.cancelSource();
     }
 
     @Override
@@ -77,7 +79,7 @@ class CircuitBreakerImpl implements CircuitBreaker {
 
     @Override
     public <T> Single<T> invoke(Supplier<? extends CompletionStage<T>> supplier) {
-        return invokeTask(DelayedTask.createSingle(supplier));
+        return invokeTask(DelayedTask.createSingle(supplier, cancelSource));
     }
 
     private <U> U invokeTask(DelayedTask<U> task) {

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/DelayedTask.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/DelayedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,11 @@ interface DelayedTask<T> {
     }
 
     static <T> DelayedTask<Single<T>> createSingle(Supplier<? extends CompletionStage<T>> supplier) {
+        return createSingle(supplier, true);
+    }
+
+    static <T> DelayedTask<Single<T>> createSingle(Supplier<? extends CompletionStage<T>> supplier,
+                                                   boolean cancelSource) {
         return new DelayedTask<>() {
             // future we returned as a result of invoke command
             private final LazyValue<CompletableFuture<T>> resultFuture = LazyValue.create(CompletableFuture::new);
@@ -119,7 +124,7 @@ interface DelayedTask<T> {
                 }
 
                 CompletableFuture<T> future = resultFuture.get();
-                createDependency(result, future);
+                createDependency(result, future, cancelSource);
                 return result.thenRun(() -> {});
             }
 

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Retry.java
@@ -61,6 +61,7 @@ public interface Retry extends FtHandler {
         private Duration overallTimeout = Duration.ofSeconds(1);
         private LazyValue<? extends ScheduledExecutorService> scheduledExecutor = FaultTolerance.scheduledExecutor();
         private String name = "Retry-" + System.identityHashCode(this);
+        private boolean cancelSource = true;
 
         private Builder() {
         }
@@ -178,6 +179,18 @@ public interface Retry extends FtHandler {
             return this;
         }
 
+        /**
+         * Policy to cancel any source stage if the value return by {@link Retry#invoke}
+         * is cancelled. Default is {@code true}; mostly used by FT MP to change default.
+         *
+         * @param cancelSource cancel source policy
+         * @return updated builder instance
+         */
+        public Builder cancelSource(boolean cancelSource) {
+            this.cancelSource = cancelSource;
+            return this;
+        }
+
         Set<Class<? extends Throwable>> applyOn() {
             return applyOn;
         }
@@ -200,6 +213,10 @@ public interface Retry extends FtHandler {
 
         String name() {
             return name;
+        }
+
+        boolean cancelSource() {
+            return cancelSource;
         }
     }
 

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/RetryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class RetryImpl implements Retry {
     private final Retry.RetryPolicy retryPolicy;
     private final AtomicLong retryCounter = new AtomicLong(0L);
     private final String name;
+    private final boolean cancelSource;
 
     RetryImpl(Retry.Builder builder) {
         this.scheduledExecutor = builder.scheduledExecutor();
@@ -46,6 +47,7 @@ class RetryImpl implements Retry {
         this.maxTimeNanos = builder.overallTimeout().toNanos();
         this.retryPolicy = builder.retryPolicy();
         this.name = builder.name();
+        this.cancelSource = builder.cancelSource();
     }
 
     @Override
@@ -86,7 +88,7 @@ class RetryImpl implements Retry {
             retryCounter.getAndIncrement();
         }
 
-        DelayedTask<Single<T>> task = DelayedTask.createSingle(context.supplier);
+        DelayedTask<Single<T>> task = DelayedTask.createSingle(context.supplier, cancelSource);
         if (delay == 0) {
             task.execute();
         } else {

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public interface Timeout extends FtHandler {
         private LazyValue<? extends ScheduledExecutorService> executor = FaultTolerance.scheduledExecutor();
         private boolean currentThread = false;
         private String name = "Timeout-" + System.identityHashCode(this);
+        private boolean cancelSource = true;
 
         private Builder() {
         }
@@ -108,6 +109,17 @@ public interface Timeout extends FtHandler {
             return this;
         }
 
+        /**
+         * Cancel source if destination stage is cancelled.
+         *
+         * @param cancelSource setting for cancel source, defaults (@code true}
+         * @return updated builder instance
+         */
+        public Builder cancelSource(boolean cancelSource) {
+            this.cancelSource = cancelSource;
+            return this;
+        }
+
         Duration timeout() {
             return timeout;
         }
@@ -122,6 +134,10 @@ public interface Timeout extends FtHandler {
 
         String name() {
             return name;
+        }
+
+        boolean cancelSource() {
+            return cancelSource;
         }
     }
 }

--- a/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
+++ b/fault-tolerance/src/main/java/io/helidon/faulttolerance/TimeoutImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,14 @@ class TimeoutImpl implements Timeout {
     private final LazyValue<? extends ScheduledExecutorService> executor;
     private final boolean currentThread;
     private final String name;
+    private final boolean cancelSource;
 
     TimeoutImpl(Timeout.Builder builder) {
         this.timeoutMillis = builder.timeout().toMillis();
         this.executor = builder.executor();
         this.currentThread = builder.currentThread();
         this.name = builder.name();
+        this.cancelSource = builder.cancelSource();
     }
 
     @Override
@@ -100,7 +102,7 @@ class TimeoutImpl implements Timeout {
             // Run invocation in current thread
             Single<T> single = Single.create(supplier.get(), true);
             callReturned.set(true);
-            createDependency(single, future);
+            createDependency(single, future, cancelSource);
 
             // Clear interrupted flag here -- required for uninterruptible busy loops
             Thread.interrupted();

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AsynchronousAntn.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
@@ -30,11 +29,10 @@ class AsynchronousAntn extends MethodAntn implements Asynchronous {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    AsynchronousAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    AsynchronousAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/BulkheadAntn.java
@@ -17,7 +17,6 @@
 package io.helidon.microprofile.faulttolerance;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
@@ -27,11 +26,10 @@ class BulkheadAntn extends MethodAntn implements Bulkhead {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    BulkheadAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    BulkheadAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/CircuitBreakerAntn.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.faulttolerance;
 import java.time.temporal.ChronoUnit;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
@@ -29,11 +28,10 @@ class CircuitBreakerAntn extends MethodAntn implements CircuitBreaker {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    CircuitBreakerAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    CircuitBreakerAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FallbackAntn.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.faulttolerance;
 import java.lang.reflect.Method;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.Fallback;
@@ -31,11 +30,10 @@ class FallbackAntn extends MethodAntn implements Fallback {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    FallbackAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    FallbackAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -29,6 +29,7 @@ import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Initialized;
 import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
 import javax.enterprise.inject.spi.AnnotatedConstructor;
 import javax.enterprise.inject.spi.AnnotatedField;
 import javax.enterprise.inject.spi.AnnotatedMethod;
@@ -252,7 +253,15 @@ public class FaultToleranceExtension implements Extension {
                 }
             });
         }
+    }
 
+    /**
+     * Creates the executors used by FT using config. Must be created during the
+     * {@code AfterDeploymentValidation} event.
+     *
+     * @param event the AfterDeploymentValidation event
+     */
+    void createFaultToleranceExecutors(@Observes AfterDeploymentValidation event) {
         // Initialize executors for MP FT - default size of 16
         io.helidon.config.Config config = MpConfig.toHelidonConfig(ConfigProvider.getConfig());
         scheduledThreadPoolSupplier = ScheduledThreadPoolSupplier.builder()

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FaultToleranceExtension.java
@@ -204,7 +204,7 @@ public class FaultToleranceExtension implements Extension {
      */
     private void registerFaultToleranceMethods(BeanManager bm, AnnotatedType<?> type) {
         for (AnnotatedMethod<?> method : type.getMethods()) {
-            if (isFaultToleranceMethod(type, method, bm)) {
+            if (isFaultToleranceMethod(method, bm)) {
                 getRegisteredMethods().add(method);
             }
         }
@@ -222,34 +222,32 @@ public class FaultToleranceExtension implements Extension {
                                          @Initialized(ApplicationScoped.class) Object event) {
         if (FaultToleranceMetrics.enabled()) {
             getRegisteredMethods().forEach(annotatedMethod -> {
-                final AnnotatedType<?> annotatedType = annotatedMethod.getDeclaringType();
-
                 // Counters for all methods
                 FaultToleranceMetrics.registerMetrics(annotatedMethod.getJavaMember());
 
                 // Metrics depending on the annotationSet present
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Retry.class, bm)) {
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, Retry.class, bm)) {
                     FaultToleranceMetrics.registerRetryMetrics(annotatedMethod.getJavaMember());
-                    new RetryAntn(annotatedType, annotatedMethod).validate();
+                    new RetryAntn(annotatedMethod).validate();
                 }
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, CircuitBreaker.class, bm)) {
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, CircuitBreaker.class, bm)) {
                     FaultToleranceMetrics.registerCircuitBreakerMetrics(annotatedMethod.getJavaMember());
-                    new CircuitBreakerAntn(annotatedType, annotatedMethod).validate();
+                    new CircuitBreakerAntn(annotatedMethod).validate();
                 }
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Timeout.class, bm)) {
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, Timeout.class, bm)) {
                     FaultToleranceMetrics.registerTimeoutMetrics(annotatedMethod.getJavaMember());
-                    new TimeoutAntn(annotatedType, annotatedMethod).validate();
+                    new TimeoutAntn(annotatedMethod).validate();
                 }
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Bulkhead.class, bm)) {
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, Bulkhead.class, bm)) {
                     FaultToleranceMetrics.registerBulkheadMetrics(annotatedMethod.getJavaMember());
-                    new BulkheadAntn(annotatedType, annotatedMethod).validate();
+                    new BulkheadAntn(annotatedMethod).validate();
                 }
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Fallback.class, bm)) {
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, Fallback.class, bm)) {
                     FaultToleranceMetrics.registerFallbackMetrics(annotatedMethod.getJavaMember());
-                    new FallbackAntn(annotatedType, annotatedMethod).validate();
+                    new FallbackAntn(annotatedMethod).validate();
                 }
-                if (MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Asynchronous.class, bm)) {
-                    new AsynchronousAntn(annotatedType, annotatedMethod).validate();
+                if (MethodAntn.isAnnotationPresent(annotatedMethod, Asynchronous.class, bm)) {
+                    new AsynchronousAntn(annotatedMethod).validate();
                 }
             });
         }
@@ -308,19 +306,17 @@ public class FaultToleranceExtension implements Extension {
      * Determines if a method has any fault tolerance annotationSet. Only {@code @Fallback}
      * is considered if fault tolerance is disabled.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The method to check.
      * @return Outcome of test.
      */
-    static boolean isFaultToleranceMethod(AnnotatedType<?> annotatedType,
-                                          AnnotatedMethod<?> annotatedMethod,
+    static boolean isFaultToleranceMethod(AnnotatedMethod<?> annotatedMethod,
                                           BeanManager bm) {
-        return MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Retry.class, bm)
-                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, CircuitBreaker.class, bm)
-                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Bulkhead.class, bm)
-                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Timeout.class, bm)
-                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Asynchronous.class, bm)
-                || MethodAntn.isAnnotationPresent(annotatedType, annotatedMethod, Fallback.class, bm);
+        return MethodAntn.isAnnotationPresent(annotatedMethod, Retry.class, bm)
+                || MethodAntn.isAnnotationPresent(annotatedMethod, CircuitBreaker.class, bm)
+                || MethodAntn.isAnnotationPresent(annotatedMethod, Bulkhead.class, bm)
+                || MethodAntn.isAnnotationPresent(annotatedMethod, Timeout.class, bm)
+                || MethodAntn.isAnnotationPresent(annotatedMethod, Asynchronous.class, bm)
+                || MethodAntn.isAnnotationPresent(annotatedMethod, Fallback.class, bm);
     }
 
     /**

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodAntn.java
@@ -78,12 +78,11 @@ abstract class MethodAntn {
     /**
      * Constructor.
      *
-     * @param annotatedType Annotated type.
      * @param annotatedMethod Annotated method.
      */
-    MethodAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        this.annotatedType = annotatedType;
+    MethodAntn(AnnotatedMethod<?> annotatedMethod) {
         this.annotatedMethod = annotatedMethod;
+        this.annotatedType = annotatedMethod.getDeclaringType();
     }
 
     Method method() {
@@ -98,23 +97,21 @@ abstract class MethodAntn {
      * @return A lookup result.
      */
     public final <A extends Annotation> LookupResult<A> lookupAnnotation(Class<A> annotClass) {
-        return lookupAnnotation(annotatedType, annotatedMethod, annotClass, null);
+        return lookupAnnotation(annotatedMethod, annotClass, null);
     }
 
     /**
      * Finds if an annotation is present on a method or its class.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod Method to check.
      * @param annotClass Annotation class.
      * @param beanManager CDI's bean manager or {@code null} if not available.
      * @return Outcome of test.
      */
-    static boolean isAnnotationPresent(AnnotatedType<?> annotatedType,
-                                       AnnotatedMethod<?> annotatedMethod,
+    static boolean isAnnotationPresent(AnnotatedMethod<?> annotatedMethod,
                                        Class<? extends Annotation> annotClass,
                                        BeanManager beanManager) {
-        return lookupAnnotation(annotatedType, annotatedMethod, annotClass, beanManager) != null;
+        return lookupAnnotation(annotatedMethod, annotClass, beanManager) != null;
     }
 
     /**
@@ -199,15 +196,13 @@ abstract class MethodAntn {
      * instance of this annotation exist (after computing the transitive closure),
      * one will be returned in an undefined manner.
      *
-     * @param type The annotated type.
      * @param method The annotated method.
      * @param annotClass The annotation class.
      * @param <A> Annotation type.
      * @return The lookup result or {@code null}.
      */
     @SuppressWarnings("unchecked")
-    static <A extends Annotation> LookupResult<A> lookupAnnotation(AnnotatedType<?> type,
-                                                                   AnnotatedMethod<?> method,
+    static <A extends Annotation> LookupResult<A> lookupAnnotation(AnnotatedMethod<?> method,
                                                                    Class<A> annotClass,
                                                                    BeanManager beanManager) {
         A annotation = (A) getMethodAnnotation(method, annotClass, beanManager);
@@ -218,6 +213,7 @@ abstract class MethodAntn {
             }
             return new LookupResult<>(MatchingType.METHOD, annotation);
         }
+        AnnotatedType<?> type = method.getDeclaringType();
         annotation = (A) getClassAnnotation(type, annotClass, beanManager);
         if (annotation != null) {
             if (LOGGER.isLoggable(Level.FINE)) {

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -39,8 +39,6 @@ import static io.helidon.microprofile.faulttolerance.MethodAntn.lookupAnnotation
 
 class MethodIntrospector {
 
-    private final AnnotatedType<?> annotatedType;
-
     private final AnnotatedMethod<?> annotatedMethod;
 
     private final Retry retry;
@@ -61,7 +59,7 @@ class MethodIntrospector {
     @SuppressWarnings("unchecked")
     MethodIntrospector(Class<?> beanClass, Method method) {
         BeanManager bm = CDI.current().getBeanManager();
-        this.annotatedType = bm.createAnnotatedType(beanClass);
+        AnnotatedType<?> annotatedType = bm.createAnnotatedType(beanClass);
         Optional<AnnotatedMethod<?>> annotatedMethodOptional =
                 (Optional<AnnotatedMethod<?>>) annotatedType.getMethods()
                         .stream()
@@ -69,12 +67,12 @@ class MethodIntrospector {
                         .findFirst();
         this.annotatedMethod = annotatedMethodOptional.orElseThrow();
 
-        this.retry = isAnnotationEnabled(Retry.class) ? new RetryAntn(annotatedType, annotatedMethod) : null;
+        this.retry = isAnnotationEnabled(Retry.class) ? new RetryAntn(annotatedMethod) : null;
         this.circuitBreaker = isAnnotationEnabled(CircuitBreaker.class)
-                ? new CircuitBreakerAntn(annotatedType, annotatedMethod) : null;
-        this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(annotatedType, annotatedMethod) : null;
-        this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(annotatedType, annotatedMethod) : null;
-        this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(annotatedType, annotatedMethod) : null;
+                ? new CircuitBreakerAntn(annotatedMethod) : null;
+        this.timeout = isAnnotationEnabled(Timeout.class) ? new TimeoutAntn(annotatedMethod) : null;
+        this.bulkhead = isAnnotationEnabled(Bulkhead.class) ? new BulkheadAntn(annotatedMethod) : null;
+        this.fallback = isAnnotationEnabled(Fallback.class) ? new FallbackAntn(annotatedMethod) : null;
     }
 
     /**
@@ -154,7 +152,7 @@ class MethodIntrospector {
      */
     private boolean isAnnotationEnabled(Class<? extends Annotation> clazz) {
         BeanManager bm = CDI.current().getBeanManager();
-        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(annotatedType, annotatedMethod, clazz, bm);
+        LookupResult<? extends Annotation> lookupResult = lookupAnnotation(annotatedMethod, clazz, bm);
         if (lookupResult == null) {
             return false;       // not present
         }

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodInvoker.java
@@ -453,6 +453,7 @@ class MethodInvoker implements FtSupplier<Object> {
             methodState.bulkhead = Bulkhead.builder()
                     .limit(introspector.getBulkhead().value())
                     .queueLength(introspector.isAsynchronous() ? introspector.getBulkhead().waitingTaskQueue() : 0)
+                    .cancelSource(false)        // for the FT TCK's
                     .build();
         }
 
@@ -460,6 +461,7 @@ class MethodInvoker implements FtSupplier<Object> {
             methodState.timeout = Timeout.builder()
                     .timeout(Duration.of(introspector.getTimeout().value(), introspector.getTimeout().unit()))
                     .currentThread(!introspector.isAsynchronous())
+                    .cancelSource(false)        // for the FT TCK's
                     .build();
         }
 

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/RetryAntn.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.faulttolerance;
 import java.time.temporal.ChronoUnit;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
@@ -29,11 +28,10 @@ class RetryAntn extends MethodAntn implements Retry {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    RetryAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    RetryAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/TimeoutAntn.java
@@ -19,7 +19,6 @@ package io.helidon.microprofile.faulttolerance;
 import java.time.temporal.ChronoUnit;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.AnnotatedType;
 
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
@@ -29,11 +28,10 @@ class TimeoutAntn extends MethodAntn implements Timeout {
     /**
      * Constructor.
      *
-     * @param annotatedType The annotated type.
      * @param annotatedMethod The annotated method.
      */
-    TimeoutAntn(AnnotatedType<?> annotatedType, AnnotatedMethod<?> annotatedMethod) {
-        super(annotatedType, annotatedMethod);
+    TimeoutAntn(AnnotatedMethod<?> annotatedMethod) {
+        super(annotatedMethod);
     }
 
     @Override


### PR DESCRIPTION
    
 - Fixed a few FT regressions. Enable configuration of Single source cancellation and moved initialization of executors to the AfterDeploymentValidation phase.

 - Simplified uses of AnnotationType/AnnotationMethod by simply passing AnnotationMethod.
