### PR TITLE
Enable thread pool growth at threshold instead of above it

### DIFF
--- a/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
+++ b/common/configurable/src/main/java/io/helidon/common/configurable/ThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -782,7 +782,7 @@ public class ThreadPool extends ThreadPoolExecutor {
 
             // Is the queue above the threshold?
 
-            if (queueSize > queueThreshold) {
+            if (queueSize >= queueThreshold) {
 
                 // Yes. Should we grow?
                 // Note that this random number generator is quite fast, and on average is faster than or equivalent to

--- a/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolTest.java
+++ b/common/configurable/src/test/java/io/helidon/common/configurable/ThreadPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -369,12 +369,12 @@ class ThreadPoolTest {
         assertThat(pool.getPoolSize(), is(coreSize));
         assertThat(pool.getQueueSize(), is(0));
 
-        // Add growthThreshold + 1 tasks to fill the queue to just above the threshold
+        // Add growthThreshold tasks to fill the queue to just the threshold
         // and make sure the pool has not grown
 
-        addTasks(growthThreshold + 1);
+        addTasks(growthThreshold);
         assertThat(pool.getPoolSize(), is(coreSize));
-        assertThat(pool.getQueueSize(), is(growthThreshold + 1));
+        assertThat(pool.getQueueSize(), is(growthThreshold));
 
         // Add 1 task at a time and the pool should grow by one thread each time since
         // we have a 100% rate. Repeat to grow to max size.
@@ -388,7 +388,7 @@ class ThreadPoolTest {
         // Ensure that pool size is at max and that the queue is still just above the threshold
 
         assertThat(pool.getPoolSize(), is(maxSize));
-        assertThat(pool.getQueueSize(), is(growthThreshold + 1));
+        assertThat(pool.getQueueSize(), is(growthThreshold));
 
         // Let tasks run until we empty the queue
 
@@ -408,14 +408,46 @@ class ThreadPoolTest {
 
         // Fill the queue again
 
-        addTasks(growthThreshold + 1);
+        addTasks(growthThreshold);
         assertThat(pool.getPoolSize(), is(coreSize));
-        assertThat(pool.getQueueSize(), is(growthThreshold + 1));
+        assertThat(pool.getQueueSize(), is(growthThreshold));
 
         // Add 1 task and ensure that we grow by 1 thread
 
         addTasks(1);
         waitUntilActiveThreadsIs(coreSize + 1);
+    }
+
+    @Test
+    void testSimpleGrowth() throws InterruptedException {
+        int coreSize = 1;
+        int maxSize = 2;
+        int growthThreshold = 0;
+        int growthRate = 100;
+
+        pool = newPool(coreSize, maxSize, growthThreshold, growthRate);
+
+        // Create single thread to fill coreSize
+        CountDownLatch running1 = new CountDownLatch(1);
+        Task task1 = new Task(running1);
+        pool.submit(task1);
+        running1.await();
+        assertThat(pool.getPoolSize(), is(coreSize));
+        assertThat(pool.getQueueSize(), is(0));
+
+        // New thread should cause immediate growth to maxSize, no queueing
+        CountDownLatch running2 = new CountDownLatch(1);
+        Task task2 = new Task(running2);
+        pool.submit(task2);
+        boolean success = running2.await(1, SECONDS);
+        assertThat(success, is(true));
+        assertThat(pool.getPoolSize(), is(maxSize));
+        assertThat(pool.getQueueSize(), is(0));
+
+        // Clean up
+        task1.finish();
+        task2.finish();
+        pool.shutdown();
     }
 
     @Test


### PR DESCRIPTION
Enable thread pool growth _at_ the threshold instead of above it. These semantics prevent unwanted queueing. See issue #4727.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>