### PR TITLE
Deserialization disabled by default.

### DIFF
--- a/common/common/src/main/java/io/helidon/common/SerializationConfig.java
+++ b/common/common/src/main/java/io/helidon/common/SerializationConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ public final class SerializationConfig {
      * This is a one-off call to set up global filter.
      */
     public static void configureRuntime() {
-        builder().build().configure();
+        builder().onNoConfig(Action.CONFIGURE).build().configure();
     }
 
     /**
@@ -366,8 +366,8 @@ public final class SerializationConfig {
      * {@link SerializationConfig#configureRuntime()} directly.
      */
     public static class Builder implements io.helidon.common.Builder<Builder, SerializationConfig> {
-        private Action onWrongConfig = configuredAction(PROP_WRONG_CONFIG_ACTION, Action.WARN);
-        private Action onNoConfig = configuredAction(PROP_NO_CONFIG_ACTION, Action.WARN);
+        private Action onWrongConfig = configuredAction(PROP_WRONG_CONFIG_ACTION, Action.FAIL);
+        private Action onNoConfig = configuredAction(PROP_NO_CONFIG_ACTION, Action.FAIL);
         private String filterPattern = System.getProperty(PROP_PATTERN);
         private TraceOption traceSerialization = configuredTrace(TraceOption.NONE);
         private boolean ignoreFiles = Boolean.getBoolean(PROP_IGNORE_FILES);
@@ -620,6 +620,10 @@ public final class SerializationConfig {
                 return delegate.checkInput(filterInfo);
             }
             Status result = delegate.checkInput(filterInfo);
+
+            if (clazz == null) {
+                return result;
+            }
 
             if (!reportedClasses.add(clazz)) {
                 if (basic) {

--- a/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
+++ b/common/common/src/test/java/io/helidon/common/SerializationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,8 @@ class SerializationConfigTest {
 
         SerializationConfig.ConfigOptions options = serializationConfig.options();
         assertThat(options.traceSerialization(), is(SerializationConfig.TraceOption.NONE));
-        // TODO this will change in 3.0.0
-        assertThat(options.onNoConfig(), is(SerializationConfig.Action.WARN));
-        // TODO this will change in 3.0.0
-        assertThat(options.onWrongConfig(), is(SerializationConfig.Action.WARN));
+        assertThat(options.onNoConfig(), is(SerializationConfig.Action.FAIL));
+        assertThat(options.onWrongConfig(), is(SerializationConfig.Action.FAIL));
         assertThat(options.filterPattern(), is("!*"));
     }
 

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,19 +260,6 @@ class MpConfigImpl implements Config {
                 .findFirst()
                 .map(Map.Entry::getValue)
                 .map(it -> (Converter<T>) it)
-                .map(it -> (Converter<T>) value -> {
-                    if (value == null) {
-                        throw new NullPointerException("Null not allowed in MP converters. Converter for type " + forType
-                                .getName());
-                    }
-                    try {
-                        return it.convert(value);
-                    } catch (IllegalArgumentException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException("Cannot convert value", e);
-                    }
-                })
                 .or(() -> findImplicit(forType));
     }
 

--- a/examples/jbatch/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/examples/jbatch/src/main/resources/META-INF/helidon/serial-config.properties
@@ -14,17 +14,6 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-# Send messages to the console
-handlers=io.helidon.common.HelidonConsoleHandler
-
-# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-
-# Quiet Weld
-org.jboss.level=WARNING
+# The JBatch uses Serialization a lot, and these are all required
+pattern=com.ibm.jbatch.**;jakarta.batch.runtime.BatchStatus;java.lang.Enum;\
+  java.util.Properties;java.util.Hashtable;java.util.Map$Entry

--- a/microprofile/config/src/main/resources/META-INF/helidon/serial-config.properties
+++ b/microprofile/config/src/main/resources/META-INF/helidon/serial-config.properties
@@ -14,17 +14,5 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-# Send messages to the console
-handlers=io.helidon.common.HelidonConsoleHandler
-
-# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-
-# Quiet Weld
-org.jboss.level=WARNING
+pattern=org.jboss.weld.bean.proxy.util.SerializableClientProxy;org.jboss.weld.bean.StringBeanIdentifier;\
+  org.eclipse.microprofile.config.Config$_$$_WeldClientProxy;io.helidon.config.mp.MpConfigBuilder$NullCheckingConverter

--- a/microprofile/tests/tck/tck-config/src/test/resources/META-INF/helidon/serial-config.properties
+++ b/microprofile/tests/tck/tck-config/src/test/resources/META-INF/helidon/serial-config.properties
@@ -14,17 +14,5 @@
 # limitations under the License.
 #
 
-# Example Logging Configuration File
-# For more information see $JAVA_HOME/jre/lib/logging.properties
-
-# Send messages to the console
-handlers=io.helidon.common.HelidonConsoleHandler
-
-# HelidonConsoleHandler uses a SimpleFormatter subclass that replaces "!thread!" with the current thread
-java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS %4$s %3$s !thread!: %5$s%6$s%n
-
-# Global logging level. Can be overridden by specific loggers
-.level=INFO
-
-# Quiet Weld
-org.jboss.level=WARNING
+# TCK converter to validate deserialization
+pattern=org.eclipse.microprofile.config.tck.converters.DuckConverter;org.eclipse.microprofile.config.tck.converters.Duck


### PR DESCRIPTION
Added serial config where required.
MP Config uses known class for converters (to avoid lambdas and complex deserialization)