### PR TITLE
Change defaults for Open ID Connect

### DIFF
--- a/examples/microprofile/idcs/src/main/resources/application.yaml
+++ b/examples/microprofile/idcs/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,8 @@ security:
         scope-audience: "http://localhost:7987/test-application"
         proxy-host: "${security.properties.proxy-host}"
         frontend-uri: "${security.properties.frontend-uri}"
+        # We want to redirect to login page (and token can be received either through cookie or header)
+        redirect: true
     - idcs-role-mapper:
         multitenant: false
         oidc-config:

--- a/examples/microprofile/oidc/src/main/resources/application.yaml
+++ b/examples/microprofile/oidc/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,3 +50,5 @@ security:
         identity-uri: "${security.properties.oidc-identity-uri}"
         frontend-uri: "${security.properties.frontend-uri}"
         server-type: "${security.properties.server-type}"
+        # We want to redirect to login page (and token can be received either through cookie or header)
+        redirect: true

--- a/examples/security/idcs-login/src/main/resources/application.yaml
+++ b/examples/security/idcs-login/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +43,8 @@ security:
       logout-enabled: true
       # Can define just a path, host will be taken from header
       post-logout-uri: "/loggedout"
+      # We want to redirect to login page (and token can be received either through cookie or header)
+      redirect: true
   - idcs-role-mapper:
       multitenant: false
       oidc-config:

--- a/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
+++ b/security/providers/oidc-common/src/main/java/io/helidon/security/providers/oidc/common/OidcConfig.java
@@ -89,7 +89,7 @@ import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
  * </tr>
  * <tr>
  *     <td>frontend-uri</td>
- *     <td>Fully URI of the frontend for redirects back from OIDC server (e.g. http://myserver/myApp)</td>
+ *     <td>Full URI of the frontend for redirects back from OIDC server (e.g. http://myserver/myApp)</td>
  * </tr>
  * </table>
  *
@@ -184,7 +184,7 @@ import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
  * </tr>
  * <tr>
  *     <td>header-use</td>
- *     <td>false</td>
+ *     <td>true</td>
  *     <td>Whether to expect JWT in a header field.</td>
  * </tr>
  * <tr>
@@ -241,7 +241,7 @@ import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
  * </tr>
  * <tr>
  *     <td>redirect</td>
- *     <td>true</td>
+ *     <td>false</td>
  *     <td>Whether to redirect to identity server when authentication failed.</td>
  * </tr>
  * <tr>
@@ -329,11 +329,11 @@ public final class OidcConfig {
     static final boolean DEFAULT_COOKIE_USE = true;
     static final String DEFAULT_PARAM_NAME = "accessToken";
     static final boolean DEFAULT_PARAM_USE = false;
-    static final boolean DEFAULT_HEADER_USE = false;
+    static final boolean DEFAULT_HEADER_USE = true;
     static final String DEFAULT_PROXY_PROTOCOL = "http";
     static final String DEFAULT_BASE_SCOPES = "openid";
     static final boolean DEFAULT_JWT_VALIDATE_JWK = true;
-    static final boolean DEFAULT_REDIRECT = true;
+    static final boolean DEFAULT_REDIRECT = false;
     static final String DEFAULT_REALM = "helidon";
     static final String DEFAULT_ATTEMPT_PARAM = "h_ra";
     static final int DEFAULT_MAX_REDIRECTS = 5;
@@ -1415,7 +1415,7 @@ public final class OidcConfig {
          *                 authenticate the user, defaults to true
          * @return updated builder instance
          */
-        @ConfiguredOption("true")
+        @ConfiguredOption("false")
         public Builder redirect(boolean redirect) {
             this.redirect = redirect;
             return this;
@@ -1583,7 +1583,7 @@ public final class OidcConfig {
          * @param useHeader set to true to use a header extracted with {@link #headerTokenHandler(TokenHandler)}
          * @return updated builder instance
          */
-        @ConfiguredOption(key = "header-use", value = "false")
+        @ConfiguredOption(key = "header-use", value = "true")
         public Builder useHeader(Boolean useHeader) {
             this.useHeader = useHeader;
             return this;


### PR DESCRIPTION
Resolves #3307 

- use headers by default
- do not redirect to IDP by default

This is a breaking change - now the `redirect` option must be set to `true` to allow the feature