### PR TITLE
Support Hocon/Json Configuration Source for MP

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -258,6 +258,11 @@
             </dependency>
             <dependency>
                 <groupId>io.helidon.config</groupId>
+                <artifactId>helidon-config-hocon-mp</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.config</groupId>
                 <artifactId>helidon-config-git</artifactId>
                 <version>${helidon.version}</version>
             </dependency>

--- a/config/config-mp/pom.xml
+++ b/config/config-mp/pom.xml
@@ -55,10 +55,6 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-yaml-mp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpConfigBuilder.java
@@ -24,7 +24,6 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -47,6 +46,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -54,8 +54,6 @@ import java.util.ServiceLoader;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import java.util.UUID;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -66,7 +64,7 @@ import io.helidon.config.ConfigException;
 import io.helidon.config.ConfigMappers;
 import io.helidon.config.ConfigValue;
 import io.helidon.config.mp.spi.MpConfigFilter;
-import io.helidon.config.yaml.mp.YamlMpConfigSource;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
@@ -82,6 +80,27 @@ import static io.helidon.config.mp.MpMetaConfig.MetaConfigSource;
 class MpConfigBuilder implements ConfigBuilder {
     private static final Logger LOGGER = Logger.getLogger(MpConfigBuilder.class.getName());
     private static final String DEFAULT_CONFIG_SOURCE = "META-INF/microprofile-config.properties";
+
+    private static final Map<String, MpMetaConfigProvider> MP_META_PROVIDERS;
+    static {
+        List<MpMetaConfigProvider> mpMetaConfigProviders =
+                HelidonServiceLoader.builder(ServiceLoader.load(MpMetaConfigProvider.class))
+                        .addService(new MpEnvironmentVariablesMetaConfigProvider())
+                        .addService(new MpSystemPropertiesMetaConfigProvider())
+                        .addService(new MpPropertiesMetaConfigProvider())
+                        .build()
+                        .asList();
+
+        Map<String, MpMetaConfigProvider> theMap = new HashMap<>();
+        // ordered by priority
+        for (MpMetaConfigProvider mpMetaConfigProvider : mpMetaConfigProviders) {
+            for (String supportedType : mpMetaConfigProvider.supportedTypes()) {
+                theMap.putIfAbsent(supportedType, mpMetaConfigProvider);
+            }
+        }
+        MP_META_PROVIDERS = Map.copyOf(theMap);
+    }
+
 
     private final List<OrdinalSource> sources = new LinkedList<>();
     private final List<OrdinalConverter> converters = new LinkedList<>();
@@ -151,14 +170,6 @@ class MpConfigBuilder implements ConfigBuilder {
         }
 
         return doGetType(clazz.getSuperclass());
-    }
-
-    private static String toProfileName(String fileName, String profile) {
-        int i = fileName.lastIndexOf('.');
-        if (i > -1) {
-            return fileName.substring(0, i) + "-" + profile + fileName.substring(i);
-        }
-        return fileName + "-" + profile;
     }
 
     @Override
@@ -236,25 +247,14 @@ class MpConfigBuilder implements ConfigBuilder {
         for (io.helidon.config.Config config : configs) {
             String type = config.get("type").asString()
                     .orElseThrow(() -> new ConfigException("Meta configuration sources must have a \"type\" property defined"));
-            // in MP, we have a hardcoded list of supported configuration source types
-            List<ConfigSource> delegates;
-            switch (type) {
-            case "system-properties":
-                delegates = List.of(MpConfigSources.systemProperties());
-                break;
-            case "environment-variables":
-                delegates = List.of(MpConfigSources.environmentVariables());
-                break;
-            case "properties":
-                delegates = propertiesSource(config);
-                break;
-            case "yaml":
-                delegates = yamlSource(config);
-                break;
-            default:
-                throw new ConfigException("Meta configuration source type \"" + type + "\" is not supported. Use on of: "
-                                                  + "system-properties, environment-variables, properties, yaml");
+            MpMetaConfigProvider mpMetaConfigProvider = MP_META_PROVIDERS.get(type);
+            if (mpMetaConfigProvider == null) {
+                throw new ConfigException("Wrong meta configuration, type " + type
+                        + " not supported, only supporting: " + MP_META_PROVIDERS.keySet());
             }
+
+            List<? extends ConfigSource> delegates = mpMetaConfigProvider.create(type, config, profile);
+
             boolean shouldCount = delegates.size() > 1;
             int counter = 0;
 
@@ -276,163 +276,6 @@ class MpConfigBuilder implements ConfigBuilder {
                 withSources(builder.build());
             }
         }
-    }
-
-    private List<ConfigSource> propertiesSource(io.helidon.config.Config config) {
-        return sourceFromMeta(config,
-                              MpConfigSources::create,
-                              MpConfigSources::classPath,
-                              MpConfigSources::classPath,
-                              MpConfigSources::create);
-    }
-
-    private List<ConfigSource> yamlSource(io.helidon.config.Config config) {
-        return sourceFromMeta(config,
-                              YamlMpConfigSource::create,
-                              YamlMpConfigSource::classPath,
-                              YamlMpConfigSource::classPath,
-                              YamlMpConfigSource::create);
-    }
-
-    private List<ConfigSource> sourceFromMeta(io.helidon.config.Config config,
-                                              Function<Path, ConfigSource> fromPath,
-                                              Function<String, List<ConfigSource>> fromClasspath,
-                                              BiFunction<String, String, List<ConfigSource>> fromClasspathWithProfile,
-                                              Function<URL, ConfigSource> fromUrl) {
-
-        boolean optional = config.get("optional").asBoolean().orElse(false);
-
-        String location;
-        Exception cause = null;
-
-        ConfigValue<Path> pathConfig = config.get("path").as(Path.class);
-        if (pathConfig.isPresent()) {
-            Path path = pathConfig.get();
-            List<ConfigSource> result = sourceFromPathMeta(path, fromPath);
-
-            if (!result.isEmpty()) {
-                return result;
-            }
-            // else the file was not found, check optional
-            location = "path " + path.toAbsolutePath();
-        } else {
-            ConfigValue<String> classpathConfig = config.get("classpath").as(String.class);
-            if (classpathConfig.isPresent()) {
-                String classpath = classpathConfig.get();
-                List<ConfigSource> sources;
-
-                if (profile == null) {
-                    sources = fromClasspath.apply(classpath);
-                } else {
-                    sources = fromClasspathWithProfile.apply(classpath, profile);
-                }
-
-                if (!sources.isEmpty()) {
-                    return sources;
-                }
-                location = "classpath " + classpath;
-            } else {
-                ConfigValue<URL> urlConfig = config.get("url").as(URL.class);
-                if (urlConfig.isPresent()) {
-                    URL url = urlConfig.get();
-                    List<ConfigSource> sources = null;
-                    try {
-                        sources = sourceFromUrlMeta(url, fromUrl);
-                    } catch (ConfigException e) {
-                        cause = e;
-                    }
-
-                    if (sources != null && !sources.isEmpty()) {
-                        return sources;
-                    }
-                    location = "url " + url;
-                } else {
-                    throw new ConfigException("MP meta configuration does not contain config source location. Node: " + config
-                            .key());
-                }
-            }
-        }
-
-        if (optional) {
-            return List.of();
-        }
-        String message = "Meta configuration could not find non-optional config source on " + location;
-        if (cause == null) {
-            throw new ConfigException(message);
-        } else {
-            throw new ConfigException(message, cause);
-        }
-    }
-
-    private List<ConfigSource> sourceFromUrlMeta(URL url, Function<URL, ConfigSource> fromUrl) {
-        ConfigSource profileSource = null;
-        ConfigSource mainSource = null;
-        Exception cause = null;
-
-        if (profile != null) {
-            try {
-                String profileUrl = toProfileName(url.toString(), profile);
-                profileSource = fromUrl.apply(new URL(profileUrl));
-            } catch (Exception e) {
-                cause = e;
-            }
-        }
-
-        try {
-            mainSource = fromUrl.apply(url);
-            if (cause != null) {
-                LOGGER.log(Level.FINEST, "Failed to load profile URL resource, succeeded loading main from " + url, cause);
-            }
-        } catch (ConfigException e) {
-            if (cause != null) {
-                e.addSuppressed(cause);
-                throw e;
-            } else {
-                if (profileSource == null) {
-                    throw e;
-                } else {
-                    LOGGER.log(Level.FINEST, "Did not find main URL config source from " + url + ", have profile source", e);
-                }
-            }
-        }
-        return composite(mainSource, profileSource);
-    }
-
-    private List<ConfigSource> sourceFromPathMeta(Path path, Function<Path, ConfigSource> fromPath) {
-        ConfigSource profileSource = null;
-        ConfigSource mainSource = null;
-
-        if (profile != null) {
-            Path fileNamePath = path.getFileName();
-            String fileName = (fileNamePath == null ? "" : fileNamePath.toString());
-            fileName = toProfileName(fileName, profile);
-            Path profileSpecific = path.resolveSibling(fileName);
-            if (Files.exists(profileSpecific) && Files.isRegularFile(profileSpecific)) {
-                profileSource = fromPath.apply(profileSpecific);
-            }
-        }
-
-        if (Files.exists(path) && Files.isRegularFile(path)) {
-            mainSource = fromPath.apply(path);
-        }
-
-        // now handle profile
-        return composite(mainSource, profileSource);
-    }
-
-    private List<ConfigSource> composite(ConfigSource mainSource, ConfigSource profileSource) {
-        // now handle profile
-        if (profileSource == null) {
-            if (mainSource == null) {
-                return List.of();
-            }
-            return List.of(mainSource);
-        }
-        if (mainSource == null) {
-            return List.of(profileSource);
-        }
-
-        return List.of(MpConfigSources.composite(profileSource, mainSource));
     }
 
     @Override

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesMetaConfigProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpEnvironmentVariablesMetaConfigProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.Prioritized;
+import io.helidon.config.Config;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Helidon MicroProfile meta-config provider for Environment Variables.
+ */
+class MpEnvironmentVariablesMetaConfigProvider implements MpMetaConfigProvider, Prioritized {
+    @Override
+    public Set<String> supportedTypes() {
+        return Set.of("environment-variables");
+    }
+
+    @Override
+    public List<? extends ConfigSource> create(String type, Config metaConfig, String profile) {
+        return List.of(MpConfigSources.environmentVariables());
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpMetaConfigUtils.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpMetaConfigUtils.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.helidon.config.ConfigException;
+import io.helidon.config.ConfigValue;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Utilities for Helidon MicroProfile Meta-Config implementation.
+ */
+public class MpMetaConfigUtils {
+    private static final Logger LOGGER = Logger.getLogger(MpMetaConfig.class.getName());
+
+    private MpMetaConfigUtils() {
+    }
+
+    /**
+     * A utility for providing a list of configuration sources.
+     *
+     * @param config configuration properties from a meta-config type
+     * @param profile name of the profile to use or null if not used
+     * @param fromPath Function used to process a config specified by a filepath
+     * @param fromClasspath Function used to process a config specified by a classpath
+     * @param fromClasspathWithProfile BiFunction used to process a config specified by a classpath and a profile name
+     * @param fromUrl Function used to process a config specified by a Url
+     *
+     * @return list of configuration sources
+     */
+    public static List<ConfigSource> sourceFromMeta(io.helidon.config.Config config,
+                                              String profile,
+                                              Function<Path, ConfigSource> fromPath,
+                                              Function<String, List<ConfigSource>> fromClasspath,
+                                              BiFunction<String, String, List<ConfigSource>> fromClasspathWithProfile,
+                                              Function<URL, ConfigSource> fromUrl) {
+
+        boolean optional = config.get("optional").asBoolean().orElse(false);
+
+        String location;
+        Exception cause = null;
+
+        ConfigValue<Path> pathConfig = config.get("path").as(Path.class);
+        if (pathConfig.isPresent()) {
+            Path path = pathConfig.get();
+            List<ConfigSource> result = sourceFromPathMeta(path, profile, fromPath);
+
+            if (!result.isEmpty()) {
+                return result;
+            }
+            // else the file was not found, check optional
+            location = "path " + path.toAbsolutePath();
+        } else {
+            ConfigValue<String> classpathConfig = config.get("classpath").as(String.class);
+            if (classpathConfig.isPresent()) {
+                String classpath = classpathConfig.get();
+                List<ConfigSource> sources;
+
+                if (profile == null) {
+                    sources = fromClasspath.apply(classpath);
+                } else {
+                    sources = fromClasspathWithProfile.apply(classpath, profile);
+                }
+
+                if (!sources.isEmpty()) {
+                    return sources;
+                }
+                location = "classpath " + classpath;
+            } else {
+                ConfigValue<URL> urlConfig = config.get("url").as(URL.class);
+                if (urlConfig.isPresent()) {
+                    URL url = urlConfig.get();
+                    List<ConfigSource> sources = null;
+                    try {
+                        sources = sourceFromUrlMeta(url, profile, fromUrl);
+                    } catch (ConfigException e) {
+                        cause = e;
+                    }
+
+                    if (sources != null && !sources.isEmpty()) {
+                        return sources;
+                    }
+                    location = "url " + url;
+                } else {
+                    throw new ConfigException("MP meta configuration does not contain config source location. Node: " + config
+                            .key());
+                }
+            }
+        }
+
+        if (optional) {
+            return List.of();
+        }
+        String message = "Meta configuration could not find non-optional config source on " + location;
+        if (cause == null) {
+            throw new ConfigException(message);
+        } else {
+            throw new ConfigException(message, cause);
+        }
+    }
+
+    private static List<ConfigSource> sourceFromUrlMeta(URL url, String profile, Function<URL, ConfigSource> fromUrl) {
+        ConfigSource profileSource = null;
+        ConfigSource mainSource = null;
+        Exception cause = null;
+
+        if (profile != null) {
+            try {
+                String profileUrl = toProfileName(url.toString(), profile);
+                profileSource = fromUrl.apply(new URL(profileUrl));
+            } catch (Exception e) {
+                cause = e;
+            }
+        }
+
+        try {
+            mainSource = fromUrl.apply(url);
+            if (cause != null) {
+                LOGGER.log(Level.FINEST, "Failed to load profile URL resource, succeeded loading main from " + url, cause);
+            }
+        } catch (ConfigException e) {
+            if (cause != null) {
+                e.addSuppressed(cause);
+                throw e;
+            } else {
+                if (profileSource == null) {
+                    throw e;
+                } else {
+                    LOGGER.log(Level.FINEST, "Did not find main URL config source from " + url + ", have profile source", e);
+                }
+            }
+        }
+        return composite(mainSource, profileSource);
+    }
+
+    private static List<ConfigSource> sourceFromPathMeta(Path path, String profile, Function<Path, ConfigSource> fromPath) {
+        ConfigSource profileSource = null;
+        ConfigSource mainSource = null;
+
+        if (profile != null) {
+            Path fileNamePath = path.getFileName();
+            String fileName = (fileNamePath == null ? "" : fileNamePath.toString());
+            fileName = toProfileName(fileName, profile);
+            Path profileSpecific = path.resolveSibling(fileName);
+            if (Files.exists(profileSpecific) && Files.isRegularFile(profileSpecific)) {
+                profileSource = fromPath.apply(profileSpecific);
+            }
+        }
+
+        if (Files.exists(path) && Files.isRegularFile(path)) {
+            mainSource = fromPath.apply(path);
+        }
+
+        // now handle profile
+        return composite(mainSource, profileSource);
+    }
+
+    private static List<ConfigSource> composite(ConfigSource mainSource, ConfigSource profileSource) {
+        // now handle profile
+        if (profileSource == null) {
+            if (mainSource == null) {
+                return List.of();
+            }
+            return List.of(mainSource);
+        }
+        if (mainSource == null) {
+            return List.of(profileSource);
+        }
+
+        return List.of(MpConfigSources.composite(profileSource, mainSource));
+    }
+
+    private static String toProfileName(String fileName, String profile) {
+        int i = fileName.lastIndexOf('.');
+        if (i > -1) {
+            return fileName.substring(0, i) + "-" + profile + fileName.substring(i);
+        }
+        return fileName + "-" + profile;
+    }
+
+
+}

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpPropertiesMetaConfigProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpPropertiesMetaConfigProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.Prioritized;
+import io.helidon.config.Config;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Helidon MicroProfile meta-config provider for Properties configuration files.
+ */
+class MpPropertiesMetaConfigProvider implements MpMetaConfigProvider, Prioritized {
+    @Override
+    public Set<String> supportedTypes() {
+        return Set.of("properties");
+    }
+
+    @Override
+    public List<? extends ConfigSource> create(String type, Config metaConfig, String profile) {
+         return MpMetaConfigUtils.sourceFromMeta(
+                metaConfig,
+                profile,
+                MpConfigSources::create,
+                MpConfigSources::classPath,
+                MpConfigSources::classPath,
+                MpConfigSources::create
+        );
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/config/config-mp/src/main/java/io/helidon/config/mp/MpSystemPropertiesMetaConfigProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/MpSystemPropertiesMetaConfigProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.Prioritized;
+import io.helidon.config.Config;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Helidon MicroProfile meta-config provider for Systems Properties.
+ */
+class MpSystemPropertiesMetaConfigProvider implements MpMetaConfigProvider, Prioritized {
+    @Override
+    public Set<String> supportedTypes() {
+        return Set.of("system-properties");
+    }
+
+    @Override
+    public List<? extends ConfigSource> create(String type, Config metaConfig, String profile) {
+        return List.of(MpConfigSources.systemProperties());
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpMetaConfigProvider.java
+++ b/config/config-mp/src/main/java/io/helidon/config/mp/spi/MpMetaConfigProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp.spi;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.config.Config;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Java Service loader interface for Meta-config providers.
+ */
+public interface MpMetaConfigProvider {
+    /**
+     * Set of supported types for a MicroProfile meta-config provider.
+     *
+     * @return meta-config provider types
+     */
+    Set<String> supportedTypes();
+
+    /**
+     * Create a list of configuration sources from a meta-config type.
+     *
+     * @param type type of the config source
+     * @param metaConfig configuration properties of a meta-config type
+     * @param profile name of the profile to use or null if not used
+     *
+     * @return list of config sources
+     */
+    List<? extends ConfigSource> create(String type, Config metaConfig, String profile);
+}

--- a/config/config-mp/src/main/java/module-info.java
+++ b/config/config-mp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ module io.helidon.config.mp {
     requires java.logging;
     requires io.helidon.common;
     requires io.helidon.config;
-    requires io.helidon.config.yaml.mp;
     requires transitive microprofile.config.api;
     requires jakarta.annotation;
     requires io.helidon.common.serviceloader;
@@ -33,6 +32,7 @@ module io.helidon.config.mp {
     uses org.eclipse.microprofile.config.spi.ConfigSourceProvider;
     uses org.eclipse.microprofile.config.spi.Converter;
     uses io.helidon.config.mp.spi.MpConfigFilter;
+    uses io.helidon.config.mp.spi.MpMetaConfigProvider;
     uses io.helidon.config.spi.ConfigParser;
 
     provides org.eclipse.microprofile.config.spi.ConfigProviderResolver with io.helidon.config.mp.MpConfigProviderResolver;

--- a/config/config-mp/src/test/resources/custom-mp-meta-config-classpath-profile.properties
+++ b/config/config-mp/src/test/resources/custom-mp-meta-config-classpath-profile.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources=false
+add-discovered-converters=false
+profile=dev
+
+sources.0.type=properties
+sources.0.classpath=meta-config/classpath.properties

--- a/config/config-mp/src/test/resources/custom-mp-meta-config-not-optional.properties
+++ b/config/config-mp/src/test/resources/custom-mp-meta-config-not-optional.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources=false
+add-discovered-converters=false
+profile=dev
+
+sources.0.type=properties
+sources.0.path=src/test/resources/not_exist.properties
+sources.0.optional=false

--- a/config/config-mp/src/test/resources/custom-mp-meta-config-ordinal.properties
+++ b/config/config-mp/src/test/resources/custom-mp-meta-config-ordinal.properties
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources=false
+add-discovered-converters=false
+
+sources.0.type=properties
+sources.0.classpath=meta-config/classpath.properties
+# Set to higher ordinality to force this to be processed last
+sources.0.ordinal=500
+sources.1.type=properties
+sources.1.path=src/test/resources/meta-config/path.properties

--- a/config/config-mp/src/test/resources/custom-mp-meta-config-path-profile.properties
+++ b/config/config-mp/src/test/resources/custom-mp-meta-config-path-profile.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources=false
+add-discovered-converters=false
+profile=dev
+
+sources.0.type=properties
+sources.0.path=src/test/resources/meta-config/path.properties

--- a/config/config-mp/src/test/resources/custom-mp-meta-config-sysprops-envvars.properties
+++ b/config/config-mp/src/test/resources/custom-mp-meta-config-sysprops-envvars.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+add-discovered-sources=false
+add-discovered-converters=false
+
+sources.0.type=system-properties
+sources.1.type=environment-variables

--- a/config/config-mp/src/test/resources/meta-config/classpath-dev.properties
+++ b/config/config-mp/src/test/resources/meta-config/classpath-dev.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value=classpath_profile

--- a/config/config-mp/src/test/resources/meta-config/path-dev.properties
+++ b/config/config-mp/src/test/resources/meta-config/path-dev.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+value=path_profile

--- a/config/hocon-mp/etc/spotbugs/exclude.xml
+++ b/config/hocon-mp/etc/spotbugs/exclude.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<FindBugsFilter
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <Match>
+        <!-- URL.openconnection() will use paths that come from config/code -->
+        <Class name="io.helidon.config.hocon.mp.HoconMpConfigSource"/>
+        <Method name="create"/>
+        <Bug pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
+    <Match>
+        <!-- URL.openconnection() will use paths that come from config/code -->
+        <Class name="io.helidon.config.hocon.mp.HoconMpConfigIncluder"/>
+        <Method name="parseHoconFromUrl"/>
+        <Bug pattern="URLCONNECTION_SSRF_FD"/>
+    </Match>
+
+</FindBugsFilter>

--- a/config/hocon-mp/pom.xml
+++ b/config/hocon-mp/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.config</groupId>
+        <artifactId>helidon-config-project</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>helidon-config-hocon-mp</artifactId>
+    <name>Helidon Config HOCON MP</name>
+
+    <description>
+        HOCON support for Helidon MP.
+    </description>
+
+    <properties>
+        <spotbugs.exclude>etc/spotbugs/exclude.xml</spotbugs.exclude>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- This dependency is to allow meta-config yaml file to be parsed during test only -->
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigIncluder.java
+++ b/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigIncluder.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import io.helidon.config.ConfigException;
+import io.helidon.config.spi.ConfigParserException;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigIncludeContext;
+import com.typesafe.config.ConfigIncluder;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigParseOptions;
+
+import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
+
+class HoconMpConfigIncluder implements ConfigIncluder {
+    private static final System.Logger LOGGER = System.getLogger(HoconMpConfigIncluder.class.getName());
+    private static final String HOCON_EXTENSION = ".conf";
+
+    private ConfigParseOptions parseOptions;
+    private String relativeUrl;
+    private Path relativePath;
+    private Charset charset;
+
+    HoconMpConfigIncluder() {
+    }
+
+    @Override
+    public ConfigIncluder withFallback(ConfigIncluder fallback) {
+        return this;
+    }
+
+    @Override
+    public ConfigObject include(ConfigIncludeContext context, String what) {
+        new Exception().printStackTrace();
+        LOGGER.log(TRACE, String.format("Received request to include resource %s, %s",
+                what, context.parseOptions().getOriginDescription()));
+
+        return relativeUrl != null ? parseHoconFromUrl(what) : parseHoconFromPath(what);
+    }
+
+    private ConfigObject parseHoconFromUrl(String includeName) {
+        String includePath = relativeUrl + patchName(includeName);
+        URL includeUrl;
+        try {
+            includeUrl = new URL(includePath);
+            System.out.println("includeURL: " + includeUrl);
+        } catch (MalformedURLException e) {
+            LOGGER.log(WARNING, String.format("Unable to create include Url for: %s with error: %s",
+                    includePath, e.getMessage()));
+            return ConfigFactory.empty().root();
+        }
+        try (InputStreamReader readable = new InputStreamReader(includeUrl.openConnection().getInputStream(), charset)) {
+            Config typesafeConfig = ConfigFactory.parseReader(readable, parseOptions);
+            return typesafeConfig.root();
+        } catch (IOException e) {
+            throw new ConfigParserException("Failed to read from include source: " + includeUrl, e);
+        }
+    }
+
+    private ConfigObject parseHoconFromPath(String includeName) {
+        Path path = relativePath.resolve(includeName);
+        if (Files.exists(path) && Files.isReadable(path) && !Files.isDirectory(path)) {
+            System.out.println("Path: " + path);
+            try (BufferedReader reader = Files.newBufferedReader(path, charset)) {
+                Config typesafeConfig = ConfigFactory.parseReader(reader, parseOptions);
+                return typesafeConfig.root();
+            } catch (IOException e) {
+                throw new ConfigException("Failed to read from include source: " + path.toAbsolutePath(), e);
+            }
+        } else {
+            return ConfigFactory.empty().root();
+        }
+    }
+
+    void charset(Charset charset) {
+        this.charset = charset;
+    }
+
+    void parseOptions(ConfigParseOptions parseOptions) {
+        this.parseOptions = parseOptions;
+    }
+
+    void relativeUrl(String relativeUrl) {
+        this.relativeUrl = relativeUrl;
+    }
+
+    void relativePath(Path relativePath) {
+        this.relativePath = relativePath;
+    }
+
+    /**
+     * Adds default Hocon extension if not present.
+     *
+     * @param what file name
+     * @return file name with extension
+     */
+    private static String patchName(String what) {
+        Optional<String> base = Optional.of(what)
+                .filter(f -> f.contains(File.separator))
+                .map(f -> f.substring(f.lastIndexOf(File.separator) + 1));
+        Optional<String> ext = Optional.of(base.orElse(what))
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(f.lastIndexOf(".") + 1));
+        return ext.isPresent() ? what : what + HOCON_EXTENSION;
+    }
+}

--- a/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigSource.java
+++ b/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpConfigSource.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.helidon.config.ConfigException;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigResolveOptions;
+import com.typesafe.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * MicroProfile {@link org.eclipse.microprofile.config.spi.ConfigSource} that can be used
+ * to add HOCON/JSON files from classpath or file system using the
+ * {@link org.eclipse.microprofile.config.spi.ConfigProviderResolver#getBuilder()}.
+ * <p>The HOCON/JSON file is transformed to a flat map as follows:</p>
+ * <strong>Object nodes</strong>
+ * <p>
+ * Each node in the tree is dot separated.
+ * <pre>
+ * server = {
+ *   host = "localhost"
+ *   port= 8080
+ * }
+ * </pre>
+ * Will be transformed to the following properties:
+ * <pre>
+ * server.host=localhost
+ * server.port=8080
+ * </pre>
+ * <strong>List nodes (arrays)</strong>
+ * <p>
+ * Each node will be indexed (0 based)
+ * <pre>
+ * providers =
+ *   [{abac = {enabled = true}}]
+ * names = [
+ *   first
+ *   second
+ *   third
+ * ]
+ * </pre>
+ * Will be transformed to the following properties:
+ * <pre>
+ * providers.0.abac.enabled=true
+ * names.0=first
+ * names.1=second
+ * names.2=third
+ * </pre>
+ */
+@SuppressWarnings("rawtypes")
+public class HoconMpConfigSource implements ConfigSource {
+    private final String name;
+    private Map<String, String> properties;
+
+    private static final boolean RESOLVING_ENABLED = true;
+    private static final ConfigResolveOptions RESOLVE_OPTIONS = ConfigResolveOptions.defaults();
+
+    private HoconMpConfigSource(String name, Map<String, String> properties) {
+        this.properties = properties;
+        this.name = "hocon: " + name;
+    }
+
+    /**
+     * Load a HOCON/JSON config source from file system.
+     *
+     * @param path path to the HOCON/JSON file
+     * @return config source loaded from the file
+     * @see #create(java.net.URL)
+     */
+    public static ConfigSource create(Path path) {
+        String name = path.toAbsolutePath().toString();
+
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            ConfigParseOptions parseOptions = getConfigParseOptions(path);
+
+            Config typesafeConfig = toConfig(reader, parseOptions);
+            // this is a mutable HashMap that we can use
+            Map<String, String> props =
+                    fromConfig(typesafeConfig.root().isEmpty() ? ConfigFactory.empty().root() : typesafeConfig.root());
+            return new HoconMpConfigSource(name, props);
+        } catch (IOException e) {
+            throw new ConfigException("Failed to load HOCON/JSON config source from path: " + path.toAbsolutePath(), e);
+        }
+    }
+
+    /**
+     * Load a HOCON/JSON config source from URL.
+     * The URL may be any URL which is supported by the used JVM.
+     *
+     * @param url url of the resource
+     * @return config source loaded from the URL
+     */
+    public static ConfigSource create(URL url) {
+        try (InputStreamReader reader = new InputStreamReader(url.openConnection().getInputStream(), StandardCharsets.UTF_8)) {
+            String name = url.toString();
+            ConfigParseOptions parseOptions = getConfigParseOptions(url);
+            Config typesafeConfig = toConfig(reader, parseOptions);
+            if (typesafeConfig.root().isEmpty()) { // empty source
+                return new HoconMpConfigSource(name, Map.of());
+            }
+            return new HoconMpConfigSource(name, fromConfig(typesafeConfig.root()));
+        } catch (Exception e) {
+            throw new ConfigException("Failed to configure HOCON/JSON config source", e);
+        }
+    }
+
+    private static <T> ConfigParseOptions getConfigParseOptions(URL url) {
+        HoconMpConfigIncluder includer = new HoconMpConfigIncluder();
+        ConfigParseOptions parseOptions = ConfigParseOptions.defaults().appendIncluder(includer);
+        includer.parseOptions(parseOptions);
+        includer.relativeUrl(getParentResourcePath(url.toString()));
+        includer.charset(StandardCharsets.UTF_8);
+        return parseOptions;
+    }
+
+    private static ConfigParseOptions getConfigParseOptions(Path path) {
+        HoconMpConfigIncluder includer = new HoconMpConfigIncluder();
+        ConfigParseOptions parseOptions = ConfigParseOptions.defaults().appendIncluder(includer);
+        includer.parseOptions(parseOptions);
+        includer.relativePath(path.getParent());
+        includer.charset(StandardCharsets.UTF_8);
+        return parseOptions;
+    }
+
+    private static Config toConfig(Reader content, ConfigParseOptions parseOptions) {
+        Config typesafeConfig = ConfigFactory.parseReader(
+                content, parseOptions);
+        if (RESOLVING_ENABLED) {
+            typesafeConfig = typesafeConfig.resolve(RESOLVE_OPTIONS);
+        }
+        return typesafeConfig;
+    }
+
+    /**
+     * Create from HOCON/JSON file(s) on classpath.
+     *
+     * @param resource resource name to locate on classpath (looks for all instances)
+     * @return list of config sources discovered (may be zero length)
+     */
+    public static List<ConfigSource> classPath(String resource) {
+        List<ConfigSource> sources = new LinkedList<>();
+        try {
+            Thread.currentThread().getContextClassLoader().getResources(resource)
+                    .asIterator()
+                    .forEachRemaining(it -> sources.add(create(it)));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read HOCON/JSON \"" + resource + "\" from classpath", e);
+        }
+
+        return sources;
+    }
+
+    /**
+     * Create from HOCON/JSON file(s) on classpath with profile support.
+     *
+     * @param resource resource name to locate on classpath (looks for all instances)
+     * @param profile name of the profile to use
+     * @return list of config sources discovered (may be zero length)
+     */
+    public static List<ConfigSource> classPath(String resource, String profile) {
+        Objects.requireNonNull(profile, "Profile must be defined");
+
+        List<ConfigSource> sources = new LinkedList<>();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Enumeration<URL> baseResources = classLoader.getResources(resource);
+            Enumeration<URL> profileResources = classLoader.getResources(toProfileResource(resource, profile));
+
+            if (profileResources.hasMoreElements()) {
+                List<URL> profileResourceList = new LinkedList<>();
+                profileResources.asIterator()
+                        .forEachRemaining(profileResourceList::add);
+
+                baseResources.asIterator()
+                        .forEachRemaining(it -> {
+                            String pathBase = pathBase(it.toString());
+                            // we need to find profile that belongs to this
+                            for (URL url : profileResourceList) {
+                                String profilePathBase = pathBase(url.toString());
+                                if (pathBase.equals(profilePathBase)) {
+                                    // Main is the profile config file and fallback is the original config file
+                                    sources.add(create(create(url), create(it)));
+                                } else {
+                                    sources.add(create(it));
+                                }
+                            }
+                        });
+            } else {
+                baseResources
+                        .asIterator()
+                        .forEachRemaining(it -> sources.add(create(it)));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read HOCON/JSON \"" + resource + "\" from classpath", e);
+        }
+
+        return sources;
+    }
+
+    private static ConfigSource create(ConfigSource main, ConfigSource fallback) {
+        String name = main.getName() + " (" + fallback.getName() + ")";
+
+        return new ConfigSource() {
+            @Override
+            public Set<String> getPropertyNames() {
+                Set<String> result = new HashSet<>(fallback.getPropertyNames());
+                result.addAll(main.getPropertyNames());
+
+                return result;
+            }
+
+            @Override
+            public String getValue(String propertyName) {
+                String value = main.getValue(propertyName);
+                if (value == null) {
+                    return fallback.getValue(propertyName);
+                }
+                return value;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                Map<String, String> result = new HashMap<>(fallback.getProperties());
+                result.putAll(main.getProperties());
+
+                return result;
+            }
+        };
+    }
+
+    private static String getParentResourcePath(String resource) {
+        // this works the same on windows and Unix systems (classpath is always forward slashes)
+        int lastSlash = resource.lastIndexOf('/');
+        String rootOfResource;
+        if (lastSlash > -1) {
+            rootOfResource = resource.substring(0, lastSlash + 1);
+        } else {
+            rootOfResource = resource;
+        }
+        return rootOfResource;
+    }
+
+    private static Map<String, String> fromConfig(ConfigObject config) {
+        Map<String, String> result = new HashMap<>();
+        process(result, "", config);
+
+        return result;
+    }
+
+    private static void process(Map<String, String> resultMap, String prefix, ConfigObject config) {
+        config.forEach((unescapedKey, value) -> {
+            String key = io.helidon.config.Config.Key.escapeName(unescapedKey);
+            processNext(resultMap, prefix(prefix, key), value);
+        });
+    }
+
+    private static void process(Map<String, String> resultMap, String prefix, ConfigList configList) {
+        int counter = 0;
+        for (ConfigValue value : configList) {
+            processNext(resultMap, prefix(prefix, String.valueOf(counter)), value);
+            counter++;
+        }
+    }
+
+    private static void processNext(Map<String, String> resultMap,
+                                    String prefix,
+                                    ConfigValue value) {
+        if (value instanceof ConfigList) {
+            process(resultMap, prefix, (ConfigList) value);
+        } else if (value instanceof ConfigObject) {
+            process(resultMap, prefix, (ConfigObject) value);
+        } else {
+            Object unwrapped = value.unwrapped();
+            String stringValue = (null == unwrapped) ? "" : String.valueOf(unwrapped);
+            resultMap.put(prefix, stringValue);
+        }
+    }
+
+    private static String prefix(String prefix, String stringKey) {
+        if (prefix.isEmpty()) {
+            return stringKey;
+        }
+
+        return prefix + "." + stringKey;
+    }
+
+    private static String pathBase(String path) {
+        int i = path.lastIndexOf('/');
+        int y = path.lastIndexOf('!');
+        int z = path.lastIndexOf(':');
+        int b = path.lastIndexOf('\\');
+
+        // we need the last index before the file name - so the highest number of all of the above
+        int max = Math.max(i, y);
+        max = Math.max(max, z);
+        max = Math.max(max, b);
+
+        if (max > -1) {
+            return path.substring(0, max);
+        }
+        return path;
+    }
+
+    private static String toProfileResource(String resource, String profile) {
+        int i = resource.lastIndexOf('.');
+        if (i > -1) {
+            return resource.substring(0, i) + "-" + profile + resource.substring(i);
+        }
+        return resource + "-" + profile;
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return Collections.unmodifiableSet(properties.keySet());
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpMetaConfigProvider.java
+++ b/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/HoconMpMetaConfigProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.Prioritized;
+import io.helidon.config.Config;
+import io.helidon.config.mp.MpMetaConfigUtils;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Helidon MicroProfile meta-config provider for Hocon and Json.
+ */
+public class HoconMpMetaConfigProvider implements MpMetaConfigProvider, Prioritized {
+    @Override
+    public Set<String> supportedTypes() {
+        return Set.of("hocon", "json");
+    }
+
+    @Override
+    public List<? extends ConfigSource> create(String type, Config metaConfig, String profile) {
+        return MpMetaConfigUtils.sourceFromMeta(
+                metaConfig,
+                profile,
+                HoconMpConfigSource::create,
+                HoconMpConfigSource::classPath,
+                HoconMpConfigSource::classPath,
+                HoconMpConfigSource::create
+        );
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/package-info.java
+++ b/config/hocon-mp/src/main/java/io/helidon/config/hocon/mp/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * HOCON config source for MicroProfile config.
+ *
+ * @see io.helidon.config Configuration API
+ */
+package io.helidon.config.hocon.mp;

--- a/config/hocon-mp/src/main/java/module-info.java
+++ b/config/hocon-mp/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for HOCON configuration sources.
+ */
+module io.helidon.config.hocon.mp {
+    requires microprofile.config.api;
+
+    requires io.helidon.config.mp;
+    requires transitive io.helidon.config;
+    requires typesafe.config;
+
+    exports io.helidon.config.hocon.mp;
+
+    provides io.helidon.config.mp.spi.MpMetaConfigProvider with io.helidon.config.hocon.mp.HoconMpMetaConfigProvider;
+
+}

--- a/config/hocon-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-hocon-mp/native-image.properties
+++ b/config/hocon-mp/src/main/resources/META-INF/native-image/io.helidon.config/helidon-config-hocon-mp/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args=--initialize-at-build-time=io.helidon.config.hocon.mp

--- a/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpConfigSourceTest.java
+++ b/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpConfigSourceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HoconJsonMpConfigSourceTest {
+    @Test
+    void testHoconViaClasspath() throws IOException {
+        ConfigSource source = HoconMpConfigSource.create(getResourceUrlPath("application.conf"));
+        // Test Main Config
+        validateHoconConfig(source);
+    }
+
+    @Test
+    void testHoconViaPath() {
+        ConfigSource source = HoconMpConfigSource.create(Paths.get("src/test/resources/application.conf")) ;
+        validateHoconConfig(source);
+    }
+
+    private void validateHoconConfig(ConfigSource source) {
+        // Test Main Config
+        assertThat(source.getValue("hocon.string"), is("String"));
+        assertThat(source.getValue("hocon.number"), is("10"));
+        assertThat(source.getValue("hocon.array.0"), is("Array 1"));
+        assertThat(source.getValue("hocon.array.1"), is("Array 2"));
+        assertThat(source.getValue("hocon.array.2"), is("Array 3"));
+        assertThat(source.getValue("hocon.boolean"), is("true"));
+        // Test Include
+        assertThat(source.getValue("hocon_include.string"), is("Include String"));
+        assertThat(source.getValue("hocon_include.number"), is("20"));
+        assertThat(source.getValue("hocon_include.array.0"), is("Include Array 1"));
+        assertThat(source.getValue("hocon_include.array.1"), is("Include Array 2"));
+        assertThat(source.getValue("hocon_include.array.2"), is("Include Array 3"));
+        assertThat(source.getValue("hocon_include.boolean"), is("false"));
+    }
+
+    @Test
+    void testJsonConfigViaClassPath() throws IOException {
+        ConfigSource source = HoconMpConfigSource.create(getResourceUrlPath("application.json"));
+        validateJsonConfig(source);
+    }
+
+    @Test
+    void testJsonConfigViaPath() throws IOException {
+        ConfigSource source = HoconMpConfigSource.create(Paths.get("src/test/resources/application.json"));
+        validateJsonConfig(source);
+    }
+
+    private void validateJsonConfig(ConfigSource source) {
+        assertThat(source.getValue("json.string"), is("String"));
+        assertThat(source.getValue("json.number"), is("10"));
+        assertThat(source.getValue("json.array.0"), is("Array 1"));
+        assertThat(source.getValue("json.array.1"), is("Array 2"));
+        assertThat(source.getValue("json.array.2"), is("Array 3"));
+        assertThat(source.getValue("json.boolean"), is("true"));
+    }
+
+    private static URL getResourceUrlPath(String resource) throws IOException {
+        Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(resource);
+        while (resources.hasMoreElements()) {
+            return resources.nextElement();
+        }
+        return null;
+    }
+}

--- a/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
+++ b/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import io.helidon.config.ConfigException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class HoconJsonMpMetaConfigTest {
+    private static ConfigProviderResolver configResolver;
+    private Config config;
+    private static final String META_CONFIG_SYSTEM_PROPERTY = "io.helidon.config.mp.meta-config";
+
+    @BeforeAll
+    static void getProviderResolver() {
+        configResolver = ConfigProviderResolver.instance();
+    }
+    @AfterAll
+    static void resetSystemProperties() {
+        System.clearProperty(META_CONFIG_SYSTEM_PROPERTY);
+    }
+
+    @BeforeEach
+    void resetConfig() {
+        if (config == null) {
+            // first run - need to remove existing props
+            System.clearProperty(META_CONFIG_SYSTEM_PROPERTY);
+            configResolver.releaseConfig(ConfigProvider.getConfig());
+        } else {
+            configResolver.releaseConfig(config);
+            config = null;
+        }
+    }
+
+    @Test
+    void testMetaHoconClasspath() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-classpath.yaml");
+        validateConfig();
+    }
+
+    @Test
+    void testMetaHoconPath() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-path.yaml");
+        validateConfig();
+    }
+
+    private void validateConfig() {
+        config = ConfigProvider.getConfig();
+
+        // Main file
+        assertThat(config.getValue("string", String.class), is("String"));
+        assertThat(config.getValue("number", String.class), is("175"));
+        assertThat(config.getValue("array.0", String.class), is("One"));
+        assertThat(config.getValue("array.1", String.class), is("Two"));
+        assertThat(config.getValue("array.2", String.class), is("Three"));
+        assertThat(config.getValue("boolean", String.class), is("true"));
+        // Include file
+        assertThat(config.getValue("custom_include.string", String.class), is("Include_String"));
+        assertThat(config.getValue("custom_include.number", String.class), is("200"));
+        assertThat(config.getValue("custom_include.array.0", String.class), is("First"));
+        assertThat(config.getValue("custom_include.array.1", String.class), is("Second"));
+        assertThat(config.getValue("custom_include.array.2", String.class), is("Third"));
+        assertThat(config.getValue("custom_include.boolean", String.class), is("false"));
+    }
+
+    @Test
+    void testMetaHoconClasspathConfigProfile() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-classpath-profile.yaml");
+        validateConfigProfile();
+    }
+
+    @Test
+    void testMetaHoconPathConfigProfile() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-path-profile.yaml");
+        validateConfigProfile();
+    }
+
+    private void validateConfigProfile() {
+        config = ConfigProvider.getConfig();
+
+        // Main file
+        assertThat(config.getValue("string", String.class), is("String_dev"));
+        assertThat(config.getValue("number", String.class), is("250"));
+        assertThat(config.getValue("array.0", String.class), is("One"));
+        assertThat(config.getValue("array.1", String.class), is("Two"));
+        assertThat(config.getValue("array.2", String.class), is("Three"));
+        assertThat(config.getValue("boolean", String.class), is("true"));
+        assertThat(config.getValue("extra", String.class), is("Extra"));
+
+        // Include file
+        assertThat(config.getValue("custom_include.string", String.class), is("Include_String"));
+        assertThat(config.getValue("custom_include.number", String.class), is("200"));
+        assertThat(config.getValue("custom_include.array.0", String.class), is("Begin"));
+        assertThat(config.getValue("custom_include.array.1", String.class), is("Middle"));
+        assertThat(config.getValue("custom_include.array.2", String.class), is("End"));
+        assertThat(config.getValue("custom_include.boolean", String.class), is("true"));
+    }
+
+
+    @Test
+    void testMetaJson() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-json.yaml");
+        config = ConfigProvider.getConfig();
+
+        assertThat(config.getValue("string", String.class), is("String"));
+        assertThat(config.getValue("number", String.class), is("175"));
+        assertThat(config.getValue("array.0", String.class), is("One"));
+        assertThat(config.getValue("array.1", String.class), is("Two"));
+        assertThat(config.getValue("array.2", String.class), is("Three"));
+        assertThat(config.getValue("boolean", String.class), is("true"));
+    }
+
+    @Test
+    void testMetaOrdinal() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "ordinal-mp-meta-config-hocon.yaml");
+        config = ConfigProvider.getConfig();
+
+        assertThat(config.getValue("string", String.class), is("String"));
+        assertThat(config.getValue("number", String.class), is("175"));
+        assertThat(config.getValue("array.0", String.class), is("First"));
+        assertThat(config.getValue("array.1", String.class), is("Second"));
+        assertThat(config.getValue("array.2", String.class), is("Third"));
+        assertThat(config.getValue("boolean", String.class), is("false"));
+    }
+
+    @Test
+    void testMetaHoconNonExistentNotOptional() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-hocon-path-not-optional.yaml");
+        try {
+            config = ConfigProvider.getConfig();
+            Assertions.fail("Expecting meta-config to fail due to not optional non-existent config source");
+        } catch (ConfigException e) {}
+    }
+}

--- a/config/hocon-mp/src/test/resources/application.conf
+++ b/config/hocon-mp/src/test/resources/application.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "include.conf"
+
+hocon = {
+    string = "String"
+    number = 10
+    array = [
+        "Array 1"
+        "Array 2"
+        "Array 3"
+    ]
+    boolean = true
+}

--- a/config/hocon-mp/src/test/resources/application.json
+++ b/config/hocon-mp/src/test/resources/application.json
@@ -1,0 +1,12 @@
+{
+  "json": {
+    "string": "String",
+    "number": 10,
+    "array": [
+      "Array 1",
+      "Array 2",
+      "Array 3"
+    ],
+    "boolean": true
+  }
+}

--- a/config/hocon-mp/src/test/resources/custom-application-dev.conf
+++ b/config/hocon-mp/src/test/resources/custom-application-dev.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include "custom-include-dev.conf"
+
+string = String_dev
+number = 250
+extra = Extra
+

--- a/config/hocon-mp/src/test/resources/custom-application.conf
+++ b/config/hocon-mp/src/test/resources/custom-application.conf
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include "custom-include.conf"
+
+string = String
+number = 175
+array = [
+    One
+    Two
+    Three
+]
+boolean = true

--- a/config/hocon-mp/src/test/resources/custom-application.json
+++ b/config/hocon-mp/src/test/resources/custom-application.json
@@ -1,0 +1,10 @@
+{
+  "string": "String",
+  "number": 175,
+  "array": [
+    "One",
+    "Two",
+    "Three"
+  ],
+  "boolean": true
+}

--- a/config/hocon-mp/src/test/resources/custom-include-dev.conf
+++ b/config/hocon-mp/src/test/resources/custom-include-dev.conf
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+custom_include {
+    array = [
+        Begin
+        Middle
+        End
+    ]
+    boolean = true
+}

--- a/config/hocon-mp/src/test/resources/custom-include.conf
+++ b/config/hocon-mp/src/test/resources/custom-include.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+custom_include {
+    string = Include_String
+    number = 200
+    array = [
+        First
+        Second
+        Third
+    ]
+    boolean = false
+}

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-classpath-profile.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-classpath-profile.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+profile: dev
+
+sources:
+  - type: "hocon"
+    classpath: "custom-application.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-classpath.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-classpath.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "hocon"
+    classpath: "custom-application.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path-not-optional.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path-not-optional.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "hocon"
+    path: "src/test/resources/non-existent.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path-profile.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path-profile.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+profile: dev
+
+sources:
+  - type: "hocon"
+    path: "src/test/resources/custom-application.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-hocon-path.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "hocon"
+    path: "src/test/resources/custom-application.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/custom-mp-meta-config-json.yaml
+++ b/config/hocon-mp/src/test/resources/custom-mp-meta-config-json.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "json"
+    classpath: "custom-application.json"
+    optional: false

--- a/config/hocon-mp/src/test/resources/include.conf
+++ b/config/hocon-mp/src/test/resources/include.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hocon_include {
+    string = "Include String"
+    number = 20
+    array = [
+        "Include Array 1"
+        "Include Array 2"
+        "Include Array 3"
+    ]
+    boolean = false
+}

--- a/config/hocon-mp/src/test/resources/ordinal-mp-meta-config-hocon.yaml
+++ b/config/hocon-mp/src/test/resources/ordinal-mp-meta-config-hocon.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "json"
+    classpath: "ordinal.json"
+    optional: false
+    ordinal: 500
+  - type: "hocon"
+    classpath: "ordinal.conf"
+    optional: false

--- a/config/hocon-mp/src/test/resources/ordinal.conf
+++ b/config/hocon-mp/src/test/resources/ordinal.conf
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include "custom-include.conf"
+
+string = String
+number = 175
+array = [
+    One
+    Two
+    Three
+]
+boolean = true

--- a/config/hocon-mp/src/test/resources/ordinal.json
+++ b/config/hocon-mp/src/test/resources/ordinal.json
@@ -1,0 +1,8 @@
+{
+  "array": [
+    "First",
+    "Second",
+    "Third"
+  ],
+  "boolean": false
+}

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -50,6 +50,7 @@
         <module>yaml-mp</module>
         <module>metadata</module>
         <module>metadata-processor</module>
+        <module>hocon-mp</module>
     </modules>
 
     <build>

--- a/config/yaml-mp/pom.xml
+++ b/config/yaml-mp/pom.xml
@@ -40,6 +40,10 @@
     <dependencies>
         <dependency>
             <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
         </dependency>
         <dependency>

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMetaConfigProvider.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMetaConfigProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.yaml.mp;
+
+import java.util.List;
+import java.util.Set;
+
+import io.helidon.common.Prioritized;
+import io.helidon.config.Config;
+import io.helidon.config.mp.MpMetaConfigUtils;
+import io.helidon.config.mp.spi.MpMetaConfigProvider;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * Helidon MicroProfile meta-config provider for Yaml.
+ */
+public class YamlMetaConfigProvider implements MpMetaConfigProvider, Prioritized {
+    @Override
+    public Set<String> supportedTypes() {
+        return Set.of("yaml");
+    }
+
+    @Override
+    public List<? extends ConfigSource> create(String type, Config metaConfig, String profile) {
+        return MpMetaConfigUtils.sourceFromMeta(
+                metaConfig,
+                profile,
+                YamlMpConfigSource::create,
+                YamlMpConfigSource::classPath,
+                YamlMpConfigSource::classPath,
+                YamlMpConfigSource::create
+        );
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+}

--- a/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
+++ b/config/yaml-mp/src/main/java/io/helidon/config/yaml/mp/YamlMpConfigSource.java
@@ -217,7 +217,8 @@ public class YamlMpConfigSource implements ConfigSource {
                             for (URL url : profileResourceList) {
                                 String profilePathBase = pathBase(url.toString());
                                 if (pathBase.equals(profilePathBase)) {
-                                    sources.add(create(create(it), create(url)));
+                                    // Main is the profile config file and fallback is the original config file
+                                    sources.add(create(create(url), create(it)));
                                 } else {
                                     sources.add(create(it));
                                 }

--- a/config/yaml-mp/src/main/java/module-info.java
+++ b/config/yaml-mp/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@ module io.helidon.config.yaml.mp {
     requires org.yaml.snakeyaml;
     requires microprofile.config.api;
 
+    requires io.helidon.config.mp;
     requires transitive io.helidon.config;
     requires io.helidon.config.yaml;
 
     exports io.helidon.config.yaml.mp;
 
     provides org.eclipse.microprofile.config.spi.ConfigSourceProvider with io.helidon.config.yaml.mp.YamlConfigSourceProvider;
+    provides io.helidon.config.mp.spi.MpMetaConfigProvider with io.helidon.config.yaml.mp.YamlMetaConfigProvider;
 }

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpConfigSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package io.helidon.config.yaml.mp;
 
+import java.io.IOException;
 import java.io.StringReader;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Enumeration;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.junit.jupiter.api.Test;
@@ -47,5 +51,34 @@ public class YamlMpConfigSourceTest {
         assertThat(source.getValue("names.0"), is("first"));
         assertThat(source.getValue("names.1"), is("second"));
         assertThat(source.getValue("names.2"), is("third"));
+    }
+
+    @Test
+    void testConfigViaClassPath() throws IOException {
+        ConfigSource source = YamlMpConfigSource.create(getResourceUrlPath("application.yaml"));
+        validateConfig(source);
+    }
+
+    @Test
+    void testConfigViaPath() throws IOException {
+        ConfigSource source = YamlMpConfigSource.create(Paths.get("src/test/resources/application.yaml"));
+        validateConfig(source);
+    }
+
+    private void validateConfig(ConfigSource source) {
+        assertThat(source.getValue("yaml.string"), is("String"));
+        assertThat(source.getValue("yaml.number"), is("10"));
+        assertThat(source.getValue("yaml.array.0"), is("Array 1"));
+        assertThat(source.getValue("yaml.array.1"), is("Array 2"));
+        assertThat(source.getValue("yaml.array.2"), is("Array 3"));
+        assertThat(source.getValue("yaml.boolean"), is("true"));
+    }
+
+    private static URL getResourceUrlPath(String resource) throws IOException {
+        Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(resource);
+        while (resources.hasMoreElements()) {
+            return resources.nextElement();
+        }
+        return null;
     }
 }

--- a/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpMetaConfigTest.java
+++ b/config/yaml-mp/src/test/java/io/helidon/config/yaml/mp/YamlMpMetaConfigTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.yaml.mp;
+
+import io.helidon.config.ConfigException;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class YamlMpMetaConfigTest {
+    private static ConfigProviderResolver configResolver;
+    private Config config;
+    private static final String META_CONFIG_SYSTEM_PROPERTY = "io.helidon.config.mp.meta-config";
+
+    @BeforeAll
+    static void getProviderResolver() {
+        configResolver = ConfigProviderResolver.instance();
+    }
+    @AfterAll
+    static void resetSystemProperties() {
+        System.clearProperty(META_CONFIG_SYSTEM_PROPERTY);
+    }
+
+    @BeforeEach
+    void resetConfig() {
+        if (config == null) {
+            // first run - need to remove existing props
+            System.clearProperty(META_CONFIG_SYSTEM_PROPERTY);
+            configResolver.releaseConfig(ConfigProvider.getConfig());
+        } else {
+            configResolver.releaseConfig(config);
+            config = null;
+        }
+    }
+
+    @Test
+    void testMetaClasspath() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-classpath.yaml");
+        validateConfig();
+    }
+
+    @Test
+    void testMetaPath() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-path.yaml");
+        validateConfig();
+    }
+
+    private void validateConfig() {
+        config = ConfigProvider.getConfig();
+
+        // Main file
+        assertThat(config.getValue("string", String.class), is("String"));
+        assertThat(config.getValue("number", String.class), is("175"));
+        assertThat(config.getValue("array.0", String.class), is("One"));
+        assertThat(config.getValue("array.1", String.class), is("Two"));
+        assertThat(config.getValue("array.2", String.class), is("Three"));
+        assertThat(config.getValue("boolean", String.class), is("true"));
+    }
+
+    @Test
+    void testMetaClasspathConfigProfile() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-classpath-profile.yaml");
+        validateConfigProfile();
+    }
+
+    @Test
+    void testMetaPathConfigProfile() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-path-profile.yaml");
+        validateConfigProfile();
+    }
+
+    private void validateConfigProfile() {
+        config = ConfigProvider.getConfig();
+
+        // Main file
+        assertThat(config.getValue("string", String.class), is("String_dev"));
+        assertThat(config.getValue("number", String.class), is("250"));
+        assertThat(config.getValue("array.0", String.class), is("One"));
+        assertThat(config.getValue("array.1", String.class), is("Two"));
+        assertThat(config.getValue("array.2", String.class), is("Three"));
+        assertThat(config.getValue("boolean", String.class), is("true"));
+        assertThat(config.getValue("extra", String.class), is("Extra"));
+    }
+
+    @Test
+    void testMetaOrdinal() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "ordinal-mp-meta-config.yaml");
+        config = ConfigProvider.getConfig();
+
+        assertThat(config.getValue("string", String.class), is("String"));
+        assertThat(config.getValue("number", String.class), is("175"));
+        assertThat(config.getValue("array.0", String.class), is("First"));
+        assertThat(config.getValue("array.1", String.class), is("Second"));
+        assertThat(config.getValue("array.2", String.class), is("Third"));
+        assertThat(config.getValue("boolean", String.class), is("false"));
+    }
+
+    @Test
+    void testMetaNonExistentNotOptional() {
+        System.setProperty(META_CONFIG_SYSTEM_PROPERTY, "custom-mp-meta-config-path-not-optional.yaml");
+        try {
+            config = ConfigProvider.getConfig();
+            Assertions.fail("Expecting meta-config to fail due to not optional non-existent config source");
+        } catch (ConfigException e) {}
+    }
+}

--- a/config/yaml-mp/src/test/resources/application.yaml
+++ b/config/yaml-mp/src/test/resources/application.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+yaml:
+  string: String
+  number: 10
+  array:
+    - "Array 1"
+    - "Array 2"
+    - "Array 3"
+  boolean: true

--- a/config/yaml-mp/src/test/resources/custom-application-dev.yaml
+++ b/config/yaml-mp/src/test/resources/custom-application-dev.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+string: String_dev
+number: 250
+extra: Extra

--- a/config/yaml-mp/src/test/resources/custom-application.yaml
+++ b/config/yaml-mp/src/test/resources/custom-application.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+string: String
+number: 175
+array:
+  - One
+  - Two
+  - Three
+boolean: true

--- a/config/yaml-mp/src/test/resources/custom-mp-meta-config-classpath-profile.yaml
+++ b/config/yaml-mp/src/test/resources/custom-mp-meta-config-classpath-profile.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+profile: dev
+
+sources:
+  - type: "yaml"
+    classpath: "custom-application.yaml"
+    optional: false

--- a/config/yaml-mp/src/test/resources/custom-mp-meta-config-classpath.yaml
+++ b/config/yaml-mp/src/test/resources/custom-mp-meta-config-classpath.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "yaml"
+    classpath: "custom-application.yaml"
+    optional: false

--- a/config/yaml-mp/src/test/resources/custom-mp-meta-config-path-not-optional.yaml
+++ b/config/yaml-mp/src/test/resources/custom-mp-meta-config-path-not-optional.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "yaml"
+    path: "src/test/resources/non-existent.conf"
+    optional: false

--- a/config/yaml-mp/src/test/resources/custom-mp-meta-config-path-profile.yaml
+++ b/config/yaml-mp/src/test/resources/custom-mp-meta-config-path-profile.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+profile: dev
+
+sources:
+  - type: "yaml"
+    path: "src/test/resources/custom-application.yaml"
+    optional: false

--- a/config/yaml-mp/src/test/resources/custom-mp-meta-config-path.yaml
+++ b/config/yaml-mp/src/test/resources/custom-mp-meta-config-path.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,20 +16,8 @@
 
 add-discovered-sources: false
 add-discovered-converters: false
-#future compatibility
-#config-profile: "dev"
 
 sources:
-  - type: "properties"
-    path: "src/test/resources/meta-config/path.properties"
-    ordinal: 50
   - type: "yaml"
-    classpath: "custom-application.yaml"
-    optional: true
-  - type: "properties"
-    classpath: "meta-config/classpath.properties"
-    name: "CLASSPATH"
-    # not sure how to test URL based unless we start a server
-#  - type: "yaml"
-#    url: "helidon-test:meta-config/url.yaml"
-#    name: "URL"
+    path: "src/test/resources/custom-application.yaml"
+    optional: false

--- a/config/yaml-mp/src/test/resources/ordinal-2.yaml
+++ b/config/yaml-mp/src/test/resources/ordinal-2.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+string: String
+number: 175
+array:
+  - One
+  - Two
+  - Three
+boolean: true

--- a/config/yaml-mp/src/test/resources/ordinal-mp-meta-config.yaml
+++ b/config/yaml-mp/src/test/resources/ordinal-mp-meta-config.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+add-discovered-sources: false
+add-discovered-converters: false
+
+sources:
+  - type: "yaml"
+    classpath: "ordinal.yaml"
+    optional: false
+    ordinal: 500
+  - type: "yaml"
+    classpath: "ordinal-2.yaml"
+    optional: false

--- a/config/yaml-mp/src/test/resources/ordinal.yaml
+++ b/config/yaml-mp/src/test/resources/ordinal.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+array:
+- First
+- Second
+- Third
+boolean: false

--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.media</groupId>
             <artifactId>helidon-media-jsonp</artifactId>
         </dependency>

--- a/examples/metrics/filtering/se/pom.xml
+++ b/examples/metrics/filtering/se/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.media</groupId>
             <artifactId>helidon-media-jsonp</artifactId>
         </dependency>

--- a/microprofile/cdi/pom.xml
+++ b/microprofile/cdi/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>helidon-config-mp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-context</artifactId>
         </dependency>

--- a/tests/integration/config/hocon-mp/pom.xml
+++ b/tests/integration/config/hocon-mp/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.tests.integration</groupId>
+        <artifactId>helidon-tests-integration-config</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-tests-integration-config-hocon-mp</artifactId>
+    <name>Helidon Tests Integration for HOCON/JSON Config on MP</name>
+    <description>Validation for HOCON/JSON Config on MP</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-hocon-mp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.server</groupId>
+            <artifactId>helidon-microprofile-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/ConfigBean.java
+++ b/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/ConfigBean.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+
+public class ConfigBean {
+    // Main Hocon config file properties
+    @Inject
+    @ConfigProperty(name = "hocon.string")
+    public String hocon_string;
+
+    @Inject
+    @ConfigProperty(name = "hocon.number")
+    public int hocon_number;
+
+    @Inject
+    @ConfigProperty(name = "hocon.array.0")
+    public String hocon_array_0;
+
+    @Inject
+    @ConfigProperty(name = "hocon.array.1")
+    public String hocon_array_1;
+
+    @Inject
+    @ConfigProperty(name = "hocon.array.2")
+    public String hocon_array_2;
+
+    @Inject
+    @ConfigProperty(name = "hocon.boolean")
+    public boolean hocon_boolean;
+
+    // Include properties
+    @Inject
+    @ConfigProperty(name = "hocon_include.string")
+    public String hocon_include_string;
+
+    @Inject
+    @ConfigProperty(name = "hocon_include.number")
+    public int hocon_include_number;
+
+    @Inject
+    @ConfigProperty(name = "hocon_include.array.0")
+    public String hocon_include_array_0;
+
+    @Inject
+    @ConfigProperty(name = "hocon_include.array.1")
+    public String hocon_include_array_1;
+
+    @Inject
+    @ConfigProperty(name = "hocon_include.array.2")
+    public String hocon_include_array_2;
+
+    @Inject
+    @ConfigProperty(name = "hocon_include.boolean")
+    public boolean hocon_include_boolean;
+
+    // Json config file properties
+    @Inject
+    @ConfigProperty(name = "json.string")
+    public String json_string;
+
+    @Inject
+    @ConfigProperty(name = "json.number")
+    public int json_number;
+
+    @Inject
+    @ConfigProperty(name = "json.array.0")
+    public String json_array_0;
+
+    @Inject
+    @ConfigProperty(name = "json.array.1")
+    public String json_array_1;
+
+    @Inject
+    @ConfigProperty(name = "json.array.2")
+    public String json_array_2;
+
+    @Inject
+    @ConfigProperty(name = "json.boolean")
+    public boolean json_boolean;
+}

--- a/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/ConfigBean.java
+++ b/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/ConfigBean.java
@@ -18,7 +18,7 @@ package io.helidon.config.hocon.mp;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class ConfigBean {
     // Main Hocon config file properties

--- a/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
+++ b/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.hocon.mp;
+
+import io.helidon.microprofile.config.ConfigCdiExtension;
+import io.helidon.microprofile.server.JaxRsCdiExtension;
+import io.helidon.microprofile.server.ServerCdiExtension;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.CDI;
+
+/**
+ * Test meta-config on MP with HOCON and JSON parsing.
+ *
+ * This will use SeContainerInitializer rather than @HelidonTest as the latter does not make meta-config work
+ */
+public class HoconJsonMpMetaConfigTest {
+    private static ConfigBean bean;
+    private static SeContainer container;
+
+    @BeforeAll
+    static void initialize() {
+        System.setProperty("io.helidon.config.mp.meta-config", "custom-mp-meta-config.yaml");
+        System.setProperty("mp.initializer.allow", "true");
+        System.setProperty("mp.initializer.no-warn", "true");
+
+        container = SeContainerInitializer.newInstance()
+                .disableDiscovery()
+                .addExtensions(ConfigCdiExtension.class, ServerCdiExtension.class, JaxRsCdiExtension.class)
+                .addBeanClasses(ConfigBean.class)
+                .initialize();
+
+        bean = CDI.current()
+                .select(ConfigBean.class)
+                .get();
+    }
+
+    @AfterAll
+    static void destroy() {
+        System.clearProperty("io.helidon.config.mp.meta-config");
+        System.clearProperty("mp.initializer.allow");
+        System.clearProperty("mp.initializer.no-warn");
+        container.close();
+    }
+
+    @Test
+    void TestHoconConfig() {
+        Assertions.assertEquals(bean.hocon_string, "Meta String");
+        Assertions.assertEquals(bean.hocon_number, 20);
+        Assertions.assertEquals(bean.hocon_array_0, "Meta Array 1");
+        Assertions.assertEquals(bean.hocon_array_1, "Meta Array 2");
+        Assertions.assertEquals(bean.hocon_array_2, "Meta Array 3");
+        Assertions.assertTrue(bean.hocon_boolean);
+     }
+
+     @Test
+    void TestHoconIncludeConfig() {
+        Assertions.assertEquals(bean.hocon_include_string, "Meta Include String");
+        Assertions.assertEquals(bean.hocon_include_number, 10);
+        Assertions.assertEquals(bean.hocon_include_array_0, "Meta Include Array 1");
+        Assertions.assertEquals(bean.hocon_include_array_1, "Meta Include Array 2");
+        Assertions.assertEquals(bean.hocon_include_array_2, "Meta Include Array 3");
+        Assertions.assertFalse(bean.hocon_include_boolean);
+    }
+
+    @Test
+    void TestJsonConfig() {
+        Assertions.assertEquals(bean.json_string, "Meta String");
+        Assertions.assertEquals(bean.json_number, 20);
+        Assertions.assertEquals(bean.json_array_0, "Meta Array 1");
+        Assertions.assertEquals(bean.json_array_1, "Meta Array 2");
+        Assertions.assertEquals(bean.json_array_2, "Meta Array 3");
+        Assertions.assertTrue(bean.json_boolean);
+    }
+}

--- a/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
+++ b/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
@@ -25,9 +25,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.enterprise.inject.se.SeContainer;
-import javax.enterprise.inject.se.SeContainerInitializer;
-import javax.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.CDI;
 
 /**
  * Test meta-config on MP with HOCON and JSON parsing.

--- a/tests/integration/config/hocon-mp/src/test/resources/application-dev.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/application-dev.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "include-dev.conf"
+
+hocon = {
+    string = "Overriden String"
+    array = [
+        "Overriden Array 1"
+        "Overriden Array 2"
+        "Overriden Array 3"
+    ]
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/application-dev.json
+++ b/tests/integration/config/hocon-mp/src/test/resources/application-dev.json
@@ -1,0 +1,10 @@
+{
+  "json": {
+    "string": "Overriden String",
+    "array": [
+      "Overriden Array 1",
+      "Overriden Array 2",
+      "Overriden Array 3"
+    ]
+  }
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/application.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/application.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "include.conf"
+
+hocon = {
+    string = "String"
+    number = 10
+    array = [
+        "Array 1"
+        "Array 2"
+        "Array 3"
+    ]
+    boolean = true
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/application.json
+++ b/tests/integration/config/hocon-mp/src/test/resources/application.json
@@ -1,0 +1,12 @@
+{
+  "json": {
+    "string": "String",
+    "number": 10,
+    "array": [
+      "Array 1",
+      "Array 2",
+      "Array 3"
+    ],
+    "boolean": true
+  }
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/custom-mp-meta-config.yaml
+++ b/tests/integration/config/hocon-mp/src/test/resources/custom-mp-meta-config.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sources:
+  - type: "environment-variables"
+  - type: "system-properties"
+  - type: "hocon"
+    classpath: "meta-application.conf"
+    optional: false
+  - type: "json"
+    classpath: "meta-application.json"
+    optional: false

--- a/tests/integration/config/hocon-mp/src/test/resources/include-dev.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/include-dev.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hocon_include {
+    string = "Include String"
+    number = 20
+    array = [
+        "Include Array 1"
+        "Include Array 2"
+        "Include Array 3"
+    ]
+    boolean = false
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/include.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/include.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hocon_include {
+    string = "Include String"
+    number = 20
+    array = [
+        "Include Array 1"
+        "Include Array 2"
+        "Include Array 3"
+    ]
+    boolean = false
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/meta-application.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/meta-application.conf
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include "meta-include.conf"
+
+hocon = {
+    string = "Meta String"
+    number = 20
+    array = [
+        "Meta Array 1"
+        "Meta Array 2"
+        "Meta Array 3"
+    ]
+    boolean = true
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/meta-application.json
+++ b/tests/integration/config/hocon-mp/src/test/resources/meta-application.json
@@ -1,0 +1,12 @@
+{
+  "json": {
+    "string": "Meta String",
+    "number": 20,
+    "array": [
+      "Meta Array 1",
+      "Meta Array 2",
+      "Meta Array 3"
+    ],
+    "boolean": true
+  }
+}

--- a/tests/integration/config/hocon-mp/src/test/resources/meta-include.conf
+++ b/tests/integration/config/hocon-mp/src/test/resources/meta-include.conf
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hocon_include {
+    string = "Meta Include String"
+    number = 10
+    array = [
+        "Meta Include Array 1"
+        "Meta Include Array 2"
+        "Meta Include Array 3"
+    ]
+    boolean = false
+}

--- a/tests/integration/config/pom.xml
+++ b/tests/integration/config/pom.xml
@@ -37,5 +37,6 @@
     <modules>
         <module>gh-2171</module>
         <module>gh-2171-yml</module>
+        <module>hocon-mp</module>
     </modules>
 </project>


### PR DESCRIPTION
Forward-port of 2.x PR: https://github.com/oracle/helidon/pull/4218

1. Meta-config is refactored to allow it to be customizable by users for other types.
2. Hocon/Json is parsed as a config source only via meta-config.

* Create hocon includer per instance of hocon config source and add justification comment for security bug filtering

* Remove support of application.conf/json hocon/json as default discoverable sources

* Initial commit for Mp config-source provider implementation

* Add MP meta-config provider test for Environment Variables

* Add Yaml MP meta-config provider tests and various resolution to review feedback

* Add helidon-config-yaml-mp as a dependency of helidon-microprofile-cdi

* Declare "uses io.helidon.config.mp.spi.MpMetaConfigProvider" in config-mp’s module-info and set priority of all implementations of MpMetaConfigProvider to 300

* Various updates/cleanups from review feedback

* Add helidon-config-yaml dependency to metrics examples after they were failing because of dependency on yaml-mp
