### PR TITLE
Avoid calling getPackage() on an annotation type 

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/AnnotationFinder.java
@@ -45,7 +45,7 @@ public class AnnotationFinder {
             "java.",
             "javax.",
             "jakarta.",
-            "org.microprofile."
+            "org.eclipse.microprofile."
     };
 
     private final Package pkg;
@@ -84,7 +84,7 @@ public class AnnotationFinder {
                                             Set<Annotation> seen, Package pkg, BeanManager bm) {
         for (Annotation a1 : set) {
             Class<? extends Annotation> a1Type = a1.annotationType();
-            if (a1Type.getPackage().equals(pkg)) {
+            if (a1Type.getName().startsWith(pkg.getName())) {       // Avoid getPackage() - Issue #4296
                 result.add(a1);
             } else if (!seen.contains(a1) && isOfInterest(a1, bm)) {
                 seen.add(a1);


### PR DESCRIPTION
Avoid calling getPackage() on an annotation type due to an issue with GraalVM 21.3.X. Sometimes it returns the correct package, sometimes it does not (returning the annotation's proxy class package instead). Also fixed package name in filtering optimization. See issue #4296.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>