### PR TITLE
Remove unneeded dependency

### DIFF
--- a/metrics/metrics/pom.xml
+++ b/metrics/metrics/pom.xml
@@ -43,10 +43,6 @@
             <artifactId>helidon-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-mp</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common-service-loader</artifactId>
         </dependency>

--- a/metrics/metrics/src/main/java/module-info.java
+++ b/metrics/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,6 @@ module io.helidon.metrics {
     requires transitive io.helidon.webserver; // webserver/webserver/Context is a public return value
     requires io.helidon.media.jsonp;
     requires java.json;
-    requires io.helidon.config.mp;
-    requires microprofile.config.api;
     requires io.helidon.servicecommon.rest;
 
     exports io.helidon.metrics;


### PR DESCRIPTION
Resolves #4377 

`helidon-metrics` had a lingering, unneeded dependency on `helidon-config-mp`.

We had removed this dependency from 3.0 in Feb. 2022. This essentially back ports that change. 

