### PR TITLE
Remove deprecated method from `HelidonRestServiceSupport`

### DIFF
--- a/service-common/rest/src/main/java/io/helidon/servicecommon/rest/HelidonRestServiceSupport.java
+++ b/service-common/rest/src/main/java/io/helidon/servicecommon/rest/HelidonRestServiceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,18 +62,6 @@ public abstract class HelidonRestServiceSupport implements RestServiceSupport {
         this.logger = logger;
         corsEnabledServiceHelper = CorsEnabledServiceHelper.create(serviceName, restServiceSettings.crossOriginConfig());
         context = (restServiceSettings.webContext().startsWith("/") ? "" : "/") + restServiceSettings.webContext();
-    }
-
-    /**
-     * Avoid using this obsolete method. Use {@link #configureEndpoint(Routing.Rules, Routing.Rules)} instead. (Neither method
-     * should typically invoked directly from user code.)
-     *
-     * @param rules routing rules (also accepts
-     * {@link io.helidon.webserver.Routing.Builder}
-     */
-    @Deprecated
-    public final void configureEndpoint(Routing.Rules rules) {
-        configureEndpoint(rules, rules);
     }
 
     /**


### PR DESCRIPTION
See #4373 

There are no examples or public doc which refer to the removed method.