### PR TITLE
Add helidon-config-yaml-mp as a dependency in helidon-microprofile-config. (#4379)

### DIFF
--- a/microprofile/config/pom.xml
+++ b/microprofile/config/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml-mp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/tests/integration/config/gh-4375/pom.xml
+++ b/tests/integration/config/gh-4375/pom.xml
@@ -24,22 +24,17 @@
     <parent>
         <groupId>io.helidon.tests.integration</groupId>
         <artifactId>helidon-tests-integration-config</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>helidon-tests-integration-config-hocon-mp</artifactId>
-    <name>Helidon Tests Integration for HOCON/JSON Config on MP</name>
-    <description>Validation for HOCON/JSON Config on MP</description>
+    <artifactId>helidon-tests-integration-config-gh-4375</artifactId>
+    <name>Helidon Tests Integration GH 4375</name>
+    <description>Validation for Github issue #4375 - Verify that helidon-config-yaml-mp is part of helidon-microprofile-config</description>
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.config</groupId>
-            <artifactId>helidon-config-hocon-mp</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.helidon.microprofile.server</groupId>
-            <artifactId>helidon-microprofile-server</artifactId>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/integration/config/gh-4375/src/test/java/io/helidon/tests/integration/gh4375/YamlMpConfigTest.java
+++ b/tests/integration/config/gh-4375/src/test/java/io/helidon/tests/integration/gh4375/YamlMpConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.gh4375;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+class YamlMpConfigTest {
+    private Config config;
+
+    @BeforeEach
+    void initialize() {
+        this.config = ConfigProvider.getConfig();
+        Assertions.assertNotNull(this.config);
+    }
+
+    @Test
+    void TestYamlMpConfigExistsInMicroprofileConfig() {
+        Assertions.assertTrue(this.config.getValue("yamlMpConfigExists", Boolean.class));
+    }
+}

--- a/tests/integration/config/gh-4375/src/test/resources/application.yaml
+++ b/tests/integration/config/gh-4375/src/test/resources/application.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+yamlMpConfigExists: true

--- a/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
+++ b/tests/integration/config/hocon-mp/src/test/java/io/helidon/config/hocon/mp/HoconJsonMpMetaConfigTest.java
@@ -34,7 +34,7 @@ import javax.enterprise.inject.spi.CDI;
  *
  * This will use SeContainerInitializer rather than @HelidonTest as the latter does not make meta-config work
  */
-public class HoconJsonMpMetaConfigTest {
+class HoconJsonMpMetaConfigTest {
     private static ConfigBean bean;
     private static SeContainer container;
 


### PR DESCRIPTION
helidon-config-yaml-mp was recently decoupled from helidon-config-mp which is part of helidon-microprofile-config and as a consequence, is not a part of that config bundle anymore. This work was done to add it back and avoid any effects of incompatibility.

(cherry picked from commit aca9bf76f046fd94f292c8a6d61ae79c65f72031)