### PR TITLE
Deal with deprecations in metrics (3.x) 

### DIFF
--- a/docs/se/cors/04_support-in-builtin-services.adoc
+++ b/docs/se/cors/04_support-in-builtin-services.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2020 Oracle and/or its affiliates.
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -74,11 +74,12 @@ sharing of the `/metrics` endpoint to `\http://foo.com`.
 ----
 private static Routing createRouting(Config config) {
 
-        CrossOriginConfig metricsCrossOriginConfig = CrossOriginConfig.builder() // <1>
-                .allowOrigins("http://foo.com")
-                .build();
+        CrossOriginConfig.Builder metricsCrossOriginConfigBuilder = CrossOriginConfig.builder() // <1>
+                .allowOrigins("http://foo.com");
+        RestServiceSettings.Builder restServiceSettingsBuilder = RestServiceSettings.builder()
+                 .crossOriginConfig(metricsCrossOriginConfigBuilder); // <2>
         MetricsSupport metrics = MetricsSupport.builder()
-                .crossOriginConfig(metricsCrossOriginConfig) // <2>
+                .restServiceSettings(restServiceSettingsBuilder) // <3>
                 .build();
         GreetService greetService = new GreetService(config);
         HealthSupport health = HealthSupport.builder()
@@ -87,14 +88,16 @@ private static Routing createRouting(Config config) {
 
         return Routing.builder()
                 .register(health)                   // Health at "/health"
-                .register(metrics)                  // Metrics at "/metrics" // <3>
+                .register(metrics)                  // Metrics at "/metrics" // <4>
                 .register("/greet", greetService)
                 .build();
     }
 ----
-<1> Create the `CrossOriginConfig` for metrics, limiting sharing to `\http://foo.com`.
-<2> Use the `CrossOriginConfig` instance in constructing the `MetricsSupport` service.
-<3> Use the `MetricsSupport` object in creating the routing rules.
+<1> Create the `CrossOriginConfig.Builder` for metrics, limiting sharing to `\http://foo.com`.
+<2> Use the `CrossOriginConfig.Builder` instance in constructing
+the `RestServiceSetting.Builder` (which assigns common settings such as the CORS configuration and the web context for the service endpoint).
+<3> Use the `RestServiceSetting.Builder` in preparing the `MetricsSupport` service.
+<4> Use the `MetricsSupport` object in creating the routing rules.
 
 include::{common-page-prefix-inc}[tag=configuring-cors-for-builtin-services]
 

--- a/docs/se/metrics/01_metrics.adoc
+++ b/docs/se/metrics/01_metrics.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ To enable Metrics, register it with the WebServer.
 
 [source,java]
 ----
-import io.helidon.metrics.api.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 //...
 
 Routing.builder()

--- a/docs/shared/metrics/metrics-capable-components.adoc
+++ b/docs/shared/metrics/metrics-capable-components.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2021 Oracle and/or its affiliates.
+    Copyright (c) 2021, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 :common-page-prefix-inc: ../../shared/common_prereqs/common_prereqs.adoc
 :common-guides: ../../common/guides
 :metrics-common: {common-guides}/metrics.adoc
-:javadoc-base-url-api: {javadoc-base-url}io.helidon.metrics.api/io/helidon/metrics/api
-:metrics-support-builder-javadoc: {javadoc-base-url-api}/MetricsSupport.Builder.html
+:javadoc-base-url-serviceapi: {javadoc-base-url}io.helidon.metrics.serviceapi/io/helidon/metrics/serviceapi
+:metrics-support-builder-javadoc: {javadoc-base-url-serviceapi}/MetricsSupport.Builder.html
 :lower-case-flavor: se
 :intro-project-name: {h1Prefix}
 :chk: icon:check[]

--- a/examples/cors/pom.xml
+++ b/examples/cors/pom.xml
@@ -66,11 +66,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.health</groupId>
             <artifactId>helidon-health-checks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
+++ b/examples/cors/src/main/java/io/helidon/examples/cors/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.cors.CorsSupport;

--- a/examples/dbclient/jdbc/pom.xml
+++ b/examples/dbclient/jdbc/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>
@@ -107,6 +107,11 @@
         <dependency>
             <groupId>io.helidon.examples.dbclient</groupId>
             <artifactId>helidon-examples-dbclient-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/examples/dbclient/jdbc/src/main/java/io/helidon/examples/dbclient/jdbc/JdbcExampleMain.java
+++ b/examples/dbclient/jdbc/src/main/java/io/helidon/examples/dbclient/jdbc/JdbcExampleMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import io.helidon.dbclient.health.DbClientHealthCheck;
 import io.helidon.health.HealthSupport;
 import io.helidon.media.jsonb.JsonbSupport;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;

--- a/examples/dbclient/jdbc/src/main/java/module-info.java
+++ b/examples/dbclient/jdbc/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ module io.helidon.examples.dbclient.jdbc {
     requires io.helidon.health;
     requires io.helidon.media.jsonb;
     requires io.helidon.media.jsonp;
-    requires io.helidon.metrics;
+    requires io.helidon.metrics.serviceapi;
     requires io.helidon.tracing;
     requires io.helidon.examples.dbclient.common;
 }

--- a/examples/dbclient/mongodb/pom.xml
+++ b/examples/dbclient/mongodb/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>
@@ -89,6 +89,11 @@
         <dependency>
             <groupId>io.helidon.examples.dbclient</groupId>
             <artifactId>helidon-examples-dbclient-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/examples/dbclient/mongodb/src/main/java/io/helidon/examples/dbclient/mongo/MongoDbExampleMain.java
+++ b/examples/dbclient/mongodb/src/main/java/io/helidon/examples/dbclient/mongo/MongoDbExampleMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import io.helidon.dbclient.tracing.DbClientTracing;
 import io.helidon.health.HealthSupport;
 import io.helidon.media.jsonb.JsonbSupport;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;

--- a/examples/dbclient/mongodb/src/main/java/module-info.java
+++ b/examples/dbclient/mongodb/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ module io.helidon.examples.dbclient.mongodb {
     requires io.helidon.health;
     requires io.helidon.media.jsonb;
     requires io.helidon.media.jsonp;
-    requires io.helidon.metrics;
+    requires io.helidon.metrics.serviceapi;
     requires io.helidon.tracing;
 
     requires io.helidon.examples.dbclient.common;

--- a/examples/dbclient/pokemons/pom.xml
+++ b/examples/dbclient/pokemons/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>
@@ -114,6 +114,11 @@
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMain.java
+++ b/examples/dbclient/pokemons/src/main/java/io/helidon/examples/dbclient/pokemons/PokemonMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.dbclient.health.DbClientHealthCheck;
 import io.helidon.health.HealthSupport;
 import io.helidon.media.jsonb.JsonbSupport;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;

--- a/examples/dbclient/pokemons/src/main/java/module-info.java
+++ b/examples/dbclient/pokemons/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ module io.helidon.examples.dbclient.pokemons.jdbc {
     requires io.helidon.health;
     requires io.helidon.media.jsonb;
     requires io.helidon.media.jsonp;
-    requires io.helidon.metrics;
+    requires io.helidon.metrics.serviceapi;
     requires io.helidon.tracing;
     requires io.helidon.dbclient;
     requires io.helidon.webserver;

--- a/examples/employee-app/pom.xml
+++ b/examples/employee-app/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.dbclient</groupId>
@@ -73,6 +73,11 @@
         <dependency>
             <groupId>io.helidon.dbclient</groupId>
             <artifactId>helidon-dbclient-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>

--- a/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
+++ b/examples/employee-app/src/main/java/io/helidon/service/employee/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonb.JsonbSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.staticcontent.StaticContentSupport;

--- a/examples/grpc/metrics/pom.xml
+++ b/examples/grpc/metrics/pom.xml
@@ -58,7 +58,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.grpc</groupId>

--- a/examples/grpc/metrics/src/main/java/io/helidon/grpc/examples/metrics/Server.java
+++ b/examples/grpc/metrics/src/main/java/io/helidon/grpc/examples/metrics/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.grpc.metrics.GrpcMetrics;
 import io.helidon.grpc.server.GrpcRouting;
 import io.helidon.grpc.server.GrpcServer;
 import io.helidon.grpc.server.GrpcServerConfiguration;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/integrations/microstream/greetings-se/pom.xml
+++ b/examples/integrations/microstream/greetings-se/pom.xml
@@ -53,7 +53,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/integrations/microstream/greetings-se/src/main/java/io/helidon/examples/integrations/microstream/greetings/se/Main.java
+++ b/examples/integrations/microstream/greetings-se/src/main/java/io/helidon/examples/integrations/microstream/greetings/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/integrations/neo4j/neo4j-se/pom.xml
+++ b/examples/integrations/neo4j/neo4j-se/pom.xml
@@ -63,7 +63,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.integrations.neo4j</groupId>

--- a/examples/integrations/neo4j/neo4j-se/src/main/java/io/helidon/examples/integrations/neo4j/se/Main.java
+++ b/examples/integrations/neo4j/neo4j-se/src/main/java/io/helidon/examples/integrations/neo4j/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/integrations/neo4j/neo4j-se/src/main/java/io/helidon/examples/integrations/neo4j/se/Main.java
+++ b/examples/integrations/neo4j/neo4j-se/src/main/java/io/helidon/examples/integrations/neo4j/se/Main.java
@@ -31,7 +31,7 @@ import io.helidon.integrations.neo4j.health.Neo4jHealthCheck;
 import io.helidon.integrations.neo4j.metrics.Neo4jMetricsSupport;
 import io.helidon.media.jsonb.JsonbSupport;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/metrics/exemplar/pom.xml
+++ b/examples/metrics/exemplar/pom.xml
@@ -47,7 +47,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.tracing</groupId>

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;

--- a/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
+++ b/examples/metrics/exemplar/src/main/java/io/helidon/examples/metrics/exemplar/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import io.helidon.common.LogConfig;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.tracing.TracerBuilder;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;

--- a/examples/metrics/filtering/se/pom.xml
+++ b/examples/metrics/filtering/se/pom.xml
@@ -44,7 +44,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;

--- a/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
+++ b/examples/metrics/filtering/se/src/main/java/io/helidon/examples/metrics/filtering/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import io.helidon.common.LogConfig;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
 import io.helidon.metrics.api.MetricsSettings;
 import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.metrics.api.RegistryFilterSettings;
 import io.helidon.metrics.api.RegistrySettings;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/metrics/kpi/pom.xml
+++ b/examples/metrics/kpi/pom.xml
@@ -44,7 +44,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/GreetService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;
 import io.helidon.webserver.ServerResponse;

--- a/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
+++ b/examples/metrics/kpi/src/main/java/io/helidon/examples/metrics/kpi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@ import io.helidon.common.LogConfig;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.KeyPerformanceIndicatorMetricsSettings;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.api.KeyPerformanceIndicatorMetricsSettings;
+import io.helidon.metrics.api.MetricsSettings;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 
@@ -130,7 +131,8 @@ public final class Main {
                         .extended(true)
                         .longRunningRequestThresholdMs(2000);
         return MetricsSupport.builder()
-                .keyPerformanceIndicatorsMetricsSettings(settingsBuilder)
+                .metricsSettings(MetricsSettings.builder()
+                                         .keyPerformanceIndicatorSettings(settingsBuilder))
                 .build();
     }
 }

--- a/examples/metrics/kpi/src/test/java/io/helidon/examples/metrics/kpi/MainTest.java
+++ b/examples/metrics/kpi/src/test/java/io/helidon/examples/metrics/kpi/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,13 +131,6 @@ public class MainTest {
 
         assertThat("Returned metrics output",
                    openMetricsOutput,
-                   chooseMatcher());
-    }
-
-    private static Matcher<String> chooseMatcher() {
-        Matcher<String> contains = containsString("# TYPE " + KPI_REGISTRY_TYPE.getName() + "_requests_inFlight_current");
-        return Main.USE_CONFIG
-                ? contains
-                : not(contains);
+                   containsString("# TYPE " + KPI_REGISTRY_TYPE.getName() + "_requests_inFlight_current"));
     }
 }

--- a/examples/openapi/pom.xml
+++ b/examples/openapi/pom.xml
@@ -55,11 +55,16 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.openapi</groupId>
             <artifactId>helidon-openapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>

--- a/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
+++ b/examples/openapi/src/main/java/io/helidon/examples/openapi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.openapi.OpenAPISupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;

--- a/examples/quickstarts/helidon-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-quickstart-se/pom.xml
@@ -59,7 +59,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/pom.xml
@@ -80,7 +80,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples/quickstarts/helidon-standalone-quickstart-se/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/todo-app/frontend/pom.xml
+++ b/examples/todo-app/frontend/pom.xml
@@ -103,7 +103,11 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -120,6 +124,11 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/Main.java
+++ b/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.config.FileSystemWatcher;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.security.Security;
 import io.helidon.security.integration.webserver.WebSecurity;
 import io.helidon.tracing.TracerBuilder;

--- a/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/TodosHandler.java
+++ b/examples/todo-app/frontend/src/main/java/io/helidon/demo/todos/frontend/TodosHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import io.helidon.common.http.Http;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.security.SecurityContext;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;

--- a/examples/webclient/standalone/pom.xml
+++ b/examples/webclient/standalone/pom.xml
@@ -45,7 +45,11 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webclient</groupId>
@@ -54,6 +58,11 @@
         <dependency>
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ClientMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ClientMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigValue;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientResponse;
 import io.helidon.webclient.metrics.WebClientMetrics;

--- a/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
+++ b/examples/webclient/standalone/src/main/java/io/helidon/examples/webclient/standalone/ServerMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.examples.webclient.standalone;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
+++ b/examples/webclient/standalone/src/test/java/io/helidon/examples/webclient/standalone/ClientMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import io.helidon.common.http.Http;
 import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 import io.helidon.webclient.WebClient;
 import io.helidon.webclient.WebClientRequestBuilder;
 import io.helidon.webclient.WebClientServiceRequest;

--- a/examples/webserver/multiport/pom.xml
+++ b/examples/webserver/multiport/pom.xml
@@ -53,7 +53,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/webserver/multiport/src/main/java/io/helidon/examples/webserver/multiport/Main.java
+++ b/examples/webserver/multiport/src/main/java/io/helidon/examples/webserver/multiport/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/examples/webserver/threadpool/pom.xml
+++ b/examples/webserver/threadpool/pom.xml
@@ -57,7 +57,12 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/examples/webserver/threadpool/src/main/java/io/helidon/examples/webserver/threadpool/Main.java
+++ b/examples/webserver/threadpool/src/main/java/io/helidon/examples/webserver/threadpool/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
-import io.helidon.metrics.MetricsSupport;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 

--- a/integrations/microstream/metrics/pom.xml
+++ b/integrations/microstream/metrics/pom.xml
@@ -39,13 +39,21 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.metrics</groupId>
-            <artifactId>helidon-metrics</artifactId>
+            <artifactId>helidon-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.helidon.metrics</groupId>
+            <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/integrations/microstream/metrics/src/main/java/io/helidon/integrations/microstream/metrics/MicrostreamMetricsSupport.java
+++ b/integrations/microstream/metrics/src/main/java/io/helidon/integrations/microstream/metrics/MicrostreamMetricsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package io.helidon.integrations.microstream.metrics;
 import java.util.Objects;
 
 import io.helidon.config.Config;
-import io.helidon.metrics.MetricsSupport;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
+import io.helidon.metrics.serviceapi.MetricsSupport;
 
 import one.microstream.storage.embedded.types.EmbeddedStorageManager;
 import org.eclipse.microprofile.metrics.Gauge;

--- a/integrations/microstream/metrics/src/main/java/module-info.java
+++ b/integrations/microstream/metrics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ module io.helidon.integrations.microstream.metrics {
 
     requires transitive io.helidon.common;
     requires transitive io.helidon.config;
-    requires transitive io.helidon.metrics;
+    requires transitive io.helidon.metrics.api;
+    requires transitive io.helidon.metrics.serviceapi;
     requires transitive microstream.storage.embedded;
     requires microstream.storage;
 }

--- a/integrations/microstream/metrics/src/test/java/io/helidon/integrations/microstream/metrics/MicrostreamMetricsTest.java
+++ b/integrations/microstream/metrics/src/test/java/io/helidon/integrations/microstream/metrics/MicrostreamMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package io.helidon.integrations.microstream.metrics;
 
 import java.util.Date;
 
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 
 import one.microstream.X;
 import one.microstream.storage.embedded.types.EmbeddedStorageManager;

--- a/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettings.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ import io.helidon.config.Config;
 
 /**
  * Settings for KPI metrics (for compatibility).
+ *
+ * @deprecated Use {@link io.helidon.metrics.api.KeyPerformanceIndicatorMetricsSettings} instead.
  */
-@Deprecated
+@Deprecated(since = "2.4.0", forRemoval = true)
 public interface KeyPerformanceIndicatorMetricsSettings extends io.helidon.metrics.api.KeyPerformanceIndicatorMetricsSettings {
 
     /**

--- a/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettingsCompatibility.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/KeyPerformanceIndicatorMetricsSettingsCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,12 @@ import java.lang.reflect.Proxy;
 
 import io.helidon.metrics.KeyPerformanceIndicatorMetricsSettings.Builder;
 
-@Deprecated
+/**
+ * Do not use; for temporary compatability only.
+ *
+ * @deprecated Use {@link io.helidon.metrics.api.KeyPerformanceIndicatorMetricsSettings} instead.
+ */
+@Deprecated(since = "2.4.0", forRemoval = true)
 class KeyPerformanceIndicatorMetricsSettingsCompatibility {
 
     static Builder builder() {

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupport.java
@@ -68,6 +68,7 @@ import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 
+
 /**
  * Support for metrics for Helidon Web Server.
  *
@@ -187,7 +188,9 @@ public final class MetricsSupport extends HelidonRestServiceSupport
      * Create a new builder to construct an instance.
      *
      * @return A new builder instance
+     * @deprecated Use {@link io.helidon.metrics.serviceapi.MetricsSupport#builder()} instead.
      */
+    @Deprecated(since = "2.5.2", forRemoval = true)
     public static Builder builder() {
         return new Builder();
     }
@@ -662,7 +665,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport
          * performance metrics configuration
          * @deprecated Use {@link #metricsSettings(MetricsSettings.Builder)} instead
          */
-        @Deprecated
+        @Deprecated(since = "2.4.0", forRemoval = true)
         public Builder config(Config config) {
             super.config(config);
             metricsSettingsBuilder.config(config);
@@ -705,7 +708,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport
          * {@link MetricsSettings.Builder#keyPerformanceIndicatorSettings(KeyPerformanceIndicatorMetricsSettings.Builder)}
          * instead.
          */
-        @Deprecated
+        @Deprecated(since = "2.4.0", forRemoval = true)
         public Builder keyPerformanceIndicatorsMetricsSettings(KeyPerformanceIndicatorMetricsSettings.Builder builder) {
             this.metricsSettingsBuilder.keyPerformanceIndicatorSettings(builder);
             return this;
@@ -720,7 +723,7 @@ public final class MetricsSupport extends HelidonRestServiceSupport
          * {@link MetricsSettings.Builder#keyPerformanceIndicatorSettings(KeyPerformanceIndicatorMetricsSettings.Builder)}
          * instead.
          */
-        @Deprecated
+        @Deprecated(since = "2.4.0", forRemoval = true)
         public Builder keyPerformanceIndicatorsMetricsConfig(Config kpiConfig) {
             return keyPerformanceIndicatorsMetricsSettings(
                     KeyPerformanceIndicatorMetricsSettings.builder().config(kpiConfig));

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupportProviderImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupportProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class MetricsSupportProviderImpl implements MetricsSupportProvider<Metric
 
     @Override
     public MetricsSupport.Builder builder() {
-        return MetricsSupport.builder();
+        return new MetricsSupport.Builder();
     }
 
     @Override

--- a/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupportProviderImpl.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/MetricsSupportProviderImpl.java
@@ -26,7 +26,7 @@ public class MetricsSupportProviderImpl implements MetricsSupportProvider<Metric
 
     @Override
     public MetricsSupport.Builder builder() {
-        return new MetricsSupport.Builder();
+        return MetricsSupport.builder();
     }
 
     @Override

--- a/metrics/metrics/src/main/java/io/helidon/metrics/RegistryFactory.java
+++ b/metrics/metrics/src/main/java/io/helidon/metrics/RegistryFactory.java
@@ -86,7 +86,7 @@ public class RegistryFactory implements io.helidon.metrics.api.RegistryFactory {
      * @return a new registry factory
      * @deprecated Use {@link io.helidon.metrics.api.RegistryFactory#create()}
      */
-    @Deprecated
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public static RegistryFactory create() {
         return RegistryFactory.class.cast(io.helidon.metrics.api.RegistryFactory.create());
     }
@@ -100,7 +100,7 @@ public class RegistryFactory implements io.helidon.metrics.api.RegistryFactory {
      * @return a new registry factory
      * @deprecated Use {@link io.helidon.metrics.api.RegistryFactory#create(Config)}
      */
-    @Deprecated
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public static RegistryFactory create(Config config) {
         return RegistryFactory.class.cast(io.helidon.metrics.api.RegistryFactory.create(config));
     }
@@ -115,7 +115,7 @@ public class RegistryFactory implements io.helidon.metrics.api.RegistryFactory {
      * @return registry factory singleton
      * @deprecated Use {@link io.helidon.metrics.api.RegistryFactory#getInstance()}
      */
-    @Deprecated
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public static RegistryFactory getInstance() {
         return RegistryFactory.class.cast(io.helidon.metrics.api.RegistryFactory.getInstance());
     }
@@ -128,7 +128,7 @@ public class RegistryFactory implements io.helidon.metrics.api.RegistryFactory {
      * @return registry factory singleton
      * @deprecated Use {@link io.helidon.metrics.api.RegistryFactory#getInstance(MetricsSettings)}
      */
-    @Deprecated
+    @Deprecated(since = "2.4.0", forRemoval = true)
     public static RegistryFactory getInstance(Config config) {
         return RegistryFactory.class.cast(io.helidon.metrics.api.RegistryFactory.getInstance(config));
     }

--- a/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/MetricsSupport.java
+++ b/metrics/service-api/src/main/java/io/helidon/metrics/serviceapi/MetricsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,15 +57,25 @@ public interface MetricsSupport extends RestServiceSupport, Service {
     }
 
     /**
-     * Creates a new {@code MetricsSupport} instance using the specified metrics settings.
+     * Creates a new {@code MetricsSupport} instance using the specified metrics settings and REST service settings.
      *
      * @param metricsSettings metrics settings to use in initializing the metrics support
      * @param restServiceSettings REST service settings for the metrics endpoint
      *
-     * @return new metrics support using specified metrics settings
+     * @return new metrics support using specified metrics settings and REST service settings
      */
     static MetricsSupport create(MetricsSettings metricsSettings, RestServiceSettings restServiceSettings) {
         return MetricsSupportManager.create(metricsSettings, restServiceSettings);
+    }
+
+    /**
+     * Creates a new {@code MetricsSupport} instance using the specified metrics settings and defaulted REST service settings.
+     *
+     * @param metricsSettings metrics settings to use in initializing the metrics support
+     * @return new metrics support using the specified metrics settings
+     */
+    static MetricsSupport create(MetricsSettings metricsSettings) {
+        return create(metricsSettings, defaultedMetricsRestServiceSettingsBuilder().build());
     }
 
     /**
@@ -79,6 +89,15 @@ public interface MetricsSupport extends RestServiceSupport, Service {
                                             defaultedMetricsRestServiceSettingsBuilder()
                                                     .config(config)
                                                     .build());
+    }
+
+    /**
+     * Returns a builder for the highest-priority {@code MetricsSupport} implementation.
+     *
+     * @return builder for {@code MetricsSupport}
+     */
+    static MetricsSupport.Builder<?, ?> builder() {
+        return MetricsSupportManager.builder();
     }
 
     /**

--- a/microprofile/metrics/pom.xml
+++ b/microprofile/metrics/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>io.helidon.metrics</groupId>
             <artifactId>helidon-metrics</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloBean.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloBean.java
+++ b/tests/functional/context-propagation/src/main/java/io/helidon/tests/functional/context/hello/HelloBean.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletionStage;
 
 import io.helidon.common.context.Context;
 import io.helidon.common.context.Contexts;
-import io.helidon.metrics.RegistryFactory;
+import io.helidon.metrics.api.RegistryFactory;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;


### PR DESCRIPTION
See #4365 

This PR is largely a forward-port of the corresponding 2.x changes  in #4396 for 3.x (code, doc, and examples).

Note: There are number of methods marked as deprecated in 2.x that we should keep in 3.x (although still marked as deprecated). This way  we do not force developers with existing applications to do work to fix applications that would break. 

Although it's true that a major release such as 3.0 allows us to make breaking changes, the upcoming rev of the MicroProfile Metrics spec will introduce breaking changes on its own that our developers will have to deal with along with other potential metrics changes in SE. 

At a very low cost--the deprecated methods carried forward into 3.0 are typically one-line delegations to their non-deprecated alternatives--we can save our developers successive conversion efforts: now (to 3.0) and again to adopt our next major release.

