### PR TITLE
HTTP Signatures: Fixed deprecation and modified defaults.

### DIFF
--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,10 +323,7 @@ public final class HttpSignProvider implements AuthenticationProvider, OutboundS
         private SignedHeadersConfig inboundRequiredHeaders = SignedHeadersConfig.builder().build();
         private OutboundConfig outboundConfig = OutboundConfig.builder().build();
         private final Map<String, InboundClientDefinition> inboundKeys = new HashMap<>();
-        // not to self - we need to switch default to false in 3.0.0
-        // and probably remove this in 4.0.0
-        @Deprecated
-        private boolean backwardCompatibleEol = true;
+        private boolean backwardCompatibleEol = false;
 
         private Builder() {
         }
@@ -485,9 +482,13 @@ public final class HttpSignProvider implements AuthenticationProvider, OutboundS
         }
 
         /**
-         * Until version 3.0.0 (exclusive) there is a trailing end of line added to the signed
+         * Enable support for Helidon versions before 3.0.0 (exclusive).
+         * <p>
+         * Until version 3.0.0 (exclusive) there was a trailing end of line added to the signed
          * data.
-         * To be able to communicate cross versions, we must configure this for newer versions
+         * To be able to communicate cross versions, we must configure this when talking to older versions of Helidon.
+         * Default value is {@code false}. In Helidon 2.x, this switch exists as well and the default is {@code true}, to
+         * allow communication between versions as needed.
          *
          * @param backwardCompatible whether to run in backward compatible mode
          * @return updated builder instance

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignature.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignature.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/HttpSignature.java
@@ -19,6 +19,7 @@ package io.helidon.security.providers.httpsign;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
@@ -281,14 +282,14 @@ class HttpSignature {
     private Optional<String> validateRsaSha256(SecurityEnvironment env,
                                                InboundClientDefinition clientDefinition) {
         try {
-            Signature signature = Signature.getInstance("SHA256withRSA");
-            signature.initVerify(clientDefinition.keyConfig()
-                                         .orElseThrow(() -> new HttpSignatureException("RSA public key configuration is "
-                                                                                               + "required"))
-                                         .publicKey()
-                                         .orElseThrow(() -> new HttpSignatureException(
-                                                 "Public key is required, yet not configured")));
-            signature.update(getBytesToSign(env, null));
+                Signature signature = Signature.getInstance("SHA256withRSA");
+                signature.initVerify(clientDefinition.keyConfig()
+                                             .orElseThrow(() -> new HttpSignatureException("RSA public key configuration is "
+                                                                                                   + "required"))
+                                             .publicKey()
+                                             .orElseThrow(() -> new HttpSignatureException(
+                                                     "Public key is required, yet not configured")));
+                signature.update(getBytesToSign(env, null));
 
             if (!signature.verify(this.signatureBytes)) {
                 return Optional.of("Signature is not valid");
@@ -325,7 +326,7 @@ class HttpSignature {
                                                 InboundClientDefinition clientDefinition) {
         try {
             byte[] signature = signHmacSha256(env, clientDefinition.hmacSharedSecret().orElse(EMPTY_BYTES), null);
-            if (!Arrays.equals(signature, this.signatureBytes)) {
+            if (!MessageDigest.isEqual(signature, this.signatureBytes)) {
                 return Optional.of("Signature is not valid");
             }
             return Optional.empty();

--- a/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
+++ b/security/providers/http-sign/src/main/java/io/helidon/security/providers/httpsign/OutboundTargetDefinition.java
@@ -188,10 +188,7 @@ public final class OutboundTargetDefinition {
         private byte[] hmacSharedSecret;
         private SignedHeadersConfig signedHeadersConfig = HttpSignProvider.DEFAULT_REQUIRED_HEADERS;
         private TokenHandler tokenHandler;
-        // this is internal deprecation to make sure we switch this flag default to false for 3.0.0
-        // to be removed in 4.0.0 (most likely)
-        @Deprecated
-        private boolean backwardCompatibleEol = true;
+        private boolean backwardCompatibleEol = false;
 
         private Builder() {
         }
@@ -303,11 +300,6 @@ public final class OutboundTargetDefinition {
 
         @Override
         public OutboundTargetDefinition build() {
-            if (backwardCompatibleEol) {
-                LOGGER.warning("HTTP signatures is using legacy HTTP signature processing. This will not work"
-                                       + " with third party tools using the same spec and with Helidon newer than 3.0.0."
-                                       + " Please configure 'backward-compatible-eol' to false to use the correct approach.");
-            }
             return new OutboundTargetDefinition(this);
         }
 
@@ -334,9 +326,13 @@ public final class OutboundTargetDefinition {
         }
 
         /**
-         * Until version 3.0.0 (exclusive) there is a trailing end of line added to the signed
+         * Enable support for Helidon versions before 3.0.0 (exclusive).
+         * <p>
+         * Until version 3.0.0 (exclusive) there was a trailing end of line added to the signed
          * data.
-         * When configured to {@code false}, the correct approach is used.
+         * To be able to communicate cross versions, we must configure this when talking to older versions of Helidon.
+         * Default value is {@code false}. In Helidon 2.x, this switch exists as well and the default is {@code true}, to
+         * allow communication between versions as needed.
          *
          * @param backwardCompatible whether to run in backward compatible mode
          * @return updated builder instance

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderBuilderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderBuilderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderBuilderTest.java
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Unit test for {@link HttpSignProvider} configured through a builder.
  */
-public class HttpSignProviderBuilderTest extends HttpSignProviderTest {
+class CurrentHttpSignProviderBuilderTest extends CurrentHttpSignProviderTest {
     private static HttpSignProvider instance;
 
     @BeforeAll
-    public static void initClass() {
+    static void initClass() {
         instance = HttpSignProvider.builder()
                 .addAcceptHeader(HttpSignHeader.AUTHORIZATION)
                 .addAcceptHeader(HttpSignHeader.SIGNATURE)
@@ -70,8 +70,7 @@ public class HttpSignProviderBuilderTest extends HttpSignProviderTest {
                 .addHost("example.org")
                 .addPath("/my/.*")
                 .customObject(OutboundTargetDefinition.class, OutboundTargetDefinition
-                        .builder("rsa-key-12345"
-                        )
+                        .builder("rsa-key-12345")
                         .signedHeaders(inboundRequiredHeaders("host", SignedHeadersConfig
                                 .REQUEST_TARGET))
                         .privateKeyConfig(KeyConfig.keystoreBuilder()

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderConfigTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.httpsign;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Unit test for {@link HttpSignProvider} configured from a configuration file.
+ */
+class CurrentHttpSignProviderConfigTest extends CurrentHttpSignProviderTest {
+    private static HttpSignProvider instance;
+
+    @BeforeAll
+    static void initClass() {
+        Config config = Config.create();
+
+        instance = HttpSignProvider.create(config.get("current.http-signatures"));
+    }
+
+    @Override
+    HttpSignProvider getProvider() {
+        return instance;
+    }
+}

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
@@ -47,23 +47,23 @@ import static org.mockito.Mockito.when;
 /**
  * Unit test for {@link HttpSignProvider}.
  */
-public abstract class HttpSignProviderTest {
+abstract class CurrentHttpSignProviderTest {
     abstract HttpSignProvider getProvider();
 
     @Test
-    public void testInboundSignatureRsa() throws ExecutionException, InterruptedException {
+    void testInboundSignatureRsa() throws ExecutionException, InterruptedException {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         headers.put("Signature",
                     List.of("keyId=\"rsa-key-12345\",algorithm=\"rsa-sha256\",headers=\"date "
-                                                     + "host (request-target) authorization\","
-                                                     + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
-                                                     + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
-                                                     + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
-                                                     + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
-                                                     + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
-                                                     + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
-                                                     + "2x7LSkqhdWGA==\""));
+                                    + "host (request-target) authorization\","
+                                    + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
+                                    + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
+                                    + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
+                                    + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
+                                    + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
+                                    + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
+                                    + "2x7LSkqhdWGA==\""));
         headers.put("host", List.of("example.org"));
         headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -99,13 +99,13 @@ public abstract class HttpSignProviderTest {
     }
 
     @Test
-    public void testInboundSignatureHmac() throws InterruptedException, ExecutionException {
+    void testInboundSignatureHmac() throws InterruptedException, ExecutionException {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         headers.put("Signature",
                     List.of("keyId=\"myServiceKeyId\",algorithm=\"hmac-sha256\",headers=\"date host (request-target) "
-                                            + "authorization\","
-                                            + "signature=\"0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI=\""));
+                                    + "authorization\","
+                                    + "signature=\"yaxxY9oY0+qKhAr9sYCfmYQyKjRVctN6z1c9ANhbZ/c=\""));
         headers.put("host", List.of("example.org"));
         headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -140,7 +140,7 @@ public abstract class HttpSignProviderTest {
     }
 
     @Test
-    public void testOutboundSignatureRsa() throws ExecutionException, InterruptedException {
+    void testOutboundSignatureRsa() throws ExecutionException, InterruptedException {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         // the generated host contains port as well, so we must explicitly define it here
@@ -178,17 +178,14 @@ public abstract class HttpSignProviderTest {
                 "rsa-key-12345",
                 "rsa-sha256",
                 List.of("date", "host", REQUEST_TARGET, "authorization"),
-                "Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
-                        + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
-                        + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
-                        + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
-                        + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
-                        + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
-                        + "2x7LSkqhdWGA==");
+                "ptxE46kM/gV8L6Q0jcrY5Sxet7vy/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
+                        + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr"
+                        + "++BvvXMuGooMI+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlXFuoLzthCgqHElCXVXrW+ZGACUaRDC"
+                        + "+XawXg6eyMWp6GVegS/NVRnaqEkBsl0hn7X/dmEXDDERyK66qn0WA==");
     }
 
     @Test
-    public void testOutboundSignatureHmac() throws ExecutionException, InterruptedException {
+    void testOutboundSignatureHmac() throws ExecutionException, InterruptedException {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         // the generated host contains port as well, so we must explicitly define it here
@@ -225,7 +222,7 @@ public abstract class HttpSignProviderTest {
                                 "myServiceKeyId",
                                 "hmac-sha256",
                                 List.of("date", REQUEST_TARGET, "host"),
-                                "SkeKVi6BoUd2/aUfXyIVIFAKEkKp7sg2KsS1UieB/+E=");
+                                "WGgirKG0IJQPGosDuTDi40uABCbxDm4oduKiH+iVuII=");
     }
 
     private void validateSignatureHeader(

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
@@ -17,6 +17,7 @@
 package io.helidon.security.providers.httpsign;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 
+import io.helidon.common.reactive.Single;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityResponse;
@@ -48,6 +50,8 @@ import static org.mockito.Mockito.when;
  * Unit test for {@link HttpSignProvider}.
  */
 abstract class CurrentHttpSignProviderTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
     abstract HttpSignProvider getProvider();
 
     @Test
@@ -80,7 +84,7 @@ abstract class CurrentHttpSignProviderTest {
         when(request.env()).thenReturn(se);
         when(request.endpointConfig()).thenReturn(ep);
 
-        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+        AuthenticationResponse atnResponse = Single.create(provider.authenticate(request)).await(TIMEOUT);
 
         assertThat(atnResponse.description().orElse("Unknown problem"),
                    atnResponse.status(),
@@ -122,7 +126,7 @@ abstract class CurrentHttpSignProviderTest {
         when(request.env()).thenReturn(se);
         when(request.endpointConfig()).thenReturn(ep);
 
-        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+        AuthenticationResponse atnResponse = Single.create(provider.authenticate(request)).await(TIMEOUT);
 
         assertThat(atnResponse.description().orElse("Unknown problem"),
                    atnResponse.status(),
@@ -160,8 +164,8 @@ abstract class CurrentHttpSignProviderTest {
         boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
         assertThat("Outbound should be supported", outboundSupported, is(true));
 
-        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
-                .get();
+        OutboundSecurityResponse response = Single.create(getProvider().outboundSecurity(request, outboundEnv, outboundEp))
+                .await(TIMEOUT);
 
         assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
 
@@ -205,8 +209,8 @@ abstract class CurrentHttpSignProviderTest {
         boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
         assertThat("Outbound should be supported", outboundSupported, is(true));
 
-        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
-                .get();
+        OutboundSecurityResponse response = Single.create(getProvider().outboundSecurity(request, outboundEnv, outboundEp))
+                                                                  .await(TIMEOUT);
 
         assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
 

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,13 +57,10 @@ abstract class CurrentHttpSignProviderTest {
         headers.put("Signature",
                     List.of("keyId=\"rsa-key-12345\",algorithm=\"rsa-sha256\",headers=\"date "
                                     + "host (request-target) authorization\","
-                                    + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
-                                    + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
-                                    + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
-                                    + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
-                                    + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
-                                    + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
-                                    + "2x7LSkqhdWGA==\""));
+                                    + "signature=\"ptxE46kM/gV8L6Q0jcrY5Sxet7vy/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
+                                    + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr"
+                                    + "++BvvXMuGooMI+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlXFuoLzthCgqHElCXVXrW+ZGACUaRDC"
+                                    + "+XawXg6eyMWp6GVegS/NVRnaqEkBsl0hn7X/dmEXDDERyK66qn0WA==\""));
         headers.put("host", List.of("example.org"));
         headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignatureTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignatureTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentHttpSignatureTest.java
@@ -40,9 +40,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Unit test for {@link HttpSignature}.
  */
-public class HttpSignatureTestOld {
+class CurrentHttpSignatureTest {
     @Test
-    public void testValid() {
+    void testValid() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"rsa-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\"";
@@ -51,7 +51,7 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testValidInvalidComponent() {
+    void testValidInvalidComponent() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"rsa-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",hurhur=\"ignored\"";
@@ -60,7 +60,7 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testValidRepeatedComponent() {
+    void testValidRepeatedComponent() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\"";
@@ -69,7 +69,7 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testValidInvalidLastComponent1() {
+    void testValidInvalidLastComponent1() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd";
@@ -78,7 +78,7 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testValidInvalidLastComponent2() {
+    void testValidInvalidLastComponent2() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=";
@@ -87,7 +87,7 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testValidInvalidLastComponent3() {
+    void testValidInvalidLastComponent3() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=\"asf";
@@ -96,32 +96,32 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testInvalid1() {
+    void testInvalid1() {
         String invalidSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 // missing quotes for headers
                 + "headers=(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=\"asf";
 
-        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, true);
+        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, false);
         Optional<String> validate = httpSignature.validate();
 
         validate.ifPresentOrElse(msg -> assertThat(msg, containsString("signature is a mandatory")),
-                                                      () -> fail("Should have failed validation"));
+                                 () -> fail("Should have failed validation"));
     }
 
     @Test
-    public void testInvalid2() {
+    void testInvalid2() {
         String invalidSignature = "This is a wrong signature";
 
-        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, true);
+        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, false);
         Optional<String> validate = httpSignature.validate();
 
         validate.ifPresentOrElse(msg -> assertThat(msg, containsString("keyId is a mandatory")),
-                                                      () -> fail("Should have failed validation"));
+                                 () -> fail("Should have failed validation"));
     }
 
     @Test
-    public void testSignRsa() {
+    void testSignRsa() {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         headers.put("DATE", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("Authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -138,23 +138,22 @@ public class HttpSignatureTestOld {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                                               "host",
-                                                                                               "(request-target)",
-                                                                                               "authorization")))
+                                                                              "host",
+                                                                              "(request-target)",
+                                                                              "authorization")))
                                        .build())
                 .build();
 
-        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
+        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
         assertThat(signature.getBase64Signature(),
-                   is("Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUfboUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx"
-                              + "+9T9ZynG7YqRjKvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet+YSb0088o"
-                              + "/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqhebieVD3Swb1VG5+/7ECQ9VAlX30U5"
-                              + "/jQ5hPO3yuvRlg5kkMjJiN7tf/68If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa"
-                              + "/YTCxIK4UFiI6h963q2x7LSkqhdWGA=="));
+                   is("ptxE46kM/gV8L6Q0jcrY5Sxet7vy/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
+                              + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr"
+                              + "++BvvXMuGooMI+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlXFuoLzthCgqHElCXVXrW"
+                              + "+ZGACUaRDC+XawXg6eyMWp6GVegS/NVRnaqEkBsl0hn7X/dmEXDDERyK66qn0WA=="));
     }
 
     @Test
-    public void testSignHmac() {
+    void testSignHmac() {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         headers.put("DATE", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("Authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -167,19 +166,19 @@ public class HttpSignatureTestOld {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                                               "host",
-                                                                                               "(request-target)",
-                                                                                               "authorization")))
+                                                                              "host",
+                                                                              "(request-target)",
+                                                                              "authorization")))
                                        .build())
                 .build();
 
-        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
+        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
 
-        assertThat(signature.getBase64Signature(), is("0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI="));
+        assertThat(signature.getBase64Signature(), is("yaxxY9oY0+qKhAr9sYCfmYQyKjRVctN6z1c9ANhbZ/c="));
     }
 
     @Test
-    public void testSignHmacAddHeaders() {
+    void testSignHmacAddHeaders() {
         SecurityEnvironment env = SecurityEnvironment.builder()
                 .targetUri(URI.create("http://localhost/test/path"))
                 .build();
@@ -190,32 +189,27 @@ public class HttpSignatureTestOld {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                                               "host")))
+                                                                              "host")))
                                        .build())
                 .build();
 
         // just make sure this does not throw an exception for missing headers
-        HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
-    }
-
-    private SecurityEnvironment buildSecurityEnv(String path, Map<String, List<String>> headers) {
-        return SecurityEnvironment.builder()
-                .path(path)
-                .headers(headers)
-                .build();
+        HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
     }
 
     @Test
-    public void testVerifyRsa() {
+    void testVerifyRsa() {
         HttpSignature signature = HttpSignature.fromHeader("keyId=\"rsa-key-12345\",algorithm=\"rsa-sha256\",headers=\"date "
                                                                    + "host (request-target) authorization\","
-                                                                   + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
-                                                                   + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
-                                                                   + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
-                                                                   + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
-                                                                   + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
-                                                                   + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
-                                                                   + "2x7LSkqhdWGA==\"", true);
+                                                                   + "signature=\"ptxE46kM/gV8L6Q0jcrY5Sxet7vy"
+                                                                   + "/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI"
+                                                                   + "/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
+                                                                   + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn"
+                                                                   + "/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr++BvvXMuGooMI"
+                                                                   + "+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlX"
+                                                                   + "FuoLzthCgqHElCXVXrW+ZGACUaRDC+XawXg6eyMWp6GVegS/NVRnaqEk"
+                                                                   + "Bsl0hn7X/dmEXDDERyK66qn0WA==\"",
+                                                           false);
         signature.validate().ifPresent(Assertions::fail);
 
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -239,10 +233,10 @@ public class HttpSignatureTestOld {
     }
 
     @Test
-    public void testVerifyHmac() {
+    void testVerifyHmac() {
         HttpSignature signature = HttpSignature.fromHeader(
                 "keyId=\"myServiceKeyId\",algorithm=\"hmac-sha256\",headers=\"date host (request-target) authorization\","
-                        + "signature=\"0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI=\"", true);
+                        + "signature=\"yaxxY9oY0+qKhAr9sYCfmYQyKjRVctN6z1c9ANhbZ/c=\"", false);
 
         signature.validate().ifPresent(Assertions::fail);
 
@@ -263,8 +257,15 @@ public class HttpSignatureTestOld {
                 .ifPresent(Assertions::fail);
     }
 
+    private SecurityEnvironment buildSecurityEnv(String path, Map<String, List<String>> headers) {
+        return SecurityEnvironment.builder()
+                .path(path)
+                .headers(headers)
+                .build();
+    }
+
     private void testValid(String validSignature) {
-        HttpSignature httpSignature = HttpSignature.fromHeader(validSignature, true);
+        HttpSignature httpSignature = HttpSignature.fromHeader(validSignature, false);
 
         assertThat(httpSignature.getAlgorithm(), is("rsa-sha256"));
         assertThat(httpSignature.getKeyId(), is("rsa-key-1"));

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentOutboundTargetDefinitionTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentOutboundTargetDefinitionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.httpsign;
+
+import io.helidon.config.Config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class CurrentOutboundTargetDefinitionTest {
+
+    private static final String OUTBOUND_SIGNATURE_KEY = "current.http-signatures.outbound.0.signature";
+
+    @Test
+    void testBuilderFromConfig() {
+        Config config = Config.create();
+        OutboundTargetDefinition.Builder builder =
+                OutboundTargetDefinition.builder(config.get(OUTBOUND_SIGNATURE_KEY));
+        OutboundTargetDefinition d = builder.build();
+        assertThat(d.keyId(), is("rsa-key-12345"));
+        assertThat(d.header(), is(HttpSignHeader.SIGNATURE));
+        assertThat(d.keyConfig().isPresent(), is(true));
+        assertThat(d.signedHeadersConfig(), is(notNullValue()));
+        assertThat(d.backwardCompatibleEol(), is(false));
+    }
+}

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/CurrentSignedHeadersConfigTest.java
@@ -32,23 +32,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Unit test for {@link SignedHeadersConfig}.
  */
-public class SignedHeadersConfigTest {
+class CurrentSignedHeadersConfigTest {
     private static Config config;
 
     @BeforeAll
-    public static void initClass() {
-        config = Config.create().get("security.providers");
+    static void initClass() {
+        config = Config.create().get("current");
     }
 
     @Test
-    public void testFromConfig() {
-        SignedHeadersConfig shc = config.get("0.http-signatures.sign-headers").as(SignedHeadersConfig.class).get();
+    void testFromConfig() {
+        SignedHeadersConfig shc = config.get("http-signatures.sign-headers").as(SignedHeadersConfig.class).get();
 
         testThem(shc);
     }
 
     @Test
-    public void testFromBuilder() {
+    void testFromBuilder() {
         SignedHeadersConfig shc = SignedHeadersConfig.builder()
                 .defaultConfig(SignedHeadersConfig.HeadersConfig.create(List.of("date")))
                 .config("get",

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderBuilderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderBuilderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderBuilderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.httpsign;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import io.helidon.common.configurable.Resource;
+import io.helidon.common.pki.KeyConfig;
+import io.helidon.security.SubjectType;
+import io.helidon.security.providers.common.OutboundConfig;
+import io.helidon.security.providers.common.OutboundTarget;
+
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Unit test for {@link HttpSignProvider} configured through a builder.
+ */
+class OldHttpSignProviderBuilderTest extends OldHttpSignProviderTest {
+    private static HttpSignProvider instance;
+
+    @BeforeAll
+    static void initClass() {
+        instance = HttpSignProvider.builder()
+                .addAcceptHeader(HttpSignHeader.AUTHORIZATION)
+                .addAcceptHeader(HttpSignHeader.SIGNATURE)
+                .optional(true)
+                .realm("prime")
+                .inboundRequiredHeaders(inboundRequiredHeaders(SignedHeadersConfig
+                                                                       .REQUEST_TARGET, "host"))
+                .addInbound(hmacInbound())
+                .addInbound(rsaInbound())
+                .outbound(OutboundConfig.builder()
+                                  .addTarget(rsaOutbound())
+                                  .addTarget(hmacOutbound())
+                                  .build())
+                .backwardCompatibleEol(true)
+                .build();
+    }
+
+    private static OutboundTarget hmacOutbound() {
+        return OutboundTarget.builder("second")
+                .addTransport("http")
+                .addHost("localhost")
+                .addPath("/second/.*")
+                .customObject(OutboundTargetDefinition.class,
+                              OutboundTargetDefinition
+                                      .builder("myServiceKeyId")
+                                      .backwardCompatibleEol(true)
+                                      .hmacSecret("MyPasswordForHmac")
+                                      .build())
+                .build();
+    }
+
+    private static OutboundTarget rsaOutbound() {
+        return OutboundTarget.builder("first")
+                .addTransport("http")
+                .addHost("example.org")
+                .addPath("/my/.*")
+                .customObject(OutboundTargetDefinition.class, OutboundTargetDefinition
+                        .builder("rsa-key-12345")
+                        .backwardCompatibleEol(true)
+                        .signedHeaders(inboundRequiredHeaders("host", SignedHeadersConfig
+                                .REQUEST_TARGET))
+                        .privateKeyConfig(KeyConfig.keystoreBuilder()
+                                                  .keystore(Resource.create(Paths.get(
+                                                          "src/test/resources/keystore"
+                                                                  + ".p12")))
+                                                  .keystorePassphrase("password"
+                                                                              .toCharArray())
+                                                  .keyAlias("myPrivateKey")
+                                                  .build())
+                        .build())
+                .build();
+    }
+
+    private static InboundClientDefinition rsaInbound() {
+        return InboundClientDefinition.builder("rsa-key-12345")
+                .principalName("aUser")
+                .subjectType(SubjectType.USER)
+                .publicKeyConfig(KeyConfig.keystoreBuilder()
+                                         .keystore(Resource.create(Paths.get("src/test/resources/keystore.p12")))
+                                         .keystorePassphrase("password".toCharArray())
+                                         .certAlias("service_cert")
+                                         .build())
+                .build();
+    }
+
+    private static InboundClientDefinition hmacInbound() {
+        return InboundClientDefinition.builder("myServiceKeyId")
+                .principalName("aSetOfTrustedServices")
+                .hmacSecret("MyPasswordForHmac")
+                .build();
+    }
+
+    private static SignedHeadersConfig inboundRequiredHeaders(String requestTarget, String host) {
+        return SignedHeadersConfig.builder()
+                .defaultConfig(SignedHeadersConfig.HeadersConfig
+                                       .create(List.of("date")))
+                .config("get",
+                        SignedHeadersConfig.HeadersConfig
+                                .create(List.of("date",
+                                                                 requestTarget,
+                                                                 host),
+                                        List.of("authorization")))
+                .build();
+    }
+
+    @Override
+    HttpSignProvider getProvider() {
+        return instance;
+    }
+}

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderConfigTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderConfigTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.BeforeAll;
 /**
  * Unit test for {@link HttpSignProvider} configured from a configuration file.
  */
-public class HttpSignProviderConfigTest extends HttpSignProviderTest {
+class OldHttpSignProviderConfigTest extends OldHttpSignProviderTest {
     private static HttpSignProvider instance;
 
     @BeforeAll
-    public static void initClass() {
+    static void initClass() {
         Config config = Config.create();
 
-        instance = HttpSignProvider.create(config.get("security.providers.0.http-signatures"));
+        instance = HttpSignProvider.create(config.get("old.http-signatures"));
     }
 
     @Override

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.security.providers.httpsign;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+
+import io.helidon.security.AuthenticationResponse;
+import io.helidon.security.EndpointConfig;
+import io.helidon.security.OutboundSecurityResponse;
+import io.helidon.security.ProviderRequest;
+import io.helidon.security.SecurityContext;
+import io.helidon.security.SecurityEnvironment;
+import io.helidon.security.SecurityResponse;
+import io.helidon.security.Subject;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.security.providers.httpsign.SignedHeadersConfig.REQUEST_TARGET;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link HttpSignProvider}.
+ */
+abstract class OldHttpSignProviderTest {
+    abstract HttpSignProvider getProvider();
+
+    @Test
+    void testInboundSignatureRsa() throws ExecutionException, InterruptedException {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        headers.put("Signature",
+                    List.of("keyId=\"rsa-key-12345\",algorithm=\"rsa-sha256\",headers=\"date "
+                                                     + "host (request-target) authorization\","
+                                                     + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
+                                                     + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
+                                                     + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
+                                                     + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
+                                                     + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
+                                                     + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
+                                                     + "2x7LSkqhdWGA==\""));
+        headers.put("host", List.of("example.org"));
+        headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
+        headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
+
+        HttpSignProvider provider = getProvider();
+
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.executorService()).thenReturn(ForkJoinPool.commonPool());
+        SecurityEnvironment se = SecurityEnvironment.builder()
+                .path("/my/resource")
+                .headers(headers)
+                .build();
+        EndpointConfig ep = EndpointConfig.create();
+
+        ProviderRequest request = mock(ProviderRequest.class);
+        when(request.securityContext()).thenReturn(context);
+        when(request.env()).thenReturn(se);
+        when(request.endpointConfig()).thenReturn(ep);
+
+        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+
+        assertThat(atnResponse.description().orElse("Unknown problem"),
+                   atnResponse.status(),
+                   is(SecurityResponse.SecurityStatus.SUCCESS));
+
+        atnResponse.user()
+                .map(Subject::principal)
+                .ifPresentOrElse(principal -> {
+                    assertThat(principal.getName(), is("aUser"));
+                    assertThat(principal.abacAttribute(HttpSignProvider.ATTRIB_NAME_KEY_ID), is(Optional.of("rsa-key-12345")));
+                }, () -> fail("User must be filled"));
+
+    }
+
+    @Test
+    void testInboundSignatureHmac() throws InterruptedException, ExecutionException {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        headers.put("Signature",
+                    List.of("keyId=\"myServiceKeyId\",algorithm=\"hmac-sha256\",headers=\"date host (request-target) "
+                                            + "authorization\","
+                                            + "signature=\"0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI=\""));
+        headers.put("host", List.of("example.org"));
+        headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
+        headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
+
+        HttpSignProvider provider = getProvider();
+
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.executorService()).thenReturn(ForkJoinPool.commonPool());
+        SecurityEnvironment se = SecurityEnvironment.builder()
+                .path("/my/resource")
+                .headers(headers)
+                .build();
+        EndpointConfig ep = EndpointConfig.create();
+
+        ProviderRequest request = mock(ProviderRequest.class);
+        when(request.securityContext()).thenReturn(context);
+        when(request.env()).thenReturn(se);
+        when(request.endpointConfig()).thenReturn(ep);
+
+        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+
+        assertThat(atnResponse.description().orElse("Unknown problem"),
+                   atnResponse.status(),
+                   is(SecurityResponse.SecurityStatus.SUCCESS));
+
+        atnResponse.service()
+                .map(Subject::principal)
+                .ifPresentOrElse(principal -> {
+                    assertThat(principal.getName(), is("aSetOfTrustedServices"));
+                    assertThat(principal.abacAttribute(HttpSignProvider.ATTRIB_NAME_KEY_ID), is(Optional.of("myServiceKeyId")));
+                }, () -> fail("User must be filled"));
+    }
+
+    @Test
+    void testOutboundSignatureRsa() throws ExecutionException, InterruptedException {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        // the generated host contains port as well, so we must explicitly define it here
+        headers.put("host", List.of("example.org"));
+        headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
+        headers.put("authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
+
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.executorService()).thenReturn(ForkJoinPool.commonPool());
+        ProviderRequest request = mock(ProviderRequest.class);
+        when(request.securityContext()).thenReturn(context);
+        SecurityEnvironment outboundEnv = SecurityEnvironment.builder()
+                .path("/my/resource")
+                .targetUri(URI.create("http://example.org/my/resource"))
+                .headers(headers)
+                .build();
+
+        EndpointConfig outboundEp = EndpointConfig.create();
+
+        boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
+        assertThat("Outbound should be supported", outboundSupported, is(true));
+
+        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
+                .get();
+
+        assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
+
+        Map<String, List<String>> updatedHeaders = response.requestHeaders();
+        assertThat(updatedHeaders, notNullValue());
+
+        //and now the value
+        validateSignatureHeader(
+                outboundEnv,
+                updatedHeaders.get("Signature").iterator().next(),
+                "rsa-key-12345",
+                "rsa-sha256",
+                List.of("date", "host", REQUEST_TARGET, "authorization"),
+                "Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
+                        + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
+                        + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
+                        + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
+                        + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
+                        + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
+                        + "2x7LSkqhdWGA==");
+    }
+
+    @Test
+    void testOutboundSignatureHmac() throws ExecutionException, InterruptedException {
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+        // the generated host contains port as well, so we must explicitly define it here
+        headers.put("host", List.of("localhost"));
+        headers.put("date", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
+
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.executorService()).thenReturn(ForkJoinPool.commonPool());
+        ProviderRequest request = mock(ProviderRequest.class);
+        when(request.securityContext()).thenReturn(context);
+
+        SecurityEnvironment outboundEnv = SecurityEnvironment.builder()
+                .path("/second/someOtherPath")
+                .targetUri(URI.create("http://localhost/second/someOtherPath"))
+                .headers(headers)
+                .build();
+
+        EndpointConfig outboundEp = EndpointConfig.create();
+
+        boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
+        assertThat("Outbound should be supported", outboundSupported, is(true));
+
+        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
+                .get();
+
+        assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
+
+        Map<String, List<String>> updatedHeaders = response.requestHeaders();
+        assertThat(updatedHeaders, notNullValue());
+
+        //and now the value
+        validateSignatureHeader(outboundEnv,
+                                updatedHeaders.get("Signature").iterator().next(),
+                                "myServiceKeyId",
+                                "hmac-sha256",
+                                List.of("date", REQUEST_TARGET, "host"),
+                                "SkeKVi6BoUd2/aUfXyIVIFAKEkKp7sg2KsS1UieB/+E=");
+    }
+
+    private void validateSignatureHeader(
+            SecurityEnvironment env,
+            String signatureHeader,
+            String myServiceKeyId,
+            String algorithm,
+            List<String> headers,
+            String actualSignature) {
+        HttpSignature httpSignature = HttpSignature.fromHeader(signatureHeader, true);
+
+        String reason = httpSignature.getAlgorithm() + ", " + httpSignature.getHeaders() + ", " + httpSignature
+                .getSignedString(new HashMap<>(), env);
+
+        assertThat(reason, httpSignature.getKeyId(), is(myServiceKeyId));
+        assertThat(reason, httpSignature.getAlgorithm(), is(algorithm));
+        assertThat(reason, httpSignature.getHeaders(), is(headers));
+        assertThat(reason, httpSignature.getBase64Signature(), is(actualSignature));
+    }
+}

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignProviderTest.java
@@ -17,6 +17,7 @@
 package io.helidon.security.providers.httpsign;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 
+import io.helidon.common.reactive.Single;
 import io.helidon.security.AuthenticationResponse;
 import io.helidon.security.EndpointConfig;
 import io.helidon.security.OutboundSecurityResponse;
@@ -48,6 +50,8 @@ import static org.mockito.Mockito.when;
  * Unit test for {@link HttpSignProvider}.
  */
 abstract class OldHttpSignProviderTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
     abstract HttpSignProvider getProvider();
 
     @Test
@@ -83,7 +87,7 @@ abstract class OldHttpSignProviderTest {
         when(request.env()).thenReturn(se);
         when(request.endpointConfig()).thenReturn(ep);
 
-        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+        AuthenticationResponse atnResponse = Single.create(provider.authenticate(request)).await(TIMEOUT);
 
         assertThat(atnResponse.description().orElse("Unknown problem"),
                    atnResponse.status(),
@@ -125,7 +129,7 @@ abstract class OldHttpSignProviderTest {
         when(request.env()).thenReturn(se);
         when(request.endpointConfig()).thenReturn(ep);
 
-        AuthenticationResponse atnResponse = provider.authenticate(request).toCompletableFuture().get();
+        AuthenticationResponse atnResponse = Single.create(provider.authenticate(request)).await(TIMEOUT);
 
         assertThat(atnResponse.description().orElse("Unknown problem"),
                    atnResponse.status(),
@@ -163,8 +167,8 @@ abstract class OldHttpSignProviderTest {
         boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
         assertThat("Outbound should be supported", outboundSupported, is(true));
 
-        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
-                .get();
+        OutboundSecurityResponse response = Single.create(getProvider().outboundSecurity(request, outboundEnv, outboundEp))
+                .await(TIMEOUT);
 
         assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
 
@@ -211,8 +215,8 @@ abstract class OldHttpSignProviderTest {
         boolean outboundSupported = getProvider().isOutboundSupported(request, outboundEnv, outboundEp);
         assertThat("Outbound should be supported", outboundSupported, is(true));
 
-        OutboundSecurityResponse response = getProvider().outboundSecurity(request, outboundEnv, outboundEp).toCompletableFuture()
-                .get();
+        OutboundSecurityResponse response = Single.create(getProvider().outboundSecurity(request, outboundEnv, outboundEp))
+                                                                  .await(TIMEOUT);
 
         assertThat(response.status(), is(SecurityResponse.SecurityStatus.SUCCESS));
 

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignatureTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignatureTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldHttpSignatureTest.java
@@ -40,9 +40,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Unit test for {@link HttpSignature}.
  */
-public class HttpSignatureTest {
+class OldHttpSignatureTest {
     @Test
-    public void testValid() {
+    void testValid() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"rsa-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\"";
@@ -51,7 +51,7 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testValidInvalidComponent() {
+    void testValidInvalidComponent() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"rsa-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",hurhur=\"ignored\"";
@@ -60,7 +60,7 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testValidRepeatedComponent() {
+    void testValidRepeatedComponent() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\"";
@@ -69,7 +69,7 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testValidInvalidLastComponent1() {
+    void testValidInvalidLastComponent1() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd";
@@ -78,7 +78,7 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testValidInvalidLastComponent2() {
+    void testValidInvalidLastComponent2() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=";
@@ -87,7 +87,7 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testValidInvalidLastComponent3() {
+    void testValidInvalidLastComponent3() {
         String validSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 + "headers=\"(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=\"asf";
@@ -96,32 +96,32 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testInvalid1() {
+    void testInvalid1() {
         String invalidSignature = "keyId=\"rsa-key-1\",algorithm=\"hamc-sha256\","
                 // missing quotes for headers
                 + "headers=(request-target) host date digest content-length\","
                 + "signature=\"Base64(RSA-SHA256(signing string))\",algorithm=\"rsa-sha256\",abcd=\"asf";
 
-        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, false);
+        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, true);
         Optional<String> validate = httpSignature.validate();
 
         validate.ifPresentOrElse(msg -> assertThat(msg, containsString("signature is a mandatory")),
-                                 () -> fail("Should have failed validation"));
+                                                      () -> fail("Should have failed validation"));
     }
 
     @Test
-    public void testInvalid2() {
+    void testInvalid2() {
         String invalidSignature = "This is a wrong signature";
 
-        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, false);
+        HttpSignature httpSignature = HttpSignature.fromHeader(invalidSignature, true);
         Optional<String> validate = httpSignature.validate();
 
         validate.ifPresentOrElse(msg -> assertThat(msg, containsString("keyId is a mandatory")),
-                                 () -> fail("Should have failed validation"));
+                                                      () -> fail("Should have failed validation"));
     }
 
     @Test
-    public void testSignRsa() {
+    void testSignRsa() {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         headers.put("DATE", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("Authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -138,22 +138,23 @@ public class HttpSignatureTest {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                              "host",
-                                                                              "(request-target)",
-                                                                              "authorization")))
+                                                                                               "host",
+                                                                                               "(request-target)",
+                                                                                               "authorization")))
                                        .build())
                 .build();
 
-        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
+        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
         assertThat(signature.getBase64Signature(),
-                   is("ptxE46kM/gV8L6Q0jcrY5Sxet7vy/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
-                              + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr"
-                              + "++BvvXMuGooMI+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlXFuoLzthCgqHElCXVXrW"
-                              + "+ZGACUaRDC+XawXg6eyMWp6GVegS/NVRnaqEkBsl0hn7X/dmEXDDERyK66qn0WA=="));
+                   is("Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUfboUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx"
+                              + "+9T9ZynG7YqRjKvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet+YSb0088o"
+                              + "/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqhebieVD3Swb1VG5+/7ECQ9VAlX30U5"
+                              + "/jQ5hPO3yuvRlg5kkMjJiN7tf/68If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa"
+                              + "/YTCxIK4UFiI6h963q2x7LSkqhdWGA=="));
     }
 
     @Test
-    public void testSignHmac() {
+    void testSignHmac() {
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         headers.put("DATE", List.of("Thu, 08 Jun 2014 18:32:30 GMT"));
         headers.put("Authorization", List.of("basic dXNlcm5hbWU6cGFzc3dvcmQ="));
@@ -166,19 +167,19 @@ public class HttpSignatureTest {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                              "host",
-                                                                              "(request-target)",
-                                                                              "authorization")))
+                                                                                               "host",
+                                                                                               "(request-target)",
+                                                                                               "authorization")))
                                        .build())
                 .build();
 
-        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
+        HttpSignature signature = HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
 
-        assertThat(signature.getBase64Signature(), is("yaxxY9oY0+qKhAr9sYCfmYQyKjRVctN6z1c9ANhbZ/c="));
+        assertThat(signature.getBase64Signature(), is("0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI="));
     }
 
     @Test
-    public void testSignHmacAddHeaders() {
+    void testSignHmacAddHeaders() {
         SecurityEnvironment env = SecurityEnvironment.builder()
                 .targetUri(URI.create("http://localhost/test/path"))
                 .build();
@@ -189,27 +190,32 @@ public class HttpSignatureTest {
                                        .defaultConfig(SignedHeadersConfig
                                                               .HeadersConfig
                                                               .create(List.of("date",
-                                                                              "host")))
+                                                                                               "host")))
                                        .build())
                 .build();
 
         // just make sure this does not throw an exception for missing headers
-        HttpSignature.sign(env, outboundDef, new HashMap<>(), false);
+        HttpSignature.sign(env, outboundDef, new HashMap<>(), true);
+    }
+
+    private SecurityEnvironment buildSecurityEnv(String path, Map<String, List<String>> headers) {
+        return SecurityEnvironment.builder()
+                .path(path)
+                .headers(headers)
+                .build();
     }
 
     @Test
-    public void testVerifyRsa() {
+    void testVerifyRsa() {
         HttpSignature signature = HttpSignature.fromHeader("keyId=\"rsa-key-12345\",algorithm=\"rsa-sha256\",headers=\"date "
                                                                    + "host (request-target) authorization\","
-                                                                   + "signature=\"ptxE46kM/gV8L6Q0jcrY5Sxet7vy"
-                                                                   + "/rqldwxJfWT5ncbALbwvr4puc3/M0q8pT/srI"
-                                                                   + "/bLvtPPZxQN9flaWyHo2ieypRSRZe5/2FrcME"
-                                                                   + "+XuGNOu9BVJlCrALgLwi2VGJ3i2BIH2EvpLqF4TmM7AHIn"
-                                                                   + "/E6trWf30Kr90sTrk1ewx7kJ0bPVfY6Pv1mJpuA4MVr++BvvXMuGooMI"
-                                                                   + "+nepToPlseGgtnYMJPuTRwZJbTLo02yN1rKnRZauCxCCd0bgi9zhJRlX"
-                                                                   + "FuoLzthCgqHElCXVXrW+ZGACUaRDC+XawXg6eyMWp6GVegS/NVRnaqEk"
-                                                                   + "Bsl0hn7X/dmEXDDERyK66qn0WA==\"",
-                                                           false);
+                                                                   + "signature=\"Rm5PjuUdJ927esGQ2gm/6QBEM9IM7J5qSZuP8NV8+GXUf"
+                                                                   + "boUV6ST2EYLYniFGt5/3BO/2+vqQdqezdTVPr/JCwqBx+9T9ZynG7YqRj"
+                                                                   + "KvXzcmvQOu5vQmCK5x/HR0fXU41Pjq+jywsD0k6KdxF6TWr6tvWRbwFet"
+                                                                   + "+YSb0088o/65Xeqghw7s0vShf7jPZsaaIHnvM9SjWgix9VvpdEn4NDvqh"
+                                                                   + "ebieVD3Swb1VG5+/7ECQ9VAlX30U5/jQ5hPO3yuvRlg5kkMjJiN7tf/68"
+                                                                   + "If/5O2Z4H+7VmW0b1U69/JoOQJA0av1gCX7HVfa/YTCxIK4UFiI6h963q"
+                                                                   + "2x7LSkqhdWGA==\"", true);
         signature.validate().ifPresent(Assertions::fail);
 
         Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -233,10 +239,10 @@ public class HttpSignatureTest {
     }
 
     @Test
-    public void testVerifyHmac() {
+    void testVerifyHmac() {
         HttpSignature signature = HttpSignature.fromHeader(
                 "keyId=\"myServiceKeyId\",algorithm=\"hmac-sha256\",headers=\"date host (request-target) authorization\","
-                        + "signature=\"yaxxY9oY0+qKhAr9sYCfmYQyKjRVctN6z1c9ANhbZ/c=\"", false);
+                        + "signature=\"0BcQq9TckrtGvlpHiMxNqMq0vW6dPVTGVDUVDrGwZyI=\"", true);
 
         signature.validate().ifPresent(Assertions::fail);
 
@@ -257,15 +263,8 @@ public class HttpSignatureTest {
                 .ifPresent(Assertions::fail);
     }
 
-    private SecurityEnvironment buildSecurityEnv(String path, Map<String, List<String>> headers) {
-        return SecurityEnvironment.builder()
-                .path(path)
-                .headers(headers)
-                .build();
-    }
-
     private void testValid(String validSignature) {
-        HttpSignature httpSignature = HttpSignature.fromHeader(validSignature, false);
+        HttpSignature httpSignature = HttpSignature.fromHeader(validSignature, true);
 
         assertThat(httpSignature.getAlgorithm(), is("rsa-sha256"));
         assertThat(httpSignature.getKeyId(), is("rsa-key-1"));

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldOutboundTargetDefinitionTest.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/OldOutboundTargetDefinitionTest.java
@@ -17,18 +17,19 @@
 package io.helidon.security.providers.httpsign;
 
 import io.helidon.config.Config;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class OutboundTargetDefinitionTest {
+class OldOutboundTargetDefinitionTest {
 
-    private static final String OUTBOUND_SIGNATURE_KEY = "security.providers.0.http-signatures.outbound.0.signature";
+    private static final String OUTBOUND_SIGNATURE_KEY = "old.http-signatures.outbound.0.signature";
 
     @Test
-    public void testBuilderFromConfig() {
+    void testBuilderFromConfig() {
         Config config = Config.create();
         OutboundTargetDefinition.Builder builder =
                 OutboundTargetDefinition.builder(config.get(OUTBOUND_SIGNATURE_KEY));
@@ -37,5 +38,6 @@ public class OutboundTargetDefinitionTest {
         assertThat(d.header(), is(HttpSignHeader.SIGNATURE));
         assertThat(d.keyConfig().isPresent(), is(true));
         assertThat(d.signedHeadersConfig(), is(notNullValue()));
+        assertThat(d.backwardCompatibleEol(), is(true));
     }
 }

--- a/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/package-info.java
+++ b/security/providers/http-sign/src/test/java/io/helidon/security/providers/httpsign/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * All tests that do not use backwardCompatibleEol are marked as Current, including tests that do not care
+ * about this property.
+ * All tests that have backwardCompatibleEol set to true are marked as Old.
+ */
+package io.helidon.security.providers.httpsign;
+

--- a/security/providers/http-sign/src/test/resources/application.yaml
+++ b/security/providers/http-sign/src/test/resources/application.yaml
@@ -14,97 +14,161 @@
 # limitations under the License.
 #
 
+current:
+  http-signatures:
+    # expected incoming headers
+    # if AUTHORIZATION is defined, challenge will be sent if missing
+    # if SIGNATURE is defined, no challenge will be sent, only fails authentication
+    headers: [ "SIGNATURE", "AUTHORIZATION" ]
+    # if set to optional, challenge will never be sent and provider
+    # will abstain if no request signature is available
+    optional: true
+    realm: "prime"
+    # required headers to be signed in request
+    # there may be more headers signed, which is OK
+    sign-headers:
+      # if method is not defined, then this is the default config
+      # MUST be present and signed
+      - always: [ "date" ]
+      - method: "get"
+        # MUST be present and signed
+        always: [ "date", "(request-target)", "host" ]
+        # MUST be signed IF present
+        if-present: [ "authorization" ]
+    inbound:
+      keys:
+        - key-id: "rsa-key-12345"
+          principal-name: "aUser"
+          # Either "Service" or "User", defaults to Service
+          # Will create appropriate principal type when constructing security subject
+          principal-type: "USER"
+          # algorithm to use
+          algorithm: "rsa-sha256"
+          # RSA public key
+          public-key:
+            keystore:
+              resource.resource-path: "keystore.p12"
+              type: "PKCS12"
+              passphrase: "password"
+              cert.alias: "service_cert"
+        - key-id: "myServiceKeyId"
+          algorithm: "hmac-sha256"
+          principal-name: "aSetOfTrustedServices"
+          hmac.secret: "MyPasswordForHmac"
+        # configuration of outbound requests, to sign them
+    outbound:
+      - name: "first"
+        transports: [ "http" ]
+        hosts: [ "example.org" ]
+        paths: [ "/my/.*" ]
+        signature:
+          header: "SIGNATURE"
+          # required headers to be signed in request
+          # there may be more headers signed, which is OK
+          sign-headers:
+            # if method is not defined, then this is the default config
+            # MUST be present and signed - for outbound, date and host will
+            # be generated if missing
+            - always: [ "date", "host", "(request-target)" ]
+              # MUST be signed IF present
+              if-present: [ "authorization" ]
+          # defaults to rsa-sha256 if private-key configured
+          # algorithm: "rsa-sha256"
+          key-id: "rsa-key-12345"
+          private-key:
+            keystore:
+              resource.resource-path: "keystore.p12"
+              type: "PKCS12"
+              passphrase: "password"
+              key.alias: "myPrivateKey"
+      - name: "second"
+        transports: [ "http" ]
+        hosts: [ "localhost" ]
+        paths: [ "/second/.*" ]
+        signature:
+          key-id: "myServiceKeyId"
+          header: "SIGNATURE"
+          # defaults to hmac-sha256 if hmac configured
+          # algorithm: "hmac-sha256"
+          hmac.secret: "MyPasswordForHmac"
 
-security:
-  config:
-    require-encryption: false
-  providers:
-    - http-signatures:
-        # expected incoming headers
-        # if AUTHORIZATION is defined, challenge will be sent if missing
-        # if SIGNATURE is defined, no challenge will be sent, only fails authentication
-        headers: ["SIGNATURE", "AUTHORIZATION"]
-        # if set to optional, challenge will never be sent and provider
-        # will abstain if no request signature is available
-        optional: true
-        realm: "prime"
-        # required headers to be signed in request
-        # there may be more headers signed, which is OK
-        sign-headers:
-          # if method is not defined, then this is the default config
-          # MUST be present and signed
-          - always: ["date"]
-          - method: "get"
-            # MUST be present and signed
-            always: ["date", "(request-target)", "host"]
-            # MUST be signed IF present
-            if-present: ["authorization"]
-        inbound:
-          keys:
-            - key-id: "rsa-key-12345"
-              principal-name: "aUser"
-              # Either "Service" or "User", defaults to Service
-              # Will create appropriate principal type when constructing security subject
-              principal-type: "USER"
-              # algorithm to use
-              algorithm: "rsa-sha256"
-              # RSA public key
-              public-key:
-                # path to keystore
-                keystore-path: "src/test/resources/keystore.p12"
-                # Keystore type
-                # PKCS12 or JKS
-                # defaults to jdk default
-                keystore-type: "PKCS12"
-                # password of the keystore
-                keystore-passphrase: "password"
-                # alias of the certificate to get public key from
-                cert-alias: "service_cert"
-            - key-id: "myServiceKeyId"
-              algorithm: "hmac-sha256"
-              principal-name: "aSetOfTrustedServices"
-              hmac.secret: "${CLEAR=MyPasswordForHmac}"
-            # configuration of outbound requests, to sign them
-        outbound:
-          - name: "first"
-            transports: ["http"]
-            hosts: ["example.org"]
-            paths: ["/my/.*"]
-            signature:
-              header: "SIGNATURE"
-              # required headers to be signed in request
-              # there may be more headers signed, which is OK
-              sign-headers:
-                  # if method is not defined, then this is the default config
-                  # MUST be present and signed - for outbound, date and host will
-                  # be generated if missing
-                - always: ["date", "host", "(request-target)"]
-                  # MUST be signed IF present
-                  if-present: ["authorization"]
-              # defaults to rsa-sha256 if private-key configured
-              # algorithm: "rsa-sha256"
-              key-id: "rsa-key-12345"
-              private-key:
-                # path to keystore
-                keystore-path: "src/test/resources/keystore.p12"
-                # Keystore type
-                # PKCS12, JSK or RSA (not really a keystore, but directly the linux style private key unencrypted)
-                # defaults to jdk default
-                keystore-type: "PKCS12"
-                # password of the keystore
-                keystore-passphrase: "password"
-                # alias of the key to sign request
-                key-alias: "myPrivateKey"
-                # password of the private key (usually the same as keystore - that's how openssl does it)
-                # also defaults to keystore-passphrase
-                # key-passphrase: "password"
-          - name: "second"
-            transports: ["http"]
-            hosts: ["localhost"]
-            paths: ["/second/.*"]
-            signature:
-              key-id: "myServiceKeyId"
-              header: "SIGNATURE"
-              # defaults to hmac-sha256 if hmac configured
-              # algorithm: "hmac-sha256"
-              hmac.secret: "${CLEAR=MyPasswordForHmac}"
+old:
+  http-signatures:
+    # expected incoming headers
+    # if AUTHORIZATION is defined, challenge will be sent if missing
+    # if SIGNATURE is defined, no challenge will be sent, only fails authentication
+    headers: [ "SIGNATURE", "AUTHORIZATION" ]
+    # if set to optional, challenge will never be sent and provider
+    # will abstain if no request signature is available
+    optional: true
+    backward-compatible-eol: true
+    realm: "prime"
+    # required headers to be signed in request
+    # there may be more headers signed, which is OK
+    sign-headers:
+      # if method is not defined, then this is the default config
+      # MUST be present and signed
+      - always: [ "date" ]
+      - method: "get"
+        # MUST be present and signed
+        always: [ "date", "(request-target)", "host" ]
+        # MUST be signed IF present
+        if-present: [ "authorization" ]
+    inbound:
+      keys:
+        - key-id: "rsa-key-12345"
+          principal-name: "aUser"
+          # Either "Service" or "User", defaults to Service
+          # Will create appropriate principal type when constructing security subject
+          principal-type: "USER"
+          # algorithm to use
+          algorithm: "rsa-sha256"
+          # RSA public key
+          public-key:
+            keystore:
+              resource.resource-path: "keystore.p12"
+              type: "PKCS12"
+              passphrase: "password"
+              cert.alias: "service_cert"
+        - key-id: "myServiceKeyId"
+          algorithm: "hmac-sha256"
+          principal-name: "aSetOfTrustedServices"
+          hmac.secret: "MyPasswordForHmac"
+        # configuration of outbound requests, to sign them
+    outbound:
+      - name: "first"
+        transports: [ "http" ]
+        hosts: [ "example.org" ]
+        paths: [ "/my/.*" ]
+        signature:
+          backward-compatible-eol: true
+          header: "SIGNATURE"
+          # required headers to be signed in request
+          # there may be more headers signed, which is OK
+          sign-headers:
+            # if method is not defined, then this is the default config
+            # MUST be present and signed - for outbound, date and host will
+            # be generated if missing
+            - always: [ "date", "host", "(request-target)" ]
+              # MUST be signed IF present
+              if-present: [ "authorization" ]
+          # defaults to rsa-sha256 if private-key configured
+          # algorithm: "rsa-sha256"
+          key-id: "rsa-key-12345"
+          private-key:
+            keystore:
+              resource.resource-path: "keystore.p12"
+              type: "PKCS12"
+              passphrase: "password"
+              key.alias: "myPrivateKey"
+      - name: "second"
+        transports: [ "http" ]
+        hosts: [ "localhost" ]
+        paths: [ "/second/.*" ]
+        signature:
+          backward-compatible-eol: true
+          key-id: "myServiceKeyId"
+          header: "SIGNATURE"
+          # defaults to hmac-sha256 if hmac configured
+          # algorithm: "hmac-sha256"
+          hmac.secret: "MyPasswordForHmac"

--- a/security/providers/http-sign/src/test/resources/application.yaml
+++ b/security/providers/http-sign/src/test/resources/application.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2016, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Resolves #4372 

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>

Backward compatible flag now defaults to false.