### PR TITLE
Restoring dependency with Tyrus 2.0.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -143,7 +143,7 @@
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>
         <version.lib.snakeyaml>1.30</version.lib.snakeyaml>
         <version.lib.typesafe-config>1.4.2</version.lib.typesafe-config>
-        <version.lib.tyrus>2.0.2</version.lib.tyrus>
+        <version.lib.tyrus>2.0.1</version.lib.tyrus>
         <version.lib.weld-api>4.0.SP1</version.lib.weld-api>
         <version.lib.weld>4.0.2.Final</version.lib.weld>
         <version.lib.yasson>2.0.4</version.lib.yasson>

--- a/microprofile/websocket/src/main/java/module-info.java
+++ b/microprofile/websocket/src/main/java/module-info.java
@@ -28,10 +28,10 @@ module io.helidon.microprofile.tyrus {
     requires io.helidon.common;
     requires io.helidon.config;
     requires io.helidon.microprofile.cdi;
-    requires org.glassfish.tyrus.core;
+    requires tyrus.core;
     requires io.helidon.microprofile.server;
     requires io.helidon.webserver.tyrus;
-    requires org.glassfish.tyrus.spi;
+    requires tyrus.spi;
 
     exports io.helidon.microprofile.tyrus;
 

--- a/webserver/tyrus/pom.xml
+++ b/webserver/tyrus/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
             <artifactId>tyrus-client</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>

--- a/webserver/tyrus/src/main/java/module-info.java
+++ b/webserver/tyrus/src/main/java/module-info.java
@@ -27,9 +27,9 @@ module io.helidon.webserver.tyrus {
     requires io.helidon.common.mapper;
     requires io.helidon.common.reactive;
 
-    requires org.glassfish.tyrus.core;
-    requires org.glassfish.tyrus.server;
-    requires org.glassfish.tyrus.spi;
+    requires tyrus.core;
+    requires tyrus.server;
+    requires tyrus.spi;
 
     exports io.helidon.webserver.tyrus;
 }


### PR DESCRIPTION
Restoring dependency with Tyrus 2.0.1. The lastest version 2.0.2 introduces a strange dependency with the client module that is problematic for us.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>