### PR TITLE
Preserve order of mapped cross-origin config path entries from config; add test (3.x)

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package io.helidon.webserver.cors;
 
 import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -173,7 +173,7 @@ public class MappedCrossOriginConfig implements Iterable<Map.Entry<String, Cross
 
         private Optional<String> nameOpt = Optional.empty();
         private Optional<Boolean> enabledOpt = Optional.empty();
-        private final Map<String, Buildable> builders = new HashMap<>();
+        private final Map<String, Buildable> builders = new LinkedHashMap<>(); // use LinkedHashMap to preserve order from config
 
         private Builder() {
         }

--- a/webserver/cors/src/test/resources/configMapperTest.yaml
+++ b/webserver/cors/src/test/resources/configMapperTest.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,3 +41,18 @@ wide:
 
 just-disabled:
   enabled: false
+
+order-check:
+  paths:
+    - path-pattern: "/authorize[/{+}]"
+      allow-origins: [ "*" ]
+      allow-methods: [ "GET" ]
+      allow-credentials: true
+    - path-pattern: "/callback[/{+}]"
+      allow-origins: [ "*" ]
+      allow-methods: [ "PUT", "POST" ]
+      allow-credentials: true
+    - path-pattern: "{^(?!((authorize)|(callback))).*$}"
+      allow-origins: [ "http://backend-base-uri}", "http://frontend-base-uri}", "http://test-origin}", "null" ]
+      allow-methods: [ "DELETE", "PATCH", "HEAD" ]
+      allow-credentials: true


### PR DESCRIPTION
Resolves #4407 for 3.x.

We should, and our documentation says that we do, apply CORS settings in the order in which they are declared in config. But we didn't.

Using a `LinkedHashMap` instead of a `HashMap` resolves this.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>