### PR TITLE
Preserve order of mapped cross-origin config path entries from config; add test (2.x)

### DIFF
--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
@@ -169,7 +169,7 @@ public class MappedCrossOriginConfig implements Iterable<Map.Entry<String, Cross
     /**
      * Fluent builder for {@code Mapped} cross-origin config.
      */
-    public static class Builder implements io.helidon.common.Builder<Builder, MappedCrossOriginConfig> {
+    public static class Builder implements io.helidon.common.Builder<MappedCrossOriginConfig> {
 
         private Optional<String> nameOpt = Optional.empty();
         private Optional<Boolean> enabledOpt = Optional.empty();

--- a/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
+++ b/webserver/cors/src/main/java/io/helidon/webserver/cors/MappedCrossOriginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,13 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.webserver.cors;
 
 import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -170,11 +169,11 @@ public class MappedCrossOriginConfig implements Iterable<Map.Entry<String, Cross
     /**
      * Fluent builder for {@code Mapped} cross-origin config.
      */
-    public static class Builder implements io.helidon.common.Builder<MappedCrossOriginConfig> {
+    public static class Builder implements io.helidon.common.Builder<Builder, MappedCrossOriginConfig> {
 
         private Optional<String> nameOpt = Optional.empty();
         private Optional<Boolean> enabledOpt = Optional.empty();
-        private final Map<String, Buildable> builders = new HashMap<>();
+        private final Map<String, Buildable> builders = new LinkedHashMap<>(); // use LinkedHashMap to preserve order from config
 
         private Builder() {
         }

--- a/webserver/cors/src/test/java/io/helidon/webserver/cors/CrossOriginConfigTest.java
+++ b/webserver/cors/src/test/java/io/helidon/webserver/cors/CrossOriginConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,14 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package io.helidon.webserver.cors;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-
 import io.helidon.config.MissingValueException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,9 +32,11 @@ import static io.helidon.webserver.cors.CrossOriginConfig.DEFAULT_AGE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 public class CrossOriginConfigTest {
 
@@ -121,5 +126,50 @@ public class CrossOriginConfigTest {
         assertThat(b.maxAgeSeconds(), is(-1L));
 
         assertThat(m.get("/cors3"), nullValue());
+    }
+
+    @Test
+    void testOrdering() {
+        Config node = testConfig.get("order-check");
+        assertThat(node, is(notNullValue()));
+        assertThat(node.exists(), is(true));
+        MappedCrossOriginConfig m = node.as(MappedCrossOriginConfig::create).get();
+
+        assertThat(m.isEnabled(), is(true));
+
+        //Make sure path elements are in the right order.
+        List<String> pathsInOrder = new ArrayList<>();
+        List<CrossOriginConfig> crossOriginConfigs = new ArrayList<>();
+        m.forEach((path, crossOrginConfig) -> {
+            pathsInOrder.add(path);
+            crossOriginConfigs.add(crossOrginConfig);
+        });
+
+        // Make sure ordering from config is what we expect.
+        assertThat("Paths configured", pathsInOrder.size(), is(3));
+        assertThat("First path", pathsInOrder.get(0), startsWith("/authorize"));
+        assertThat("Second path", pathsInOrder.get(1), startsWith("/callback"));
+        assertThat("Third path", pathsInOrder.get(2), is("{^(?!((authorize)|(callback))).*$}"));
+
+        // Make sure the aggregator retains the correct order.
+        Aggregator agg = Aggregator.builder().mappedConfig(node).build();
+
+        Optional<CrossOriginConfig> crossOriginConfigOpt = agg.lookupCrossOrigin("/authorize", "GET", Optional::empty);
+        assertThat("Match found for /authorize", crossOriginConfigOpt.isPresent(), is(true));
+        assertThat("Match for /authorize", crossOriginConfigOpt.get().pathPattern(), is(crossOriginConfigs.get(0).pathPattern()));
+
+        crossOriginConfigOpt = agg.lookupCrossOrigin("/authorize/else", "GET", Optional::empty);
+        assertThat("Match found for /authorize/else", crossOriginConfigOpt.isPresent(), is(true));
+        assertThat("Match for /authorize/else",
+                   crossOriginConfigOpt.get().pathPattern(),
+                   is(crossOriginConfigs.get(0).pathPattern()));
+
+        crossOriginConfigOpt = agg.lookupCrossOrigin("/callback", "PUT", Optional::empty);
+        assertThat("Match found for /callback", crossOriginConfigOpt.isPresent(), is(true));
+        assertThat("Match for /callback", crossOriginConfigOpt.get().pathPattern(), is(crossOriginConfigs.get(1).pathPattern()));
+
+        crossOriginConfigOpt = agg.lookupCrossOrigin("/callback/other", "PUT", Optional::empty);
+        assertThat("Match found for /callback/other", crossOriginConfigOpt.isPresent(), is(true));
+        assertThat("Match for /callback/other", crossOriginConfigOpt.get().pathPattern(), is(crossOriginConfigs.get(1).pathPattern()));
     }
 }

--- a/webserver/cors/src/test/resources/configMapperTest.yaml
+++ b/webserver/cors/src/test/resources/configMapperTest.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,3 +41,18 @@ wide:
 
 just-disabled:
   enabled: false
+
+order-check:
+  paths:
+    - path-pattern: "/authorize[/{+}]"
+      allow-origins: [ "*" ]
+      allow-methods: [ "GET" ]
+      allow-credentials: true
+    - path-pattern: "/callback[/{+}]"
+      allow-origins: [ "*" ]
+      allow-methods: [ "PUT", "POST" ]
+      allow-credentials: true
+    - path-pattern: "{^(?!((authorize)|(callback))).*$}"
+      allow-origins: [ "http://backend-base-uri}", "http://frontend-base-uri}", "http://test-origin}", "null" ]
+      allow-methods: [ "DELETE", "PATCH", "HEAD" ]
+      allow-credentials: true


### PR DESCRIPTION
Resolves #4407 for 2.x

See #4431 (the 3.x PR) for an explanation.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>