### PR TITLE
4367 doc update for java marshaller deprecation

### DIFF
--- a/docs/se/grpc/09_marshalling.adoc
+++ b/docs/se/grpc/09_marshalling.adoc
@@ -24,11 +24,7 @@
 
 == Default Marshalling Support
 
-Helidon gRPC supports Protobuf and Java serialization-based message marshallers out of the box.
-
-=== Protobuf Marshalling
-
-Protobuf marshaller will be used by default for any request and response classes that extend `com.google.protobuf.MessageLite` class, which is the case for all classes generated from a `proto` file using `protoc` compiler.
+Helidon gRPC supports Protobuf out of the box. Protobuf marshaller will be used by default for any request and response classes that extend `com.google.protobuf.MessageLite` class, which is the case for all classes generated from a `proto` file using `protoc` compiler.
 
 That means that you don't need any special handling or configuration in order to support Protobuf serialization of requests and responses.
 

--- a/docs/se/grpc/09_marshalling.adoc
+++ b/docs/se/grpc/09_marshalling.adoc
@@ -32,14 +32,6 @@ Protobuf marshaller will be used by default for any request and response classes
 
 That means that you don't need any special handling or configuration in order to support Protobuf serialization of requests and responses.
 
-=== Java Serialization Marshalling
-
-By default, any class that doesn't extend `com.google.protobuf.MessageLite` will be serialized using `JavaMarshaller`, which uses Java serialization.
-
-`JavaMarshaller` is useful for quick prototypes, but it is not recommended for production use. For one, it only supports gRPC-based communication between Java clients and servers, which is quite limiting. It is also not very efficient, and last but not least, it introduces security vulnerabilities.
-
-Because of the issues above, `JavaMarshaller` has been deprecated in Helidon 2.3, and will be permanently removed in Helidon 3.0. In the meantime, it is disabled by default and has to be explicitly enabled by setting `grpc.marshaller.java.enabled` configuration property to `true`. Otherwise, the `UnsupportedOperationException` will be thrown if you attempt to use it.
-
 == Custom Marshalling
 
 Helidon makes the use of custom marshallers trivial, and provides one custom implementation, `JsonbMarshaller`, out of the box.

--- a/docs/se/grpc/09_marshalling.adoc
+++ b/docs/se/grpc/09_marshalling.adoc
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
-    Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+    Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/docs/sitegen.yaml
+++ b/docs/sitegen.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2018, 2022 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/sitegen.yaml
+++ b/docs/sitegen.yaml
@@ -46,7 +46,6 @@ pages:
     - includes:
         - "**/*.adoc"
       excludes:
-        - "se/grpc/09_marshalling.adoc"
         - "common/**"
         - "shared/**"
 backend:


### PR DESCRIPTION
Update marshalling doc to remove JavaMarshaller after it was deprecated and include marshalling doc in sitegen.yaml