### PR TITLE
Fix code with 'TODO 3.0.0-JAKARTA' comment

### DIFF
--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsHistogram.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsHistogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsHistogram.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsHistogram.java
@@ -51,7 +51,6 @@ public class JdbcMetricsHistogram implements Histogram {
 
     @Override
     public long getSum() {
-        // TODO 3.0.0-JAKARTA
         return (long) (histogram.getCount() * histogram.getSnapshot().getMean());
     }
 }

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.metrics.Timer;
 public class JdbcMetricsTimer implements Timer {
 
     private final com.codahale.metrics.Timer meter;
+    private long elapsedTimeNanos;
 
     JdbcMetricsTimer(final com.codahale.metrics.Timer meter) {
         this.meter = meter;
@@ -34,17 +35,27 @@ public class JdbcMetricsTimer implements Timer {
 
     @Override
     public <T> T time(Callable<T> event) throws Exception {
-        return meter.time(event);
+        long start = System.nanoTime();
+        try {
+            return meter.time(event);
+        } finally {
+            updateElapsedWithStart(start);
+        }
     }
 
     @Override
     public void time(Runnable event) {
-        meter.time(event);
+        long start = System.nanoTime();
+        try {
+            meter.time(event);
+        } finally {
+            updateElapsedWithStart(start);
+        }
     }
 
     @Override
     public Context time() {
-        return new JdbcMetricsTimerContext(meter.time());
+        return new JdbcMetricsTimerContext(meter.time(), this::updateElapsed);
     }
 
     @Override
@@ -79,11 +90,21 @@ public class JdbcMetricsTimer implements Timer {
 
     @Override
     public void update(Duration duration) {
+        updateElapsed(duration.toNanos());
         meter.update(duration);
     }
 
     @Override
     public Duration getElapsedTime() {
-        return Duration.ZERO;
+        return Duration.ofNanos(elapsedTimeNanos);
+    }
+
+    private long updateElapsed(long delta) {
+        elapsedTimeNanos += delta;
+        return delta;
+    }
+
+    private long updateElapsedWithStart(long start) {
+        return updateElapsed(System.nanoTime() - start);
     }
 }

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimer.java
@@ -79,13 +79,11 @@ public class JdbcMetricsTimer implements Timer {
 
     @Override
     public void update(Duration duration) {
-        // TODO 3.0.0-JAKARTA
         meter.update(duration);
     }
 
     @Override
     public Duration getElapsedTime() {
-        // TODO 3.0.0-JAKARTA
         return Duration.ZERO;
     }
 }

--- a/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimerContext.java
+++ b/dbclient/metrics-jdbc/src/main/java/io/helidon/dbclient/metrics/jdbc/JdbcMetricsTimerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package io.helidon.dbclient.metrics.jdbc;
 
+import java.util.function.Function;
+
 import org.eclipse.microprofile.metrics.Timer;
 
 /**
@@ -23,14 +25,17 @@ import org.eclipse.microprofile.metrics.Timer;
 public class JdbcMetricsTimerContext implements Timer.Context {
 
     private final com.codahale.metrics.Timer.Context context;
+    private final Function<Long, Long> elapsedTimeUpdater;
 
-    JdbcMetricsTimerContext(final com.codahale.metrics.Timer.Context context) {
+    JdbcMetricsTimerContext(final com.codahale.metrics.Timer.Context context,
+                            Function<Long, Long> elapsedTimeUpdater) {
         this.context = context;
+        this.elapsedTimeUpdater = elapsedTimeUpdater;
     }
 
     @Override
     public long stop() {
-        return context.stop();
+        return elapsedTimeUpdater.apply(context.stop());
     }
 
     @Override

--- a/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
+++ b/grpc/metrics/src/main/java/io/helidon/grpc/metrics/GrpcMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,18 +152,6 @@ public class GrpcMetrics
      */
     public GrpcMetrics units(String units) {
         return new GrpcMetrics(metricRule.units(units));
-    }
-
-    /**
-     * Set the reusability of the metric.
-     * @param reusable {@code true} if this metric may be reused
-     * @return a {@link io.helidon.grpc.metrics.GrpcMetrics} interceptor
-     * @see org.eclipse.microprofile.metrics.Metadata
-     */
-    // TODO 3.0.0-JAKARTA
-    // reusability is missing from new metrics API
-    public GrpcMetrics reusable(boolean reusable) {
-        return new GrpcMetrics(metricRule.reusable(reusable));
     }
 
     /**
@@ -575,12 +563,6 @@ public class GrpcMetrics
         private Optional<String> units = Optional.empty();
 
         /**
-         * The reusability status of this metric.
-         * @see org.eclipse.microprofile.metrics.Metadata
-         */
-        private boolean reusable;
-
-        /**
          * The function to use to obtain the metric name.
          */
         private Optional<NamingFunction> nameFunction = Optional.empty();
@@ -596,7 +578,6 @@ public class GrpcMetrics
             this.displayName = copy.displayName;
             this.units = copy.units;
             this.nameFunction = copy.nameFunction;
-            this.reusable = copy.reusable;
         }
 
         /**
@@ -659,12 +640,6 @@ public class GrpcMetrics
         private MetricsRules units(String units) {
             MetricsRules rules = new MetricsRules(this);
             rules.units = Optional.of(units);
-            return rules;
-        }
-
-        private MetricsRules reusable(boolean reusable) {
-            MetricsRules rules = new MetricsRules(this);
-            rules.reusable = reusable;
             return rules;
         }
 

--- a/integrations/graal/mp-native-image-extension/pom.xml
+++ b/integrations/graal/mp-native-image-extension/pom.xml
@@ -61,11 +61,6 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.classfilewriter</groupId>
-            <artifactId>jboss-classfilewriter</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/integrations/graal/mp-native-image-extension/pom.xml
+++ b/integrations/graal/mp-native-image-extension/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.classfilewriter</groupId>
+            <artifactId>jboss-classfilewriter</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
+++ b/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
+++ b/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
@@ -16,6 +16,7 @@
 package io.helidon.integrations.graal.mp.nativeimage.extension;
 
 import java.lang.reflect.Type;
+import java.security.ProtectionDomain;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -26,6 +27,7 @@ import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import org.jboss.classfilewriter.ClassFile;
 import org.jboss.weld.event.ObserverNotifier;
 import org.jboss.weld.executor.DaemonThreadFactory;
 import org.jboss.weld.util.reflection.ParameterizedTypeImpl;
@@ -92,12 +94,12 @@ public class WeldSubstitutions {
 
         }
     }
-// TODO 3.0.0-JAKARTA
-//    @TargetClass(className = "org.jboss.weld.util.bytecode.ClassFileUtils")
-//    static final class ClassFileUtils {
-//        @Substitute
-//        public static Class<?> toClass(ClassFile ct, ClassLoader loader, ProtectionDomain domain) {
-//            throw new IllegalStateException("Cannot load " + ct.getName());
-//        }
-//    }
+
+    @TargetClass(className = "org.jboss.weld.util.bytecode.ClassFileUtils")
+    static final class ClassFileUtils {
+        @Substitute
+        public static Class<?> toClass(ClassFile ct, ClassLoader loader, ProtectionDomain domain) {
+            throw new IllegalStateException("Cannot load " + ct.getName());
+        }
+    }
 }

--- a/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
+++ b/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/WeldSubstitutions.java
@@ -16,7 +16,6 @@
 package io.helidon.integrations.graal.mp.nativeimage.extension;
 
 import java.lang.reflect.Type;
-import java.security.ProtectionDomain;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -27,7 +26,6 @@ import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import org.jboss.classfilewriter.ClassFile;
 import org.jboss.weld.event.ObserverNotifier;
 import org.jboss.weld.executor.DaemonThreadFactory;
 import org.jboss.weld.util.reflection.ParameterizedTypeImpl;
@@ -92,14 +90,6 @@ public class WeldSubstitutions {
          */
         public static void set(Object object, Executor executor) {
 
-        }
-    }
-
-    @TargetClass(className = "org.jboss.weld.util.bytecode.ClassFileUtils")
-    static final class ClassFileUtils {
-        @Substitute
-        public static Class<?> toClass(ClassFile ct, ClassLoader loader, ProtectionDomain domain) {
-            throw new IllegalStateException("Cannot load " + ct.getName());
         }
     }
 }

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
+++ b/metrics/api/src/main/java/io/helidon/metrics/api/NoOpMetricImpl.java
@@ -157,7 +157,6 @@ class NoOpMetricImpl extends AbstractMetric implements NoOpMetric {
 
         @Override
         public long getSum() {
-            // TODO 3.0.0-JAKARTA
             return 0;
         }
     }
@@ -278,7 +277,6 @@ class NoOpMetricImpl extends AbstractMetric implements NoOpMetric {
 
         @Override
         public Duration getElapsedTime() {
-            // TODO 3.0.0-JAKARTA
             return Duration.ZERO;
         }
 
@@ -360,13 +358,11 @@ class NoOpMetricImpl extends AbstractMetric implements NoOpMetric {
 
         @Override
         public Duration getMaxTimeDuration() {
-            // TODO 3.0.0-JAKARTA
             return Duration.ZERO;
         }
 
         @Override
         public Duration getMinTimeDuration() {
-            // TODO 3.0.0-JAKARTA
             return Duration.ZERO;
         }
 

--- a/microprofile/grpc/server/pom.xml
+++ b/microprofile/grpc/server/pom.xml
@@ -95,7 +95,6 @@
         </dependency>
         <dependency>
             <!--
-            TODO 3.0.0-JAKARTA
             need to use this version to work around the same groupId/artifactId and
             different package names in Jakarta
             This is needed for the Generated annotation in grpc sources

--- a/microprofile/rest-client/src/main/java/io/helidon/microprofile/restclient/HelidonInboundHeaderProvider.java
+++ b/microprofile/rest-client/src/main/java/io/helidon/microprofile/restclient/HelidonInboundHeaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/rest-client/src/main/java/io/helidon/microprofile/restclient/HelidonInboundHeaderProvider.java
+++ b/microprofile/rest-client/src/main/java/io/helidon/microprofile/restclient/HelidonInboundHeaderProvider.java
@@ -20,15 +20,14 @@ import java.util.Map;
 
 import io.helidon.common.context.Contexts;
 
-//TODO 3.0.0-JAKARTA
-//import org.glassfish.jersey.microprofile.restclient.InboundHeadersProvider;
+import org.glassfish.jersey.microprofile.restclient.InboundHeadersProvider;
 
 /**
  * Provider which propagates inbound request headers via Helidon {@link io.helidon.common.context.Context}.
  */
-class HelidonInboundHeaderProvider /*implements InboundHeadersProvider*/ {
+class HelidonInboundHeaderProvider implements InboundHeadersProvider {
 
-//    @Override
+    @Override
     public Map<String, List<String>> inboundHeaders() {
         return Contexts.context()
                 .flatMap(context -> context.get(InboundHeaders.class))

--- a/microprofile/rest-client/src/main/java/module-info.java
+++ b/microprofile/rest-client/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/microprofile/rest-client/src/main/java/module-info.java
+++ b/microprofile/rest-client/src/main/java/module-info.java
@@ -24,8 +24,7 @@ module io.helidon.microprofile.restclient {
     requires microprofile.rest.client.api;
     requires io.helidon.common.context;
     requires jersey.common;
-    //TODO 3.0.0-JAKARTA
-//    requires jersey.mp.rest.client;
+    requires jersey.mp.rest.client;
     requires jakarta.ws.rs;
 
     exports io.helidon.microprofile.restclient;

--- a/security/integration/grpc/pom.xml
+++ b/security/integration/grpc/pom.xml
@@ -123,7 +123,6 @@
         </dependency>
         <dependency>
             <!--
-            TODO 3.0.0-JAKARTA
             need to use this version to work around the same groupId/artifactId and
             different package names in Jakarta
             This is needed for the Generated annotation in grpc sources -->

--- a/tests/integration/mp-grpc/pom.xml
+++ b/tests/integration/mp-grpc/pom.xml
@@ -102,7 +102,6 @@
         </dependency>
         <dependency>
             <!--
-            TODO 3.0.0-JAKARTA
             need to use this version to work around the same groupId/artifactId and
             different package names in Jakarta
             This is needed for the Generated annotation in grpc sources -->


### PR DESCRIPTION
1. Update metrics related code in `JdbcMetricsHistogram` and `JdbcMetricsTimer`. 
2. Remove TODO comment in and `NoOpMetricImpl` as it was reviewed that no extra work needs to be done on them
3. Remove `reusable` feature as it has never been accessed by grpc metrics code.
4. Remove WeldSubstitutions.ClassFileUtils as the file no longer exists in Weld
5. HelidonInboundHeaderProvider was restored to use `implements InboundHeadersProvider` because `org.glassfish.jersey.ext.microprofile:jersey-mp-rest-client` dependency was restored back via PR 3884
6. Stick with the use of javax.annotation:javax.annotation-api as there is no suitable library replacement.
7.  Remove internal class `ClassFileUtils` from `WeldSubstitutions` as the file no longer exists in Weld.