### PR TITLE
Mock connector

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1122,6 +1122,11 @@
                 <artifactId>helidon-microprofile-tests-testng</artifactId>
                 <version>${helidon.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.helidon.messaging.mock</groupId>
+                <artifactId>helidon-messaging-mock</artifactId>
+                <version>${helidon.version}</version>
+            </dependency>
             <!-- Logging -->
             <dependency>
                 <groupId>io.helidon.logging</groupId>

--- a/messaging/connectors/mock/pom.xml
+++ b/messaging/connectors/mock/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.messaging</groupId>
+        <artifactId>helidon-messaging-connectors-project</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.helidon.messaging.mock</groupId>
+    <artifactId>helidon-messaging-mock</artifactId>
+    <packaging>jar</packaging>
+    <name>Helidon Messaging Mock Connector</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
+            <artifactId>microprofile-reactive-messaging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+            <artifactId>microprofile-reactive-streams-operators-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockConnector.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockConnector.java
@@ -38,7 +38,6 @@ import org.reactivestreams.FlowAdapters;
 
 /**
  * Helidon messaging mock connector for testing purposes.
- *
  * Mock connector for testing Helidon messaging
  * without the need of connection to actual messaging broker.
  */

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockConnector.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockConnector.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.helidon.messaging.connectors.mock;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.helidon.common.reactive.BufferedEmittingPublisher;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.spi.Connector;
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory;
+import org.eclipse.microprofile.reactive.messaging.spi.IncomingConnectorFactory;
+import org.eclipse.microprofile.reactive.messaging.spi.OutgoingConnectorFactory;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
+import org.reactivestreams.FlowAdapters;
+
+
+/**
+ * Helidon messaging mock connector for testing purposes.
+ *
+ * Mock connector for testing Helidon messaging
+ * without the need of connection to actual messaging broker.
+ */
+@Connector(MockConnector.CONNECTOR_NAME)
+@TestConnector
+@ApplicationScoped
+public class MockConnector implements IncomingConnectorFactory, OutgoingConnectorFactory {
+
+    /**
+     * Connector name.
+     */
+    public static final String CONNECTOR_NAME = "helidon-mock";
+
+    private final Map<String, BufferedEmittingPublisher<Message<?>>> emitterMap = new HashMap<>();
+    private final Map<String, MockOutgoing<?>> subscriberMap = new HashMap<>();
+
+    private final ReentrantLock emitterLock = new ReentrantLock();
+    private final ReentrantLock subscriberLock = new ReentrantLock();
+
+    @Override
+    public PublisherBuilder<? extends Message<?>> getPublisherBuilder(Config config) {
+        String channelName = config.getValue(ConnectorFactory.CHANNEL_NAME_ATTRIBUTE, String.class);
+        BufferedEmittingPublisher<Message<?>> emitter = incoming(channelName, Object.class).emitter();
+        Class<?> mockDataType = config.getOptionalValue("mock-data-type", Class.class).orElse(String.class);
+        config.getOptionalValues("mock-data", mockDataType)
+                .ifPresent(list -> list.forEach(s -> emitter.emit(Message.of(s))));
+
+        return ReactiveStreams.<Object>fromPublisher(FlowAdapters.toPublisher(emitter))
+                .map(o -> {
+                    if (o instanceof Message<?>) {
+                        return (Message<?>) o;
+                    } else {
+                        return Message.of(o);
+                    }
+                });
+    }
+
+    @Override
+    public SubscriberBuilder<? extends Message<?>, Void> getSubscriberBuilder(Config config) {
+        String channelName = config.getValue(ConnectorFactory.CHANNEL_NAME_ATTRIBUTE, String.class);
+        return ReactiveStreams.<Message<?>>builder()
+                .to(outgoing(channelName, Object.class).subscriber());
+    }
+
+    /**
+     * Retrieve mocker for incoming channel. Incoming channel needs to be configured to use MockConnector with:
+     * <pre>{@code
+     * @AddConfig(key = "mp.messaging.incoming.test-channel-incoming", value = MockConnector.CONNECTOR_NAME)
+     * }</pre>
+     *
+     * @param channelName Channel name, for example {@code test-channel-incoming}
+     * @param type        Type of the payload
+     * @param <P>         type of the payload
+     * @return mocker for desired chanel
+     */
+    public <P> MockIncoming<P> incoming(String channelName, Class<P> type) {
+        emitterLock.lock();
+        try {
+            return new MockIncoming<P>(emitterMap.computeIfAbsent(channelName, k -> BufferedEmittingPublisher.create()));
+        } finally {
+            emitterLock.unlock();
+        }
+    }
+
+    /**
+     * Retrieve mocker for outgoing channel. Outgoing channel needs to be configured to use MockConnector with:
+     * <pre>{@code
+     * @AddConfig(key = "mp.messaging.outgoing.test-channel-outgoing", value = MockConnector.CONNECTOR_NAME)
+     * }</pre>
+     *
+     * @param channelName Channel name, for example {@code test-channel-outgoing}
+     * @param type        Type of the payload
+     * @param <P>         type of the payload
+     * @return mocker for desired chanel
+     */
+    @SuppressWarnings("unchecked")
+    public <P> MockOutgoing<P> outgoing(String channelName, Class<P> type) {
+        subscriberLock.lock();
+        try {
+            return (MockOutgoing<P>) subscriberMap.computeIfAbsent(channelName, k -> new MockOutgoing<P>(new MockSubscriber()));
+        } finally {
+            subscriberLock.unlock();
+        }
+    }
+
+}

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockIncoming.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockIncoming.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.messaging.connectors.mock;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import io.helidon.common.reactive.BufferedEmittingPublisher;
+import io.helidon.common.reactive.Single;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Mock-able incoming channel connected to the mock connector.
+ *
+ * @param <P> type of the payload
+ */
+public class MockIncoming<P> {
+
+    private final BufferedEmittingPublisher<Message<?>> publisher;
+    private final CompletableFuture<Void> onAbortOrComplete;
+
+    MockIncoming(BufferedEmittingPublisher<Message<?>> publisher) {
+        this.publisher = publisher;
+        onAbortOrComplete = new CompletableFuture<>();
+        publisher.onAbort(throwable -> onAbortOrComplete.complete(null));
+    }
+
+    /**
+     * Emit one or more payloads directly to the mocked channel.
+     *
+     * @param payload one or more payloads to send down the stream
+     * @return this channel mocker
+     */
+    @SafeVarargs
+    public final MockIncoming<P> emit(P... payload) {
+        for (P item : payload) {
+            publisher.emit(Message.of(item));
+        }
+        return this;
+    }
+
+    /**
+     * Emit one or more messages directly to the mocked channel.
+     *
+     * @param message one or more messages to send down the stream
+     * @return this channel mocker
+     */
+    @SafeVarargs
+    public final MockIncoming<P> emit(Message<P>... message) {
+        for (Message<P> msg : message) {
+            publisher.emit(msg);
+        }
+        return this;
+    }
+
+    /**
+     * Send terminal complete signal to the channel.
+     *
+     * @return this channel mocker
+     */
+    public MockIncoming<P> complete() {
+        publisher.complete();
+        onAbortOrComplete.complete(null);
+        return this;
+    }
+
+    /**
+     * Send terminal error signal to the channel.
+     *
+     * @param t cause of the channel termination
+     * @return this channel mocker
+     */
+    public MockIncoming<P> fail(Throwable t) {
+        publisher.fail(t);
+        onAbortOrComplete.complete(null);
+        return this;
+    }
+
+    /**
+     * Wait and block till the stream is in terminal state
+     * and asserts if the terminal state is caused by cancel signal.
+     *
+     * @param timeout Timeout for waiting on the stream being cancelled.
+     * @return this mock
+     */
+    public MockIncoming<P> awaitCancelled(Duration timeout) {
+        Single.create(onAbortOrComplete, true).await(timeout);
+        assertThat(publisher.isCancelled(), is(true));
+        return this;
+    }
+
+    BufferedEmittingPublisher<Message<?>> emitter() {
+        return this.publisher;
+    }
+}

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockOutgoing.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockOutgoing.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.messaging.connectors.mock;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.helidon.common.reactive.Single;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Mock-able outgoing channel connected to the mock connector.
+ *
+ * @param <P> type of the payload
+ */
+public class MockOutgoing<P> {
+
+    private final MockSubscriber mockSubscriber;
+
+    MockOutgoing(MockSubscriber mockSubscriber) {
+        this.mockSubscriber = mockSubscriber;
+    }
+
+    /**
+     * Control backpressure manually and request {@code n} items from upstream.
+     *
+     * @param n number of items requested from upstream
+     * @return this mocker
+     */
+    public MockOutgoing<P> request(long n) {
+        if (n <= 0L) {
+            throw new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden!");
+        }
+        if (mockSubscriber.upstream() == null) {
+            throw new IllegalStateException("Not subscribed yet.");
+        }
+        mockSubscriber.upstream().request(n);
+        return this;
+    }
+
+    /**
+     * Request {@code unbounded} number of items from upstream and effectively turn off backpressure.
+     *
+     * @return this mocker
+     */
+    public MockOutgoing<P> requestMax() {
+        return request(Long.MAX_VALUE);
+    }
+
+    /**
+     * Returns single which is completed when the terminates with the complete signal.
+     *
+     * @return this mocker
+     */
+    public Single<Void> whenComplete() {
+        return mockSubscriber.completed();
+    }
+
+    /**
+     * Block current thread until channel gets terminated with complete signal.
+     *
+     * @param timeout timeout when reached before complete signal is received, Completion exception is thrown.
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    public MockOutgoing<P> awaitComplete(Duration timeout) {
+        whenComplete().await(timeout);
+        return this;
+    }
+
+    /**
+     * Block current thread until expected number of items is received.
+     *
+     * @param count number of items to be received for releasing current thread
+     * @param timeout timeout when reached before specified number of items is received, Completion exception is thrown.
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    public MockOutgoing<P> awaitCount(Duration timeout, int count) {
+        CompletableFuture<Void> latch = new CompletableFuture<>();
+        Consumer<Integer> counter = l -> {
+            if (l >= count) {
+                latch.complete(null);
+            }
+        };
+        mockSubscriber.counters().add(counter);
+        counter.accept(mockSubscriber.data().size());
+        Single.create(latch, true).await(timeout);
+        return this;
+    }
+
+    /**
+     * Block current thread until expected message is received.
+     *
+     * @param waitingFor function for comparing each received message, when true is returned, wait is over.
+     * @param timeout timeout when reached before expected item is received, Completion exception is thrown.
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    @SuppressWarnings("unchecked")
+    public MockOutgoing<P> awaitMessage(Duration timeout, Function<Message<P>, Boolean> waitingFor) {
+        this.request(1);
+        CompletableFuture<Void> latch = new CompletableFuture<>();
+        Consumer<Message<?>> checker = m -> {
+            if (waitingFor.apply((Message<P>) m)) {
+                latch.complete(null);
+            } else {
+                this.request(1);
+            }
+        };
+        mockSubscriber.checkers().add(checker);
+        mockSubscriber.data().forEach(checker);
+        Single.create(latch, true).await(timeout);
+        return this;
+    }
+
+    /**
+     * Block current thread until expected messages are received.
+     *
+     * @param mapper to be used for unwrapping the message for comparison with expected values
+     * @param expectedItems one or more expected values
+     * @param timeout timeout when reached before expected item is received, Completion exception is thrown.
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    @SuppressWarnings("unchecked")
+    public MockOutgoing<P> awaitData(Duration timeout, Function<Message<P>, P> mapper, P... expectedItems) {
+        this.request(expectedItems.length);
+        try {
+            this.awaitCount(timeout, expectedItems.length);
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof TimeoutException) {
+                assertThat("Not all " + expectedItems.length + " items delivered in time.",
+                        mockSubscriber.data().stream()
+                                .map(message -> mapper.apply((Message<P>) message))
+                                .toList(),
+                        Matchers.contains(expectedItems));
+            } else {
+                throw e;
+            }
+
+        }
+        assertThat(mockSubscriber.data().stream()
+                .map(message -> mapper.apply((Message<P>) message))
+                .collect(Collectors.toList()), Matchers.contains(expectedItems));
+        return this;
+    }
+
+    /**
+     * Block current thread until expected payloads are received.
+     *
+     * @param expectedItems one or more expected payload values
+     * @param timeout timeout when reached before expected item is received, Completion exception is thrown.
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    @SafeVarargs
+    public final MockOutgoing<P> awaitPayloads(Duration timeout, P... expectedItems) {
+        return awaitData(timeout, Message::getPayload, expectedItems);
+    }
+
+    /**
+     * Assert if matching data has been received.
+     *
+     * @param mapper  to be used for unwrapping the messages for matching
+     * @param matcher matcher to be used for asserting whole collection of the received and with provided mapper unwrapped data.
+     * @param <T> matching type
+     * @return this mocker
+     * @throws java.util.concurrent.CancellationException if the future was cancelled
+     * @throws java.util.concurrent.CompletionException   if the future completed exceptionally,
+     *                                                    was interrupted while waiting or the wait timed out
+     */
+    @SuppressWarnings("unchecked")
+    public <T> MockOutgoing<P> assertData(Function<Message<P>, P> mapper, Matcher<? super T> matcher) {
+        T result = (T) mockSubscriber.data().stream()
+                .map(message -> mapper.apply((Message<P>) message))
+                .toList();
+        assertThat(result, matcher);
+        return this;
+    }
+
+    /**
+     * Assert if matching payloads has been received.
+     *
+     * @param matcher applied on the whole collection of the received payloads
+     * @param <T>     matching type
+     * @return this mocker
+     */
+    public <T> MockOutgoing<P> assertPayloads(Matcher<? super T> matcher) {
+        return assertData(Message::getPayload, matcher);
+    }
+
+    /**
+     * Assert if matching payloads has been received.
+     *
+     * @param expected applied on the whole collection of the received payloads
+     * @return this mocker
+     */
+    @SafeVarargs
+    public final MockOutgoing<P> assertPayloads(P... expected) {
+        return assertPayloads(Matchers.contains(expected));
+    }
+
+    /**
+     * Assert if matching messages has been received.
+     *
+     * @param mapper to be used for unwrapping each message before comparison
+     * @param items  applied on the whole collection of the received payloads
+     * @return this mocker
+     */
+    @SafeVarargs
+    public final MockOutgoing<P> assertData(Function<Message<P>, P> mapper, P... items) {
+        return assertData(Message::getPayload, Matchers.contains(items));
+    }
+
+    /**
+     * Get all received data at this moment.
+     *
+     * @return All received data at this moment in unmodifiable list
+     */
+    @SuppressWarnings("unchecked")
+    public List<Message<P>> data() {
+        return mockSubscriber.data().stream().map(m -> (Message<P>) m).toList();
+    }
+
+    MockSubscriber subscriber(){
+        return mockSubscriber;
+    }
+}

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockSubscriber.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/MockSubscriber.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.messaging.connectors.mock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import io.helidon.common.reactive.Single;
+import io.helidon.common.reactive.SubscriptionHelper;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+class MockSubscriber implements Subscriber<Message<?>> {
+
+    private final AtomicReference<Flow.Subscription> upstream = new AtomicReference<>();
+    private final List<Message<?>> items = new CopyOnWriteArrayList<>();
+    private final CompletableFuture<Void> completed = new CompletableFuture<>();
+    private final List<Consumer<Integer>> counters = Collections.synchronizedList(new ArrayList<>());
+    private final List<Consumer<Message<?>>> checkers = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+        SubscriptionHelper.setOnce(upstream, new Flow.Subscription() {
+            @Override
+            public void request(long n) {
+                if (n <= 0L) {
+                    onError(new IllegalArgumentException("Rule §3.9 violated: non-positive requests are forbidden!"));
+                } else {
+                    subscription.request(n);
+                }
+            }
+
+            @Override
+            public void cancel() {
+                SubscriptionHelper.cancel(upstream);
+            }
+        });
+    }
+
+    @Override
+    public void onNext(Message<?> item) {
+        items.add(item);
+        counters.forEach(c -> c.accept(items.size()));
+        checkers.forEach(c -> c.accept(item));
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        completed.completeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        completed.complete(null);
+    }
+
+    List<Message<?>> data(){
+        return Collections.unmodifiableList(items);
+    }
+
+    List<Consumer<Integer>> counters() {
+        return counters;
+    }
+
+    List<Consumer<Message<?>>> checkers() {
+        return checkers;
+    }
+
+    Flow.Subscription upstream(){
+        return upstream.get();
+    }
+
+    Single<Void> completed(){
+        return Single.create(completed, true);
+    }
+}

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/TestConnector.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/TestConnector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.messaging.connectors.mock;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Qualifier annotation for Helidon messaging test connector.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD, METHOD, PARAMETER})
+public @interface TestConnector {
+}

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/package-info.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/package-info.java
@@ -52,6 +52,7 @@
  *                 .awaitMessage(TIMEOUT, longMessage -> longMessage.getPayload() == 12L)
  *                 .assertPayloads(9L, 10L, 11L, 12L);
  *     }
+ * }
  * }</pre>
  */
 package io.helidon.messaging.connectors.mock;

--- a/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/package-info.java
+++ b/messaging/connectors/mock/src/main/java/io/helidon/messaging/connectors/mock/package-info.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Helidon messaging mock connector for testing purposes.
+ *
+ * Mock connector can be used for testing Helidon messaging
+ * without the need of connection to actual messaging broker.
+ *
+ * <pre>{@code
+ * @HelidonTest
+ * @DisableDiscovery
+ * @AddBean(MockConnector.class)
+ * @AddExtension(MessagingCdiExtension.class)
+ * //Use mock connector as an upstream for channel test-channel-incoming
+ * @AddConfig(key = "mp.messaging.incoming.test-channel-incoming", value = MockConnector.CONNECTOR_NAME)
+ * //mock-data-type is optional, defaults to String.class
+ * @AddConfig(key = "mp.messaging.incoming.test-channel-incoming.mock-data-type", value = "java.lang.Long")
+ * //mock-data is optional, can generate data to the connected channel right after start
+ * @AddConfig(key = "mp.messaging.incoming.test-channel-incoming.mock-data", value = "9,10,11,12")
+ * //Use mock connector as a downstream for channel test-channel-outgoing
+ * @AddConfig(key = "mp.messaging.outoging.test-channel-outgoing.connector", value = MockConnector.CONNECTOR_NAME)
+ * public class MockConnectorTest {
+ *
+ *     @Inject
+ *     @TestConnector
+ *     private MockConnector mockConnector;
+ *
+ *     @Incoming("test-channel-incoming")
+ *     @Outgoing("test-channel-outgoing")
+ *     public long sampleProcessorMethod(long payload) {
+ *         return payload;
+ *     }
+ *
+ *     @Test
+ *     void sampleTestMethod() {
+ *         mockConnector.outgoing("test-channel-outgoing", Long.TYPE)
+ *                 .awaitMessage(TIMEOUT, longMessage -> longMessage.getPayload() == 12L)
+ *                 .assertPayloads(9L, 10L, 11L, 12L);
+ *     }
+ * }</pre>
+ */
+package io.helidon.messaging.connectors.mock;

--- a/messaging/connectors/mock/src/main/java/module-info.java
+++ b/messaging/connectors/mock/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Microprofile messaging MockConnector.
+ */
+module helidon.messaging.mock {
+    requires java.logging;
+    requires io.helidon.common.reactive;
+    requires microprofile.reactive.messaging.api;
+    requires microprofile.reactive.streams.operators.api;
+    requires org.reactivestreams;
+    requires hamcrest.all;
+    requires microprofile.config.api;
+    requires jakarta.cdi;
+    requires jakarta.inject;
+}

--- a/messaging/connectors/mock/src/main/resources/META-INF/bean.xml
+++ b/messaging/connectors/mock/src/main/resources/META-INF/bean.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020, 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/messaging/connectors/pom.xml
+++ b/messaging/connectors/pom.xml
@@ -35,5 +35,6 @@
         <module>jms</module>
         <module>aq</module>
         <module>jms-shim</module>
+        <module>mock</module>
     </modules>
 </project>

--- a/microprofile/messaging/core/pom.xml
+++ b/microprofile/messaging/core/pom.xml
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.messaging.mock</groupId>
+            <artifactId>helidon-messaging-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureResolver.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureResolver.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -50,6 +51,7 @@ final class MethodSignatureResolver {
     private final List<Supplier<Optional<MethodSignatureType>>> resolveRules = new ArrayList<>();
     private final Method method;
 
+    @SuppressWarnings("checkstyle:MethodLength")
     private MethodSignatureResolver(Method method) {
         this.method = method;
         returnType = method.getReturnType();
@@ -167,10 +169,18 @@ final class MethodSignatureResolver {
         addRule(MethodSignatureType.OUTGOING_PUBLISHER_MSG_2_VOID,
                 () -> hasNoParams()
                         && returnsClassWithGenericParams(Publisher.class, MsgType.MESSAGE));
+        // Flow.Publisher<Message<U>> method()
+        addRule(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_MSG_2_VOID,
+                () -> hasNoParams()
+                        && returnsClassWithGenericParams(Flow.Publisher.class, MsgType.MESSAGE));
         // Publisher<U> method()
         addRule(MethodSignatureType.OUTGOING_PUBLISHER_PAYL_2_VOID,
                 () -> hasNoParams()
                         && returnsClassWithGenericParams(Publisher.class, MsgType.PAYLOAD));
+        // Flow.Publisher<U> method()
+        addRule(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_PAYL_2_VOID,
+                () -> hasNoParams()
+                        && returnsClassWithGenericParams(Flow.Publisher.class, MsgType.PAYLOAD));
         // PublisherBuilder<Message<U>> method()
         addRule(MethodSignatureType.OUTGOING_PUBLISHER_BUILDER_MSG_2_VOID,
                 () -> hasNoParams()

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureType.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureType.java
@@ -385,9 +385,24 @@ enum MethodSignatureType {
      * Publisher method signature type.
      * <br>
      * Invoke at: assembly time
+     * <pre>Publisher&lt;Message&lt;U&gt;&gt; method()</pre>
+     */
+    OUTGOING_FLOW_PUBLISHER_MSG_2_VOID(true, null),
+
+    /**
+     * Publisher method signature type.
+     * <br>
+     * Invoke at: assembly time
      * <pre>Publisher&lt;U&gt; method()</pre>
      */
     OUTGOING_PUBLISHER_PAYL_2_VOID(true, null),
+    /**
+     * Publisher method signature type.
+     * <br>
+     * Invoke at: assembly time
+     * <pre>Publisher&lt;U&gt; method()</pre>
+     */
+    OUTGOING_FLOW_PUBLISHER_PAYL_2_VOID(true, null),
 
     /**
      * Publisher method signature type.

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/OutgoingMethod.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/OutgoingMethod.java
@@ -18,6 +18,7 @@ package io.helidon.microprofile.messaging;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 
 import io.helidon.common.Errors;
 import io.helidon.config.Config;
@@ -28,6 +29,7 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.FlowAdapters;
 import org.reactivestreams.Publisher;
 
 
@@ -49,8 +51,14 @@ class OutgoingMethod extends AbstractMessagingMethod implements OutgoingMember {
                     case OUTGOING_PUBLISHER_MSG_2_VOID:
                         publisher = (Publisher<?>) getMethod().invoke(getBeanInstance());
                         break;
+                    case OUTGOING_FLOW_PUBLISHER_MSG_2_VOID:
+                        publisher = FlowAdapters.toPublisher((Flow.Publisher<?>) getMethod().invoke(getBeanInstance()));
+                        break;
                     case OUTGOING_PUBLISHER_PAYL_2_VOID:
                         publisher = new WrappingPublisher((Publisher<?>) getMethod().invoke(getBeanInstance()));
+                        break;
+                    case OUTGOING_FLOW_PUBLISHER_PAYL_2_VOID:
+                        publisher = new WrappingPublisher((Flow.Publisher<?>) getMethod().invoke(getBeanInstance()));
                         break;
                     case OUTGOING_PUBLISHER_BUILDER_MSG_2_VOID:
                         publisher = ((PublisherBuilder<?>) getMethod().invoke(getBeanInstance()))

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/WrappingPublisher.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/WrappingPublisher.java
@@ -16,7 +16,10 @@
 
 package io.helidon.microprofile.messaging;
 
+import java.util.concurrent.Flow;
+
 import org.eclipse.microprofile.reactive.messaging.Message;
+import org.reactivestreams.FlowAdapters;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -27,6 +30,10 @@ class WrappingPublisher implements Publisher<Object> {
 
     WrappingPublisher(Publisher<?> source) {
         this.source = source;
+    }
+
+    WrappingPublisher(Flow.Publisher<?> source) {
+        this.source = FlowAdapters.toPublisher(source);
     }
 
     @Override

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
@@ -27,8 +27,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.helidon.common.reactive.Multi;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -129,6 +132,42 @@ class MethodSignatureResolverTest {
     @Outgoing("out-channel-name")
     @ExpectedSignatureType(MethodSignatureType.OUTGOING_PUBLISHER_MSG_2_VOID)
     Publisher<ExtendedMessage<String>> outgoing_publisher_msg_2_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_MSG_2_VOID)
+    Multi<Message<String>> outgoing_multi_msg_1_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_PAYL_2_VOID)
+    Multi<String> outgoing_multi_payload_1_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_PAYL_2_VOID)
+    Flow.Publisher<String> outgoing_multi_payload_2_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_MSG_2_VOID)
+    Multi<ExtendedMessage<String>> outgoing_multi_msg_2_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_MSG_2_VOID)
+    Flow.Publisher<Message<String>> outgoing_flow_msg_1_void1() {
+        return null;
+    }
+
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.OUTGOING_FLOW_PUBLISHER_MSG_2_VOID)
+    Flow.Publisher<ExtendedMessage<String>> outgoing_flow_msg_2_void1() {
         return null;
     }
 

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MockConnectorTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MockConnectorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.microprofile.messaging;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.helidon.common.reactive.Multi;
+import io.helidon.messaging.connectors.mock.MockConnector;
+import io.helidon.messaging.connectors.mock.TestConnector;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.messaging.connectors.mock.MockConnector.CONNECTOR_NAME;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.INCOMING_PREFIX;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.OUTGOING_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import jakarta.inject.Inject;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(MockConnector.class)
+@AddExtension(MessagingCdiExtension.class)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-1.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-1.mock-data", value = "a,b,c,d")
+@AddConfig(key = INCOMING_PREFIX + "test-channel-3.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-2.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-4.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-5.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-5.mock-data-type", value = "java.lang.Long")
+@AddConfig(key = INCOMING_PREFIX + "test-channel-5.mock-data", value = "9,10,11,12")
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-6.connector", value = CONNECTOR_NAME)
+public class MockConnectorTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private final List<Long> consumeTest3Result = new ArrayList<>();
+
+    @Inject
+    @TestConnector
+    private MockConnector mockConnector;
+
+    @Incoming("test-channel-1")
+    @Outgoing("test-channel-2")
+    public String receive(String msg) {
+        return msg.toUpperCase();
+    }
+
+    @Incoming("test-channel-3")
+    public void consumeTest3Method(long payload) {
+        consumeTest3Result.add(payload);
+    }
+
+    @Outgoing("test-channel-4")
+    public Multi<Message<Long>> produceTest4Method() {
+        return Multi.just(1L, 2L, 3L, 4L).map(Message::of);
+    }
+
+    @Incoming("test-channel-5")
+    @Outgoing("test-channel-6")
+    public long consumeTest5Method(long payload) {
+        return payload;
+    }
+
+    @Test
+    void processorTest12() {
+        mockConnector.outgoing("test-channel-2", String.class)
+                .awaitPayloads(TIMEOUT, "A", "B", "C", "D");
+        mockConnector.incoming("test-channel-1", String.class)
+                .emit("e");
+        mockConnector.outgoing("test-channel-2", String.class)
+                .awaitPayloads(TIMEOUT, "A", "B", "C", "D", "E");
+    }
+
+    @Test
+    void consumeTest3() {
+        mockConnector.incoming("test-channel-3", Long.class)
+                .emit(1L, 2L, 3L)
+                .complete();
+        assertThat(consumeTest3Result, contains(1L, 2L, 3L));
+    }
+
+    @Test
+    void produceTest4() {
+        mockConnector.outgoing("test-channel-4", Long.class)
+                .awaitData(TIMEOUT, Message::getPayload, 1L, 2L, 3L, 4L)
+                .assertPayloads(Matchers.containsInAnyOrder(4L, 1L, 2L, 3L))
+                .assertPayloads(1L, 2L, 3L, 4L);
+    }
+
+    @Test
+    void processTest6() {
+        mockConnector.outgoing("test-channel-6", Long.TYPE)
+                .awaitMessage(TIMEOUT, longMessage -> longMessage.getPayload() == 12L)
+                .assertPayloads(9L, 10L, 11L, 12L);
+    }
+}
+

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MultiSupportTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MultiSupportTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.microprofile.messaging;
+
+import java.time.Duration;
+import java.util.concurrent.Flow;
+
+import io.helidon.common.reactive.Multi;
+import io.helidon.messaging.connectors.mock.MockConnector;
+import io.helidon.messaging.connectors.mock.TestConnector;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.messaging.connectors.mock.MockConnector.CONNECTOR_NAME;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.OUTGOING_PREFIX;
+
+import jakarta.inject.Inject;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(MockConnector.class)
+@AddExtension(MessagingCdiExtension.class)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-1.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-2.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-3.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-4.connector", value = CONNECTOR_NAME)
+public class MultiSupportTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+
+    @Inject
+    @TestConnector
+    private MockConnector mockConnector;
+
+    @Outgoing("test-channel-1")
+    Multi<String> multiWithPayload() {
+        return Multi.just("a", "b", "c");
+    }
+
+    @Outgoing("test-channel-2")
+    Flow.Publisher<String> flowPubWithPayload() {
+        return Multi.just("e", "f", "g");
+    }
+
+    @Outgoing("test-channel-3")
+    Flow.Publisher<Message<Integer>> flowPubWithMsg() {
+        return Multi.range(0, 3).map(Message::of);
+    }
+
+    @Outgoing("test-channel-4")
+    Multi<Message<Integer>> multiWithMsg() {
+        return Multi.range(3, 3).map(Message::of);
+    }
+
+    @Test
+    void multiWithPayloadTest() {
+        mockConnector.outgoing("test-channel-1", String.class)
+                .awaitData(TIMEOUT, Message::getPayload, "a", "b", "c");
+    }
+
+    @Test
+    void flowPubWithPayloadTest() {
+        mockConnector.outgoing("test-channel-2", String.class)
+                .awaitData(TIMEOUT, Message::getPayload, "e", "f", "g");
+    }
+
+    @Test
+    void flowPubWithMsgTest() {
+        mockConnector.outgoing("test-channel-3", Integer.class)
+                .awaitData(TIMEOUT, Message::getPayload, 0, 1, 2);
+    }
+
+    @Test
+    void multiWithMsgTest() {
+        mockConnector.outgoing("test-channel-4", Integer.class)
+                .awaitData(TIMEOUT, Message::getPayload, 3, 4, 5);
+    }
+}


### PR DESCRIPTION
Fixes #1855

**Features:**
- Switch from/to production connectors only by config
- Injectable bean with methods to emit to or receive from specific channel

Example:
```java
@HelidonTest
@DisableDiscovery
@AddBean(MockConnector.class)
@AddExtension(MessagingCdiExtension.class)
//Use mock connector as an upstream for channel test-channel-incoming
@AddConfig(key = "mp.messaging.incoming.test-channel-incoming", value = MockConnector.CONNECTOR_NAME)
//mock-data-type is optional, defaults to String.class
@AddConfig(key = "mp.messaging.incoming.test-channel-incoming.mock-data-type", value = "java.lang.Long")
//mock-data is optional, can generate data to the connected channel right after start
@AddConfig(key = "mp.messaging.incoming.test-channel-incoming.mock-data", value = "9,10,11,12")
//Use mock connector as a downstream for channel test-channel-outgoing
@AddConfig(key = "mp.messaging.outoging.test-channel-outgoing.connector", value = MockConnector.CONNECTOR_NAME)
public class MockConnectorTest {

    @Inject
    @TestConnector
    private MockConnector mockConnector;

    @Incoming("test-channel-incoming")
    @Outgoing("test-channel-outgoing")
    public long sampleProcessorMethod(long payload) {
        return payload;
    }

    @Test
    void sampleTestMethod() {
        mockConnector.outgoing("test-channel-outgoing", Long.TYPE)
                .awaitMessage(TIMEOUT, longMessage -> longMessage.getPayload() == 12L)
                .assertPayloads(9L, 10L, 11L, 12L);
    }
```