### PR TITLE
Multi support in Reactive Messaging 3.0

### DIFF
--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/Literals.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/Literals.java
@@ -18,6 +18,7 @@
 package io.helidon.microprofile.messaging;
 
 import java.io.Serial;
+import java.util.concurrent.Flow;
 
 import io.helidon.common.reactive.Multi;
 
@@ -36,10 +37,13 @@ class Literals {
     private Literals(){
     }
 
+    static <T> TypeLiteral<Flow.Publisher<T>> flowPublisherType() {
+        return new TypeLiteral<>() {
+        };
+    }
+
     static <T> TypeLiteral<Multi<T>> multiType() {
         return new TypeLiteral<>() {
-            @Serial
-            private static final long serialVersionUID = -3906621393273806089L;
         };
     }
 

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MessagingCdiExtension.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MessagingCdiExtension.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 
 import io.helidon.common.reactive.Multi;
@@ -179,7 +180,7 @@ public class MessagingCdiExtension implements Extension {
         });
     }
 
-    <T extends Multi<?>> void multiInjectionPoints(@Observes ProcessInjectionPoint<?, T> pip) {
+    <T extends Flow.Publisher<?>> void multiInjectionPoints(@Observes ProcessInjectionPoint<?, T> pip) {
         String channelName = configureInternalChannel(pip);
         String fieldName = pip.getInjectionPoint().getMember().getName();
         // No @Channel annotation
@@ -192,6 +193,7 @@ public class MessagingCdiExtension implements Extension {
                     new IncomingPublisher(channelName, fieldName, MessageUtils.hasGenericMessageType(type));
             channelRouter.registerPublisher(injectedPublisher);
             abd.addBean()
+                    .addType(Literals.flowPublisherType())
                     .addType(Literals.multiType())
                     .beanClass(Multi.class)
                     .addQualifiers(Literals.channel(channelName), Literals.internalChannel(channelName))

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureResolver.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureResolver.java
@@ -144,9 +144,17 @@ final class MethodSignatureResolver {
         addRule(MethodSignatureType.PROCESSOR_PUBLISHER_MSG_2_MSG,
                 () -> returnsClassWithGenericParams(Publisher.class, MsgType.MESSAGE)
                         && hasFirstParam(MsgType.MESSAGE));
+        // Flow.Publisher<Message<O>> method(Message<I>msg);
+        addRule(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_MSG_2_MSG,
+                () -> returnsClassWithGenericParams(Flow.Publisher.class, MsgType.MESSAGE)
+                        && hasFirstParam(MsgType.MESSAGE));
         // Publisher<O> method(I payload);
         addRule(MethodSignatureType.PROCESSOR_PUBLISHER_PAYL_2_PAYL,
                 () -> returnsClassWithGenericParams(Publisher.class, MsgType.PAYLOAD)
+                        && hasFirstParam(MsgType.PAYLOAD));
+        // Flow.Publisher<O> method(I payload);
+        addRule(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_PAYL_2_PAYL,
+                () -> returnsClassWithGenericParams(Flow.Publisher.class, MsgType.PAYLOAD)
                         && hasFirstParam(MsgType.PAYLOAD));
         // Message<O> method(Message<I> msg)
         addRule(MethodSignatureType.PROCESSOR_MSG_2_MSG,

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureType.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/MethodSignatureType.java
@@ -163,6 +163,21 @@ enum MethodSignatureType {
      * Processor method signature type.
      * <br>
      * Invoke at: every incoming
+     * <pre>Flow.Publisher&lt;Message&lt;O&gt;&gt; method(Message&lt;I&gt; msg);</pre>
+     * <ul>
+     *  <li>Default acknowledgment strategy: MANUAL</li>
+     *  <li>Supported acknowledgment strategies: NONE, MANUAL, PRE_PROCESSING</li>
+     * </ul>
+     */
+    PROCESSOR_FLOW_PUBLISHER_MSG_2_MSG(false, Acknowledgment.Strategy.MANUAL,
+            Acknowledgment.Strategy.NONE,
+            Acknowledgment.Strategy.MANUAL,
+            Acknowledgment.Strategy.PRE_PROCESSING
+    ),
+    /**
+     * Processor method signature type.
+     * <br>
+     * Invoke at: every incoming
      * <pre>Publisher&lt;O&gt; method(I payload);</pre>
      * <ul>
      *  <li>Default acknowledgment strategy: PRE_PROCESSING</li>
@@ -170,6 +185,20 @@ enum MethodSignatureType {
      * </ul>
      */
     PROCESSOR_PUBLISHER_PAYL_2_PAYL(false, Acknowledgment.Strategy.PRE_PROCESSING,
+            Acknowledgment.Strategy.NONE,
+            Acknowledgment.Strategy.PRE_PROCESSING
+    ),
+    /**
+     * Processor method signature type.
+     * <br>
+     * Invoke at: every incoming
+     * <pre>Flow.Publisher&lt;O&gt; method(I payload);</pre>
+     * <ul>
+     *  <li>Default acknowledgment strategy: PRE_PROCESSING</li>
+     *  <li>Supported acknowledgment strategies: NONE, PRE_PROCESSING</li>
+     * </ul>
+     */
+    PROCESSOR_FLOW_PUBLISHER_PAYL_2_PAYL(false, Acknowledgment.Strategy.PRE_PROCESSING,
             Acknowledgment.Strategy.NONE,
             Acknowledgment.Strategy.PRE_PROCESSING
     ),

--- a/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/ProcessorMethod.java
+++ b/microprofile/messaging/core/src/main/java/io/helidon/microprofile/messaging/ProcessorMethod.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.FlowAdapters;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -64,10 +65,21 @@ class ProcessorMethod extends AbstractMessagingMethod implements OutgoingMember,
         } else {
             switch (getType()) {
                 case PROCESSOR_PUBLISHER_MSG_2_MSG:
-                    processor = invokeProcessor(msg -> ReactiveStreams.fromPublisher(invoke(msg)));
+                    processor = invokeProcessor(msg ->
+                            ReactiveStreams.fromPublisher(invoke(msg)));
+                    break;
+                case PROCESSOR_FLOW_PUBLISHER_MSG_2_MSG:
+                    processor = invokeProcessor(msg ->
+                            ReactiveStreams.fromPublisher(FlowAdapters.toPublisher(invoke(msg))));
                     break;
                 case PROCESSOR_PUBLISHER_PAYL_2_PAYL:
-                    processor = invokeProcessor(msg -> ReactiveStreams.fromPublisher(invoke(msg.getPayload())));
+                    processor = invokeProcessor(msg ->
+                            ReactiveStreams.fromPublisher(invoke(msg.getPayload())));
+                    break;
+                case PROCESSOR_FLOW_PUBLISHER_PAYL_2_PAYL:
+                    processor = invokeProcessor(msg -> {
+                        return ReactiveStreams.fromPublisher(FlowAdapters.toPublisher(invoke(msg.getPayload())));
+                    });
                     break;
                 case PROCESSOR_PUBLISHER_BUILDER_MSG_2_MSG:
                     processor = invokeProcessor(this::invoke);

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/FlowSupportTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/FlowSupportTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.helidon.microprofile.messaging;
+
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Flow;
+
+import io.helidon.common.reactive.Multi;
+import io.helidon.messaging.connectors.mock.MockConnector;
+import io.helidon.microprofile.tests.junit5.AddBean;
+import io.helidon.microprofile.tests.junit5.AddConfig;
+import io.helidon.microprofile.tests.junit5.AddExtension;
+import io.helidon.microprofile.tests.junit5.DisableDiscovery;
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.messaging.connectors.mock.MockConnector.CONNECTOR_NAME;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.INCOMING_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+@HelidonTest
+@DisableDiscovery
+@AddBean(MockConnector.class)
+@AddExtension(MessagingCdiExtension.class)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-1.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-1.mock-data-type", value = "java.lang.Integer")
+@AddConfig(key = INCOMING_PREFIX + "test-channel-1.mock-data", value = "1,2,3")
+public class FlowSupportTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+
+    @Inject
+    @Channel("test-channel-1")
+    private Flow.Publisher<Integer> flowChannel1;
+
+
+    @Test
+    void injectedFlowPub() {
+        List<Integer> actual = Multi.create(flowChannel1)
+                .limit(3)
+                .collectList()
+                .await(TIMEOUT);
+
+        assertThat(actual, contains(1,2,3));
+    }
+}

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/FlowSupportTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/FlowSupportTest.java
@@ -17,14 +17,13 @@
 
 package io.helidon.microprofile.messaging;
 
-import jakarta.inject.Inject;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Flow;
 
 import io.helidon.common.reactive.Multi;
 import io.helidon.messaging.connectors.mock.MockConnector;
+import io.helidon.messaging.connectors.mock.TestConnector;
 import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.AddConfig;
 import io.helidon.microprofile.tests.junit5.AddExtension;
@@ -32,12 +31,18 @@ import io.helidon.microprofile.tests.junit5.DisableDiscovery;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
 import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.junit.jupiter.api.Test;
 
 import static io.helidon.messaging.connectors.mock.MockConnector.CONNECTOR_NAME;
 import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.INCOMING_PREFIX;
+import static org.eclipse.microprofile.reactive.messaging.spi.ConnectorFactory.OUTGOING_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+
+import jakarta.inject.Inject;
 
 @HelidonTest
 @DisableDiscovery
@@ -46,14 +51,48 @@ import static org.hamcrest.Matchers.contains;
 @AddConfig(key = INCOMING_PREFIX + "test-channel-1.connector", value = CONNECTOR_NAME)
 @AddConfig(key = INCOMING_PREFIX + "test-channel-1.mock-data-type", value = "java.lang.Integer")
 @AddConfig(key = INCOMING_PREFIX + "test-channel-1.mock-data", value = "1,2,3")
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-2.connector", value = CONNECTOR_NAME)
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-3.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-4-in.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-4-in.mock-data", value = "a,b,c")
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-4-out.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-5-in.connector", value = CONNECTOR_NAME)
+@AddConfig(key = INCOMING_PREFIX + "test-channel-5-in.mock-data", value = "a,b,c")
+@AddConfig(key = OUTGOING_PREFIX + "test-channel-5-out.connector", value = CONNECTOR_NAME)
 public class FlowSupportTest {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(15);
 
     @Inject
+    @TestConnector
+    private MockConnector mockConnector;
+
+    @Inject
     @Channel("test-channel-1")
     private Flow.Publisher<Integer> flowChannel1;
 
+    @Outgoing("test-channel-2")
+    Flow.Publisher<String> flowPubWithPayload() {
+        return Multi.just("e", "f", "g");
+    }
+
+    @Outgoing("test-channel-3")
+    Flow.Publisher<Message<Integer>> flowPubWithMsg() {
+        return Multi.range(0, 3).map(Message::of);
+    }
+
+    @Incoming("test-channel-4-in")
+    @Outgoing("test-channel-4-out")
+    Flow.Publisher<Message<String>> flowPubProcFlatMapMsg(Message<String> msg) {
+        String payload = msg.getPayload();
+        return Multi.just(payload, payload.toUpperCase()).map(Message::of);
+    }
+
+    @Incoming("test-channel-5-in")
+    @Outgoing("test-channel-5-out")
+    Flow.Publisher<String> flowPubProcFlatMapPay(String payload) {
+        return Multi.just(payload, payload.toUpperCase());
+    }
 
     @Test
     void injectedFlowPub() {
@@ -62,6 +101,30 @@ public class FlowSupportTest {
                 .collectList()
                 .await(TIMEOUT);
 
-        assertThat(actual, contains(1,2,3));
+        assertThat(actual, contains(1, 2, 3));
+    }
+
+    @Test
+    void flowPubWithPayloadTest() {
+        mockConnector.outgoing("test-channel-2", String.class)
+                .awaitData(TIMEOUT, Message::getPayload, "e", "f", "g");
+    }
+
+    @Test
+    void flowPubWithMsgTest() {
+        mockConnector.outgoing("test-channel-3", Integer.class)
+                .awaitData(TIMEOUT, Message::getPayload, 0, 1, 2);
+    }
+
+    @Test
+    void flowPubProcFlatMapMsgTest() {
+        mockConnector.outgoing("test-channel-4-out", String.class)
+                .awaitData(TIMEOUT, Message::getPayload, "a", "A", "b", "B", "c", "C");
+    }
+
+    @Test
+    void flowPubProcFlatMapPayTest() {
+        mockConnector.outgoing("test-channel-5-out", String.class)
+                .awaitData(TIMEOUT, Message::getPayload, "a", "A", "b", "B", "c", "C");
     }
 }

--- a/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
+++ b/microprofile/messaging/core/src/test/java/io/helidon/microprofile/messaging/MethodSignatureResolverTest.java
@@ -397,6 +397,20 @@ class MethodSignatureResolverTest {
 
     @Incoming("in-channel-name")
     @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_MSG_2_MSG)
+    Flow.Publisher<Message<String>> processor_flow_publisher_msg_2_msgxxx(Message<String> msg) {
+        return null;
+    }
+
+    @Incoming("in-channel-name")
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_MSG_2_MSG)
+    Multi<Message<String>> processor_multi_publisher_msg_2_msgxxx(Message<String> msg) {
+        return null;
+    }
+
+    @Incoming("in-channel-name")
+    @Outgoing("out-channel-name")
     @ExpectedSignatureType(MethodSignatureType.PROCESSOR_PUBLISHER_MSG_2_MSG)
     Publisher<ExtendedMessage<String>> processor_publisher_msg_2_msg(ExtendedMessage<String> msg) {
         return null;
@@ -420,6 +434,22 @@ class MethodSignatureResolverTest {
     @Outgoing("out-channel-name")
     @ExpectedSignatureType(MethodSignatureType.PROCESSOR_PUBLISHER_PAYL_2_PAYL)
     Publisher<String> processor_publisher_payl_2_payl(String payload) {
+        return null;
+    }
+
+
+    @Incoming("in-channel-name")
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_PAYL_2_PAYL)
+    Flow.Publisher<String> processor_flow_publisher_payl_2_payl(String payload) {
+        return null;
+    }
+
+
+    @Incoming("in-channel-name")
+    @Outgoing("out-channel-name")
+    @ExpectedSignatureType(MethodSignatureType.PROCESSOR_FLOW_PUBLISHER_PAYL_2_PAYL)
+    Multi<String> processor_multi_publisher_payl_2_payl(String payload) {
         return null;
     }
 


### PR DESCRIPTION
Support for Multi/Flow.Publisher in following signatures:
```java
    @Inject
    @Channel("test-channel-5")
    private Multi<Integer> multiChannel5;

    @Outgoing("test-channel-4")
    Multi<Message<Integer>> multiWithMsg() {
        return Multi.range(3, 3).map(Message::of);
    }

    @Incoming("test-channel-7-in")
    @Outgoing("test-channel-7-out")
    Multi<Message<String>> multiPubProcFlatMapMsg(Message<String> msg) {
        String payload = msg.getPayload();
        return Multi.just(payload, payload.toUpperCase()).map(Message::of);
    }
```

Signed-off-by: Daniel Kec <daniel.kec@oracle.com>