### PR TITLE
Revert back to using javax.validation as jakarta.validation is not supported by micronaut

### DIFF
--- a/config/etcd/src/main/java/module-info.java
+++ b/config/etcd/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,6 @@ module io.helidon.config.etcd {
     requires io.helidon.common;
     requires io.helidon.common.media.type;
     requires io.grpc;
-    // TODO 3.0.0-JAKARTA
-    // used only for compilation of generated classes
     requires static java.annotation;
 
     exports io.helidon.config.etcd;

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -104,9 +104,9 @@
         <version.lib.mariadb-java-client>2.6.2</version.lib.mariadb-java-client>
         <version.lib.maven-wagon>2.10</version.lib.maven-wagon>
         <version.lib.micrometer>1.6.6</version.lib.micrometer>
-        <version.lib.micronaut>3.1.3</version.lib.micronaut>
-        <version.lib.micronaut.data>3.1.2</version.lib.micronaut.data>
-        <version.lib.micronaut.sql>4.0.4</version.lib.micronaut.sql>
+        <version.lib.micronaut>3.4.3</version.lib.micronaut>
+        <version.lib.micronaut.data>3.3.0</version.lib.micronaut.data>
+        <version.lib.micronaut.sql>4.4.0</version.lib.micronaut.sql>
         <version.lib.microprofile-config>3.0.1</version.lib.microprofile-config>
         <version.lib.microprofile-fault-tolerance-api>4.0</version.lib.microprofile-fault-tolerance-api>
         <version.lib.microprofile-graphql>2.0</version.lib.microprofile-graphql>

--- a/integrations/micronaut/data/pom.xml
+++ b/integrations/micronaut/data/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -67,13 +68,6 @@
             <groupId>io.micronaut.data</groupId>
             <artifactId>micronaut-data-model</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <!-- 3.0.0-JAKARTA -->
-                    <groupId>io.micronaut</groupId>
-                    <artifactId>micronaut-validation</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.cdi</groupId>
@@ -155,12 +149,11 @@
                                     <artifactId>micronaut-inject-java</artifactId>
                                     <version>${version.lib.micronaut}</version>
                                 </path>
-                                <!-- 3.0.0-JAKARTA -->
-<!--                                <path>-->
-<!--                                    <groupId>io.micronaut</groupId>-->
-<!--                                    <artifactId>micronaut-validation</artifactId>-->
-<!--                                    <version>${version.lib.micronaut}</version>-->
-<!--                                </path>-->
+                                <path>
+                                    <groupId>io.micronaut</groupId>
+                                    <artifactId>micronaut-validation</artifactId>
+                                    <version>${version.lib.micronaut}</version>
+                                </path>
                                 <path>
                                     <groupId>io.micronaut.data</groupId>
                                     <artifactId>micronaut-data-processor</artifactId>

--- a/integrations/micronaut/data/src/test/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtensionTest.java
+++ b/integrations/micronaut/data/src/test/java/io/helidon/integrations/micronaut/cdi/data/MicronautDataCdiExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,12 @@ import io.helidon.microprofile.tests.junit5.AddBean;
 import io.helidon.microprofile.tests.junit5.Configuration;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 
+import javax.validation.ConstraintViolationException;
+import javax.validation.constraints.Pattern;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
-import jakarta.validation.ConstraintViolationException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -80,7 +82,6 @@ class MicronautDataCdiExtensionTest {
         assertThat(myBean.getOwner("Hoppy"), is("Barney"));
     }
 
-    @Disabled("3.0.0-JAKARTA")
     @Test
     void testBeanValidation() {
         assertThrows(ConstraintViolationException.class, () -> myBean.getOwner("wrong name"), "Name should not contain spaces");
@@ -108,9 +109,8 @@ class MicronautDataCdiExtensionTest {
         @Inject
         CdiOnly cdiOnly;
 
-        // TODO 3.0.0-JAKARTA - javax.validation used by Micronaut
         @Transactional
-        public String getOwner(/*@Pattern(regexp = "\\w+")*/ String pet) {
+        public String getOwner(@Pattern(regexp = "\\w+") String pet) {
             assertThat(connection, notNullValue());
             assertThat(cdiOnly.message(), is("Hello"));
             return petRepository.findByName(pet)


### PR DESCRIPTION
Note: Use jakarta.validation-api version 2.0.2 instead of version 3.0.0 to be able to use javax.validation instead of jakarta.validation.