### PR TITLE
Removed final from proxied types, these could no longer be proxied.

### DIFF
--- a/etc/scripts/test-packaging-native.sh
+++ b/etc/scripts/test-packaging-native.sh
@@ -54,8 +54,7 @@ mvn ${MAVEN_ARGS} -e clean install
 # Build native images
 # mp-2 is too big, waiting for more memory
 # Only SE is tested as part of the pipeline for now
-# readonly native_image_tests="se-1 mp-1 mp-3"
-readonly native_image_tests="se-1"
+readonly native_image_tests="se-1 mp-1 mp-3"
 for native_test in ${native_image_tests}; do
     cd ${WS_DIR}/tests/integration/native-image/${native_test}
     mvn ${MAVEN_ARGS} -e clean package -Pnative-image
@@ -63,5 +62,5 @@ done
 
 # Run this one because it has no pre-reqs and self-tests
 # Uses relative path to read configuration
-# cd ${WS_DIR}/tests/integration/native-image/mp-1
-# ${WS_DIR}/tests/integration/native-image/mp-1/target/helidon-tests-native-image-mp-1 || true
+cd ${WS_DIR}/tests/integration/native-image/mp-1
+${WS_DIR}/tests/integration/native-image/mp-1/target/helidon-tests-native-image-mp-1 || true

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DeadlockHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.eclipse.microprofile.health.Liveness;
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 @BuiltInHealthCheck
-public final class DeadlockHealthCheck implements HealthCheck {
+public class DeadlockHealthCheck implements HealthCheck {
     private static final Logger LOGGER = Logger.getLogger(DeadlockHealthCheck.class.getName());
     private static final String NAME = "deadlock";
 

--- a/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/DiskSpaceHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ import org.eclipse.microprofile.health.Liveness;
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 @BuiltInHealthCheck
-public final class DiskSpaceHealthCheck implements HealthCheck {
+public class DiskSpaceHealthCheck implements HealthCheck {
     /**
      * Default path on the file system the health check will be executed for.
      * If you need to check a different path (e.g. application runtime disks are not mounted the same

--- a/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
+++ b/health/health-checks/src/main/java/io/helidon/health/checks/HeapMemoryHealthCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import org.eclipse.microprofile.health.Liveness;
 @Liveness
 @ApplicationScoped // this will be ignored if not within CDI
 @BuiltInHealthCheck
-public final class HeapMemoryHealthCheck implements HealthCheck {
+public class HeapMemoryHealthCheck implements HealthCheck {
     /**
      * Default threshold percentage.
      */

--- a/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/ProxyBean.java
+++ b/integrations/graal/mp-native-image-extension/src/main/java/io/helidon/integrations/graal/mp/nativeimage/extension/ProxyBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import jakarta.enterprise.inject.spi.InjectionPoint;
 final class ProxyBean implements Bean<Object> {
     // this is the bean class (producer class, or the type itself for managed beans)
     private final Class<?> beanClass;
-    // the types of the produced bean (or
+    // the types of the produced bean
     private final Set<Type> types;
 
     ProxyBean(Class<?> beanClass, Set<Type> types) {


### PR DESCRIPTION
Follow up for #4341 

Re-enabled MP native image packaging test

Removed final from types that are proxied (health checks), as Weld can no longer proxy them with Java 17.
