### PR TITLE
Load both bean definitions of the same type instead of choosing just one

### DIFF
--- a/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautBean.java
+++ b/integrations/micronaut/cdi/src/main/java/io/helidon/integrations/micronaut/cdi/MicronautBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ class MicronautBean {
 
     @Override
     public String toString() {
-        return beanType.getName();
+        // Add hashcode to return a unique name for cases where bean types are the same
+        return beanType.getName() + "@" + Integer.toHexString(this.hashCode());
     }
 }


### PR DESCRIPTION
Notes:
1. TestMicronautBean has 2 bean definitions and both needs to be loaded. This behaviour is the same as in v2.5.1.
2. Add hashcode on the return value of overridden MicronautBean.toString to make it unique.