### PR TITLE
Enhance/Improve gRPC docs containing the following changes:

### DIFF
--- a/docs/includes/grpc-marshalling.adoc
+++ b/docs/includes/grpc-marshalling.adoc
@@ -16,12 +16,11 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= Marshalling
+ifndef::rootdir[:rootdir: {docdir}/..]
 :description: Helidon gRPC Marshalling
 :keywords: helidon, grpc, java, marshalling
-:rootdir: {docdir}/../..
 
-include::{rootdir}/includes/se.adoc[]
+= Marshalling
 
 == Default Marshalling Support
 
@@ -31,8 +30,11 @@ That means that you don't need any special handling or configuration in order to
 
 == Custom Marshalling
 
-Helidon makes the use of custom marshallers trivial, and provides one custom implementation, `JsonbMarshaller`, out of the box.
+Helidon makes the use of custom marshallers trivial and provides one custom implementation, link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[`JsonbMarshaller`], out of the box.
 
-You can also easily implement your own marshallers to support serialization formats that are not supported natively by Helidon, by implementing `Marshaller` and `MarshallerSupplier` interfaces.
+You can also easily implement your own marshaller to support serialization formats that are not supported natively
+by Helidon, by implementing `Marshaller` and `MarshallerSupplier` interfaces. Check out the mentioned built-in marshaller,
+link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JsonbMarshaller.java],
+as an implementation example.
 
-For example, https://coherence.community/[Oracle Coherence CE] provides a marshaller for a highly optimized, binary, platform independent Portable Object Format (POF). You can find more information about POF in https://coherence.community/20.12/docs/#/docs/core/04_portable_types[Coherence documentation]
+Furthermore, https://coherence.community/[Oracle Coherence CE] provides a marshaller for a highly optimized, binary, platform independent Portable Object Format (POF). You can find more information about POF in https://coherence.community/20.12/docs/#/docs/core/04_portable_types[Coherence documentation]

--- a/docs/includes/grpc-marshalling.adoc
+++ b/docs/includes/grpc-marshalling.adoc
@@ -30,11 +30,78 @@ That means that you don't need any special handling or configuration in order to
 
 == Custom Marshalling
 
-Helidon makes the use of custom marshallers trivial and provides one custom implementation, link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[`JsonbMarshaller`], out of the box.
+Helidon makes the use of custom marshallers trivial and provides one custom implementation, link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JSON-B Marshaller], out of the box.
 
 You can also easily implement your own marshaller to support serialization formats that are not supported natively
-by Helidon, by implementing `Marshaller` and `MarshallerSupplier` interfaces. Check out the mentioned built-in marshaller,
-link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JsonbMarshaller.java],
-as an implementation example.
+by Helidon, by implementing `Marshaller` and `MarshallerSupplier` interfaces. As an example, check out
+the source code of the built-in marshaller:
+link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JsonbMarshaller.java].
 
 Furthermore, https://coherence.community/[Oracle Coherence CE] provides a marshaller for a highly optimized, binary, platform independent Portable Object Format (POF). You can find more information about POF in https://coherence.community/20.12/docs/#/docs/core/04_portable_types[Coherence documentation]
+
+=== Setting the custom marshaller
+ifeval::["{flavor-lc}" == "mp"]
+
+You can annotate your service's class or interface with @GrpcMarshaller:
+
+.Sample code with `@GrpcMarshaller` annotation
+[source,java]
+----
+@Grpc
+@ApplicationScoped
+@GrpcMarshaller("jsonb")  //<1>
+public class AsyncStringService {
+    // code is omitted
+}
+----
+<1> Set the named marshaller supplier via the @GrpcMarshaller annotation.
+
+endif::[]
+
+ifeval::["{flavor-lc}" == "se"]
+
+ifeval::["{feature-name}" == "gRPC Server"]
+You can implement the `update` method on your service's class and set the custom marshaller supplier via the
+`ServiceDescriptor.Rules.marshallerSupplier()` method:
+
+.Sample code for setting the marshaller on the gRPC service
+[source,java]
+----
+public class GreetServiceJava
+        implements GrpcService {
+    private String greeting;
+
+
+    public GreetServiceJava(Config config) {
+        this.greeting = config.get("app.greeting").asString().orElse("Ciao");
+    }
+
+    @Override
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.marshallerSupplier(new JsonbMarshaller.Supplier())  // <1>
+                .unary("Greet", this::greet)
+                .unary("SetGreeting", this::setGreeting);
+    }
+
+    // Implement Service methods
+}
+----
+<1> Specify the custom marshaller to use.
+endif::[]
+
+ifeval::["{feature-name}" == "gRPC Client"]
+You can set the custom marshaller supplier via the `ClientServiceDescriptor.builder.marshallerSupplier()` method:
+
+.Sample code for setting the marshaller on the ClientServiceDescriptor
+[source,java]
+----
+ClientServiceDescriptor descriptor = ClientServiceDescriptor
+        .builder(HelloService.class)
+        .marshallerSupplier(new JsonbMarshaller.Supplier())  // <1>
+        .clientStreaming("JoinString")
+        .build();
+----
+<1> Specify the custom marshaller to use.
+endif::[]
+
+endif::[]

--- a/docs/includes/grpc-marshalling.adoc
+++ b/docs/includes/grpc-marshalling.adoc
@@ -24,13 +24,13 @@ ifndef::rootdir[:rootdir: {docdir}/..]
 
 == Default Marshalling Support
 
-Helidon gRPC supports Protobuf out of the box. Protobuf marshaller will be used by default for any request and response classes that extend `com.google.protobuf.MessageLite` class, which is the case for all classes generated from a `proto` file using `protoc` compiler.
+Helidon gRPC supports Protobuf out of the box. The Protobuf marshaller will be used by default for any request and response classes that extend `com.google.protobuf.MessageLite`, which is the case for all classes generated from a `proto` file using `protoc` compiler.
 
 That means that you don't need any special handling or configuration in order to support Protobuf serialization of requests and responses.
 
 == Custom Marshalling
 
-Helidon makes the use of custom marshallers trivial and provides one custom implementation, link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JSON-B Marshaller], out of the box.
+Helidon makes the use of custom marshallers trivial and provides one custom implementation, link:{helidon-github-tree-url}/grpc/core/src/main/java/io/helidon/grpc/core/JsonbMarshaller.java[JsonbMarshaller], out of the box.
 
 You can also easily implement your own marshaller to support serialization formats that are not supported natively
 by Helidon, by implementing `Marshaller` and `MarshallerSupplier` interfaces. As an example, check out

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -35,8 +35,8 @@ include::{rootdir}/includes/mp.adoc[]
 - <<Examples, Examples>>
 
 == Overview
-Building Java gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boiler plate code typically
-associated to more traditional approaches of writing gRPC Java clients. At its simplest, a gRPC Java client can be written using
+Building java-based gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boiler plate code typically
+associated to more traditional approaches of writing gRPC java clients. At its simplest, a gRPC java client can be written using
 nothing more than a suitably annotated interface.
 
 include::{rootdir}/includes/dependencies.adoc[]
@@ -51,7 +51,7 @@ include::{rootdir}/includes/dependencies.adoc[]
 
 == API
 
-The following annotations are used to work with Helidon MP gRPC Clients:
+The following annotations are used to work with Helidon MP gRPC clients:
 
 * `@GrpcChannel` - an annotation used to inject a gRPC channel.
 * `@InProcessGrpcChannel` -  an annotation used to tell the Helidon MP gRPC API to inject an in-process channel.
@@ -67,7 +67,7 @@ include::{rootdir}/config/io_helidon_grpc_client_GrpcChannelDescriptor.adoc[leve
 Channels are configured in the `grpc` section of the Helidon application configuration. The examples below use an `application.yaml`
 file but there are many other ways to use and override xref:../config/introduction.adoc[configuration in Helidon]
 
-.General form of gRPC Channels configuration
+.General form of a gRPC channels configuration
 [source,yaml]
 ----
 grpc:
@@ -76,12 +76,12 @@ grpc:
       host: localhost  # <3>
       port: 1408  # <4>
 ----
-<1> Channels are configured in the`channels` section
-<2> Each sub-section is the Channel name that is then used to refer to this Channel in the application code
-<3> Each channel contains a host name
-<4> and a port.
+<1> Channels are configured in the `channels` section.
+<2> Each subsection is the channel name that is then used to refer to this channel in the application code.
+<3> Each channel contains a host name.
+<4> It also contains a port.
 
-While most client application only connect to a single server it is possible to configure multiple named channels if the client
+While most client application only connect to a single server, it is possible to configure multiple named channels if the client
 needs to connect to multiple servers.
 
 .Multiple gRPC Channels configuration example
@@ -125,13 +125,13 @@ grpc:
 
 The SSL configuration uses the Helidon `Resource` class to locate configured keys and certificates.
 In the example above the `tls-cert-path` config key has the `-path` suffix which tells the configuration to load `/certs/foo.cert`
-as a file. If `/certs/foo.cert` was a resource on the classpath the configuration key could have been changed to
+as a file. If `/certs/foo.cert` was a resource on the classpath, the configuration key could have been changed to
 `tls-cert-resource-path` to load `/certs/foo.cert` from the classpath. The same applies to the `tls-key` and `tls-ca-cert`
 configuration keys. See the `io.helidon.common.configurable.Resource` class for details.
 
 == Usage
 === Using Channels
-Once one or more channels have been configured, then they can be used by client code. The simplest way to use a channel is
+Once one or more channels have been configured, then they can be used by the client code. The simplest way to use a channel is
 to inject it into beans using CDI. The Helidon gRPC client APIs have CDI producers that can provide `io.grpc.Channel` instances.
 
 For example, a class might have an injectable `io.grpc.Channel` field:
@@ -150,7 +150,7 @@ configuration in the examples provided in the  <<Configuration, configuration se
 When an instance of the CDI bean with the channel field is instantiated, a channel will be injected into it.
 
 ==== The In-Process Channel
-If code is running in an application that is executing as part of a Helidon MP gRPC server, there is a special in-process channel
+If code is running in an application that is executing as part of the Helidon MP gRPC server, there is a special in-process channel
 available. This allows code executing on the server to make calls to gRPC services deployed on that server in the same way an
 external client does. To inject an in-process channel, a different qualifier annotation is used.
 
@@ -161,7 +161,7 @@ external client does. To inject an in-process channel, a different qualifier ann
     @InProcessGrpcChannel  // <2>
     private Channel channel;
 ----
-<1> The `@Inject` annotation is used the same as previously.
+<1> The `@Inject` annotation tells CDI to identify the injectable qualifiers.
 <2> The `@InProcessGrpcChannel` is the qualifier that is used to tell the Helidon MP gRPC API to inject an in-process channel.
 
 
@@ -185,7 +185,7 @@ public class Client {
 }
 ----
 
-<1> The `@Inject` annotation tells the CDI to inject the client implementation; the gRPC MP APIs have a bean provider that does this.
+<1> The `@Inject` annotation tells the CDI to inject the client implementation.
 <2> The `@GrpcProxy` annotation is used by the CDI container to match the injection point to the gRPC MP APIs provider
 <3> The `@GrpcChannel` annotation identifies the gRPC channel to be used by the client. The name used in the annotation refers to
 a channel name in the application configuration.
@@ -193,18 +193,18 @@ a channel name in the application configuration.
 When the CDI container instantiates instances of the `Client`, it will inject a dynamic proxy into the `stringService` field
 and then any code in methods in the `Client` class can call methods on the `StringService` which will be translated to gRPC calls.
 
-In the example above there is no need to use a `Channel` directly. The correct channel is added to the dynamic client
+In the example above, there is no need to use a `Channel` directly. The correct channel is added to the dynamic client
 proxy internally by the Helidon MP gRPC APIs.
 
 === Building a gRPC Client
 There are a few steps to building and using a gRPC client in Helidon MP.
 
-As discussed in the xref:server.adoc#_defining_service_methods[Defining Service methods] section of the xref:server.adoc[Server-Side Services] there are four different types of gRPC method.
+As discussed in the xref:server.adoc#_defining_service_methods[Defining Service methods] section of the xref:server.adoc[Server-Side Services], there are four different types of gRPC method.
 
-* Unary - a simple method with at most a single request value and returning at most a single response value.
-* Server Streaming - a method that takes at most a single request value but may return zero or more response values.
-* Client Streaming - a request that takes one or more request values and returns at most one response value.
-* Bi-directional Streaming - a method that can take one or more request values and return zero or more response values.
+* `Unary` - a simple method with at most a single request value and returning at most a single response value.
+* `Server Streaming` - a method that takes at most a single request value but may return zero or more response values.
+* `Client Streaming` - a request that takes one or more request values and returns at most one response value.
+* `Bi-directional Streaming` - a method that can take one or more request values and return zero or more response values.
 
 And as with the server-side APIs, the Helidon MP gRPC client APIs support a number of different method signatures for each of the
 different gRPC method types.
@@ -228,10 +228,10 @@ public interface StringService {
 ----
 
 The service has been written using the Helidon MP APIs but could just as easily be a traditional gRPC Java service generated from
-Protobuf files. The client API is agnostic of the server side implementation, it only cares about the method type, the request
+Protobuf files. The client API is agnostic of the server side implementation, it only cares about the method types, the request
 and response types and the type of Marshaller used to serialize the request and response.
 
-To write a client for the StringService all that is required is an interface.
+To write a client for the StringService, all that is required is an interface.
 
 [source,java]
 .Simple gRPC Service

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -119,9 +119,9 @@ grpc:
 ----
 <1> The `tls` section of the channel configuration is used to configure TLS.
 <2> The `enabled` value is used to enable or disable TLS for this channel.
-<3> The `tls-cert` value is the location of the TLS certificate file
-<4> The `tls-key` value is the location of the TLS key file
-<5> The `tls-ca-cert` value is the location of the TLS CA certificate file
+<3> The `tls-cert` value is the location of the TLS certificate file.
+<4> The `tls-key` value is the location of the TLS key file.
+<5> The `tls-ca-cert` value is the location of the TLS CA certificate file.
 
 The SSL configuration uses the Helidon `Resource` class to locate configured keys and certificates.
 In the example above the `tls-cert-path` config key has the `-path` suffix which tells the configuration to load `/certs/foo.cert`
@@ -186,7 +186,7 @@ public class Client {
 ----
 
 <1> The `@Inject` annotation tells the CDI to inject the client implementation.
-<2> The `@GrpcProxy` annotation is used by the CDI container to match the injection point to the gRPC MP APIs provider
+<2> The `@GrpcProxy` annotation is used by the CDI container to match the injection point to the gRPC MP APIs provider.
 <3> The `@GrpcChannel` annotation identifies the gRPC channel to be used by the client. The name used in the annotation refers to
 a channel name in the application configuration.
 

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -35,8 +35,8 @@ include::{rootdir}/includes/mp.adoc[]
 - <<Examples, Examples>>
 
 == Overview
-Building java-based gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boiler plate code typically
-associated to more traditional approaches of writing gRPC java clients. At its simplest, a gRPC java client can be written using
+Building Java-based gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boilerplate code typically
+associated to more traditional approaches of writing gRPC Java clients. At its simplest, a gRPC Java client can be written using
 nothing more than a suitably annotated interface.
 
 include::{rootdir}/includes/dependencies.adoc[]
@@ -65,7 +65,7 @@ CDI beans that require them.
 include::{rootdir}/config/io_helidon_grpc_client_GrpcChannelDescriptor.adoc[leveloffset=1, tag=config]
 
 Channels are configured in the `grpc` section of the Helidon application configuration. The examples below use an `application.yaml`
-file but there are many other ways to use and override xref:../config/introduction.adoc[configuration in Helidon]
+file but there are many other ways to use and override xref:{rootdir}/mp/config/introduction.adoc[configuration in Helidon]
 
 .General form of a gRPC channels configuration
 [source,yaml]

--- a/docs/mp/grpc/client.adoc
+++ b/docs/mp/grpc/client.adoc
@@ -32,6 +32,7 @@ include::{rootdir}/includes/mp.adoc[]
 - <<API, API>>
 - <<Configuration, Configuration>>
 - <<Usage, Usage>>
+- <<Examples, Examples>>
 
 == Overview
 Building Java gRPC clients using the Helidon MP gRPC APIs is very simple and removes a lot of the boiler plate code typically
@@ -198,7 +199,7 @@ proxy internally by the Helidon MP gRPC APIs.
 === Building a gRPC Client
 There are a few steps to building and using a gRPC client in Helidon MP.
 
-As discussed in the xref:server-side-services.adoc#_defining_service_methods[Defining Service methods] section of the xref:server-side-services.adoc[Server-Side Services] there are four different types of gRPC method.
+As discussed in the xref:server.adoc#_defining_service_methods[Defining Service methods] section of the xref:server.adoc[Server-Side Services] there are four different types of gRPC method.
 
 * Unary - a simple method with at most a single request value and returning at most a single response value.
 * Server Streaming - a method that takes at most a single request value but may return zero or more response values.
@@ -276,3 +277,10 @@ public interface StringService {
     public CompletableFuture<String> upper(String s);
 }
 ----
+
+== Examples
+link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-client[Basic gRPC Client] example demonstrates  a
+simple gRPC client that invokes services from deployed gRPC server applications provided in the
+link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-server-implicit[Basic gRPC Server] and
+link:{helidon-github-tree-url}/examples/grpc/microprofile/metrics[gRPC Server metrics] examples.
+

--- a/docs/mp/grpc/server.adoc
+++ b/docs/mp/grpc/server.adoc
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
-= gRPC MicroProfile Server Services
+= gRPC MicroProfile Server
 :description: Helidon gRPC MicroProfile Server-Side Services
 :keywords: helidon, java, grpc, microprofile, micro-profile, mp
 :feature-name: gRPC MicroProfile Server
@@ -31,9 +31,11 @@ include::{rootdir}/includes/mp.adoc[]
 - <<Maven Coordinates, Maven Coordinates>>
 - <<API, API>>
 - <<Usage, Usage>>
+- <<Configuration, Configuration>>
+- <<Examples, Examples>>
 
 == Overview
-The gRPC Microprofile APIs are an extension to xref:{rootdir}/mp/introduction.adoc[Helidon MP] to allow building
+The gRPC Microprofile APIs are an extension to xref:../introduction.adoc[Helidon MP] to allow building
 of gRPC services and clients that integrate with the Microprofile APIs. Using Helidon gRPC MP makes building gRPC services
 and clients an easier process compared to the traditional approach using Protobuf files and code generation. Services can be built
 using POJOs that are then discovered and deployed at runtime in the same way the Helidon MP discovers and deploys web resources
@@ -57,8 +59,9 @@ include::{rootdir}/includes/dependencies.adoc[]
 The following annotations are used to implement Helidon MP gRPC Services:
 
 * `@Grpc` - an annotation used to mark a class as representing a gRPC service.
+* `@GrpcMarshaller` -  an annotation used to annotate a type or method to specify the named marshaller supplier to use for rpc method calls.
 
-gRPC types of method:
+gRPC method types:
 
 * <<Unary Methods, `@Unary`>> - a simple method with at most a single request value and returning at most a single response value.
 * <<ServerStreaming Methods, `@ServerStreaming`>> -  a method that takes at most a single request value but may return zero or more response values.
@@ -71,9 +74,10 @@ gRPC types of method:
 
 The traditional approach to building Java gRPC services is to write Protobuf files describing the service and then
 use these to generate service stubs and finally implementing the service methods by extending the generated stub classes.
-Using Helidon gRPC MP you just need to write an annotated service implementation class that is just a normal POJO.
+Using Helidon gRPC MP, all you need to do is write an annotated service implementation class that is just a normal POJO.
 
 For example:
+
 [source,java]
 .Simple gRPC Service
 ----
@@ -92,7 +96,7 @@ The code above is a simple service with a single unary method that just converts
 The important parts in the example are the `@ApplicationScoped`, `@Grpc` and `@Unary` annotations. These,
 along with other annotations discussed later, allow the gRPC MP APIs to discover, configure and deploy the service.
 
-Of course Helidon gRPC MP does not preclude you from using the Protobuf files approach, traditional gRPC Java services
+Of course Helidon gRPC MP does not preclude you from using the Protobuf files approach as traditional gRPC Java services
 also work in a gRPC MP server.
 
 As already shown above, a Helidon gRPC MP service is just an annotated POJO. To make a class a service, it requires two
@@ -111,8 +115,8 @@ public class StringService {
 then deployed by the gRPC MP server.
 
 === Service Name
-By default when a class is annotated with `Grpc` the class name will be used as the gRPC service name. So in the example
-above the service name will be `StringService`. This can be change by supplying a name to the annotation.
+By default when a class is annotated with `Grpc`, the class name will be used as the gRPC service name. So in the example
+above, the service name will be `StringService`. This can be changed by supplying a name to the annotation.
 
 [source,java]
 ----
@@ -120,7 +124,7 @@ above the service name will be `StringService`. This can be change by supplying 
 @io.helidon.microprofile.grpc.core.Grpc(name="Strings") // <1>
 public class StringService {
 ----
-<1> in the example above, the name of the deployed service will be `Strings`.
+<1> The name of the deployed service will be `Strings`.
 
 
 === Defining Service Methods
@@ -142,12 +146,11 @@ The Helidon gRPC MP API determines a method type by its annotation, which should
 ----
 
 ==== Request and Response Types
-A gRPC service method typically takes a request parameter and returns a response value (streaming methods may take or return
+A gRPC service method typically takes a request parameter and returns a response value (`streaming` methods may take or return
 multiple requests or responses). In traditional gRPC Java, the types used for the request and response values must be
 Protobuf serializable classes but this is not the case with Helidon gRPC. Helidon supports
- xref:../../se/grpc/marshalling.adoc[pluggable Marshallers]
-and by default will support any Java primitive or Java `Serializable` as well as Protobuf types. Any type that can be marshalled
-by the built-in marshallers or custom supplied marshaller may be used as a request or response type.
+link:../../includes/grpc-marshalling.adoc[pluggable Marshallers] and by default will support Protobuf types. Any type that
+can be marshalled by the built-in marshallers or custom supplied marshaller may be used as a request or response type.
 
 ==== Unary Methods
 A unary gRPC method is the simplest type of service method. Typically a unary method takes a request value and returns a
@@ -240,7 +243,7 @@ methods.
 A client streaming method receives a stream of requests from the client and when the request stream is complete, it sends back a
 response. A traditional gRPC Java client streaming method takes two `StreamObserver` parameters, one is the stream of client
 requests and the other is used to send back the single response in the same way that a unary method sends a response. As with
-unary methods Helidon gRPC MP supports different method signatures for client streaming methods.
+unary methods, Helidon gRPC MP supports different method signatures for client streaming methods.
 
 All of the signatures below are valid client streaming methods in Helidon gRPC MP.
 [source,java]
@@ -258,7 +261,7 @@ public StreamObserver<RequestType> invoke(CompletableFuture<ResponseType> observ
 
 ==== Bi-Directional Streaming Methods
 A bidirectional streaming method is a method that is a constant stream of client requests and server responses. Other than
-the standard gRPC Java `StreamObserver`, there are not any other built in types that make sense to use to implement
+the standard gRPC Java `StreamObserver`, there are not any other built-in types that make sense to use to implement
 different method signatures for a bidirectional method so the only supported signature is the standard gRPC Java method.
 
 [source,java]
@@ -270,7 +273,7 @@ public StreamObserver<RequestType> invoke(StreamObserver<ResponseType> observer)
 === Deploying Protobuf Services
 Whilst the examples above show how simple it is to write gRPC services with basic POJOs, there may be cases where there is a
 requirement to deploy services built the traditional way using gRPC Java generated classes or built as
-xref:../../se/grpc/server.adoc#_service_implementation[non-microprofile Helidon gRCP services].
+xref:../../se/grpc/server.adoc#_service_implementation[non-microprofile Helidon gRPC services].
 
 ==== Annotate the Service Implementation
 When the gRPC MP server is starting, it will discover all CDI beans of type `io.grpc.BindableService`. Service sub-classes
@@ -318,3 +321,31 @@ the xref:../../se/grpc/server.adoc#_grpc_server_routing[basic gRPC server docume
 The `GrpcMpExtension` instances are discovered and loaded using the service loader so for the example above to work, a file
 `META-INF/services/io.helidon.microprofile.grpc.server.spi.GrpcMpExtension` would need to be created that contained the names
 of the service implementations.
+
+== Configuration
+Configure the gRPC Server using the Helidon microprofile configuration framework by which the ConfigSource defaults to
+`microprofile-config.properties`. Alternatively, you can also use other ConfigSources such as `application.yaml`.
+Refer to xref:../config/introduction.adoc[MicroProfile Config] for more details about the different options for
+ConfigSources.
+
+include::{rootdir}/config/io_helidon_grpc_server_GrpcServerConfiguration.adoc[leveloffset=1, tag=config]
+
+.GrpcServer configuration file example using `application.yaml`
+[source,yaml]
+----
+grpc:
+  name: test.server  # <1>
+  port: 3333  # <2>
+----
+<1> Specifies the name of the gRPC server.
+<2> Sets the server port.
+
+== Examples
+Helidon MP includes some examples that demonstrate gRPC server usage:
+
+* link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-server-implicit[Basic gRPC Server example] provides
+a simple gRPC application that deploys a gRPC service that will be discovered by CDI. Two additional services are
+included that are not normally CDI managed beans, but are manually added as CDI managed beans so that they can also be
+discovered by Helidon MP.
+* link:{helidon-github-tree-url}/examples/grpc/microprofile/metrics[gRPC Server Metrics example] demonstrates a
+Helidon MP application that enables `metrics` and `tracing` on a gRPC Service.

--- a/docs/mp/grpc/server.adoc
+++ b/docs/mp/grpc/server.adoc
@@ -149,7 +149,7 @@ The Helidon gRPC MP API determines a method type by its annotation, which should
 A gRPC service method typically takes a request parameter and returns a response value (`streaming` methods may take or return
 multiple requests or responses). In traditional gRPC Java, the types used for the request and response values must be
 Protobuf serializable classes but this is not the case with Helidon gRPC. Helidon supports
-link:../../includes/grpc-marshalling.adoc[pluggable Marshallers] and by default will support Protobuf types. Any type that
+<<Custom Marshalling, pluggable Marshallers>> and by default will support Protobuf types. Any type that
 can be marshalled by the built-in marshallers or custom supplied marshaller may be used as a request or response type.
 
 ==== Unary Methods
@@ -296,8 +296,7 @@ public class StringService implements GrpcService {
 ----
 
 ==== Implement a GrpcMpExtension
-If it is not possible to annotate the service class (for example the code is built by a third party), another way to deploy none
-CDI bean services is to implement a gRPC MP server extension.
+If it is not possible to annotate the service class (for example the code is built by a third party), another way to deploy non-CDI bean services is to implement a gRPC MP server extension.
 The extension will then be called when the MP server is starting and be given the chance to add additional services for deployment.
 An extension should implement the `io.helidon.microprofile.grpc.server.spi.GrpcMpExtension` interface.
 
@@ -316,11 +315,13 @@ public class MyExtension
 
 <1> The `configure` method of the extension will be called to allow the extension to add extra configuration to the server.
 <2> In this example, an instance of the `StringService` is registered with the routing (as described in
-the xref:../../se/grpc/server.adoc#_grpc_server_routing[basic gRPC server documentation about Routing]).
+the xref:../../se/grpc/server.adoc#_grpc_server_routing[gRPC server routing] documentation).
 
 The `GrpcMpExtension` instances are discovered and loaded using the service loader so for the example above to work, a file
 `META-INF/services/io.helidon.microprofile.grpc.server.spi.GrpcMpExtension` would need to be created that contained the names
 of the service implementations.
+
+include::{rootdir}/includes/grpc-marshalling.adoc[leveloffset=2]
 
 == Configuration
 Configure the gRPC Server using the Helidon microprofile configuration framework by which the ConfigSource defaults to
@@ -341,7 +342,7 @@ grpc:
 <2> Sets the server port.
 
 == Examples
-Helidon MP includes some examples that demonstrate gRPC server usage:
+Helidon MP includes some examples that demonstrate the gRPC server usage:
 
 * link:{helidon-github-tree-url}/examples/grpc/microprofile/basic-server-implicit[Basic gRPC Server example] provides
 a simple gRPC application that deploys a gRPC service that will be discovered by CDI. Two additional services are

--- a/docs/mp/grpc/server.adoc
+++ b/docs/mp/grpc/server.adoc
@@ -35,7 +35,7 @@ include::{rootdir}/includes/mp.adoc[]
 - <<Examples, Examples>>
 
 == Overview
-The gRPC Microprofile APIs are an extension to xref:../introduction.adoc[Helidon MP] to allow building
+The gRPC Microprofile APIs are an extension to xref:{rootdir}/mp/introduction.adoc[Helidon MP] to allow building
 of gRPC services and clients that integrate with the Microprofile APIs. Using Helidon gRPC MP makes building gRPC services
 and clients an easier process compared to the traditional approach using Protobuf files and code generation. Services can be built
 using POJOs that are then discovered and deployed at runtime in the same way the Helidon MP discovers and deploys web resources
@@ -107,6 +107,7 @@ annotations.
 @ApplicationScoped                             // <1>
 @io.helidon.microprofile.grpc.core.Grpc        // <2>
 public class StringService {
+    /* code is omitted */
 }
 ----
 
@@ -273,7 +274,7 @@ public StreamObserver<RequestType> invoke(StreamObserver<ResponseType> observer)
 === Deploying Protobuf Services
 Whilst the examples above show how simple it is to write gRPC services with basic POJOs, there may be cases where there is a
 requirement to deploy services built the traditional way using gRPC Java generated classes or built as
-xref:../../se/grpc/server.adoc#_service_implementation[non-microprofile Helidon gRPC services].
+xref:{rootdir}/se/grpc/server.adoc#_service_implementation[non-microprofile Helidon gRPC services].
 
 ==== Annotate the Service Implementation
 When the gRPC MP server is starting, it will discover all CDI beans of type `io.grpc.BindableService`. Service sub-classes
@@ -315,7 +316,7 @@ public class MyExtension
 
 <1> The `configure` method of the extension will be called to allow the extension to add extra configuration to the server.
 <2> In this example, an instance of the `StringService` is registered with the routing (as described in
-the xref:../../se/grpc/server.adoc#_grpc_server_routing[gRPC server routing] documentation).
+the xref:{rootdir}/se/grpc/server.adoc#_grpc_server_routing[gRPC server routing] documentation).
 
 The `GrpcMpExtension` instances are discovered and loaded using the service loader so for the example above to work, a file
 `META-INF/services/io.helidon.microprofile.grpc.server.spi.GrpcMpExtension` would need to be created that contained the names
@@ -324,9 +325,9 @@ of the service implementations.
 include::{rootdir}/includes/grpc-marshalling.adoc[leveloffset=2]
 
 == Configuration
-Configure the gRPC Server using the Helidon microprofile configuration framework by which the ConfigSource defaults to
+Configure the gRPC server using the Helidon microprofile configuration framework by which the ConfigSource defaults to
 `microprofile-config.properties`. Alternatively, you can also use other ConfigSources such as `application.yaml`.
-Refer to xref:../config/introduction.adoc[MicroProfile Config] for more details about the different options for
+Refer to xref:{rootdir}/mp/config/introduction.adoc[MicroProfile Config] for more details about the different options for
 ConfigSources.
 
 include::{rootdir}/config/io_helidon_grpc_server_GrpcServerConfiguration.adoc[leveloffset=1, tag=config]

--- a/docs/mp/introduction.adoc
+++ b/docs/mp/introduction.adoc
@@ -130,7 +130,7 @@ Helidon MP is an Eclipse MicroProfile {version-lib-microprofile-api} runtime tha
 | xref:{rootdir}/mp/cors/cors.adoc[CORS]
 | Cross Origin Resource Sharing – API to control if and how REST resources served by their applications can be shared across origins 
 
-| xref:{rootdir}/mp/grpc/server-side-services.adoc[gRPC]
+| xref:{rootdir}/mp/grpc/server.adoc[gRPC]
 | gRPC server and client
 
 | xref:{rootdir}/mp/integrations/oci.adoc[OCI SDK]

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -162,7 +162,7 @@ hence their corresponding Marshallers), etc.
 <2> We create a `Channel` to the service that is running on `localhost:1408`.
 <3> Finally, we create our `GrpcServiceClient` by using the above mentioned `ClientServiceDescriptor`.
 and `Channel`. This `client` reference will be used to invoke various gRPC methods in our
-`StringService`
+`StringService`.
 <4> We define a static inner class that implements the `io.grpc.StreamObserver` interface. An instance
 of this class can be used wherever a `io.grpc.StreamObserver` is required (like server streaming,
 bi-directional streaming methods).
@@ -420,7 +420,7 @@ At this point the `client` object can be used to invoke any of the four types of
 earlier sections.
 
 
-=== Creating gRPC clients for non protobuf services
+=== Creating gRPC clients for non-protobuf services
 
 If your service is *not* using protobuf for serialization, then the client framework allows
 you to programmatically initialize `ClientMethodDescriptor` and create clients to invoke

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -66,16 +66,16 @@ include::{rootdir}/includes/dependencies.adoc[]
 
 . The first step to create a Helidon gRPC client application is to describe the set of methods in the gRPC service. Helidon
 gRPC Client Framework (simply called the "Client framework" in the remainder of the document) provides a class called
-`ClientServiceDescriptor` to describe the set of methods of a service that the client may invoke. There are three ways to build and initialize a `ClientServiceDescriptor`.
+`ClientServiceDescriptor` to describe the set of methods of a service that the client may invoke. There are several ways to build and initialize a `ClientServiceDescriptor`.
 * The first option is to initialize `ClientServiceDescriptor` using `protoc` generated artifacts like
 `BindableService` or `io.grpc.ServiceDescriptor`. This option is possible if the gRPC service
-was built using `.proto` file. In this case the set of gRPC methods, their types and
+was built using `.proto` file. In this case, the set of gRPC methods, their types and
 the appropriate marshallers are detected automatically. This is certainly the easiest way to initialize
 a `ClientServiceDescriptor`.
-* The next option is to programmatically build the `ClientServiceDescriptor`. This option should be
+* The other option is to programmatically build the `ClientServiceDescriptor`. This option should be
 taken if the service was *not* built from protobuf files or if the `protoc` generated artifacts are not
 available to the client.
-* The last option is to load the method descriptions from a configuration file. (** Not yet implemented**).
+// * The last option is to load the method descriptions from a configuration file. (** Not yet implemented**).
 . The next step is to create a gRPC `Channel` to use to communicate with the server.
 . Finally, you create an instance of `GrpcServiceClient` passing the `ClientMethodDescriptor` and the `Channel` instances.
 
@@ -105,7 +105,7 @@ message StringMessage {
 }
 ----
 
-If you run it through `protoc` it will generate a class (among other things) called `StringService`.
+If you run it through `protoc`, it will generate a class (among other things) called `StringService`.
 Assuming that the `StringService` server is running on port 1408, here is how you can create a Helidon gRPC
 Client that uses the Client Framework to invoke various types of gRPC methods.
 
@@ -156,7 +156,7 @@ public class ProtoBasedStringServiceClient {
 ----
 
 <1> Initialize the builder by specifying the `StringService's` proto `ServiceDescriptor`. From
-the `ServiceDescriptor` the builder detects the service name, the set of method names, the type of
+the `ServiceDescriptor`, the builder detects the service name, the set of method names, the type of
 each method (like Unary, ServerStreaming, etc.), the request and response types (and
 hence their corresponding Marshallers), etc.
 <2> We create a `Channel` to the service that is running on `localhost:1408`.
@@ -164,7 +164,7 @@ hence their corresponding Marshallers), etc.
 and `Channel`. This `client` reference will be used to invoke various gRPC methods in our
 `StringService`
 <4> We define a static inner class that implements the `io.grpc.StreamObserver` interface. An instance
-of this class can be used whereever a `io.grpc.StreamObserver` is required (like server streaming,
+of this class can be used wherever a `io.grpc.StreamObserver` is required (like server streaming,
 bi-directional streaming methods).
 
 ==== Invoking a unary method on the StringService
@@ -187,7 +187,7 @@ public class ProtoBasedStringServiceClient {
         String lcase = client.blockingUnary("Lower", input);  // <2>
 
         StringMessageStream stream = new StringMessageStream<StringMessage>();
-        client.blockingUnary("Lower", input);  // <3>
+        client.blockingUnary("Lower", stream);  // <3>
     }
 
     public static class StringMessageStream<T> { /* code omitted */ }
@@ -199,7 +199,7 @@ a `CompletableFuture<Response>` where `<Response>` is the response type. Here we
 `Lower` method passing the input `StringMessage`. This method returns a `CompletableFuture<StringMessage>`
 as response thus allowing the client to obtain the result asynchronously.
 <2> This is simply a wrapper around the above method. This method blocks till the result is available.
-<3> Here, we create invoke the `unary` method by passing the `StringMessageStream` whose `onNext` method
+<3> Here, we invoke the `unary` method by passing the `StringMessageStream` whose `onNext` method
 will be called (once) when the result is available.
 
 ==== Invoking a client streaming method on the StringService
@@ -404,7 +404,7 @@ The service name and the method name ("Lower") are specified.
 <2> Set the request type of the method to be `StringMessage` (since the `Lower` method takes `StringMessage` as a parameter).
 <3> Set the response type of the method to be `StringMessage` (since the `Lower` method returns a `StringMessage` as a parameter).
 <4> Build the `ClientMethodDescriptor`. Note that the return value is a `ClientMethodDescriptor` that contains
-the correct Marshallers for the request & response types.
+the correct Marshaller for the request & response types.
 <5> Use the `clientStreaming()` method on `ClientMethodDescriptor` to create a builder for a gRPC client streaming method.
 The service name and the method name ("Join") are specified.
 <6> Use the `serverStreaming()` method on `ClientMethodDescriptor` to create a builder for a gRPC server streaming method.
@@ -426,11 +426,11 @@ If your service is *not* using protobuf for serialization, then the Client frame
 you to programmatically initialize `ClientMethodDescriptor` and create clients to invoke
 methods on the service.
 
-All you have to do is create the set of `ClientMethodDescriptor's` and the `ClientServiceDescriptor` as
-described in the previous section, but with one change. Just *do not* set the request and response types
-in the `ClientMethodDescriptor`. That's all!! In fact, there is an API in the `ClientServiceDescriptor`
-that makes this even simpler. You can simply pass the method name. For example, to create a client streaming
-method called `"JoinString"` that uses java serialization, simply call the `clientStreaming("JoinString")`.
+All you have to do is create the set of ``ClientMethodDescriptor``s and the `ClientServiceDescriptor` as
+described in the previous section. Just *do not* set the request and response types
+in the `ClientMethodDescriptor` anymore. Furthermore, there is an API in the `ClientServiceDescriptor`
+that makes this even simpler where you can simply pass the method name. For example, to create a client streaming
+method called `"JoinString"` that uses some custom marshalling, simply call the `clientStreaming("JoinString")`.
 
 Lets see an example of creating a client for a service that uses Java serialization.
 
@@ -438,7 +438,8 @@ Lets see an example of creating a client for a service that uses Java serializat
 ----
 public static void main(String[] args) throws Exception {
     ClientServiceDescriptor descriptor = ClientServiceDescriptor.builder(HelloService.class)  // <1>
-                                                                .clientStreaming("JoinString")  // <2>
+                                                                .marshallerSupplier(new JsonbMarshaller.Supplier())  // <2>
+                                                                .clientStreaming("JoinString")  // <3>
                                                                 .build();
 
     Channel channel = ManagedChannelBuilder.forAddress("localhost", 1408)
@@ -457,14 +458,16 @@ public static void main(String[] args) throws Exception {
 ----
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
-<2> Add the "JoinString" client streaming method to the `ClientServiceDescriptor`. Since  we didn't set
-the request or response type (like we did in the previous sections), Java serialization will be used for
-Marshalling and Unmarshalling the request and response values.
+<2> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
+<3> Add the "JoinString" client streaming method to the `ClientServiceDescriptor`.
+
+Since we didn't set the request or response type (like we did in the previous sections), the custom marshaller will be
+used for Marshalling and Unmarshalling the request and response values.
 
 Note that whether a `ClientServiceDescriptor` is built using protobuf artifacts or is built programmatically,
 the same set of APIs provided by the Client Framework can be used to invoke gRPC methods.
 
-include::marshalling.adoc[leveloffset=2]
+include::{rootdir}/includes/grpc-marshalling.adoc[leveloffset=2]
 
 == Configuration
 Configure the gRPC client using the Helidon configuration framework, either programmatically or via a configuration file.
@@ -508,7 +511,7 @@ Assuming that the server is running on port 1408, create a client as follows:
 ----
 public static void main(String[] args) throws Exception {
     ClientServiceDescriptor descriptor = ClientServiceDescriptor.builder(HelloService.class)  // <1>
-                                                                .marshallerSupplier(new JavaMarshall.Supplier()) // <2>
+                                                                .marshallerSupplier(new JsonbMarshaller.Supplier()) // <2>
                                                                 .unary("SayHello")  // <3>
                                                                 .build();
 
@@ -525,7 +528,7 @@ public static void main(String[] args) throws Exception {
 ----
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
-<2> Specify custom marshaller using Java serialization to marshall requests and responses.
+<2> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
 <3> Add the `SayHello` unary method to the `ClientServiceDescriptor`. This method, by default, uses Java serialization for
 marshalling and unmarshalling the request and response values.
 <4> Create a gRPC `Channel` that will communicate with the server running in localhost and on port 1408 (using plaintext).
@@ -535,5 +538,13 @@ a client that can be used to define the set of methods described by the specifie
 <6> Invoke the `SayHello` method which returns a `CompletionStage<String>`.
 <7> Print the result.
 
-The example above creates a very simple client to the gRPC server that by default uses Java serialization to marshall
-requests and responses.
+=== Additional gRPC Client examples
+A set of gRPC client examples for Helidon SE can be found in the following links:
+
+* link:{helidon-github-tree-url}/examples/grpc/client-standalone[Basic gRPC Standalone Client]
+* link:{helidon-github-tree-url}/examples/grpc/metrics[gRPC Server Metrics]
+* link:{helidon-github-tree-url}/examples/grpc/opentracing[OpenTracing on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security[Basic Auth Security on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security-outbound[Outbound Security on a gRPC Server]
+

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -41,7 +41,7 @@ allows a uniform way to access gRPC services that use either Protobuf or some cu
 significantly simpler.
 * It allows you to configure some of the Helidon value-added features, such
 as xref:server.adoc#_security[security],  xref:server.adoc#_service_metrics[metrics collection] and xref:server.adoc#_interceptors[interceptors] down to the method level.
-* It allows you to easily specify custom marshaller for requests and
+* It allows you to easily specify custom marshallers for requests and
 responses if `protobuf` does not satisfy your needs.
 
 The class `GrpcServiceClient` acts as the client object for accessing a gRPC service. Creating a `GrpcServiceClient` involves:
@@ -111,7 +111,7 @@ Client that uses the Client Framework to invoke various types of gRPC methods.
 
 ==== Creating and initializing a ClientServiceDescriptor for StringService (generated from `protoc`)
 
-Lets build a class called `ProtoBasedStringServiceClient` that invokes the various types of
+Let's build a class called `ProtoBasedStringServiceClient` that invokes the various types of
 gRPC methods that our `StringService` offers.
 
 
@@ -197,20 +197,20 @@ public class ProtoBasedStringServiceClient {
 <1> This variant of the `unary` API takes the method name and a request object and returns
 a `CompletableFuture<Response>` where `<Response>` is the response type. Here we invoke the
 `Lower` method passing the input `StringMessage`. This method returns a `CompletableFuture<StringMessage>`
-as response thus allowing the client to obtain the result asynchronously.
-<2> This is simply a wrapper around the above method. This method blocks till the result is available.
+as its response thus allowing the client to obtain the result asynchronously.
+<2> This is simply a wrapper around the above method. This method blocks until the result is available.
 <3> Here, we invoke the `unary` method by passing the `StringMessageStream` whose `onNext` method
 will be called (once) when the result is available.
 
 ==== Invoking a client streaming method on the StringService
 
-Lets invoke the `Join` method which causes the server to return a single result *after* the client
-has streamed the request values to the server. gRPC API expects the client application to provide
+Let's invoke the `Join` method which causes the server to return a single result *after* the client
+has streamed the request values to the server. The gRPC API expects the client application to provide
 an instance of `io.grpc.StreamObserver` as an argument during the invocation of the client
 streaming method.
 
-In order to simplify the task of invoking Client Streaming methods, Helidon Client Framework provides
-a couple of methods to invoke gRPC Client Streaming methods. The first variant takes an `Iterable` as
+In order to simplify the task of invoking Client Streaming methods, the Helidon Client Framework provides
+two methods to invoke gRPC Client Streaming methods. The first variant takes an `Iterable` as
 argument which in turn is converted into a `io.grpc.StreamObserver`. The second variant takes a
 `io.grpc.StreamObserver` as argument. The first variant can be used if the number of values to be
 streamed in small and known a priori.
@@ -246,7 +246,7 @@ public class ProtoBasedStringServiceClient {
         clientStream.onCompleted();  // <5>
     }
 
-    public static class StringMessageStream<T> { /* code imitted */ }
+    public static class StringMessageStream<T> { /* code is omitted */ }
 
 }
 ----
@@ -266,7 +266,7 @@ have been streamed from the client.
 
 === Invoking a server streaming method on the StringService (generated from `protoc`)
 
-Lets invoke the "Split" method which causes the server to stream the results back.
+Let's invoke the "Split" method which causes the server to stream the results back.
 
 [source,java]
 ----
@@ -284,7 +284,7 @@ public class ProtoBasedStringServiceClient {
         grpcClient.serverStreaming("Split", input, observer);  // <3>
     }
 
-    public static class StringMessageStream<T> { /* code imitted */ }
+    public static class StringMessageStream<T> { /* code is omitted */ }
 
 }
 ----
@@ -297,7 +297,7 @@ each word.
 
 === Invoking a bi-directional streaming method on the StringService (generated from `protoc`)
 
-Now lets invoke the `Echo` method in which both the client and the server have to stream
+Now let's invoke the `Echo` method in which both the client and the server have to stream
 the request and response.
 
 [source,java]
@@ -321,7 +321,7 @@ public class ProtoBasedStringServiceClient {
         clientStream.onCompleted();  // <4>
     }
 
-    public static class StringMessageStream<T> { /* code imitted */ }
+    public static class StringMessageStream<T> { /* code is omitted */ }
 
 }
 ----
@@ -338,18 +338,18 @@ streamed all its values.
 
 === Programmatically creating ClientServiceDescriptor for StringService
 
-Assuming that the service is still running on port 1408, lets see how to create our Client
-without using the `StringService` 's proto `ServiceDescriptor`.
+Assuming that the service is still running on port 1408, let's see how to create our Client
+without using the ``StringService``'s proto `ServiceDescriptor`.
 
-Since we are *not* going to use the `StringService` 's proto `ServiceDescriptor`, we need to
-describe the methods that the client need to invoke. The Helidon client framework provides a
-bunch of APIs to easily describe gRPC methods.
+Since we are *not* going to use the ``StringService``'s proto `ServiceDescriptor`, we need to
+describe the methods that the client needs to invoke. The Helidon client framework provides
+several methods to easily describe gRPC methods.
 
 For example, to register a unary method, we need to use the `unary` method and configure it to
 specify the request and response types.
 
-Other than describing the methods that our client will invoke, the rest of the following
-code should be very similar (or same) as the previous section!!
+Other than describing the methods that our client will invoke, the rest of the code should be
+very similar to (or the same as) the previous section!!
 
 [source,java]
 ----
@@ -422,7 +422,7 @@ earlier sections.
 
 === Creating gRPC clients for non protobuf services
 
-If your service is *not* using protobuf for serialization, then the Client framework allows
+If your service is *not* using protobuf for serialization, then the client framework allows
 you to programmatically initialize `ClientMethodDescriptor` and create clients to invoke
 methods on the service.
 
@@ -451,12 +451,12 @@ public static void main(String[] args) throws Exception {
                                         .map(w -> StringMessage.newBuilder().setText(w).build())
                                         .collect(Collectors.toList());
 
-  CompletableFuture<StringMessage> result = grpcClient.clientStreaming("Join", input);
+    CompletableFuture<StringMessage> result = grpcClient.clientStreaming("Join", input);
 }
 ----
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
-<2> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
+<2> Specify a custom marshaller using the built-in JSON-B marshaller to serialize/deserialize requests and responses.
 <3> Add the "JoinString" client streaming method to the `ClientServiceDescriptor`.
 
 Since we didn't set the request or response type (like we did in the previous sections), the custom marshaller will be
@@ -526,8 +526,8 @@ public static void main(String[] args) throws Exception {
 ----
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
-<2> Specify custom marshaller using the built-in JsonB marshaller to marshall request and response values.
-<3> Add the `SayHello` unary method to the `ClientServiceDescriptor`, which will use the specified custom marshaller.
+<2> Specify a custom marshaller using the built-in JSON-B marshaller to serialize/deserialize request and response values.
+<3> Add the `SayHello` unary method to the `ClientServiceDescriptor` which will use the specified custom marshaller.
 <4> Create a gRPC `Channel` that will communicate with the server running in localhost and on port 1408 (using plaintext).
 <5> Create the `GrpcServiceClient` that uses the above `Channel` and `ClientServiceDescriptor`. `GrpcClientService` represents
 a client that can be used to define the set of methods described by the specified `ClientServiceDescriptor`. In our case, the

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -34,8 +34,8 @@ include::{rootdir}/includes/se.adoc[]
 
 == Overview
 
-Helidon gRPC Client provides a framework for creating link:http://grpc.io/[gRPC] client applications. The client framework
-allows a uniform way to access gRPC services that use either Protobuf or some custom serialization format. The benefits of using Helidon gRPC Client Framework include:
+Helidon gRPC client provides a framework for creating link:http://grpc.io/[gRPC] client applications. The client framework
+allows a uniform way to access gRPC services that use either Protobuf or some custom serialization format. The benefits of using Helidon gRPC client Framework include:
 
 * It provides a number of helper methods that make client implementation
 significantly simpler.
@@ -65,7 +65,7 @@ include::{rootdir}/includes/dependencies.adoc[]
 === Client Implementation Basics
 
 . The first step to create a Helidon gRPC client application is to describe the set of methods in the gRPC service. Helidon
-gRPC Client Framework (simply called the "Client framework" in the remainder of the document) provides a class called
+gRPC client Framework (simply called the "Client framework" in the remainder of the document) provides a class called
 `ClientServiceDescriptor` to describe the set of methods of a service that the client may invoke. There are several ways to build and initialize a `ClientServiceDescriptor`.
 * The first option is to initialize `ClientServiceDescriptor` using `protoc` generated artifacts like
 `BindableService` or `io.grpc.ServiceDescriptor`. This option is possible if the gRPC service
@@ -210,7 +210,7 @@ an instance of `io.grpc.StreamObserver` as an argument during the invocation of 
 streaming method.
 
 In order to simplify the task of invoking Client Streaming methods, the Helidon Client Framework provides
-two methods to invoke gRPC Client Streaming methods. The first variant takes an `Iterable` as
+two methods to invoke gRPC client Streaming methods. The first variant takes an `Iterable` as
 argument which in turn is converted into a `io.grpc.StreamObserver`. The second variant takes a
 `io.grpc.StreamObserver` as argument. The first variant can be used if the number of values to be
 streamed in small and known a priori.
@@ -404,7 +404,7 @@ The service name and the method name ("Lower") are specified.
 <2> Set the request type of the method to be `StringMessage` (since the `Lower` method takes `StringMessage` as a parameter).
 <3> Set the response type of the method to be `StringMessage` (since the `Lower` method returns a `StringMessage` as a parameter).
 <4> Build the `ClientMethodDescriptor`. Note that the return value is a `ClientMethodDescriptor` that contains
-the correct Marshaller for the request & response types.
+the correct marshaller for the request & response types.
 <5> Use the `clientStreaming()` method on `ClientMethodDescriptor` to create a builder for a gRPC client streaming method.
 The service name and the method name ("Join") are specified.
 <6> Use the `serverStreaming()` method on `ClientMethodDescriptor` to create a builder for a gRPC server streaming method.
@@ -501,7 +501,7 @@ Please refer to gRPC documentation: https://grpc.io/grpc-java/javadoc/io/grpc/Ma
 === Quick Start
 
 First, create and run a minimalist `HelloService` gRPC server application as described in the
-xref:server.adoc#_quick_start[gRPC Server quick start example].
+xref:server.adoc#_quick_start[gRPC server quick start example].
 
 Assuming that the server is running on port 1408, create a client as follows:
 
@@ -535,7 +535,7 @@ a client that can be used to define the set of methods described by the specifie
 <6> Invoke the `SayHello` method which returns a `CompletionStage<String>`.
 <7> Print the result.
 
-=== Additional gRPC Client examples
+=== Additional gRPC client examples
 A set of gRPC client examples for Helidon SE can be found in the following links:
 
 * link:{helidon-github-tree-url}/examples/grpc/client-standalone[Basic gRPC Standalone Client]

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -77,7 +77,7 @@ taken if the service was *not* built from protobuf files or if the `protoc` gene
 available to the client.
 // * The last option is to load the method descriptions from a configuration file. (** Not yet implemented**).
 . The next step is to create a gRPC `Channel` to use to communicate with the server.
-. Finally, you create an instance of `GrpcServiceClient` passing the `ClientMethodDescriptor` and the `Channel` instances.
+. Finally, we create an instance of `GrpcServiceClient` passing the `ClientMethodDescriptor` and the `Channel` instances.
 
 === Creating gRPC clients from `protoc` generated artifacts
 
@@ -160,7 +160,7 @@ the `ServiceDescriptor`, the builder detects the service name, the set of method
 each method (like Unary, ServerStreaming, etc.), the request and response types (and
 hence their corresponding Marshallers), etc.
 <2> We create a `Channel` to the service that is running on `localhost:1408`.
-<3> Finally, we create our `GrpcServiceClient` by using the above mentioned `ClientServiceDescriptor`
+<3> Finally, we create our `GrpcServiceClient` by using the above mentioned `ClientServiceDescriptor`.
 and `Channel`. This `client` reference will be used to invoke various gRPC methods in our
 `StringService`
 <4> We define a static inner class that implements the `io.grpc.StreamObserver` interface. An instance
@@ -411,9 +411,9 @@ The service name and the method name ("Join") are specified.
 The service name and the method name ("Split") are specified.
 <7> Use the `bidirectional()` method on `ClientMethodDescriptor` to create a builder for a gRPC Bidi streaming method.
 The service name and the method name ("Echo") are specified.
-<8> Create a `ClientServiceDescriptor` for service named `StringService` and add all our `ClientMethodDescriptor` s.
+<8> Create a `ClientServiceDescriptor` for service named `StringService` and add all our ``ClientMethodDescriptor``s.
 <9> We create a `Channel` to the service that is running on `localhost:1408`.
-<10> Finally, we create our `GrpcServiceClient` by using the above mentioned `ClientServiceDescriptor`
+<10> Finally, we create our `GrpcServiceClient` by using the above-mentioned `ClientServiceDescriptor`
 and `Channel`.
 
 At this point the `client` object can be used to invoke any of the four types of methods we have seen in the

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -527,7 +527,7 @@ public static void main(String[] args) throws Exception {
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
 <2> Specify custom marshaller using the built-in JsonB marshaller to marshall request and response values.
-<3> Add the `SayHello` unary method to the `ClientServiceDescriptor`.
+<3> Add the `SayHello` unary method to the `ClientServiceDescriptor`, which will use the specified custom marshaller.
 <4> Create a gRPC `Channel` that will communicate with the server running in localhost and on port 1408 (using plaintext).
 <5> Create the `GrpcServiceClient` that uses the above `Channel` and `ClientServiceDescriptor`. `GrpcClientService` represents
 a client that can be used to define the set of methods described by the specified `ClientServiceDescriptor`. In our case, the

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -411,7 +411,7 @@ The service name and the method name ("Join") are specified.
 The service name and the method name ("Split") are specified.
 <7> Use the `bidirectional()` method on `ClientMethodDescriptor` to create a builder for a gRPC Bidi streaming method.
 The service name and the method name ("Echo") are specified.
-<8> Create a `ClientServiceDescriptor` for service named `StringService` and add all our ``ClientMethodDescriptor``s.
+<8> Create a `ClientServiceDescriptor` for a service named `StringService` and add all the defined  ``ClientMethodDescriptor``s.
 <9> We create a `Channel` to the service that is running on `localhost:1408`.
 <10> Finally, we create our `GrpcServiceClient` by using the above-mentioned `ClientServiceDescriptor`
 and `Channel`.

--- a/docs/se/grpc/client.adoc
+++ b/docs/se/grpc/client.adoc
@@ -432,8 +432,6 @@ in the `ClientMethodDescriptor` anymore. Furthermore, there is an API in the `Cl
 that makes this even simpler where you can simply pass the method name. For example, to create a client streaming
 method called `"JoinString"` that uses some custom marshalling, simply call the `clientStreaming("JoinString")`.
 
-Lets see an example of creating a client for a service that uses Java serialization.
-
 [source,java]
 ----
 public static void main(String[] args) throws Exception {
@@ -528,9 +526,8 @@ public static void main(String[] args) throws Exception {
 ----
 
 <1> Create a `ClientServiceDescriptor` for the `HelloService`.
-<2> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
-<3> Add the `SayHello` unary method to the `ClientServiceDescriptor`. This method, by default, uses Java serialization for
-marshalling and unmarshalling the request and response values.
+<2> Specify custom marshaller using the built-in JsonB marshaller to marshall request and response values.
+<3> Add the `SayHello` unary method to the `ClientServiceDescriptor`.
 <4> Create a gRPC `Channel` that will communicate with the server running in localhost and on port 1408 (using plaintext).
 <5> Create the `GrpcServiceClient` that uses the above `Channel` and `ClientServiceDescriptor`. `GrpcClientService` represents
 a client that can be used to define the set of methods described by the specified `ClientServiceDescriptor`. In our case, the

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -56,11 +56,6 @@ responses if Protobuf does not satisfy your needs.
 * It provides built in support for <<Service Health Checks, health checks>>.
 
 
-=== Experimental
-
-WARNING: The Helidon gRPC feature is currently experimental and the APIs are
-subject to changes until gRPC support is stabilized.
-
 include::{rootdir}/includes/dependencies.adoc[]
 
 [source,xml]
@@ -72,7 +67,7 @@ include::{rootdir}/includes/dependencies.adoc[]
 ----
 
 [[security_maven_coordinartes]]
-If `gRPC server security` is required as described in this <<Security, section>> , add the following dependency to your project’s pom.xml:
+If `gRPC server security` is required as described in the <<Security>> section, add the following dependency to your project’s pom.xml:
 [source,xml]
 ----
 <dependency>
@@ -108,7 +103,6 @@ Both "standard" gRPC services that implement `io.grpc.BindableService` interface
 (typically implemented by extending generated server-side stub and overriding
 its methods), and Helidon gRPC services that implement
 `io.helidon.grpc.server.GrpcService` interface can be registered.
-
 The difference is that Helidon gRPC services allow you to customize behavior
 down to the method level, and provide a number of useful helper methods that
 make service implementation easier, as we'll see in a moment.
@@ -173,7 +167,8 @@ class EchoService implements GrpcService {
 
     @Override
     public void update(ServiceDescriptor.Rules rules) {
-        rules.unary("Echo", this::echo); // <1>
+        rules.marshallerSupplier(new JsonbMarshaller.Supplier()) // <1>
+             .unary("Echo", this::echo); // <2>
     }
 
     /**
@@ -182,30 +177,28 @@ class EchoService implements GrpcService {
      * @param request   the echo request containing the message to echo
      * @param observer  the response observer
      */
-    public void echo(String request, StreamObserver<String> observer) {  // <2>
-        complete(observer, request);  // <3>
+    public void echo(String request, StreamObserver<String> observer) {  // <3>
+        complete(observer, request);  // <4>
     }
 }
 ----
 
-<1> Define unary method `Echo` and map it to the `this::echo` handler.
-<2> Create a handler for the `Echo` method.
-<3> Send the request string back to the client by completing response observer.
+<1> Specify a custom marshaller to marshall requests and responses.
+<2> Define unary method `Echo` and map it to the `this::echo` handler.
+<3> Create a handler for the `Echo` method.
+<4> Send the request string back to the client by completing response observer.
 
 NOTE: The `complete` method shown in the example above is just one of many helper
 methods available in the `GrpcService` class. See the full list
 link:{grpc-server-javadoc-base-url}/io/helidon/grpc/server/GrpcService.html[here].
 
 The example above implements a service with a single unary method, which will be
-exposed at the `EchoService/Echo' endpoint. The service does not explicitly define
-a marshaller for requests and responses, so Java serialization will be used as a
-default.
-
-Unfortunately, this implies that you will have to implement clients by hand and
-configure them to use the same marshaller as the server. Obviously, one of the
-major selling points of gRPC is that it makes it easy to generate clients for a
-number of languages (as long as you use Protobuf for marshalling), so let's see
-how we would implement Protobuf enabled Helidon gRPC service.
+exposed at the `EchoService/Echo' endpoint. The service explicitly defines
+a marshaller for requests and responses, so this implies that you will have to
+implement clients by hand and configure them to use the same marshaller as the
+server. Obviously, one of the major selling points of gRPC is that it makes it easy to
+generate clients for a number of languages (as long as you use Protobuf for marshalling),
+so let's see how we would implement Protobuf enabled Helidon gRPC service.
 
 ==== Implementing Protobuf Services
 
@@ -513,7 +506,7 @@ While global metrics capture is certainly useful, it is not always sufficient.
 Keeping a separate `timer` for each gRPC method may be an overkill, so the user
 could decide to use a lighter-weight metric type, such as `counter` or a `meter`.
 
-However, she may still want to enable `histogram` or a `timer` for some services,
+However, user may still want to enable `histogram` or a `timer` for some services,
 or even only some methods of some services.
 
 This can be easily accomplished by overriding the type of the captured metric at
@@ -619,7 +612,7 @@ Typically the units value is one of the constants from `org.eclipse.microprofile
 
 ==== Overriding the Metric Name
 
-By default the metric name is the gRPC service name followed by a dot ('.') followed by the method name.
+By default, the metric name is the gRPC service name followed by a dot ('.') followed by the method name.
 It is possible to supply a function that can be used to override the default behaviour.
 
 The function should implement the `io.helidon.grpc.metrics.GrpcMetrics.NamingFunction` interface
@@ -648,7 +641,7 @@ GrpcRouting routing = GrpcRouting.builder()
                 .nameFunction((svc, method, metric) -> "grpc." + service.name() + '.' + method) // <1>
 ----
 <1> the `NamingFunction` is just a lambda that returns the concatenated service name and method name
-with the prefix `grpc.` So for a service "Foo", method "bar" the above example would produce a name "grpc.Foo.bar".
+with the prefix ``grpc.``. So for a service "Foo" and method "bar", the above example would produce a name "grpc.Foo.bar".
 
 === Security
 To enable Server Security, refer to earlier section about <<security_maven_coordinartes, Security maven coordinates>> for guidance on what dependency to add in the project's pom.xml.
@@ -732,7 +725,7 @@ security
 ----
 
 ===== Client security
-When using the Helidon SE gRPC client API security can be configured for a gRPC service
+When using the Helidon SE gRPC client, API security can be configured for a gRPC service
 or at the individual method level. The client API has a custom `CallCredentials` implementation that
 integrates with the Helidon security APIs.
 
@@ -794,9 +787,9 @@ Outbound security covers three scenarios:
 * Calling a secure gRPC service from inside a web server method handler
 * Calling a secure web endpoint from inside a gRPC service method handler
 
-Within each scenario credentials can be propagated if the gRPC/http method
+Within each scenario, credentials can be propagated if the gRPC/http method
 handler is executing within a security context or credentials can be overridden
-to provide a different set of credentials to use to call the outbound endpoint.
+to provide a different set of credentials to use for calling the outbound endpoint.
 
 [source,java]
 .Example calling a secure gRPC service from inside a gRPC service method handler
@@ -849,7 +842,7 @@ Response webResponse = client.target(url)
         .get();
 ----
 
-include::marshalling.adoc[leveloffset=2]
+include::{rootdir}/includes/grpc-marshalling.adoc[leveloffset=2]
 
 == Configuration
 Configure the gRPC Server using the Helidon configuration framework, either programmatically
@@ -918,8 +911,8 @@ public static void main(String[] args) throws Exception {
 static class HelloService implements GrpcService { // <5>
     @Override
     public void update(ServiceDescriptor.Rules rules) {
-        rules.unary("SayHello", ((request, responseObserver) -> complete(responseObserver, "Hello " + request))); // <6>
-        rules.marshallerSupplier(new JavaMarshaller.Supplier()); // <7>
+        rules.marshallerSupplier(new JsonbMarshaller.Supplier()) // <6>
+             .unary("SayHello", ((request, responseObserver) -> complete(responseObserver, "Hello " + request))); // <7>
     }
 }
 ----
@@ -929,5 +922,16 @@ static class HelloService implements GrpcService { // <5>
 <3> Wait for the server to start while throwing possible errors as exceptions.
 <4> The server is bound to a default port (1408).
 <5> Implement the simplest possible gRPC service.
-<6> Add unary method `HelloService/SayHello` to the service definition.
-<7> Specify custom marshaller using Java serialization to marshall requests and responses.
+<6> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
+<7> Add unary method `HelloService/SayHello` to the service definition.
+
+=== Additional gRPC Server examples
+A set of gRPC Server examples for Helidon SE can be found in the following links:
+
+* link:{helidon-github-tree-url}/examples/grpc/basics[Basic gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/metrics[gRPC Server Metrics]
+* link:{helidon-github-tree-url}/examples/grpc/opentracing[OpenTracing on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security[Basic Auth Security on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security-abac[Attribute-Based Access Control (ABAC) security on a gRPC Server]
+* link:{helidon-github-tree-url}/examples/grpc/security-outbound[Outbound Security on a gRPC Server]
+

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -33,15 +33,15 @@ include::{rootdir}/includes/se.adoc[]
 - <<Examples, Examples>>
 
 == Overview
-Helidon gRPC Server provides a framework for creating link:http://grpc.io/[gRPC] applications.
+The Helidon gRPC Server provides a framework for creating link:http://grpc.io/[gRPC] applications.
 While it allows you to deploy any standard gRPC service that
 implements `io.grpc.BindableService` interface, including services generated
 from the Protobuf IDL files (and even allows you to customize them to a certain
 extent), using Helidon gRPC framework to implement your services has a number of
 benefits:
 
-* It allows you to define both HTTP and gRPC services using similar programming
-model, simplifying learning curve for developers.
+* It allows you to define both HTTP and gRPC services using a similar programming
+model, simplifying the learning curve for developers.
 
 * It provides a number of helper methods that make service implementation
 significantly simpler.
@@ -50,10 +50,10 @@ significantly simpler.
 as <<Security, security>> and <<Service Metrics, metrics collection>>
 down to the method level.
 
-* It allows you to easily specify custom marshaller for requests and
+* It allows you to easily specify custom marshallers for requests and
 responses if Protobuf does not satisfy your needs.
 
-* It provides built in support for <<Service Health Checks, health checks>>.
+* It provides built-in support for <<Service Health Checks, health checks>>.
 
 
 include::{rootdir}/includes/dependencies.adoc[]
@@ -79,8 +79,8 @@ If `gRPC server security` is required as described in the <<Security>> section, 
 == Usage
 === gRPC Server Routing
 
-Unlike Webserver, which allows you to route requests based on path expression
-and the HTTP verb, gRPC server always routes requests based on the service and
+Unlike the webserver, which allows you to route requests based on path expression
+and the HTTP verb, the gRPC server always routes requests based on the service and
 method name. This makes routing configuration somewhat simpler -- all you need
 to do is register your services:
 
@@ -100,7 +100,7 @@ private static GrpcRouting createRouting(Config config) {
 <3> Register `MathService` instance.
 
 Both "standard" gRPC services that implement `io.grpc.BindableService` interface
-(typically implemented by extending generated server-side stub and overriding
+(typically implemented by extending the generated server-side stub and overriding
 its methods), and Helidon gRPC services that implement
 `io.helidon.grpc.server.GrpcService` interface can be registered.
 The difference is that Helidon gRPC services allow you to customize behavior
@@ -110,7 +110,7 @@ make service implementation easier, as we'll see in a moment.
 ==== Customizing Service Definitions
 
 When registering a service, regardless of its type, you can customize its
-descriptor by providing configuration consumer as a second argument to the
+descriptor by providing a configuration consumer as a second argument to the
 `register` method.
 
 This is particularly useful when registering standard `BindableService`
@@ -158,7 +158,7 @@ private static GrpcRouting createRouting(Config config) {
 === Service Implementation
 
 At the very basic level, all you need to do in order to implement a Helidon
-gRPC service is create a class that implements `io.helidon.grpc.server.GrpcService`
+gRPC service is create a class that implements the `io.helidon.grpc.server.GrpcService`
 interface and define one or more methods for the service:
 
 [source,java]
@@ -192,7 +192,7 @@ NOTE: The `complete` method shown in the example above is just one of many helpe
 methods available in the `GrpcService` class. See the full list
 link:{grpc-server-javadoc-base-url}/io/helidon/grpc/server/GrpcService.html[here].
 
-The example above implements a service with a single unary method, which will be
+The example above implements a service with a single unary method which will be
 exposed at the `EchoService/Echo' endpoint. The service explicitly defines
 a marshaller for requests and responses, so this implies that you will have to
 implement clients by hand and configure them to use the same marshaller as the
@@ -264,7 +264,7 @@ class EchoService implements GrpcService {
 }
 ----
 
-<1> Specify proto descriptor in order to provide necessary type information and
+<1> Specify the proto descriptor in order to provide necessary type information and
 enable Protobuf marshalling.
 <2> Define unary method `Echo` and map it to the `this::echo` handler.
 <3> Create a handler for the `Echo` method, using Protobuf message types for request and response.
@@ -295,9 +295,9 @@ class LoggingInterceptor implements ServerInterceptor {   // <1>
 }
 ----
 
-<1> Implement `io.grpc.ServerInterceptor`
-<2> Implement the logging logic
-<3> Start intercepted call
+<1> Implement the interceptor class using `io.grpc.ServerInterceptor`.
+<2> Implement the logging logic.
+<3> The intercepted call is started.
 
 ==== Registering Interceptors
 
@@ -315,7 +315,7 @@ private static GrpcRouting createRouting(Config config) {
 }
 ----
 
-<1> Adds `LoggingInterceptor` to all methods of `GreetService` and `EchoService`
+<1> Adds `LoggingInterceptor` to all methods of `GreetService` and `EchoService`.
 
 You can also register an interceptor for a specific service, either by implementing
 `GrpcService.update` method:
@@ -336,7 +336,7 @@ public class MyService implements GrpcService {
 }
 ----
 
-<1> Adds `LoggingInterceptor` to all methods of `MyService`
+<1> Adds `LoggingInterceptor` to all methods of `MyService`.
 
 Or by configuring `ServiceDescriptor` externally, when creating `GrpcRouting`, which
 allows you to add interceptors to plain `io.grpc.BindableService` services as well:
@@ -351,7 +351,7 @@ private static GrpcRouting createRouting(Config config) {
 }
 ----
 
-<1> Adds `LoggingInterceptor` to all methods of `GreetService` only
+<1> Adds `LoggingInterceptor` to all methods of `GreetService` only.
 
 Finally, you can also register an interceptor at the method level:
 
@@ -372,11 +372,11 @@ public class MyService implements GrpcService {
 }
 ----
 
-<1> Adds `LoggingInterceptor` to `MyService::MyMethod` only
+<1> Adds `LoggingInterceptor` to `MyService::MyMethod` only.
 
 === Service Health Checks
 
-Helidon gRPC services provide a built-in support for Helidon Health Checks.
+Helidon gRPC services provide built-in support for Helidon Health Checks.
 
 Unless a custom health check is implemented by the service developer, each service
 deployed to the gRPC server will be provisioned with a default health check, which
@@ -415,15 +415,15 @@ heckResponse healthCheck() {
 }
 ----
 
-<1> Configure a custom health check for the service
-<2> Determine service status
-<3> Use service name as a health check name for consistency
-<4> Use determined service status
-<5> Optionally, provide additional metadata
+<1> Configure a custom health check for the service.
+<2> Determine the service status.
+<3> Use service name as a health check name for consistency.
+<4> Set the determined service status.
+<5> Optionally provide additional metadata.
 
-You can also define custom health check for an existing service, including plain
-`io.grpc.BindableService` implementations, using service configurer inside the
-`GrpcRouting` deefinition:
+You can also define custom health checks for an existing service, including plain
+`io.grpc.BindableService` implementations, using a service configurer inside the
+`GrpcRouting` definition:
 
 [source,java]
 ----
@@ -439,10 +439,10 @@ private static GrpcRouting createRouting() {
 ==== Exposing Health Checks
 
 All gRPC service health checks are managed by the Helidon gRPC Server, and are
-automatically exposed to the gRPC clients using custom implementation of the
+automatically exposed to the gRPC clients using a custom implementation of the
 standard gRPC `HealthService` API.
 
-However, they can also be exposed to REST clients via standard Helidon/Microprofile
+However, they can also be exposed to REST clients via the standard Helidon/Microprofile
 `/health` endpoint:
 
 [source,java]
@@ -461,26 +461,26 @@ However, they can also be exposed to REST clients via standard Helidon/Microprof
         WebServer.create(webServerConfig(), routing).start();   // <5>
 ----
 
-<1> Create `GrpcServer` instance
-<2> Start gRPC server, which will deploy all services and register default and custom health checks
-<3> Add gRPC server managed health checks to `HealthSupport` instance
-<4> Add `HealthSupport` to the web server routing definition
-<5> Create and start web server
+<1> Create the `GrpcServer` instance.
+<2> Start the gRPC server which will deploy all the services and register default and custom health checks.
+<3> Add gRPC server managed health checks to `HealthSupport` instance.
+<4> Add `HealthSupport` to the web server routing definition.
+<5> Create and start the web server
 
-All gRPC health checks will now be available via `/health` REST endpoint, in
+All gRPC health checks will now be available via the `/health` REST endpoint, in
 addition to the standard gRPC `HealthService`
 
 === Service Metrics
-Helidon gRPC Server has built-in support for metrics capture, which allows
+The Helidon gRPC Server has built-in support for metrics capture, which allows
 service developers to easily enable application-level metrics for their services.
 
 ==== Enabling Metrics Capture
 
-By default, gRPC Server only captures two vendor-level metrics: `grpc.request.count`
-and `grpc.request.meter`.These metrics provide aggregate view of requests across
+By default, the gRPC Server only captures two vendor-level metrics: `grpc.request.count`
+and `grpc.request.meter`. These metrics provide an aggregate view of requests across
 all services, and serve as an indication of the overall server load.
 
-However, users can enable more fine grained metrics by simply configuring a built-in
+However, users can enable more fine-grained metrics by simply configuring a built-in
 `GrpcMetrics` interceptor within the routing:
 
 [source,java]
@@ -494,7 +494,7 @@ private static GrpcRouting createRouting(Config config) {
 }
 ----
 
-<1> Capture metrics for all methods of all services as a `timer`
+<1> Capture the metrics for all methods of all services as a `timer`.
 
 In the example above we have chosen to create and keep a `timer` metric type for
 each method of each service. Alternatively, we could've chosen to use a
@@ -503,20 +503,20 @@ each method of each service. Alternatively, we could've chosen to use a
 ==== Overriding Metrics Capture
 
 While global metrics capture is certainly useful, it is not always sufficient.
-Keeping a separate `timer` for each gRPC method may be an overkill, so the user
-could decide to use a lighter-weight metric type, such as `counter` or a `meter`.
+Keeping a separate `timer` for each gRPC method may be excessive, so the user
+could decide to use a lighter-weight metric type, such as a `counter` or a `meter`.
 
-However, user may still want to enable `histogram` or a `timer` for some services,
+However, the user may still want to enable a `histogram` or a `timer` for some services,
 or even only some methods of some services.
 
 This can be easily accomplished by overriding the type of the captured metric at
-either service or the method level:
+either the service or the method level:
 
 [source,java]
 ----
 private static GrpcRouting createRouting(Config config) {
     return GrpcRouting.builder()
-            .intercept(GrpcMetrics.counted())   // <1>
+            .intercept(GrpcMetrics.counted())  // <1>
             .register(new MyService())
             .build();
 }
@@ -526,9 +526,9 @@ public static class MyService implements GrpcService {
     @Override
     public void update(ServiceDescriptor.Rules rules) {
         rules
-            .intercept(GrpcMetrics.metered())                     // <2>
+            .intercept(GrpcMetrics.metered())  // <2>
             .unary("MyMethod", this::myMethod,
-                       cfg -> cfg.intercept(GrpcMetrics.timer())) // <3>
+                       cfg -> cfg.intercept(GrpcMetrics.timer())); // <3>
     }
 
     private <ReqT, ResT> void myMethod(ReqT request, StreamObserver<ResT> observer) {
@@ -537,14 +537,14 @@ public static class MyService implements GrpcService {
 }
 ----
 
-<1> Use `counter` for all methods of all services, unless overridden
-<2> Use `meter` for all methods of `MyService`
-<3> Use `timer` for `MyService::MyMethod`
+<1> Use `counter` for all methods of all services, unless overridden.
+<2> Use `meter` for all methods of `MyService`.
+<3> Use `timer` for `MyService::MyMethod`.
 
 ==== Exposing Metrics Externally
 
-Collected metrics are stored in the standard Helidon Metric Registries, such as vendor and
-application registry, and can be exposed via standard `/metrics` REST API.
+Collected metrics are stored in the standard Helidon metric registries, such as the vendor and
+application registries, and can be exposed via the standard `/metrics` REST API.
 
 [source,java]
 ----
@@ -555,20 +555,20 @@ Routing routing = Routing.builder()
 WebServer.create(webServerConfig(), routing)  // <2>
          .start()
 ----
-<1> Add `MetricsSupport` instance to web server routing
-<2> Create and start Helidon web server
+<1> Add the `MetricsSupport` instance to web server routing.
+<2> Create and start the Helidon web server.
 
 See xref:../metrics/metrics.adoc[Helidon Metrics] documentation for more details.
 
-==== Specifying Metric Meta-data
+==== Specifying Metric Metadata
 
-Helidon metrics contain meta-data such as tags, a description, units etc. It is possible to
-add this additional meta-data when specifying the metrics.
+Helidon metrics contain metadata such as tags, a description, units etc. It is possible to
+add this additional metadata when specifying the metrics.
 
 ===== Adding Tags
 
-To add tags to a metric a `Map` of key/value tags can be supplied.
-For example:
+To add tags to a metric, a `Map` of key/value tags can be supplied.
+
 [source,java]
 ----
 Map<String, String> tagMap = new HashMap<>();
@@ -580,12 +580,12 @@ GrpcRouting routing = GrpcRouting.builder()
         .register(new MyService())
         .build();
 ----
-<1> the `tags()` method is used to add the `Map` of tags to the metric.
+<1> The `tags()` method is used to add the `Map` of tags to the metric.
 
 ===== Adding a Description
 
-A meaningful description can be added to a metric:
-For example:
+A meaningful description can be added to a metric.
+
 [source,java]
 ----
 GrpcRouting routing = GrpcRouting.builder()
@@ -594,12 +594,12 @@ GrpcRouting routing = GrpcRouting.builder()
         .build();
 ----
 
-<1> the `description()` method is used to add the description to the metric.
+<1> The `description()` method is used to add the description to the metric.
 
 ===== Adding Metric Units
 
-A units value can be added to the Metric:
-For example:
+A `units` value can be added to a metric.
+
 [source,java]
 ----
 GrpcRouting routing = GrpcRouting.builder()
@@ -607,15 +607,16 @@ GrpcRouting routing = GrpcRouting.builder()
         .register(new MyService())
         .build();
 ----
-<1> the `units()` method is used to add the metric units to the metric.
-Typically the units value is one of the constants from `org.eclipse.microprofile.metrics.MetricUnits` class.
+<1> The `units()` method is used to specify the metric units,
+the value of which is one of the constants from the `org.eclipse.microprofile.metrics.MetricUnits` class.
 
 ==== Overriding the Metric Name
 
 By default, the metric name is the gRPC service name followed by a dot ('.') followed by the method name.
 It is possible to supply a function that can be used to override the default behaviour.
 
-The function should implement the `io.helidon.grpc.metrics.GrpcMetrics.NamingFunction` interface
+The function should implement the `io.helidon.grpc.metrics.GrpcMetrics.NamingFunction` interface.
+
 [source,java]
 ----
 @FunctionalInterface
@@ -631,27 +632,26 @@ public interface NamingFunction {
     String createName(ServiceDescriptor service, String methodName, MetricType metricType);
 }
 ----
-This is a functional interface so lambda can be used too.
+This is a functional interface so a lambda expression can be used too.
 
-For example:
 [source,java]
 ----
 GrpcRouting routing = GrpcRouting.builder()
         .intercept(GrpcMetrics.counted()
                 .nameFunction((svc, method, metric) -> "grpc." + service.name() + '.' + method) // <1>
 ----
-<1> the `NamingFunction` is just a lambda that returns the concatenated service name and method name
+<1> The `NamingFunction` is just a lambda that returns the concatenated service name and method name
 with the prefix ``grpc.``. So for a service "Foo" and method "bar", the above example would produce a name "grpc.Foo.bar".
 
 === Security
-To enable Server Security, refer to earlier section about <<security_maven_coordinartes, Security maven coordinates>> for guidance on what dependency to add in the project's pom.xml.
+To enable server security, refer to the earlier section about <<security_maven_coordinartes, Security maven coordinates>> for guidance on what dependency to add in the project's pom.xml.
 
 ==== Bootstrapping
 
-There are two steps to configure security with gRPC server:
+There are two steps to configure security with the gRPC server:
 
-1. Create security instance and register it with server
-2. Protect gRPC services of server with various security features
+1. Create the security instance and register it the with server.
+2. Protect the gRPC services of the server with various security features.
 
 [source,java]
 .Example using builders
@@ -751,13 +751,13 @@ GrpcServiceClient client = GrpcServiceClient.create(channel, descriptor); // <5>
 
 String response = client.blockingUnary("Lower", "ABCD"); // <6>
 ----
-<1> Create the Helidon `Security` instance (in this case using the basic auth provider)
+<1> Create the Helidon `Security` instance which, in this case, will use the basic auth provider.
 <2> Create the `GrpcClientSecurity` gRPC `CallCredentials` adding the user and password
 property expected by the basic auth provider.
 <3> Create the gRPC `ClientServiceDescriptor` for the `StringService` gRPC service.
-<4> Set the `GrpcClientSecurity` instance as the call credentials for all methods of the service
-<5> Create a `GrpcServiceClient` that will allow methods to be called on the service
-<6> Call the "Lower" method which will use the configured basic auth credentials
+<4> Set the `GrpcClientSecurity` instance as the call credentials for all methods of the service.
+<5> Create a `GrpcServiceClient` that will allow methods to be called on the service.
+<6> Call the "Lower" method which will use the configured basic auth credentials.
 
 
 [source,java]
@@ -783,9 +783,9 @@ will be called without any credentials.
 ===== Outbound security
 Outbound security covers three scenarios:
 
-* Calling a secure gRPC service from inside a gRPC service method handler
-* Calling a secure gRPC service from inside a web server method handler
-* Calling a secure web endpoint from inside a gRPC service method handler
+* Calling a secure gRPC service from inside a gRPC service method handler.
+* Calling a secure gRPC service from inside a web server method handler.
+* Calling a secure web endpoint from inside a gRPC service method handler.
 
 Within each scenario, credentials can be propagated if the gRPC/http method
 handler is executing within a security context or credentials can be overridden
@@ -917,12 +917,12 @@ static class HelloService implements GrpcService { // <5>
 }
 ----
 
-<1> Register gRPC service.
+<1> Register the gRPC service.
 <2> Start the server.
 <3> Wait for the server to start while throwing possible errors as exceptions.
 <4> The server is bound to a default port (1408).
 <5> Implement the simplest possible gRPC service.
-<6> Specify custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
+<6> Specify a custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
 <7> Add unary method `HelloService/SayHello` to the service definition.
 
 === Additional gRPC Server examples

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -434,7 +434,7 @@ private static GrpcRouting createRouting() {
 }
 ----
 
-<1> Configure custom health check for an existing or legacy service
+<1> Configure custom health check for an existing or legacy service.
 
 ==== Exposing Health Checks
 
@@ -465,7 +465,7 @@ However, they can also be exposed to REST clients via the standard Helidon/Micro
 <2> Start the gRPC server which will deploy all the services and register default and custom health checks.
 <3> Add gRPC server managed health checks to `HealthSupport` instance.
 <4> Add `HealthSupport` to the web server routing definition.
-<5> Create and start the web server
+<5> Create and start the web server.
 
 All gRPC health checks will now be available via the `/health` REST endpoint, in
 addition to the standard gRPC `HealthService`

--- a/docs/se/grpc/server.adoc
+++ b/docs/se/grpc/server.adoc
@@ -33,7 +33,7 @@ include::{rootdir}/includes/se.adoc[]
 - <<Examples, Examples>>
 
 == Overview
-The Helidon gRPC Server provides a framework for creating link:http://grpc.io/[gRPC] applications.
+The Helidon gRPC server provides a framework for creating link:http://grpc.io/[gRPC] applications.
 While it allows you to deploy any standard gRPC service that
 implements `io.grpc.BindableService` interface, including services generated
 from the Protobuf IDL files (and even allows you to customize them to a certain
@@ -438,7 +438,7 @@ private static GrpcRouting createRouting() {
 
 ==== Exposing Health Checks
 
-All gRPC service health checks are managed by the Helidon gRPC Server, and are
+All gRPC service health checks are managed by the Helidon gRPC server, and are
 automatically exposed to the gRPC clients using a custom implementation of the
 standard gRPC `HealthService` API.
 
@@ -471,12 +471,12 @@ All gRPC health checks will now be available via the `/health` REST endpoint, in
 addition to the standard gRPC `HealthService`
 
 === Service Metrics
-The Helidon gRPC Server has built-in support for metrics capture, which allows
+The Helidon gRPC server has built-in support for metrics capture, which allows
 service developers to easily enable application-level metrics for their services.
 
 ==== Enabling Metrics Capture
 
-By default, the gRPC Server only captures two vendor-level metrics: `grpc.request.count`
+By default, the gRPC server only captures two vendor-level metrics: `grpc.request.count`
 and `grpc.request.meter`. These metrics provide an aggregate view of requests across
 all services, and serve as an indication of the overall server load.
 
@@ -558,7 +558,7 @@ WebServer.create(webServerConfig(), routing)  // <2>
 <1> Add the `MetricsSupport` instance to web server routing.
 <2> Create and start the Helidon web server.
 
-See xref:../metrics/metrics.adoc[Helidon Metrics] documentation for more details.
+See xref:{rootdir}/se/metrics/metrics.adoc[Helidon Metrics] documentation for more details.
 
 ==== Specifying Metric Metadata
 
@@ -845,12 +845,12 @@ Response webResponse = client.target(url)
 include::{rootdir}/includes/grpc-marshalling.adoc[leveloffset=2]
 
 == Configuration
-Configure the gRPC Server using the Helidon configuration framework, either programmatically
+Configure the gRPC server using the Helidon configuration framework, either programmatically
 or via a configuration file.
 
-=== Configuring the gRPC Server in your code
+=== Configuring the gRPC server in your code
 
-The easiest way to configure the gRPC Server is in your application code.
+The easiest way to configure the gRPC server is in your application code.
 
 [source,java]
 ----
@@ -863,7 +863,7 @@ GrpcServer grpcServer = GrpcServer.create(configuration, routing);
 See all configuration options
 link:{javadoc-base-url}/io.helidon.grpc/GrpcServerConfiguration.html[here].
 
-=== Configuring the gRPC Server in a configuration file
+=== Configuring the gRPC server in a configuration file
 
 You can also define the gRPC server configuration in a file.
 
@@ -905,7 +905,7 @@ public static void main(String[] args) throws Exception {
             .toCompletableFuture()
             .get(10, TimeUnit.SECONDS); // Implement the simplest possible gRPC service. // <3>
 
-    System.out.println("gRPC Server started at: http://localhost:" + grpcServer.port()); // <4>
+    System.out.println("gRPC server started at: http://localhost:" + grpcServer.port()); // <4>
 }
 
 static class HelloService implements GrpcService { // <5>
@@ -925,8 +925,8 @@ static class HelloService implements GrpcService { // <5>
 <6> Specify a custom marshaller using the built-in JsonB marshaller to marshall requests and responses.
 <7> Add unary method `HelloService/SayHello` to the service definition.
 
-=== Additional gRPC Server examples
-A set of gRPC Server examples for Helidon SE can be found in the following links:
+=== Additional gRPC server examples
+A set of gRPC server examples for Helidon SE can be found in the following links:
 
 * link:{helidon-github-tree-url}/examples/grpc/basics[Basic gRPC Server]
 * link:{helidon-github-tree-url}/examples/grpc/metrics[gRPC Server Metrics]

--- a/docs/sitegen.yaml
+++ b/docs/sitegen.yaml
@@ -315,7 +315,7 @@ backend:
                   type: "icon"
                   value: "swap_horiz"
                 sources:
-                  - "server-side-services.adoc"
+                  - "server.adoc"
                   - "client.adoc"
               - type: "PAGE"
                 title: "GraphQL"


### PR DESCRIPTION
1. Add Configuration section to MP Server doc.
2. Add more examples by providing links to various example scenarios available in the example directory of the Helidon repository.
3. Remove any examples of Java Serialization as the custom marshaller.
4. Remove Experimental warning from the doc.