### PR TITLE
Upgrade protobuf to support osx-aarch_64 architecture

### DIFF
--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -231,4 +231,3 @@
         <snapshotRepository />
     </distributionManagement>
 </project>
-

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -231,3 +231,4 @@
         <snapshotRepository />
     </distributionManagement>
 </project>
+

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -180,7 +180,7 @@
                     <artifactId>protobuf-maven-plugin</artifactId>
                     <version>${version.plugin.protobuf}</version>
                     <configuration>
-                        <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
+                        <protocArtifact>com.google.protobuf:protoc:${version.lib.google-protobuf}:exe:${os.detected.classifier}</protocArtifact>
                         <pluginId>grpc-java</pluginId>
                         <pluginArtifact>io.grpc:protoc-gen-grpc-java:${version.lib.grpc}:exe:${os.detected.classifier}</pluginArtifact>
                     </configuration>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -56,7 +56,7 @@
         <version.lib.google-api-client>1.34.1</version.lib.google-api-client>
         <version.lib.google-oauth-client>1.33.3</version.lib.google-oauth-client>
         <version.lib.google-error-prone>2.3.3</version.lib.google-error-prone>
-        <version.lib.google-protobuf>3.19.2</version.lib.google-protobuf>
+        <version.lib.google-protobuf>3.21.4</version.lib.google-protobuf>
         <version.lib.graalvm>21.3.0</version.lib.graalvm>
         <version.lib.graphql-java>15.0</version.lib.graphql-java>
         <version.lib.graphql-java.extended.scalars>15.0.0</version.lib.graphql-java.extended.scalars>

--- a/pom.xml
+++ b/pom.xml
@@ -585,7 +585,7 @@
                     <version>${version.plugin.protobuf}</version>
                     <configuration>
                         <!--suppress UnresolvedMavenProperty -->
-                        <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
+                        <protocArtifact>com.google.protobuf:protoc:${version.lib.google-protobuf}:exe:${os.detected.classifier}</protocArtifact>
                         <pluginId>grpc-java</pluginId>
                         <!--suppress UnresolvedMavenProperty -->
                         <pluginArtifact>


### PR DESCRIPTION
And use version defined by a property instead of a hardcoded one.

Resolves #4482 for 2.x

Once this is merged, I will create an update for 3.x branch as well

@dalexandrov @ljnelson  could you please verify on the architecture this really fixes the problem? Thanks!