### PR TITLE
Change log level to fine for exception caught while intercepting

### DIFF
--- a/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/InterceptionRunnerImpl.java
+++ b/service-common/rest-cdi/src/main/java/io/helidon/servicecommon/restcdi/InterceptionRunnerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,10 @@ class InterceptionRunnerImpl implements InterceptionRunner {
                     RuntimeException::new);
         }
         if (escapingException != null) {
-            LOGGER.log(Level.WARNING, ERROR_DURING_INTERCEPTION, escapingException);
+            // this exception is to be handled by JAX-RS after reported here, it should not be logged automatically
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, ERROR_DURING_INTERCEPTION, escapingException);
+            }
             throw escapingException;
         }
         return result;


### PR DESCRIPTION
Related to #4493 - the reproducer was showing a warning message that was a bit too aggressive, changed log level.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>