### PR TITLE
Changes to FT implementation to support interception of proxy methods

### DIFF
--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FtAnnotatedMethod.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/FtAnnotatedMethod.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.microprofile.faulttolerance;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedParameter;
+import javax.enterprise.inject.spi.AnnotatedType;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Wrapper for a Java method that implements the {@link AnnotatedMethod} interface.
+ * This wrapper is necessary to handle proxy methods, such as those created from
+ * a RestClient interface.
+ */
+class FtAnnotatedMethod implements AnnotatedMethod<Object> {
+
+    private final Method method;
+
+    private final AnnotatedType<Object> type;
+
+    FtAnnotatedMethod(Method method) {
+        this.method = method;
+        this.type = new AnnotatedType<>() {
+            private final Class<?> clazz = method.getDeclaringClass();
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public Class<Object> getJavaClass() {
+                return (Class<Object>) clazz;
+            }
+
+            @Override
+            public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
+                return clazz.getAnnotation(annotationType);
+            }
+
+            @Override
+            public Set<Annotation> getAnnotations() {
+                return Set.of(clazz.getAnnotations());
+            }
+
+            @Override
+            public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+                return clazz.isAnnotationPresent(annotationType);
+            }
+
+            @Override
+            public Set<AnnotatedConstructor<Object>> getConstructors() {
+                throw new IllegalStateException("Should not be called");
+            }
+
+            @Override
+            public Set<AnnotatedMethod<? super Object>> getMethods() {
+                throw new IllegalStateException("Should not be called");
+            }
+
+            @Override
+            public Set<AnnotatedField<? super Object>> getFields() {
+                throw new IllegalStateException("Should not be called");
+            }
+
+            @Override
+            public Type getBaseType() {
+                throw new IllegalStateException("Should not be called");
+            }
+
+            @Override
+            public Set<Type> getTypeClosure() {
+                throw new IllegalStateException("Should not be called");
+            }
+        };
+    }
+
+    @Override
+    public Method getJavaMember() {
+        return method;
+    }
+
+    @Override
+    public AnnotatedType<Object> getDeclaringType() {
+        return type;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
+        Set<T> set = getAnnotations(annotationType);
+        return set.isEmpty() ? null : set.iterator().next();
+    }
+
+    @Override
+    public <T extends Annotation> Set<T> getAnnotations(Class<T> annotationType) {
+        T[] annotationsByType = getJavaMember().getAnnotationsByType(annotationType);
+        return new LinkedHashSet<>(asList(annotationsByType));
+    }
+
+    @Override
+    public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+        return getJavaMember().isAnnotationPresent(annotationType);
+    }
+
+    public Set<Annotation> getAnnotations() {
+        Annotation[] annotations = getJavaMember().getAnnotations();
+        return new LinkedHashSet<>(asList(annotations));
+    }
+
+    @Override
+    public Type getBaseType() {
+        throw new IllegalStateException("Should not be called");
+    }
+
+    @Override
+    public Set<Type> getTypeClosure() {
+        throw new IllegalStateException("Should not be called");
+    }
+
+    @Override
+    public List<AnnotatedParameter<Object>> getParameters() {
+        throw new IllegalStateException("Should not be called");
+    }
+
+    @Override
+    public boolean isStatic() {
+        throw new IllegalStateException("Should not be called");
+    }
+}

--- a/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
+++ b/microprofile/fault-tolerance/src/main/java/io/helidon/microprofile/faulttolerance/MethodIntrospector.java
@@ -65,7 +65,7 @@ class MethodIntrospector {
                         .stream()
                         .filter(am -> am.getJavaMember().equals(method))
                         .findFirst();
-        this.annotatedMethod = annotatedMethodOptional.orElseThrow();
+        this.annotatedMethod = annotatedMethodOptional.orElse(new FtAnnotatedMethod(method));
 
         this.retry = isAnnotationEnabled(Retry.class) ? new RetryAntn(annotatedMethod) : null;
         this.circuitBreaker = isAnnotationEnabled(CircuitBreaker.class)

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -54,6 +54,7 @@
         <module>config</module>
         <module>jep290</module>
         <module>mp-bean-validation</module>
+        <module>restclient</module>
     </modules>
 
     <profiles>

--- a/tests/integration/restclient/pom.xml
+++ b/tests/integration/restclient/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>helidon-tests-integration</artifactId>
+        <groupId>io.helidon.tests.integration</groupId>
+        <version>2.5.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-tests-integration-restclient</artifactId>
+    <name>Helidon Integration Test RestClient</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.microprofile.bundles</groupId>
+            <artifactId>helidon-microprofile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.rest-client</groupId>
+            <artifactId>helidon-microprofile-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.microprofile.tests</groupId>
+            <artifactId>helidon-microprofile-tests-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;
+
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+
+@Path("/greet")
+public class GreetResource {
+
+    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Collections.emptyMap());
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject getDefaultMessage() {
+        return createResponse("World");
+    }
+
+    private JsonObject createResponse(String who) {
+        String msg = String.format("%s %s!", "Hello", who);
+
+        return JSON.createObjectBuilder()
+                .add("message", msg)
+                .build();
+    }
+}

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResource.java
@@ -25,6 +25,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 
+/**
+ * A typical greet resource that only handles a single GET for a default message.
+ */
 @Path("/greet")
 public class GreetResource {
 

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;
+
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * RestClient interfaces that includes a few FT annotations.
+ */
+@Path("/greet")
+@RegisterProvider(GreetResourceFilter.class)
+@RegisterRestClient(baseUri="http://localhost:8080")
+public interface GreetResourceClient {
+
+    @GET
+    @Retry
+    @Timeout(value = 3000)
+    @Produces(MediaType.APPLICATION_JSON)
+    JsonObject getDefaultMessage();
+}

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceClient.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
- * RestClient interfaces that includes a few FT annotations.
+ * RestClient interface for a simple greet resource that includes a few FT annotations.
  */
 @Path("/greet")
 @RegisterProvider(GreetResourceFilter.class)

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceFilter.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceFilter.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.net.URI;
 
 /**
- * Replaces 8080 port by ephemeral port allocated for the webserver.
+ * A client request filter that replaces port 8080 by the ephemeral port allocated for the
+ * webserver in each run. This is necessary since {@link GreetResourceClient} uses an annotation
+ * to specify the base URI, and its value cannot be changed dynamically.
  */
 public class GreetResourceFilter implements ClientRequestFilter  {
 

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceFilter.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Replaces 8080 port by ephemeral port allocated for the webserver.
+ */
+public class GreetResourceFilter implements ClientRequestFilter  {
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        URI uri = requestContext.getUri();
+        String fixedUri = uri.toString().replace("8080", extractDynamicPort());
+        requestContext.setUri(URI.create(fixedUri));
+    }
+
+    private String extractDynamicPort() {
+        String uriString = uriInfo.getBaseUri().toString();
+        int k = uriString.lastIndexOf(":");
+        int j = uriString.indexOf("/", k);
+        return uriString.substring(k + 1, j);
+    }
+}

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
@@ -29,6 +29,11 @@ import javax.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
+/**
+ * A greet resource proxy class that forwards calls to the real greet service
+ * using a RestClient proxy. It tries both a proxy built manually as well as
+ * one injected into this class.
+ */
 @Path("/proxy")
 public class GreetResourceProxy {
 

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/GreetResourceProxy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Path("/proxy")
+public class GreetResourceProxy {
+
+    @Context
+    private UriInfo uriInfo;
+
+    /**
+     * An injected client whose base URI needs to be patched by {@link GreetResourceFilter}
+     * to use the ephemeral port.
+     */
+    @Inject
+    @RestClient
+    private GreetResourceClient injectedClient;
+
+    /**
+     * A built client whose base URI can be updated upon creation time.
+     */
+    private GreetResourceClient builderClient;
+
+    @PostConstruct
+    public void initialize() {
+        builderClient = RestClientBuilder.newBuilder()
+                .baseUri(uriInfo.getBaseUri())
+                .build(GreetResourceClient.class);
+    }
+
+    /**
+     * Test both clients and compares responses before returning one.
+     *
+     * @return JSON response.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObject getDefaultMessage() {
+        JsonObject msg1 = injectedClient.getDefaultMessage();
+        JsonObject msg2 = builderClient.getDefaultMessage();
+        if (!msg1.getString("message").equals(msg2.getString("message"))) {
+            throw new IllegalStateException("Oops");
+        }
+        return msg1;
+    }
+}

--- a/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/package-info.java
+++ b/tests/integration/restclient/src/main/java/io/helidon/tests/integration/restclient/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;

--- a/tests/integration/restclient/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/restclient/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       version="2.0"
+       bean-discovery-mode="annotated">
+</beans>

--- a/tests/integration/restclient/src/main/resources/META-INF/microprofile-config.properties
+++ b/tests/integration/restclient/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server.port=8080
+server.host=0.0.0.0

--- a/tests/integration/restclient/src/test/java/io/helidon/tests/integration/restclient/MainTest.java
+++ b/tests/integration/restclient/src/test/java/io/helidon/tests/integration/restclient/MainTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.integration.restclient;
+
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.ws.rs.client.WebTarget;
+
+import io.helidon.microprofile.tests.junit5.HelidonTest;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@HelidonTest
+class MainTest {
+
+    private static final String retryTotal = "ft.io.helidon.tests.integration.restclient.GreetResourceClient." +
+            "getDefaultMessage.retry.callsSucceededNotRetried.total";
+
+    @Inject
+    private WebTarget target;
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Test
+    void testHelloWorld() {
+        // Get access to @Retry counter
+        MetricID id = new MetricID(retryTotal);
+        Counter counter = registry.getCounters().get(id);
+
+        // Initially counter must be zero
+        assertEquals(0L, counter.getCount());
+
+        // Invoke proxy and verify return value
+        JsonObject jsonObject = target
+                .path("proxy")
+                .request()
+                .get(JsonObject.class);
+        assertEquals("Hello World!", jsonObject.getString("message"));
+
+        // Verify that @Retry code was executed by looking at counter
+        assertEquals(2L, counter.getCount());
+    }
+}


### PR DESCRIPTION
Changes to FT implementation to support interception of proxy methods created from RestClient interfaces. New test that shows integration between RestClient and FT both using injected proxies and proxies created from builders. Issue #4355.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>