### PR TITLE
Remove redundant __pkg__ folder in a project generated by helidon CLI

### DIFF
--- a/archetypes/helidon/src/main/archetype/mp/custom/custom-mp.xml
+++ b/archetypes/helidon/src/main/archetype/mp/custom/custom-mp.xml
@@ -30,12 +30,6 @@
     <exec src="/mp/custom/database.xml"/>
     <exec src="/mp/common/common-mp.xml"/>
     <output>
-        <files if="${security}">
-            <directory>files</directory>
-            <includes>
-                <include if="${security.atn} contains 'http-signature'">src/*/resources/keystore.p12</include>
-            </includes>
-        </files>
         <model>
             <value key="helidon-test">true</value>
             <value key="readme-description">Minimal Helidon MP project suitable to start from scratch.</value>


### PR DESCRIPTION
resolves [#764](https://github.com/oracle/helidon/issues/4645)

Signed-off-by: aserkes <andrii.serkes@oracle.com>