### PR TITLE
Updated WebSocketHandler to correctly propagate query params from weberver to Tyrus

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/UriComponent.java
+++ b/common/http/src/main/java/io/helidon/common/http/UriComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package io.helidon.webserver;
+package io.helidon.common.http;
 
 import java.net.URLDecoder;
-
-import io.helidon.common.http.HashParameters;
-import io.helidon.common.http.Parameters;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -27,11 +24,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Extracted from Jersey
  * <p>
  * Utility class for validating, encoding and decoding components of a URI.
- *
- * @author Paul Sandoz
- * @author Marek Potociar (marek.potociar at oracle.com)
  */
-final class UriComponent {
+public final class UriComponent {
 
     private UriComponent() {
     }
@@ -47,7 +41,7 @@ final class UriComponent {
      *               should be in decoded form.
      * @return the multivalued map of query parameters.
      */
-    static Parameters decodeQuery(String query, boolean decode) {
+    public static Parameters decodeQuery(String query, boolean decode) {
         return decodeQuery(query, true, decode);
     }
 
@@ -64,7 +58,7 @@ final class UriComponent {
      *                     should be in decoded form.
      * @return the multivalued map of query parameters.
      */
-    static Parameters decodeQuery(String query, boolean decodeNames, boolean decodeValues) {
+    public static Parameters decodeQuery(String query, boolean decodeNames, boolean decodeValues) {
         Parameters queryParameters = HashParameters.create();
 
         if (query == null || query.isEmpty()) {

--- a/common/http/src/test/java/io/helidon/common/http/UriComponentTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/UriComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package io.helidon.webserver;
+package io.helidon.common.http;
 
 import java.net.URI;
 import java.net.URLEncoder;
 import java.util.Optional;
-
-import io.helidon.common.http.Parameters;
 
 import org.junit.jupiter.api.Test;
 

--- a/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
+++ b/webserver/webserver/src/main/java/io/helidon/webserver/Request.java
@@ -33,6 +33,7 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.MediaType;
 import io.helidon.common.http.Parameters;
+import io.helidon.common.http.UriComponent;
 import io.helidon.common.reactive.Single;
 import io.helidon.media.common.MessageBodyContext;
 import io.helidon.media.common.MessageBodyReadableContent;

--- a/webserver/websocket/src/main/java/module-info.java
+++ b/webserver/websocket/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module io.helidon.webserver.websocket {
 
     requires java.logging;
     requires transitive io.helidon.webserver;
+    requires io.helidon.common.http;
     requires transitive jakarta.websocket;
     requires io.netty.transport;
     requires io.netty.handler;

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/EchoEndpoint.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/EchoEndpoint.java
@@ -63,6 +63,24 @@ public class EchoEndpoint {
         }
     }
 
+    /**
+     * Verify session includes expected query params.
+     *
+     * @param session Websocket session.
+     * @param logger A logger.
+     * @throws IOException Exception during close.
+     */
+    private static void verifyQueryParams(Session session, Logger logger) throws IOException {
+        if (!"user=Helidon".equals(session.getQueryString())) {
+            logger.warning("Websocket session does not include required query params");
+            session.close();
+        }
+        if (!session.getRequestParameterMap().get("user").get(0).equals("Helidon")) {
+            logger.warning("Websocket session does not include required query parameter map");
+            session.close();
+        }
+    }
+
     public static class ServerConfigurator extends ServerEndpointConfig.Configurator {
 
         @Override
@@ -77,6 +95,7 @@ public class EchoEndpoint {
     public void onOpen(Session session) throws IOException {
         LOGGER.info("OnOpen called");
         verifyRunningThread(session, LOGGER);
+        verifyQueryParams(session, LOGGER);
         if (!modifyHandshakeCalled.get()) {
             session.close();        // unexpected
         }
@@ -86,6 +105,7 @@ public class EchoEndpoint {
     public void echo(Session session, String message) throws Exception {
         LOGGER.info("Endpoint OnMessage called '" + message + "'");
         verifyRunningThread(session, LOGGER);
+        verifyQueryParams(session, LOGGER);
         if (!isDecoded(message)) {
             throw new InternalError("Message has not been decoded");
         }
@@ -102,6 +122,7 @@ public class EchoEndpoint {
     public void onClose(Session session) throws IOException {
         LOGGER.info("OnClose called");
         verifyRunningThread(session, LOGGER);
+        verifyQueryParams(session, LOGGER);
         modifyHandshakeCalled.set(false);
     }
 }

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/EchoServiceTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/EchoServiceTest.java
@@ -37,7 +37,7 @@ public class EchoServiceTest extends TyrusSupportBaseTest {
     @Test
     public void testEchoSingle() {
         try {
-            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo");
+            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo?user=Helidon");
             new EchoClient(uri).echo("One");
         } catch (Exception e) {
             fail("Unexpected exception " + e);
@@ -47,7 +47,7 @@ public class EchoServiceTest extends TyrusSupportBaseTest {
     @Test
     public void testEchoMultiple() {
         try {
-            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo");
+            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo?user=Helidon");
             new EchoClient(uri).echo("One", "Two", "Three");
         } catch (Exception e) {
             fail("Unexpected exception " + e);

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/HttpClientTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/HttpClientTest.java
@@ -42,7 +42,7 @@ class HttpClientTest extends TyrusSupportBaseTest {
 
     @Test
     void testJdkClient() throws ExecutionException, InterruptedException, TimeoutException {
-        URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo");
+        URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo?user=Helidon");
         ClientListener listener = new ClientListener();
 
         WebSocket webSocket = HttpClient.newHttpClient()

--- a/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/RoutingTest.java
+++ b/webserver/websocket/src/test/java/io/helidon/webserver/websocket/test/RoutingTest.java
@@ -37,7 +37,7 @@ public class RoutingTest extends TyrusSupportBaseTest {
     @Test
     public void testEcho() {
         try {
-            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo");
+            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/echo?user=Helidon");
             new EchoClient(uri).echo("One");
         } catch (Exception e) {
             fail("Unexpected exception " + e);
@@ -47,7 +47,7 @@ public class RoutingTest extends TyrusSupportBaseTest {
     @Test
     public void testDoubleEcho() {
         try {
-            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/doubleEcho");
+            URI uri = URI.create("ws://localhost:" + webServer().port() + "/tyrus/doubleEcho?user=Helidon");
             new EchoClient(uri, (s1, s2) -> s2.equals(s1 + s1)).echo("One");
         } catch (Exception e) {
             fail("Unexpected exception " + e);


### PR DESCRIPTION
Updated WebSocketHandler to correctly propagate query params from weberver to Tyrus. Moved UriComponent over to common/http for sharing purposes. Updated tests to verify changes. Issue #4575.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>