### PR TITLE
Injection of Map from configuration now honors prefix (backport)

### DIFF
--- a/microprofile/config/src/test/java/io/helidon/microprofile/config/MpConfigInjectionTest.java
+++ b/microprofile/config/src/test/java/io/helidon/microprofile/config/MpConfigInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.helidon.microprofile.config;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.Map;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -38,6 +39,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -59,8 +61,30 @@ class MpConfigInjectionTest {
     @Specific
     private SubBean subBean;
 
+
     @Test
-    public void testImplicitConversion() {
+    void testInjectMapNoPrefix() {
+        Map<String, String> allProperties = bean.allProperties;
+        assertAll(
+                () -> assertThat(allProperties, hasEntry("inject.of", "of")),
+                () -> assertThat(allProperties, hasEntry("inject.valueOf", "valueOf")),
+                () -> assertThat(allProperties, hasEntry("inject.parse", "parse")),
+                () -> assertThat(allProperties, hasEntry("inject.ctor", "ctor"))
+        );
+    }
+
+    @Test
+    void testInjectMapWithPrefix() {
+        Map<String, String> injectProperties = bean.injectProperties;
+        assertAll(
+                () -> assertThat(injectProperties, hasEntry("of", "of")),
+                () -> assertThat(injectProperties, hasEntry("valueOf", "valueOf")),
+                () -> assertThat(injectProperties, hasEntry("parse", "parse")),
+                () -> assertThat(injectProperties, hasEntry("ctor", "ctor"))
+        );
+    }
+    @Test
+    void testImplicitConversion() {
         assertAll("Implicit conversion injection",
                   () -> assertThat("of", bean.of, is(Of.of("of"))),
                   () -> assertThat("valueOf", bean.valueOf, is(ValueOf.valueOf("valueOf"))),
@@ -70,7 +94,7 @@ class MpConfigInjectionTest {
     }
 
     @Test
-    public void testImplicitConversionSubclass() {
+    void testImplicitConversionSubclass() {
         assertAll("Implicit conversion injection",
                   () -> assertThat("of", subBean.of, is(Of.of("of"))),
                   () -> assertThat("valueOf", subBean.valueOf, is(ValueOf.valueOf("valueOf"))),
@@ -95,6 +119,14 @@ class MpConfigInjectionTest {
         @Inject
         @ConfigProperty(name = "inject.ctor")
         public Ctor ctor;
+
+        @Inject
+        @ConfigProperty(name = "")
+        public Map<String, String> allProperties;
+
+        @Inject
+        @ConfigProperty(name = "inject")
+        public Map<String, String> injectProperties;
     }
 
     @Qualifier


### PR DESCRIPTION
Backport of #4653 for 2.x
Resolves #4414 

This is a refactoring (not a cherry-pick) due to quite big differences of sources between 3 and 2.

Signed-off-by: Tomas Langer <tomas.langer@oracle.com>