### PR TITLE
Fix release.sh to update version in attributes.adoc 

### DIFF
--- a/docs/includes/attributes.adoc
+++ b/docs/includes/attributes.adoc
@@ -23,7 +23,7 @@ ifndef::attributes-included[]
 // functional attributes
 :imagesdir: {rootdir}/images
 
-:helidon-version: 3.0.0-SNAPSHOT
+:helidon-version: 3.0.1-SNAPSHOT
 :helidon-version-is-release: false
 
 ifeval::["{helidon-version-is-release}" != "true"]

--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -136,6 +136,15 @@ update_version(){
         mv ${bfile}.tmp ${bfile}
     done
 
+    # Hack to update helidon-version in doc files
+    for dfile in `egrep ":helidon-version: .*" -r . --include attributes.adoc | cut -d ':' -f 1 | sort | uniq `
+    do
+        cat ${dfile} | \
+            sed -e s@':helidon-version: .*'@":helidon-version: ${FULL_VERSION}"@g \
+            > ${dfile}.tmp
+        mv ${dfile}.tmp ${dfile}
+    done
+
     # Invoke prepare hook
     if [ -n "${PREPARE_HOOKS}" ]; then
         for prepare_hook in ${PREPARE_HOOKS} ; do


### PR DESCRIPTION
This caused us to release docs referencing a bad Helidon version. See #4685 