### PR TITLE
Updates to replace PR 4639 - neo4j build issues and language review

### DIFF
--- a/docs/mp/integrations/neo4j.adoc
+++ b/docs/mp/integrations/neo4j.adoc
@@ -53,7 +53,7 @@ NOTE: Check <<Neo4j Metrics propagation, Neo4j Metrics propagation>> and <<Neo4j
 
 The support for Neo4j is implemented in Neo4j driver level. Just add the dependency, add configuration in `microprofile-config.properties` file and Neo4j driver will be configured by Helidon and can be injected using CDI.
 
-First describe Neo4j connection properties:
+To implement Neo4j, you must first provide the connection properties as shown below:
 
 [source,properties]
 ----

--- a/docs/se/integrations/neo4j.adoc
+++ b/docs/se/integrations/neo4j.adoc
@@ -27,7 +27,7 @@ include::{rootdir}/includes/se.adoc[]
 == Contents
 
 - <<Overview, Overview>>
-- <<maven-coordinates, Maven Coordinates>>
+- <<Maven Coordinates, Maven Coordinates>>
 - <<Usage, Usage>>
 - <<Configuration, Configuration>>
 - <<Examples, Examples>>

--- a/docs/se/integrations/neo4j.adoc
+++ b/docs/se/integrations/neo4j.adoc
@@ -53,7 +53,7 @@ NOTE: Check <<Neo4j Metrics Propagation, Neo4j Metrics Propagation>> and <<Neo4j
 
 The support for Neo4j is implemented in Neo4j driver level. Just add the dependency, add configuration in `application.yaml` file and Neo4j driver will be configured by Helidon and can be used with `Neo4j` support object.
 
-First describe Neo4j connection properties:
+To implement Neo4j, you must first provide the connection properties as shown below:
 
 [source,properties]
 ----
@@ -197,7 +197,7 @@ public class MovieService implements Service {
 
 ----
 
-To use the service, as well as to add metrics and health support the following routing should be created:
+To use the service, as well as to add metrics and health support, the following routing should be created:
 
 [source,java]
 ----

--- a/docs/se/integrations/neo4j.adoc
+++ b/docs/se/integrations/neo4j.adoc
@@ -47,7 +47,7 @@ include::{rootdir}/includes/dependencies.adoc[]
    <artifactId>helidon-integrations-neo4j</artifactId>
 </dependency>
 ----
-NOTE: Check <<Neo4j Metrics propagation, Neo4j Metrics propagation>> and <<Neo4j Health Checks, Neo4j Health Checks>> for additional dependencies for _Neo4j_ `Metrics` and `Health Checks` integration.
+NOTE: Check <<Neo4j Metrics Propagation, Neo4j Metrics Propagation>> and <<Neo4j Health Checks, Neo4j Health Checks>> for additional dependencies for _Neo4j_ `Metrics` and `Health Checks` integration.
 
 == Usage
 
@@ -273,7 +273,7 @@ Full example code is available in link:https://github.com/oracle/helidon/tree/ma
 
 == Additional Information
 
-=== Neo4j Metrics propagation
+=== Neo4j Metrics Propagation
 
 Neo4j metrics can be propagated to the user as `MicroProfile` metrics. This is implemented in a separate Maven module. Just add:
 


### PR DESCRIPTION
This PR replaces PR #4639 for se and mp neo4j.adoc.

@dalexandrov there was a broken reference caused by a case change in a heading. The references are case sensitive so I needed to make some updates. 