### PR TITLE
Unescape the keys when config is returned as a map in 3.x branch (#4678)

### DIFF
--- a/config/config/src/main/java/io/helidon/config/ConfigMappers.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigMappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -631,11 +631,11 @@ public final class ConfigMappers {
      */
     public static Map<String, String> toMap(Config config) {
         if (config.isLeaf()) {
-            return new StringMap(config.key().toString(), config.asString().get());
+            return new StringMap(Config.Key.unescapeName(config.key().toString()), config.asString().get());
         } else {
             return new StringMap(config.traverse()
                                          .filter(Config::isLeaf)
-                                         .map(node -> new AbstractMap.SimpleEntry<>(node.key().toString(), node.asString().get()))
+                                         .map(node -> new AbstractMap.SimpleEntry<>(Config.Key.unescapeName(node.key().toString()), node.asString().get()))
                                          .collect(Collectors.toSet()));
         }
     }

--- a/config/config/src/main/java/io/helidon/config/ConfigValues.java
+++ b/config/config/src/main/java/io/helidon/config/ConfigValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,6 +173,11 @@ public final class ConfigValues {
         Supplier<Optional<Map<String, String>>> valueSupplier = () -> {
             Map<?, ?> map = mapperManager.map(config, Map.class);
 
+            map = map.entrySet().stream().collect(
+                    Collectors.toMap(
+                            entry -> Config.Key.unescapeName(entry.getKey().toString()), entry -> entry.getValue()
+                    )
+            );
             if (map instanceof ConfigMappers.StringMap) {
                 return Optional.of((ConfigMappers.StringMap) map);
             }

--- a/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
+++ b/config/hocon/src/test/java/io/helidon/config/hocon/HoconConfigParserTest.java
@@ -202,11 +202,11 @@ public class HoconConfigParserTest {
         assertThat(keys, containsInAnyOrder("oracle~1com", "oracle~1com.prop1", "oracle~1com.prop2",
                                             "oracle", "oracle.com", "oracle.cz"));
 
-        //map
+        //map, expect keys to be unescaped
         Map<String, String> map = config.asMap().get();
         assertThat(map.keySet(), hasSize(4));
-        assertThat(map.get("oracle~1com.prop1"), is("val1"));
-        assertThat(map.get("oracle~1com.prop2"), is("val2"));
+        assertThat(map.get("oracle.com.prop1"), is("val1"));
+        assertThat(map.get("oracle.com.prop2"), is("val2"));
         assertThat(map.get("oracle.com"), is("1"));
         assertThat(map.get("oracle.cz"), is("2"));
     }

--- a/config/tests/integration-tests/src/test/java/io/helidon/config/tests/AbstractComplexConfigTest.java
+++ b/config/tests/integration-tests/src/test/java/io/helidon/config/tests/AbstractComplexConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -565,8 +565,8 @@ public abstract class AbstractComplexConfigTest {
         //map
         Map<String, String> map = config.asMap().get();
         assertThat(map.keySet(), hasSize(4));
-        assertThat(map.get("oracle~1com.prop1"), is("val1"));
-        assertThat(map.get("oracle~1com.prop2"), is("val2"));
+        assertThat(map.get("oracle.com.prop1"), is("val1"));
+        assertThat(map.get("oracle.com.prop2"), is("val2"));
         assertThat(map.get("oracle.com"), is("1"));
         assertThat(map.get("oracle.cz"), is("2"));
     }


### PR DESCRIPTION
* Unescape the keys when config is returned as a map

* Update copyright year

* Using as(Map.class).get() and as(new GenericType<Map>(){}).get() should have keys unescaped