### PR TITLE
Config metadata should be optional and provided

### DIFF
--- a/metrics/api/pom.xml
+++ b/metrics/api/pom.xml
@@ -48,6 +48,8 @@
         <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-metadata</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>

--- a/metrics/api/src/main/java/module-info.java
+++ b/metrics/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ module io.helidon.metrics.api {
     requires transitive io.helidon.config;
 
     requires transitive microprofile.metrics.api;
-    requires io.helidon.config.metadata;
+    requires static io.helidon.config.metadata;
 
     exports io.helidon.metrics.api;
     exports io.helidon.metrics.api.spi;

--- a/metrics/service-api/src/main/java/module-info.java
+++ b/metrics/service-api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ module io.helidon.metrics.serviceapi {
 
     requires io.helidon.common.serviceloader;
     requires io.helidon.webserver;
-    requires io.helidon.config.metadata;
+    requires static io.helidon.config.metadata;
     requires io.helidon.servicecommon.rest;
     requires io.helidon.metrics.api;
 

--- a/microprofile/server/src/main/java/module-info.java
+++ b/microprofile/server/src/main/java/module-info.java
@@ -41,7 +41,7 @@ module io.helidon.microprofile.server {
     // there is now a hardcoded dependency on Weld, to configure additional bean defining annotation
     requires java.management;
     requires microprofile.config.api;
-    requires io.helidon.config.metadata;
+    requires static io.helidon.config.metadata;
 
     exports io.helidon.microprofile.server;
 


### PR DESCRIPTION
It should not resolve as a transitive dependency (no need to fix in `main`)
Signed-off-by: Tomas Langer <tomas.langer@oracle.com>