### PR TITLE
Issue #4741 - Upgrade Postgre driver

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -138,7 +138,7 @@
         <version.lib.opentracing.tracerresolver>0.1.8</version.lib.opentracing.tracerresolver>
         <version.lib.perfmark-api>0.23.0</version.lib.perfmark-api>
         <version.lib.parsson>1.0.2</version.lib.parsson>
-        <version.lib.postgresql>42.3.3</version.lib.postgresql>
+        <version.lib.postgresql>42.4.1</version.lib.postgresql>
         <version.lib.prometheus>0.9.0</version.lib.prometheus>
         <version.lib.slf4j>1.7.32</version.lib.slf4j>
         <version.lib.smallrye-openapi>2.1.16</version.lib.smallrye-openapi>


### PR DESCRIPTION
Fixes #4741.
According to [PostgreSQL JDBC driver Release Notes](https://jdbc.postgresql.org/documentation/changelog.html#version_42.4.1) this problem is resolved in version 42.4.1.

So JDBC driver version was updated to latest - `42.4.1`.
