### PR TITLE
Make Application subclasses available via our context during Feature executions

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -258,18 +258,16 @@ public class ServerCdiExtension implements Extension {
                         .forEach(s -> shared.register(Bindings.service(s)));
             }
 
-            // Add all applications
-            jaxRsApplications.forEach(it -> {
-                // Make Application subclass instance available in our context
-                // to be used by JAX-RS features and other startup code
-                Application app = it.applicationClass()
-                        .map(appClass -> CDI.current().select(appClass).get())
-                        .orElseThrow();
-                Context parent = Contexts.context().orElse(null);
-                Context startupContext = Context.create(parent);
-                startupContext.register(app);
-                Contexts.runInContext(startupContext, () -> addApplication(jaxRs, it, shared));
-            });
+            // Add all applications making the Application subclass (if accessible via
+            // CDI) available in our context to be used by JAX-RS features
+            jaxRsApplications.forEach(it -> it.applicationClass()
+                    .flatMap(appClass -> CDI.current().select(appClass).stream().findFirst())
+                    .ifPresentOrElse(app -> {
+                        Context parent = Contexts.context().orElse(null);
+                        Context startupContext = Context.create(parent);
+                        startupContext.register(app);
+                        Contexts.runInContext(startupContext, () -> addApplication(jaxRs, it, shared));
+                    }, () -> addApplication(jaxRs, it, shared)));
         }
         STARTUP_LOGGER.finest("Registered jersey application(s)");
     }

--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -264,15 +264,11 @@ public class ServerCdiExtension implements Extension {
                 // to be used by JAX-RS features and other startup code
                 Application app = it.applicationClass()
                         .map(appClass -> CDI.current().select(appClass).get())
-                        .orElse(null);
-                if (app != null) {
-                    Context parent = Contexts.context().orElse(null);
-                    Context startupContext = Context.create(parent);
-                    startupContext.register(app);
-                    Contexts.runInContext(startupContext, () -> addApplication(jaxRs, it, shared));
-                } else {
-                    addApplication(jaxRs, it, shared);
-                }
+                        .orElseThrow();
+                Context parent = Contexts.context().orElse(null);
+                Context startupContext = Context.create(parent);
+                startupContext.register(app);
+                Contexts.runInContext(startupContext, () -> addApplication(jaxRs, it, shared));
             });
         }
         STARTUP_LOGGER.finest("Registered jersey application(s)");

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Feature2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Feature2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,23 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.helidon.tests.functional.multipleapps;
 
-import java.util.Set;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
-
-/**
- * First application.
- */
-@ApplicationScoped
-@ApplicationPath("app1")
-public class GreetApplication1 extends Application {
+@ConstrainedTo(RuntimeType.SERVER)
+public class Feature2 implements DynamicFeature {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource1.class, Filter1.class, SharedFilter.class, SharedFeature.class);
+    public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {
+        featureContext.register(Filter3.class);
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class GreetApplication2 extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
+        return Set.of(GreetResource2.class, SharedFilter.class, Feature2.class, SharedFeature.class);
     }
 
     @Override

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022k Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022k Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import javax.ws.rs.core.Response;
 import io.helidon.microprofile.tests.junit5.HelidonTest;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,5 +67,11 @@ class MainTest {
         JsonObject jsonObject = response.readEntity(JsonObject.class);
         assertEquals("Hello World 2!", jsonObject.getString("message"),
                 "default message");
+    }
+
+    @Test
+    void testContextApps() {
+        assertThat(SharedFeature.applications(), hasItem(GreetApplication1.class));
+        assertThat(SharedFeature.applications(), hasItem(GreetApplication2.class));
     }
 }


### PR DESCRIPTION
A global/shared Feature is executed for each Application subclass. This change makes the Application subclass available to the Feature during its execution. Just like for requests, the availability is through the Helidon context. Updated functional tests for multiple apps.