### PR TITLE
2.x: Exclude unstable tests sensitive to pipeline network environment

### DIFF
--- a/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
+++ b/microprofile/tests/tck/tck-rest-client/src/test/tck-suite.xml
@@ -27,6 +27,29 @@
                     <exclude name="testProxy"/>
                 </methods>
             </class>
+            <!-- These tests are sensitive to pipeline network environment and are unstable -->
+            <class name="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutTest">
+                <methods>
+                    <exclude name="testConnectTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigTest">
+                <methods>
+                    <exclude name="testConnectTimeout"/>
+                    <exclude name="testReadTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutViaMPConfigWithConfigKeyTest">
+                <methods>
+                    <exclude name="testConnectTimeout"/>
+                    <exclude name="testReadTimeout"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.rest.client.tck.timeout.TimeoutBuilderIndependentOfMPConfigTest">
+                <methods>
+                    <exclude name="testConnectTimeout"/>
+                </methods>
+            </class>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Something has changed in our pipeline network environment that is causing these tests to be unstable. Disabling until we get a better resolution.

See: #4763