### PR TITLE
Make Application subclasses available via our context during Feature executions (3.x)

### DIFF
--- a/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
+++ b/microprofile/server/src/main/java/io/helidon/microprofile/server/ServerCdiExtension.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 
 import io.helidon.common.Prioritized;
 import io.helidon.common.configurable.ServerThreadPoolSupplier;
+import io.helidon.common.context.Context;
+import io.helidon.common.context.Contexts;
 import io.helidon.common.http.Http;
 import io.helidon.config.Config;
 import io.helidon.microprofile.cdi.BuildTimeStart;
@@ -255,8 +257,16 @@ public class ServerCdiExtension implements Extension {
                         .forEach(s -> shared.register(Bindings.service(s)));
             }
 
-            // Add all applications
-            jaxRsApplications.forEach(it -> addApplication(jaxRs, it, shared));
+            // Add all applications making the Application subclass (if accessible via
+            // CDI) available in our context to be used by JAX-RS features
+            jaxRsApplications.forEach(it -> it.applicationClass()
+                    .flatMap(appClass -> CDI.current().select(appClass).stream().findFirst())
+                    .ifPresentOrElse(app -> {
+                        Context parent = Contexts.context().orElse(null);
+                        Context startupContext = Context.create(parent);
+                        startupContext.register(app);
+                        Contexts.runInContext(startupContext, () -> addApplication(jaxRs, it, shared));
+                    }, () -> addApplication(jaxRs, it, shared)));
         }
         STARTUP_LOGGER.finest("Registered jersey application(s)");
     }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Feature2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/Feature2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.FeatureContext;
 
 @ConstrainedTo(RuntimeType.SERVER)
-public class MyFeature implements DynamicFeature {
+public class Feature2 implements DynamicFeature {
 
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication1.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,6 @@ public class GreetApplication1 extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource1.class, Filter1.class, SharedFilter.class);
+        return Set.of(GreetResource1.class, Filter1.class, SharedFilter.class, SharedFeature.class);
     }
 }

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/GreetApplication2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class GreetApplication2 extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Set.of(GreetResource2.class, SharedFilter.class, MyFeature.class);
+        return Set.of(GreetResource2.class, SharedFilter.class, Feature2.class, SharedFeature.class);
     }
 
     @Override

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFeature.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFeature.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.tests.functional.multipleapps;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.FeatureContext;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.helidon.common.context.Contexts;
+
+@ConstrainedTo(RuntimeType.SERVER)
+@ApplicationScoped
+public class SharedFeature implements DynamicFeature {
+
+    private static final Set<Class<? extends Application>> applications = new HashSet<>();
+
+    static Set<Class<? extends Application>> applications() {
+        return applications;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void configure(ResourceInfo resourceInfo, FeatureContext featureContext) {
+        // Collect all application subclasses started
+        Application app = Contexts.context().flatMap(c -> c.get(Application.class)).orElse(null);
+        assert app != null;
+        applications.add(!app.getClass().isSynthetic() ? app.getClass()
+                : (Class<? extends Application>) app.getClass().getSuperclass());
+    }
+}

--- a/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFeature.java
+++ b/tests/functional/jax-rs-multiple-apps/src/main/java/io/helidon/tests/functional/multipleapps/SharedFeature.java
@@ -16,13 +16,13 @@
 
 package io.helidon.tests.functional.multipleapps;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ConstrainedTo;
-import javax.ws.rs.RuntimeType;
-import javax.ws.rs.container.DynamicFeature;
-import javax.ws.rs.container.ResourceInfo;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.FeatureContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.DynamicFeature;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.FeatureContext;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
+++ b/tests/functional/jax-rs-multiple-apps/src/test/java/io/helidon/tests/functional/multipleapps/MainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -68,5 +70,11 @@ class MainTest {
         JsonObject jsonObject = response.readEntity(JsonObject.class);
         assertEquals("Hello World 2!", jsonObject.getString("message"),
                 "default message");
+    }
+
+    @Test
+    void testContextApps() {
+        assertThat(SharedFeature.applications(), hasItem(GreetApplication1.class));
+        assertThat(SharedFeature.applications(), hasItem(GreetApplication2.class));
     }
 }


### PR DESCRIPTION
A global/shared Feature is executed for each Application subclass. This change makes the Application subclass available to the Feature during its execution. Just like for requests, the availability is through the Helidon context. Updated functional tests for multiple apps.