### PR TITLE
4.x: Fix version in example

### DIFF
--- a/examples/nima/quickstart-standalone/pom.xml
+++ b/examples/nima/quickstart-standalone/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.helidon.examples.nima</groupId>
     <artifactId>helidon-nima-examples-quickstart-standalone</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <name>Helidon Níma Examples Quickstart Standalone</name>
     <description>Example demonstrating a standalone project without a Warp parent.</description>


### PR DESCRIPTION
Having a different version in an example trips up the release script when it goes to update the project version.