### PR TITLE
Config and name

### DIFF
--- a/examples/nima/basic/src/main/java/io/helidon/examples/nima/basic/BasicMain.java
+++ b/examples/nima/basic/src/main/java/io/helidon/examples/nima/basic/BasicMain.java
@@ -55,6 +55,6 @@ public class BasicMain {
      * @param router HTTP routing builder to configure routes for this service
      */
     static void routing(HttpRouting.Builder router) {
-        router.get("/*", (req, res) -> res.send("Warp Works!"));
+        router.get("/*", (req, res) -> res.send("Níma Works!"));
     }
 }

--- a/examples/nima/basic/src/test/java/io/helidon/examples/nima/basic/AbstractBasicRoutingTest.java
+++ b/examples/nima/basic/src/test/java/io/helidon/examples/nima/basic/AbstractBasicRoutingTest.java
@@ -43,7 +43,7 @@ abstract class AbstractBasicRoutingTest {
                 .request()
                 .as(String.class);
 
-        assertThat(response, is("Warp Works!"));
+        assertThat(response, is("Níma Works!"));
     }
 
     @Test
@@ -52,6 +52,6 @@ abstract class AbstractBasicRoutingTest {
                 .request()
                 .as(String.class);
 
-        assertThat(response, is("Warp Works!"));
+        assertThat(response, is("Níma Works!"));
     }
 }

--- a/examples/nima/observe/src/main/java/io/helidon/examples/nima/observe/ObserveMain.java
+++ b/examples/nima/observe/src/main/java/io/helidon/examples/nima/observe/ObserveMain.java
@@ -52,6 +52,6 @@ public class ObserveMain {
      */
     static void routing(HttpRouting.Builder router) {
         router.update(ObserveSupport.create())
-                .get("/", (req, res) -> res.send("Warp Works!"));
+                .get("/", (req, res) -> res.send("Níma Works!"));
     }
 }

--- a/examples/nima/observe/src/main/resources/application.yaml
+++ b/examples/nima/observe/src/main/resources/application.yaml
@@ -14,15 +14,14 @@
 # limitations under the License.
 #
 
-nima:
-  server:
-    host: "127.0.0.1"
-    port: 8080
-  observe:
-    info:
-      values:
-        name: "Observe Example"
-        version: "1.0.0"
+server:
+  host: "127.0.0.1"
+  port: 8080
+observe:
+  info:
+    values:
+      name: "Observe Example"
+      version: "1.0.0"
 
 app:
   greeting: "Hello!"

--- a/examples/nima/observe/src/test/java/io/helidon/examples/nima/observe/AbstractObserveTest.java
+++ b/examples/nima/observe/src/test/java/io/helidon/examples/nima/observe/AbstractObserveTest.java
@@ -45,7 +45,7 @@ abstract class AbstractObserveTest {
                 .request()
                 .as(String.class);
 
-        assertThat(response, is("Warp Works!"));
+        assertThat(response, is("Níma Works!"));
     }
 
     @Test

--- a/examples/nima/protocols/src/main/java/io/helidon/examples/nima/protocols/ProtocolsMain.java
+++ b/examples/nima/protocols/src/main/java/io/helidon/examples/nima/protocols/ProtocolsMain.java
@@ -41,7 +41,7 @@ import static io.helidon.nima.grpc.webserver.ResponseHelper.complete;
  * Example showing supported protocols.
  */
 public class ProtocolsMain {
-    private static final byte[] RESPONSE = "Hello from WARP!".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RESPONSE = "Hello from Níma!".getBytes(StandardCharsets.UTF_8);
 
     private ProtocolsMain() {
     }

--- a/examples/nima/quickstart-standalone/pom.xml
+++ b/examples/nima/quickstart-standalone/pom.xml
@@ -24,7 +24,7 @@
     <version>4.0.0-SNAPSHOT</version>
 
     <name>Helidon Níma Examples Quickstart Standalone</name>
-    <description>Example demonstrating a standalone project without a Warp parent.</description>
+    <description>Example demonstrating a standalone project without an application parent.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/examples/nima/quickstart-standalone/src/main/resources/application.yaml
+++ b/examples/nima/quickstart-standalone/src/main/resources/application.yaml
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-nima:
-  server:
-    host: "127.0.0.1"
-    port: 8080
+server:
+  host: "127.0.0.1"
+  port: 8080

--- a/examples/nima/quickstart/src/main/resources/application.yaml
+++ b/examples/nima/quickstart/src/main/resources/application.yaml
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-nima:
-  server:
-    host: "127.0.0.1"
-    port: 8080
+server:
+  host: "127.0.0.1"
+  port: 8080

--- a/nima/observe/observe/src/main/java/io/helidon/nima/observe/ObserveSupport.java
+++ b/nima/observe/observe/src/main/java/io/helidon/nima/observe/ObserveSupport.java
@@ -114,7 +114,7 @@ public class ObserveSupport implements Consumer<HttpRouting.Builder> {
         private Config config;
 
         private Builder() {
-            config(Nima.config().get("nima.observe"));
+            config(Nima.config().get("observe"));
         }
 
         @Override

--- a/nima/tests/benchmark/techempower/src/main/resources/application.yaml
+++ b/nima/tests/benchmark/techempower/src/main/resources/application.yaml
@@ -14,23 +14,22 @@
 # limitations under the License.
 #
 
-nima:
-  server:
-    sockets:
-      - name: "@default"
-        host: "127.0.0.1"
-        port: 8080
-        backlog: 8192
+server:
+  sockets:
+    - name: "@default"
+      host: "127.0.0.1"
+      port: 8080
+      backlog: 8192
+      receive-buffer-size: 64000
+      write-queue-length: 8192
+      connection-options:
+        read-timeout-seconds: 0
+        connect-timeout-seconds: 0
+        send-buffer-size: 64000
         receive-buffer-size: 64000
-        write-queue-length: 8192
-        connection-options:
-          read-timeout-seconds: 0
-          connect-timeout-seconds: 0
-          send-buffer-size: 64000
-          receive-buffer-size: 64000
-    connection-providers:
-      "http_1_1":
-        validate-headers: false
-        validate-path: false
-        recv-log: false
-        send-log: false
+  connection-providers:
+    "http_1_1":
+      validate-headers: false
+      validate-path: false
+      recv-log: false
+      send-log: false

--- a/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketOriginTest.java
+++ b/nima/tests/integration/websocket/server/src/test/java/io/helidon/nima/tests/integration/websocket/webserver/WebSocketOriginTest.java
@@ -62,7 +62,7 @@ class WebSocketOriginTest {
     static void updateServer(WebServer.Builder builder) {
         builder.addConnectionProvider(Http1ConnectionProvider.builder()
                                               .addUpgradeProvider(WsUpgradeProvider.builder()
-                                                                          .addOrigin("WarpTest")
+                                                                          .addOrigin("NimaTest")
                                                                           .build())
                                               .build());
     }
@@ -79,7 +79,7 @@ class WebSocketOriginTest {
         CompletableFuture<Boolean> wsCompleted = new CompletableFuture<>();
 
         java.net.http.WebSocket webSocket = client.newWebSocketBuilder()
-                .header("Origin", "WarpTest")
+                .header("Origin", "NimaTest")
                 .buildAsync(URI.create("ws://localhost:" + port + "/single"),
                             new java.net.http.WebSocket.Listener() {
                                 @Override

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/WebServer.java
@@ -133,7 +133,7 @@ public interface WebServer {
                 HelidonServiceLoader.builder(ServiceLoader.load(ServerConnectionProvider.class));
 
         Builder(Config rootConfig) {
-            Config config = rootConfig.get("nima.server");
+            Config config = rootConfig.get("server");
             config.get("host").asString().ifPresent(this::host);
             config.get("port").asInt().ifPresent(this::port);
 

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ConnectionProvider.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ConnectionProvider.java
@@ -141,7 +141,7 @@ public class Http1ConnectionProvider implements ServerConnectionProvider {
 
         private Builder() {
             Config config = Config.create()
-                    .get("nima.server.connection-providers.http_1_1");
+                    .get("server.connection-providers.http_1_1");
 
             config.get("validate-headers").asBoolean().ifPresent(this::validateHeaders);
             config.get("validate-path").asBoolean().ifPresent(this::validatePath);


### PR DESCRIPTION
Use the correct root node for configuration.
Remove old code name and use Níma instead.