### PR TITLE
JWT-Auth implementation encrypted token recognition fixed

### DIFF
--- a/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
+++ b/microprofile/jwt-auth/src/main/java/io/helidon/microprofile/jwt/auth/JwtAuthProvider.java
@@ -247,7 +247,7 @@ public class JwtAuthProvider extends SynchronousProvider implements Authenticati
                     SignedJwt signedJwt;
                     try {
                         headers = JwtHeaders.parseToken(token);
-                        if (headers.encryption().isPresent()) {
+                        if (headers.encryption().isPresent() || decryptionKeys.get() != null) {
                             EncryptedJwt encryptedJwt = EncryptedJwt.parseToken(headers, token);
                             if (!headers.contentType().map("JWT"::equals).orElse(false)) {
                                 throw new JwtException("Header \"cty\" (content type) must be set to \"JWT\" "

--- a/microprofile/tests/tck/tck-jwt-auth/tck-base-suite.xml
+++ b/microprofile/tests/tck/tck-jwt-auth/tck-base-suite.xml
@@ -58,12 +58,6 @@
                     <exclude name="testNeedsGroup1Mapping"/>
                 </methods>
             </class>
-            <!-- There is no reason why this should fail -->
-            <class name="org.eclipse.microprofile.jwt.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest">
-                <methods>
-                    <exclude name="callEchoSignToken"/>
-                </methods>
-            </class>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Implementation changed according to the JWT-Auth spec chapter: [Requirements for accepting signed and encrypted tokens](https://download.eclipse.org/microprofile/microprofile-jwt-auth-1.2/microprofile-jwt-auth-spec-1.2.html#_requirements_for_accepting_signed_and_encrypted_tokens)