### PR TITLE
Shutdown executors while stopping the server

### DIFF
--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/ServerListener.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLParameters;
@@ -45,6 +46,7 @@ import io.helidon.nima.http.media.MediaContext;
 import io.helidon.nima.webserver.http.DirectHandlers;
 import io.helidon.nima.webserver.spi.ServerConnectionProvider;
 
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
 
@@ -250,6 +252,8 @@ class ServerListener {
                                                     simpleHandlers);
 
                     readerExecutor.submit(handler);
+                } catch (RejectedExecutionException e) {
+                    LOGGER.log(ERROR, "Executor rejected handler for new connection");
                 } catch (Exception e) {
                     // we may get an SSL handshake errors, which should only fail one socket, not the listener
                     LOGGER.log(TRACE, "Failed to handle accepted socket", e);

--- a/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ExecutorShutdownTest.java
+++ b/nima/webserver/webserver/src/test/java/io/helidon/nima/webserver/ExecutorShutdownTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.nima.webserver;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class ExecutorShutdownTest {
+    @Test
+    void testShutdown() {
+        try (ExecutorService executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual()
+                .allowSetThreadLocals(true)
+                .inheritInheritableThreadLocals(false)
+                .factory())) {
+            ServerListener.shutdownExecutor(executor);
+            assertThat(executor.isShutdown(), is(true));
+        }
+    }
+}


### PR DESCRIPTION
Attempt to shutdown executors gracefully while the server is being stopped. After shutdown, no new `ConnectionHandler` will be accepted for execution (submit() call on executor will fail). 