### PR TITLE
Port and cleanup of old reactive tests for Nima bulkheads

### DIFF
--- a/nima/fault-tolerance/pom.xml
+++ b/nima/fault-tolerance/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/Async.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/Async.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.faulttolerance;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+public interface Async {
+
+    /**
+     * Invoke a synchronous operation asynchronously.
+     * This method never throws an exception. Any exception is returned via the
+     * {@link java.util.concurrent.CompletableFuture} result.
+     *
+     * @param supplier supplier of value (or a method reference)
+     * @param <T> type of returned value
+     * @return a Single that is a "promise" of the future result
+     */
+    <T> CompletableFuture<T> invoke(Supplier<T> supplier);
+
+    /**
+     * Async with default executor service.
+     *
+     * @return a default async instance
+     */
+    static Async create() {
+        return AsyncImpl.DefaultAsyncInstance.instance();
+    }
+
+    /**
+     * Convenience method to avoid having to call {@link #create()}.
+     *
+     * @param supplier supplier of value (or a method reference)
+     * @param <T> type of returned value
+     * @return a Single that is a "promise" of the future result
+     */
+    static <T> CompletableFuture<T> invokeStatic(Supplier<T> supplier) {
+        return create().invoke(supplier);
+    }
+}

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/Async.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/Async.java
@@ -19,6 +19,10 @@ package io.helidon.nima.faulttolerance;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+/**
+ * Runs synchronous suppliers asynchronously using virtual threads. Includes
+ * convenient static method to avoid creating instances of this class.
+ */
 public interface Async {
 
     /**

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/AsyncImpl.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/AsyncImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.nima.faulttolerance;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+class AsyncImpl implements Async {
+
+    private AsyncImpl() {
+    }
+
+    @Override
+    public <T> CompletableFuture<T> invoke(Supplier<T> supplier) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        Thread.ofVirtual().start(() -> {
+            try {
+                T t = supplier.get();
+                result.complete(t);
+            } catch (Exception e) {
+                result.completeExceptionally(e);
+            }
+        });
+        return result;
+    }
+
+    static final class DefaultAsyncInstance {
+        private static final Async INSTANCE = new AsyncImpl();
+
+        static Async instance() {
+            return INSTANCE;
+        }
+    }
+}

--- a/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/BulkheadImpl.java
+++ b/nima/fault-tolerance/src/main/java/io/helidon/nima/faulttolerance/BulkheadImpl.java
@@ -36,9 +36,7 @@ class BulkheadImpl implements Bulkhead {
     BulkheadImpl(Builder builder) {
         this.inProgress = new Semaphore(builder.limit(), true);
         this.name = builder.name();
-
         this.maxQueue = builder.queueLength();
-
     }
 
     @Override

--- a/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/BulkheadTest.java
+++ b/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/BulkheadTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class BulkheadTest {
     private static final System.Logger LOGGER = System.getLogger(BulkheadTest.class.getName());
 
-    private static final long WAIT_TIMEOUT_MILLIS = 1000;
+    private static final long WAIT_TIMEOUT_MILLIS = 2000;
 
     @BeforeAll
     static void setupTest() {

--- a/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/BulkheadTest.java
+++ b/nima/fault-tolerance/src/test/java/io/helidon/nima/faulttolerance/BulkheadTest.java
@@ -16,16 +16,233 @@
 
 package io.helidon.nima.faulttolerance;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
 import io.helidon.common.LogConfig;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-/**
- * TODO create a bulkhead test based on virtual threads
- */
+import static java.lang.System.Logger.Level.INFO;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 class BulkheadTest {
+    private static final System.Logger LOGGER = System.getLogger(BulkheadTest.class.getName());
+
+    private static final long WAIT_TIMEOUT_MILLIS = 1000;
+
     @BeforeAll
     static void setupTest() {
         LogConfig.configureRuntime();
+    }
+
+    @Test
+    void testBulkhead() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        // Create bulkhead of 1 with queue length 1
+        String name = "unit:testBulkhead";
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(1)
+                .name(name)
+                .build();
+
+        // Submit first inProgress task
+        Task inProgress = new Task(0);
+        CompletableFuture<Integer> inProgressResult = Async.invokeStatic(
+                () -> bulkhead.invoke(inProgress::run));
+
+        // Wait until started before submitting enqueued
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress not started");
+        }
+
+        // Submit new task that should be queued
+        Task enqueued = new Task(1);
+        CountDownLatch enqueuedSubmitted = new CountDownLatch(1);
+        CompletableFuture<Integer> enqueuedResult = Async.invokeStatic(() -> {
+            enqueuedSubmitted.countDown();
+            return bulkhead.invoke(enqueued::run);
+        });
+
+        // Wait until previous task is "likely" queued
+        if (!enqueuedSubmitted.await(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            fail("Task enqueued never submitted");
+        }
+
+        // Submit new task that should be rejected
+        Task rejected = new Task(2);
+        CompletableFuture<Integer> rejectedResult = Async.invokeStatic(
+                () -> bulkhead.invoke(rejected::run));
+
+        assertThat(inProgress.isStarted(), is(true));
+        assertThat(inProgress.isBlocked(), is(true));
+        assertThat(enqueued.isStarted(), is(false));
+        assertThat(enqueued.isBlocked(), is(true));
+        assertThat(rejected.isStarted(), is(false));
+        assertThat(rejected.isBlocked(), is(true));
+
+        // Unblock inProgress task and get result to free bulkhead
+        inProgress.unblock();
+        inProgressResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        // Wait for enqueued task to start and check state
+        if (!enqueued.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task enqueued not started");
+        }
+        assertThat(enqueued.isStarted(), is(true));
+        assertThat(enqueued.isBlocked(), is(true));
+        assertThat(rejected.isStarted(), is(false));
+        assertThat(rejected.isBlocked(), is(true));
+
+        // Unblock enqueued task and get result
+        enqueued.unblock();
+        enqueuedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        // Verify rejected task was indeed rejected
+        ExecutionException executionException = assertThrows(ExecutionException.class,
+                () -> rejectedResult.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        Throwable cause = executionException.getCause();
+        assertThat(cause, notNullValue());
+        assertThat(cause, instanceOf(BulkheadException.class));
+        assertThat(cause.getMessage(), is("Bulkhead queue \"" + name + "\" is full"));
+    }
+
+    @Test
+    void testBulkheadQueue() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        // Create bulkhead of 1 with a queue of 1000
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(1000)
+                .build();
+
+        // Submit request to bulkhead of limit 1
+        Task first = new Task(0);
+        CompletableFuture<?> firstFuture = Async.invokeStatic(() -> bulkhead.invoke(first::run));
+
+        // Wait until started before submitting additional tasks
+        if (!first.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task first not started");
+        }
+
+        // Submit additional request to fill up queue
+        Task[] tasks = new Task[999];
+        for (int i = 0; i < tasks.length; i++) {
+            Task task = new Task(i + 1);
+            tasks[i] = task;
+            CompletableFuture<?> f = Async.invokeStatic(() -> bulkhead.invoke(task::run));
+            tasks[i].future(f);
+        }
+
+        // Verify all tasks are queued and unblock them
+        for (Task task : tasks) {
+            assertFalse(task.isStarted());
+            task.unblock();
+        }
+
+        // Let first complete operation and free bulkhead
+        assertTrue(first.isBlocked());
+        first.unblock();
+        firstFuture.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        // Get all results
+        for (Task task : tasks) {
+            task.future().get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Test
+    void testBulkheadWithError() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        // Create bulkhead of 1 with a queue of 1
+        Bulkhead bulkhead = Bulkhead.builder()
+                .limit(1)
+                .queueLength(1)
+                .build();
+
+        // First check exception throw using synchronous call
+        assertThrows(IllegalStateException.class,
+                () -> bulkhead.invoke(() -> { throw new IllegalStateException(); }));
+
+        // Send 2 tasks to bulkhead, one that fails
+        Task inProgress = new Task(0);
+        CompletableFuture<?> inProgressFuture = Async.invokeStatic(
+                () -> bulkhead.invoke(inProgress::run));
+        CompletableFuture<?> failedFuture = Async.invokeStatic(
+                () -> bulkhead.invoke(() -> { throw new IllegalStateException(); }));
+
+        // Verify completion of inProgress task
+        if (!inProgress.waitUntilStarted(WAIT_TIMEOUT_MILLIS)) {
+            fail("Task inProgress never started");
+        }
+        inProgress.unblock();
+        inProgressFuture.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+
+        // Verify failure of other task
+        ExecutionException executionException = assertThrows(ExecutionException.class,
+                () -> failedFuture.get(WAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        Throwable cause = executionException.getCause();
+        assertThat(cause, notNullValue());
+        assertThat(cause, instanceOf(IllegalStateException.class));
+    }
+
+    /**
+     * A task to submit to a bulkhead. Can be checked for startup and manually
+     * unblocked for completion.
+     */
+    private static class Task {
+        private final CountDownLatch started = new CountDownLatch(1);
+        private final CountDownLatch blocked = new CountDownLatch(1);
+
+        private final int index;
+        private CompletableFuture<?> future;
+
+        Task(int index) {
+            this.index = index;
+        }
+
+        int run() {
+            LOGGER.log(INFO, "Task " + index + " running on thread " + Thread.currentThread().getName());
+
+            started.countDown();
+            try {
+                blocked.await();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return index;
+        }
+
+        boolean isStarted() {
+            return started.getCount() == 0;
+        }
+
+        boolean waitUntilStarted(long millis) throws InterruptedException {
+            return started.await(millis, TimeUnit.MILLISECONDS);
+        }
+
+        boolean isBlocked() {
+            return blocked.getCount() == 1;
+        }
+
+        void unblock() {
+            blocked.countDown();
+        }
+
+        void future(CompletableFuture<?> future) {
+            this.future = future;
+        }
+
+        CompletableFuture<?> future() {
+            return future;
+        }
     }
 }


### PR DESCRIPTION
Port and cleanup of old reactive tests for Nima bulkheads. Restored Async class for convenience, now implemented using virtual threads.