### PR TITLE
Dns resolver type method on webclient builder

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -383,11 +383,6 @@
                 <version>${version.lib.netty}</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
-                <version>${version.lib.netty}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.lib.yasson}</version>

--- a/webclient/webclient/src/main/java/io/helidon/webclient/WebClient.java
+++ b/webclient/webclient/src/main/java/io/helidon/webclient/WebClient.java
@@ -403,6 +403,18 @@ public interface WebClient {
             return this;
         }
 
+        /**
+         * Set which type of DNS resolver should be used.
+         *
+         * @param dnsResolverType type of the DNS resolver to be used
+         * @return updated builder instance
+         */
+        public Builder dnsResolverType(DnsResolverType dnsResolverType) {
+            configuration.dnsResolverType(dnsResolverType);
+            return this;
+        }
+
+
         WebClientConfiguration configuration() {
             configuration.clientServices(services());
             return configuration.build();


### PR DESCRIPTION
This PR also removes redundant netty-resolver-dns dependency.