### PR TITLE
Refactor HTTP header class names to a more natural approach.

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/ClientRequestHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ClientRequestHeaders.java
@@ -19,8 +19,8 @@ package io.helidon.common.http;
 /**
  * Mutable headers of a client request.
  */
-public interface HeadersClientRequest extends HeadersServerRequest,
-                                              HeadersWritable<HeadersClientRequest> {
+public interface ClientRequestHeaders extends ServerRequestHeaders,
+                                              WritableHeaders<ClientRequestHeaders> {
 
     /**
      * Create client request headers from writable headers.
@@ -28,8 +28,8 @@ public interface HeadersClientRequest extends HeadersServerRequest,
      * @param delegate headers
      * @return client request headers
      */
-    static HeadersClientRequest create(HeadersWritable<?> delegate) {
-        return new HeadersClientRequestImpl(delegate);
+    static ClientRequestHeaders create(WritableHeaders<?> delegate) {
+        return new ClientRequestHeadersImpl(delegate);
     }
 
     /**
@@ -38,8 +38,8 @@ public interface HeadersClientRequest extends HeadersServerRequest,
      * @param headers headers
      * @return client request headers
      */
-    static HeadersClientRequest create(Headers headers) {
-        return new HeadersClientRequestImpl(HeadersWritable.create(headers));
+    static ClientRequestHeaders create(Headers headers) {
+        return new ClientRequestHeadersImpl(WritableHeaders.create(headers));
     }
 
     /**
@@ -48,7 +48,7 @@ public interface HeadersClientRequest extends HeadersServerRequest,
      * @param accepted media types to accept
      * @return updated headers
      */
-    default HeadersClientRequest accept(HttpMediaType... accepted) {
+    default ClientRequestHeaders accept(HttpMediaType... accepted) {
         String[] values = new String[accepted.length];
         for (int i = 0; i < accepted.length; i++) {
             HttpMediaType mediaType = accepted[i];

--- a/common/http/src/main/java/io/helidon/common/http/ClientRequestHeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/ClientRequestHeadersImpl.java
@@ -30,12 +30,12 @@ import io.helidon.common.http.Http.HeaderValue;
 /**
  * Client request headers.
  */
-class HeadersClientRequestImpl implements HeadersClientRequest {
-    private final HeadersWritable<?> delegate;
+class ClientRequestHeadersImpl implements ClientRequestHeaders {
+    private final WritableHeaders<?> delegate;
 
     private List<HttpMediaType> mediaTypes;
 
-    HeadersClientRequestImpl(HeadersWritable<?> delegate) {
+    ClientRequestHeadersImpl(WritableHeaders<?> delegate) {
         this.delegate = delegate;
     }
 
@@ -85,31 +85,31 @@ class HeadersClientRequestImpl implements HeadersClientRequest {
     }
 
     @Override
-    public HeadersClientRequest setIfAbsent(HeaderValue header) {
+    public ClientRequestHeaders setIfAbsent(HeaderValue header) {
         delegate.setIfAbsent(header);
         return this;
     }
 
     @Override
-    public HeadersClientRequest add(HeaderValue header) {
+    public ClientRequestHeaders add(HeaderValue header) {
         delegate.add(header);
         return this;
     }
 
     @Override
-    public HeadersClientRequest remove(HeaderName name) {
+    public ClientRequestHeaders remove(HeaderName name) {
         delegate.remove(name);
         return this;
     }
 
     @Override
-    public HeadersClientRequest remove(HeaderName name, Consumer<HeaderValue> removedConsumer) {
+    public ClientRequestHeaders remove(HeaderName name, Consumer<HeaderValue> removedConsumer) {
         delegate.remove(name, removedConsumer);
         return this;
     }
 
     @Override
-    public HeadersClientRequest set(HeaderValue header) {
+    public ClientRequestHeaders set(HeaderValue header) {
         delegate.set(header);
         return this;
     }
@@ -125,7 +125,7 @@ class HeadersClientRequestImpl implements HeadersClientRequest {
     }
 
     @Override
-    public HeadersClientRequest clear() {
+    public ClientRequestHeaders clear() {
         delegate.clear();
         return this;
     }

--- a/common/http/src/main/java/io/helidon/common/http/ClientResponseHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ClientResponseHeaders.java
@@ -33,15 +33,15 @@ import static io.helidon.common.http.Http.Header.LOCATION;
 /**
  * HTTP Headers of a client response.
  */
-public interface HeadersClientResponse extends Headers {
+public interface ClientResponseHeaders extends Headers {
     /**
      * Create a new instance from headers parsed from client response.
      *
      * @param responseHeaders client response headers
      * @return immutable instance of client response HTTP headers
      */
-    static HeadersClientResponse create(Headers responseHeaders) {
-        return new HeadersClientResponseImpl(responseHeaders);
+    static ClientResponseHeaders create(Headers responseHeaders) {
+        return new ClientResponseHeadersImpl(responseHeaders);
     }
 
     /**

--- a/common/http/src/main/java/io/helidon/common/http/ClientResponseHeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/ClientResponseHeadersImpl.java
@@ -20,10 +20,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
 
-class HeadersClientResponseImpl implements HeadersClientResponse {
+class ClientResponseHeadersImpl implements ClientResponseHeaders {
     private final Headers headers;
 
-    HeadersClientResponseImpl(Headers headers) {
+    ClientResponseHeadersImpl(Headers headers) {
         this.headers = headers;
     }
 

--- a/common/http/src/main/java/io/helidon/common/http/DirectHandler.java
+++ b/common/http/src/main/java/io/helidon/common/http/DirectHandler.java
@@ -56,7 +56,7 @@ public interface DirectHandler {
     default TransportResponse handle(TransportRequest request,
                                      EventType eventType,
                                      Http.Status defaultStatus,
-                                     HeadersServerResponse responseHeaders,
+                                     ServerResponseHeaders responseHeaders,
                                      Throwable thrown) {
         return handle(request, eventType, defaultStatus, responseHeaders, thrown.getMessage());
     }
@@ -79,7 +79,7 @@ public interface DirectHandler {
     TransportResponse handle(TransportRequest request,
                              EventType eventType,
                              Http.Status defaultStatus,
-                             HeadersServerResponse responseHeaders,
+                             ServerResponseHeaders responseHeaders,
                              String message);
 
     /**
@@ -123,7 +123,7 @@ public interface DirectHandler {
          *
          * @return headers or an empty map
          */
-        HeadersServerRequest headers();
+        ServerRequestHeaders headers();
     }
 
     /**
@@ -185,7 +185,7 @@ public interface DirectHandler {
      */
     class TransportResponse {
         private final Http.Status status;
-        private final HeadersServerResponse headers;
+        private final ServerResponseHeaders headers;
         private final byte[] entity;
         private final boolean keepAlive;
 
@@ -219,7 +219,7 @@ public interface DirectHandler {
          *
          * @return headers
          */
-        public HeadersServerResponse headers() {
+        public ServerResponseHeaders headers() {
             return headers;
         }
 
@@ -247,7 +247,7 @@ public interface DirectHandler {
         public static class Builder implements io.helidon.common.Builder<Builder, TransportResponse> {
             private Http.Status status = Http.Status.BAD_REQUEST_400;
             private byte[] entity;
-            private HeadersServerResponse headers = HeadersServerResponse.create();
+            private ServerResponseHeaders headers = ServerResponseHeaders.create();
             private boolean keepAlive = true;
 
             private Builder() {
@@ -275,7 +275,7 @@ public interface DirectHandler {
              * @param headers headers to use
              * @return updated builder
              */
-            public Builder headers(HeadersServerResponse headers) {
+            public Builder headers(ServerResponseHeaders headers) {
                 this.headers = headers;
                 return this;
             }

--- a/common/http/src/main/java/io/helidon/common/http/DirectHandlerDefault.java
+++ b/common/http/src/main/java/io/helidon/common/http/DirectHandlerDefault.java
@@ -26,7 +26,7 @@ final class DirectHandlerDefault implements DirectHandler {
     public TransportResponse handle(TransportRequest request,
                                     EventType eventType,
                                     Http.Status defaultStatus,
-                                    HeadersServerResponse headers,
+                                    ServerResponseHeaders headers,
                                     String message) {
         return TransportResponse.builder()
                 .status(defaultStatus)

--- a/common/http/src/main/java/io/helidon/common/http/DirectHandlerEmptyRequest.java
+++ b/common/http/src/main/java/io/helidon/common/http/DirectHandlerEmptyRequest.java
@@ -16,11 +16,11 @@
 
 package io.helidon.common.http;
 
-record DirectHandlerEmptyRequest(String protocolVersion, String method, String path, HeadersServerRequest headers)
+record DirectHandlerEmptyRequest(String protocolVersion, String method, String path, ServerRequestHeaders headers)
         implements DirectHandler.TransportRequest {
     static final DirectHandlerEmptyRequest INSTANCE =
             new DirectHandlerEmptyRequest("",
                                           "",
                                           "",
-                                          HeadersServerRequest.create(HeadersWritable.create()));
+                                          ServerRequestHeaders.create(WritableHeaders.create()));
 }

--- a/common/http/src/main/java/io/helidon/common/http/HeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/HeadersImpl.java
@@ -32,7 +32,7 @@ import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.Http.HeaderValueWriteable;
 
 @SuppressWarnings("unchecked")
-class HeadersImpl<T extends HeadersWritable<T>> implements HeadersWritable<T> {
+class HeadersImpl<T extends WritableHeaders<T>> implements WritableHeaders<T> {
     static final int KNOWN_HEADER_SIZE = HeaderEnum.values().length;
     /*
      Optimization for most commonly used header names

--- a/common/http/src/main/java/io/helidon/common/http/Http1HeadersParser.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http1HeadersParser.java
@@ -43,8 +43,8 @@ public final class Http1HeadersParser {
      * @param validate       whether to validate headers
      * @return a new mutable headers instance containing all headers parsed from reader
      */
-    public static HeadersWritable<?> readHeaders(DataReader reader, int maxHeadersSize, boolean validate) {
-        HeadersWritable<?> headers = HeadersWritable.create();
+    public static WritableHeaders<?> readHeaders(DataReader reader, int maxHeadersSize, boolean validate) {
+        WritableHeaders<?> headers = WritableHeaders.create();
         int maxLength = maxHeadersSize;
 
         while (true) {
@@ -72,7 +72,7 @@ public final class Http1HeadersParser {
     }
 
     private static Http.HeaderName readHeaderName(DataReader reader,
-                                                  HeadersWritable<?> headers,
+                                                  WritableHeaders<?> headers,
                                                   int maxLength,
                                                   boolean validate) {
         switch (reader.lookup()) {

--- a/common/http/src/main/java/io/helidon/common/http/RequestException.java
+++ b/common/http/src/main/java/io/helidon/common/http/RequestException.java
@@ -26,7 +26,7 @@ public class RequestException extends RuntimeException {
     private final Http.Status status;
     private final DirectHandler.TransportRequest transportRequest;
     private final boolean keepAlive;
-    private final HeadersServerResponse responseHeaders;
+    private final ServerResponseHeaders responseHeaders;
 
     /**
      * A new exception with a predefined status, even type.
@@ -93,7 +93,7 @@ public class RequestException extends RuntimeException {
      *
      * @return response headers
      */
-    public HeadersServerResponse responseHeaders() {
+    public ServerResponseHeaders responseHeaders() {
         return responseHeaders;
     }
 
@@ -107,7 +107,7 @@ public class RequestException extends RuntimeException {
         private DirectHandler.EventType type;
         private Http.Status status;
         private Boolean keepAlive;
-        private final HeadersServerResponse responseHeaders = HeadersServerResponse.create();
+        private final ServerResponseHeaders responseHeaders = ServerResponseHeaders.create();
 
         private Builder() {
         }

--- a/common/http/src/main/java/io/helidon/common/http/ServerRequestHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerRequestHeaders.java
@@ -29,7 +29,7 @@ import io.helidon.common.parameters.Parameters;
 /**
  * HTTP headers of a server request.
  */
-public interface HeadersServerRequest extends Headers {
+public interface ServerRequestHeaders extends Headers {
     /**
      * Header value of the non compliant {@code Accept} header sent by
      * {@link java.net.HttpURLConnection} when none is set.
@@ -56,8 +56,8 @@ public interface HeadersServerRequest extends Headers {
      * @param headers headers parsed from server request
      * @return immutable instance of request headers
      */
-    static HeadersServerRequest create(Headers headers) {
-        return new HeadersServerRequestImpl(headers);
+    static ServerRequestHeaders create(Headers headers) {
+        return new ServerRequestHeadersImpl(headers);
     }
 
     /**
@@ -65,8 +65,8 @@ public interface HeadersServerRequest extends Headers {
      *
      * @return empty headers
      */
-    static HeadersServerRequest create() {
-        return new HeadersServerRequestImpl(HeadersWritable.create());
+    static ServerRequestHeaders create() {
+        return new ServerRequestHeadersImpl(WritableHeaders.create());
     }
 
     /**

--- a/common/http/src/main/java/io/helidon/common/http/ServerRequestHeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerRequestHeadersImpl.java
@@ -26,13 +26,13 @@ import java.util.function.Supplier;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.parameters.Parameters;
 
-class HeadersServerRequestImpl implements HeadersServerRequest {
+class ServerRequestHeadersImpl implements ServerRequestHeaders {
     private final Headers headers;
     private List<HttpMediaType> cachedAccepted;
     private Parameters cacheCookies;
     private Optional<HttpMediaType> cacheContentType;
 
-    HeadersServerRequestImpl(Headers headers) {
+    ServerRequestHeadersImpl(Headers headers) {
         this.headers = headers;
     }
 
@@ -60,7 +60,7 @@ class HeadersServerRequestImpl implements HeadersServerRequest {
     @Override
     public Optional<HttpMediaType> contentType() {
         if (cacheContentType == null) {
-            cacheContentType = HeadersServerRequest.super.contentType();
+            cacheContentType = ServerRequestHeaders.super.contentType();
         }
         return cacheContentType;
     }
@@ -109,7 +109,7 @@ class HeadersServerRequestImpl implements HeadersServerRequest {
     @Override
     public Parameters cookies() {
         if (cacheCookies == null) {
-            cacheCookies = HeadersServerRequest.super.cookies();
+            cacheCookies = ServerRequestHeaders.super.cookies();
         }
         return cacheCookies;
     }

--- a/common/http/src/main/java/io/helidon/common/http/ServerResponseHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerResponseHeaders.java
@@ -33,16 +33,16 @@ import static io.helidon.common.http.Http.Header.LOCATION;
 /**
  * Mutable headers of a server response.
  */
-public interface HeadersServerResponse extends HeadersClientResponse,
-                                               HeadersWritable<HeadersServerResponse> {
+public interface ServerResponseHeaders extends ClientResponseHeaders,
+                                               WritableHeaders<ServerResponseHeaders> {
 
     /**
      * Create a new instance of mutable server response headers.
      *
      * @return new server response headers
      */
-    static HeadersServerResponse create() {
-        return new HeadersServerResponseImpl();
+    static ServerResponseHeaders create() {
+        return new ServerResponseHeadersImpl();
     }
 
     /**
@@ -51,8 +51,8 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param existing headers to add to these response headers
      * @return new server response headers
      */
-    static HeadersServerResponse create(Headers existing) {
-        return new HeadersServerResponseImpl(existing);
+    static ServerResponseHeaders create(Headers existing) {
+        return new ServerResponseHeadersImpl(existing);
     }
 
     /**
@@ -62,7 +62,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param acceptableMediaTypes media types to add.
      * @return this instance
      */
-    default HeadersServerResponse addAcceptPatches(HttpMediaType... acceptableMediaTypes) {
+    default ServerResponseHeaders addAcceptPatches(HttpMediaType... acceptableMediaTypes) {
         String[] values = new String[acceptableMediaTypes.length];
         for (int i = 0; i < acceptableMediaTypes.length; i++) {
             HttpMediaType acceptableMediaType = acceptableMediaTypes[i];
@@ -79,7 +79,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param acceptableMediaTypes media types to add.
      * @return this instance
      */
-    default HeadersServerResponse addAcceptPatches(MediaType... acceptableMediaTypes) {
+    default ServerResponseHeaders addAcceptPatches(MediaType... acceptableMediaTypes) {
         String[] values = new String[acceptableMediaTypes.length];
         for (int i = 0; i < acceptableMediaTypes.length; i++) {
             MediaType acceptableMediaType = acceptableMediaTypes[i];
@@ -95,7 +95,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param cookie a cookie definition
      * @return this instance
      */
-    HeadersServerResponse addCookie(SetCookie cookie);
+    ServerResponseHeaders addCookie(SetCookie cookie);
 
     /**
      * Adds {@code Set-Cookie} header based on <a href="https://tools.ietf.org/html/rfc6265">RFC6265</a> with {@code Max-Age}
@@ -106,7 +106,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param maxAge {@code Max-Age} cookie parameter
      * @return this instance
      */
-    default HeadersServerResponse addCookie(String name, String value, Duration maxAge) {
+    default ServerResponseHeaders addCookie(String name, String value, Duration maxAge) {
         return addCookie(SetCookie.builder(name, value)
                                  .maxAge(maxAge)
                                  .build());
@@ -119,7 +119,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param value value of the cookie
      * @return this instance
      */
-    default HeadersServerResponse addCookie(String name, String value) {
+    default ServerResponseHeaders addCookie(String name, String value) {
         return addCookie(SetCookie.create(name, value));
     }
 
@@ -129,7 +129,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param name name of the cookie.
      * @return this instance
      */
-    HeadersServerResponse clearCookie(String name);
+    ServerResponseHeaders clearCookie(String name);
 
     /**
      * Sets the value of {@link Header#LAST_MODIFIED} header.
@@ -139,7 +139,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param modified Last modified date/time.
      * @return this instance
      */
-    default HeadersServerResponse lastModified(Instant modified) {
+    default ServerResponseHeaders lastModified(Instant modified) {
         ZonedDateTime dt = ZonedDateTime.ofInstant(modified, ZoneId.systemDefault());
         return set(HeaderValue.create(LAST_MODIFIED, true, false, dt.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
@@ -152,7 +152,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param modified Last modified date/time.
      * @return this instance
      */
-    default HeadersServerResponse lastModified(ZonedDateTime modified) {
+    default ServerResponseHeaders lastModified(ZonedDateTime modified) {
         return set(HeaderValue.create(LAST_MODIFIED, true, false, modified.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 
@@ -164,7 +164,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param location Location header value.
      * @return updated headers
      */
-    default HeadersServerResponse location(URI location) {
+    default ServerResponseHeaders location(URI location) {
         return set(HeaderValue.create(LOCATION, true, false, location.toASCIIString()));
     }
 
@@ -176,7 +176,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param dateTime Expires date/time.
      * @return updated headers
      */
-    default HeadersServerResponse expires(ZonedDateTime dateTime) {
+    default ServerResponseHeaders expires(ZonedDateTime dateTime) {
         return set(HeaderValue.create(EXPIRES, dateTime.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 
@@ -188,7 +188,7 @@ public interface HeadersServerResponse extends HeadersClientResponse,
      * @param dateTime Expires date/time.
      * @return updated headers
      */
-    default HeadersServerResponse expires(Instant dateTime) {
+    default ServerResponseHeaders expires(Instant dateTime) {
         return set(HeaderValue.create(EXPIRES, ZonedDateTime.ofInstant(dateTime, ZoneId.systemDefault())
                 .format(Http.DateTime.RFC_1123_DATE_TIME)));
     }

--- a/common/http/src/main/java/io/helidon/common/http/ServerResponseHeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerResponseHeadersImpl.java
@@ -22,25 +22,25 @@ import java.util.List;
 
 import io.helidon.common.LazyValue;
 
-class HeadersServerResponseImpl extends HeadersImpl<HeadersServerResponse> implements HeadersServerResponse {
+class ServerResponseHeadersImpl extends HeadersImpl<ServerResponseHeaders> implements ServerResponseHeaders {
     private static final LazyValue<ZonedDateTime> START_OF_YEAR_1970 = LazyValue.create(
             () -> ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT+0")));
 
-    HeadersServerResponseImpl() {
+    ServerResponseHeadersImpl() {
     }
 
-    HeadersServerResponseImpl(Headers existing) {
+    ServerResponseHeadersImpl(Headers existing) {
         super(existing);
     }
 
     @Override
-    public HeadersServerResponse addCookie(SetCookie cookie) {
+    public ServerResponseHeaders addCookie(SetCookie cookie) {
         add(Http.HeaderValue.create(Http.Header.SET_COOKIE, cookie.toString()));
         return this;
     }
 
     @Override
-    public HeadersServerResponse clearCookie(String name) {
+    public ServerResponseHeaders clearCookie(String name) {
         SetCookie expiredCookie = SetCookie.builder(name, "deleted")
                 .path("/")
                 .expires(START_OF_YEAR_1970.get())

--- a/common/http/src/main/java/io/helidon/common/http/WritableHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/WritableHeaders.java
@@ -28,13 +28,13 @@ import io.helidon.common.media.type.MediaType;
  *
  * @param <B> type of the headers (for inheritance)
  */
-public interface HeadersWritable<B extends HeadersWritable<B>> extends Headers {
+public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
     /**
      * Create a new instance of writable headers.
      *
      * @return mutable HTTP headers
      */
-    static HeadersWritable<?> create() {
+    static WritableHeaders<?> create() {
         return new HeadersImpl<>();
     }
 
@@ -44,7 +44,7 @@ public interface HeadersWritable<B extends HeadersWritable<B>> extends Headers {
      * @param headers headers to add to the new mutable instance
      * @return mutable HTTP headers
      */
-    static HeadersWritable<?> create(Headers headers) {
+    static WritableHeaders<?> create(Headers headers) {
         return new HeadersImpl<>(headers);
     }
 

--- a/common/http/src/test/java/io/helidon/common/http/Http1HeadersParserTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/Http1HeadersParserTest.java
@@ -33,7 +33,7 @@ class Http1HeadersParserTest {
                 "Set-Cookie: c1=v1\r\nSet-Cookie: c2=v2\r\n"
                         + "Header: hv1\r\nheader: hv2\r\nheaDer: hv3\r\n"
                         + "\r\n").getBytes(StandardCharsets.US_ASCII));
-        HeadersWritable<?> headers = Http1HeadersParser.readHeaders(reader, 1024, true);
+        WritableHeaders<?> headers = Http1HeadersParser.readHeaders(reader, 1024, true);
 
         testHeader(headers, "Set-Cookie", "c1=v1", "c2=v2");
         testHeader(headers, "set-cookie", "c1=v1", "c2=v2");

--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/SocketHttpClient.java
@@ -32,9 +32,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.helidon.common.http.HeadersClientResponse;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.WritableHeaders;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -110,8 +110,8 @@ public class SocketHttpClient implements AutoCloseable {
      * @param response full HTTP response
      * @return headers map
      */
-    public static HeadersClientResponse headersFromResponse(String response) {
-        HeadersWritable<?> headers = HeadersWritable.create();
+    public static ClientResponseHeaders headersFromResponse(String response) {
+        WritableHeaders<?> headers = WritableHeaders.create();
 
         assertThat(response, notNullValue());
         int index = response.indexOf("\n\n");
@@ -121,7 +121,7 @@ public class SocketHttpClient implements AutoCloseable {
         String hdrsPart = response.substring(0, index);
         String[] lines = hdrsPart.split("\\n");
         if (lines.length <= 1) {
-            return HeadersClientResponse.create(headers);
+            return ClientResponseHeaders.create(headers);
         }
 
         boolean first = true;
@@ -136,7 +136,7 @@ public class SocketHttpClient implements AutoCloseable {
             }
             headers.add(Http.Header.create(line.substring(0, i).trim()), line.substring(i + 1).trim());
         }
-        return HeadersClientResponse.create(headers);
+        return ClientResponseHeaders.create(headers);
     }
 
     /**

--- a/examples/nima/media/src/main/java/io/helidon/examples/nima/media/FileService.java
+++ b/examples/nima/media/src/main/java/io/helidon/examples/nima/media/FileService.java
@@ -25,8 +25,8 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import io.helidon.common.http.ContentDisposition;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.multipart.MultiPart;
 import io.helidon.nima.http.media.multipart.ReadablePart;
@@ -119,7 +119,7 @@ final class FileService implements HttpService {
             res.status(BAD_REQUEST_400).send("Not a file");
             return;
         }
-        HeadersServerResponse headers = res.headers();
+        ServerResponseHeaders headers = res.headers();
         headers.contentType(MediaTypes.APPLICATION_OCTET_STREAM);
         headers.set(ContentDisposition.builder()
                             .filename(filePath.getFileName().toString())

--- a/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonStructures.java
+++ b/jersey/connector/src/main/java/io/helidon/jersey/connector/HelidonStructures.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 import javax.net.ssl.SSLContext;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.config.Config;
 import io.helidon.reactive.media.common.DefaultMediaSupport;
 import io.helidon.reactive.media.common.MessageBodyReader;
@@ -51,7 +51,7 @@ class HelidonStructures {
     }
 
     static Headers createHeaders(Map<String, List<String>> data) {
-        HeadersWritable<?> headers = HeadersWritable.create();
+        WritableHeaders<?> headers = WritableHeaders.create();
         data.forEach((key, value) -> headers.set(Http.Header.create(key), value));
         return headers;
     }

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http2.FlowControl;
 import io.helidon.nima.http2.Http2Flag;
 import io.helidon.nima.http2.Http2FrameData;
@@ -145,7 +145,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolProvider.SubProto
             @Override
             public void sendHeaders(Metadata headers) {
                 // todo ignoring headers, just sending required response headers
-                HeadersWritable<?> writable = HeadersWritable.create();
+                WritableHeaders<?> writable = WritableHeaders.create();
                 writable.set(GRPC_CONTENT_TYPE);
                 writable.set(GRPC_ENCODING_IDENTITY);
 
@@ -184,7 +184,7 @@ class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolProvider.SubProto
             @Override
             public void close(Status status, Metadata trailers) {
                 // todo ignoring trailers
-                HeadersWritable<?> writable = HeadersWritable.create();
+                WritableHeaders<?> writable = WritableHeaders.create();
                 writable.set(GrpcStatus.OK);
                 Http2Headers http2Headers = Http2Headers.create(writable);
                 streamWriter.writeHeaders(http2Headers,

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandlerNotFound.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandlerNotFound.java
@@ -17,7 +17,7 @@
 package io.helidon.nima.grpc.webserver;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http2.FlowControl;
 import io.helidon.nima.http2.Http2Flag;
 import io.helidon.nima.http2.Http2FrameHeader;
@@ -44,7 +44,7 @@ class GrpcProtocolHandlerNotFound implements Http2SubProtocolProvider.SubProtoco
 
     @Override
     public void init() {
-        HeadersWritable<?> writable = HeadersWritable.create();
+        WritableHeaders<?> writable = WritableHeaders.create();
         writable.set(GrpcStatus.NOT_FOUND);
         Http2Headers http2Headers = Http2Headers.create(writable);
         streamWriter.writeHeaders(http2Headers,

--- a/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.encoding.ContentEncoder;
 import io.helidon.nima.http.encoding.spi.ContentEncodingProvider;
@@ -67,7 +67,7 @@ public class DeflateEncodingProvider implements ContentEncodingProvider {
             }
 
             @Override
-            public void headers(HeadersWritable<?> headers) {
+            public void headers(WritableHeaders<?> headers) {
                 headers.add(CONTENT_ENCODING_DEFLATE);
                 headers.remove(Http.Header.CONTENT_LENGTH);
             }

--- a/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncoder.java
+++ b/nima/http/encoding/encoding/src/main/java/io/helidon/nima/http/encoding/ContentEncoder.java
@@ -18,7 +18,7 @@ package io.helidon.nima.http.encoding;
 
 import java.io.OutputStream;
 
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 
 /**
  * Content encoder.
@@ -42,6 +42,6 @@ public interface ContentEncoder {
      *
      * @param headers headers to update
      */
-    default void headers(HeadersWritable<?> headers) {
+    default void headers(WritableHeaders<?> headers) {
     }
 }

--- a/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
+++ b/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
@@ -25,9 +25,9 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import io.helidon.common.Weighted;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderValue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.encoding.ContentEncoder;
 import io.helidon.nima.http.encoding.spi.ContentEncodingProvider;
@@ -82,7 +82,7 @@ public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
             }
 
             @Override
-            public void headers(HeadersWritable<?> headers) {
+            public void headers(WritableHeaders<?> headers) {
                 headers.add(CONTENT_ENCODING_GZIP);
                 headers.remove(CONTENT_LENGTH);
             }

--- a/nima/http/media/jsonb/src/main/java/io/helidon/nima/http/media/jsonb/JsonbMediaSupportProvider.java
+++ b/nima/http/media/jsonb/src/main/java/io/helidon/nima/http/media/jsonb/JsonbMediaSupportProvider.java
@@ -19,9 +19,9 @@ package io.helidon.nima.http.media.jsonb;
 import io.helidon.common.GenericType;
 import io.helidon.common.Weighted;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.EntityReader;
 import io.helidon.nima.http.media.EntityWriter;
@@ -61,7 +61,7 @@ public class JsonbMediaSupportProvider implements MediaSupportProvider, Weighted
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
         if (JSON_OBJECT_TYPE.equals(type)) {
             return WriterResponse.unsupported();
         }
@@ -103,7 +103,7 @@ public class JsonbMediaSupportProvider implements MediaSupportProvider, Weighted
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         if (type.equals(JSON_OBJECT_TYPE)) {
             return WriterResponse.unsupported();
         }

--- a/nima/http/media/jsonb/src/main/java/io/helidon/nima/http/media/jsonb/JsonbWriter.java
+++ b/nima/http/media/jsonb/src/main/java/io/helidon/nima/http/media/jsonb/JsonbWriter.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.EntityWriter;
 
@@ -46,7 +46,7 @@ class JsonbWriter<T> implements EntityWriter<T> {
                       T object,
                       OutputStream outputStream,
                       Headers requestHeaders,
-                      HeadersWritable<?> responseHeaders) {
+                      WritableHeaders<?> responseHeaders) {
 
         responseHeaders.setIfAbsent(Http.HeaderValues.CONTENT_TYPE_JSON);
 
@@ -67,7 +67,7 @@ class JsonbWriter<T> implements EntityWriter<T> {
     }
 
     @Override
-    public void write(GenericType<T> type, T object, OutputStream outputStream, HeadersWritable<?> headers) {
+    public void write(GenericType<T> type, T object, OutputStream outputStream, WritableHeaders<?> headers) {
         headers.setIfAbsent(Http.HeaderValues.CONTENT_TYPE_JSON);
         write(type, object, outputStream);
     }

--- a/nima/http/media/jsonp/src/main/java/io/helidon/nima/http/media/jsonp/JsonpMediaSupportProvider.java
+++ b/nima/http/media/jsonp/src/main/java/io/helidon/nima/http/media/jsonp/JsonpMediaSupportProvider.java
@@ -21,8 +21,8 @@ import java.util.Map;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.EntityReader;
 import io.helidon.nima.http.media.EntityWriter;
@@ -75,7 +75,7 @@ public class JsonpMediaSupportProvider implements MediaSupportProvider {
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
 
         if (isSupportedType(type)) {
             return new WriterResponse<>(SupportLevel.SUPPORTED, this::writer);
@@ -105,7 +105,7 @@ public class JsonpMediaSupportProvider implements MediaSupportProvider {
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         // if the type is JsonStructure, we support it and do not care about content type
         // you provide json, you get json...
         if (isSupportedType(type)) {

--- a/nima/http/media/jsonp/src/main/java/io/helidon/nima/http/media/jsonp/JsonpWriter.java
+++ b/nima/http/media/jsonp/src/main/java/io/helidon/nima/http/media/jsonp/JsonpWriter.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.EntityWriter;
 
@@ -48,7 +48,7 @@ class JsonpWriter<T extends JsonStructure> implements EntityWriter<T> {
                       T object,
                       OutputStream outputStream,
                       Headers requestHeaders,
-                      HeadersWritable<?> responseHeaders) {
+                      WritableHeaders<?> responseHeaders) {
 
         responseHeaders.setIfAbsent(Http.HeaderValues.CONTENT_TYPE_JSON);
 
@@ -69,7 +69,7 @@ class JsonpWriter<T extends JsonStructure> implements EntityWriter<T> {
     }
 
     @Override
-    public void write(GenericType<T> type, T object, OutputStream outputStream, HeadersWritable<?> headers) {
+    public void write(GenericType<T> type, T object, OutputStream outputStream, WritableHeaders<?> headers) {
         headers.setIfAbsent(Http.HeaderValues.CONTENT_TYPE_JSON);
         write(type, object, outputStream);
     }

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/EntityWriter.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/EntityWriter.java
@@ -20,7 +20,7 @@ import java.io.OutputStream;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 
 /**
  * Writer of entity into bytes.
@@ -41,7 +41,7 @@ public interface EntityWriter<T> {
                T object,
                OutputStream outputStream,
                Headers requestHeaders,
-               HeadersWritable<?> responseHeaders);
+               WritableHeaders<?> responseHeaders);
 
     /**
      * Write client request entity and close the stream.
@@ -54,5 +54,5 @@ public interface EntityWriter<T> {
     void write(GenericType<T> type,
                T object,
                OutputStream outputStream,
-               HeadersWritable<?> headers);
+               WritableHeaders<?> headers);
 }

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/FormParamsSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/FormParamsSupportProvider.java
@@ -33,10 +33,10 @@ import java.util.regex.Pattern;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.uri.UriEncoding;
@@ -76,7 +76,7 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
 
         if (!type.equals(Parameters.GENERIC_TYPE)) {
             return WriterResponse.unsupported();
@@ -121,7 +121,7 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         if (!type.equals(Parameters.GENERIC_TYPE)) {
             return WriterResponse.unsupported();
         }
@@ -177,7 +177,7 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
                           Parameters object,
                           OutputStream outputStream,
                           Headers requestHeaders,
-                          HeadersWritable<?> responseHeaders) {
+                          WritableHeaders<?> responseHeaders) {
             write(object, outputStream, responseHeaders);
         }
 
@@ -185,13 +185,13 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
         public void write(GenericType<Parameters> type,
                           Parameters object,
                           OutputStream outputStream,
-                          HeadersWritable<?> headers) {
+                          WritableHeaders<?> headers) {
             write(object, outputStream, headers);
         }
 
         private void write(Parameters toWrite,
                            OutputStream outputStream,
-                           HeadersWritable<?> writableHeaders) {
+                           WritableHeaders<?> writableHeaders) {
 
             Charset charset;
             if (writableHeaders.contains(Http.Header.CONTENT_TYPE)) {

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/MediaContext.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/MediaContext.java
@@ -18,7 +18,7 @@ package io.helidon.nima.http.media;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 
 /**
  * Media context to obtain readers and writers of various supported content types.
@@ -54,7 +54,7 @@ public interface MediaContext {
      */
     <T> EntityWriter<T> writer(GenericType<T> type,
                                Headers requestHeaders,
-                               HeadersWritable<?> responseHeaders);
+                               WritableHeaders<?> responseHeaders);
 
     /**
      * Reader for client response entity.
@@ -78,5 +78,5 @@ public interface MediaContext {
      * @return entity writer for the type, or a writer that will fail if none found
      */
     <T> EntityWriter<T> writer(GenericType<T> type,
-                               HeadersWritable<?> requestHeaders);
+                               WritableHeaders<?> requestHeaders);
 }

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/MediaContextImpl.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/MediaContextImpl.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.helidon.common.GenericType;
 import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.spi.MediaSupportProvider;
 import io.helidon.nima.http.media.spi.MediaSupportProvider.ReaderResponse;
 import io.helidon.nima.http.media.spi.MediaSupportProvider.WriterResponse;
@@ -74,7 +74,7 @@ class MediaContextImpl implements MediaContext {
     @Override
     public <T> EntityWriter<T> writer(GenericType<T> type,
                                       Headers requestHeaders,
-                                      HeadersWritable<?> responseHeaders) {
+                                      WritableHeaders<?> responseHeaders) {
         WriterResponse<T> compatible = null;
         for (MediaSupportProvider provider : providers) {
             WriterResponse<T> response = provider.writer(type, requestHeaders, responseHeaders);
@@ -114,7 +114,7 @@ class MediaContextImpl implements MediaContext {
     }
 
     @Override
-    public <T> EntityWriter<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> EntityWriter<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         WriterResponse<T> compatible = null;
         for (MediaSupportProvider provider : providers) {
             WriterResponse<T> response = provider.writer(type, requestHeaders);
@@ -153,7 +153,7 @@ class MediaContextImpl implements MediaContext {
                           Object object,
                           OutputStream outputStream,
                           Headers requestHeaders,
-                          HeadersWritable responseHeaders) {
+                          WritableHeaders responseHeaders) {
             if (LOGGED_WRITERS.computeIfAbsent(type, it -> new AtomicBoolean()).compareAndSet(false, true)) {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media writer configured for " + type);
             }
@@ -165,7 +165,7 @@ class MediaContextImpl implements MediaContext {
         public void write(GenericType type,
                           Object object,
                           OutputStream outputStream,
-                          HeadersWritable headers) {
+                          WritableHeaders headers) {
 
             if (LOGGED_WRITERS.computeIfAbsent(type, it -> new AtomicBoolean()).compareAndSet(false, true)) {
                 LOGGER.log(System.Logger.Level.WARNING, "There is no media writer configured for " + type);
@@ -246,7 +246,7 @@ class MediaContextImpl implements MediaContext {
                           Object object,
                           OutputStream outputStream,
                           Headers requestHeaders,
-                          HeadersWritable responseHeaders) {
+                          WritableHeaders responseHeaders) {
             delegate.write(type, object, outputStream, requestHeaders, responseHeaders);
         }
 
@@ -254,7 +254,7 @@ class MediaContextImpl implements MediaContext {
         public void write(GenericType type,
                           Object object,
                           OutputStream outputStream,
-                          HeadersWritable headers) {
+                          WritableHeaders headers) {
             delegate.write(type,
                            object,
                            outputStream,

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/PathSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/PathSupportProvider.java
@@ -26,8 +26,8 @@ import java.nio.file.Path;
 import io.helidon.common.GenericType;
 import io.helidon.common.http.ContentDisposition;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.spi.MediaSupportProvider;
@@ -49,7 +49,7 @@ public class PathSupportProvider implements MediaSupportProvider {
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
         if (Path.class.isAssignableFrom(type.rawType())) {
             return new WriterResponse<>(SupportLevel.SUPPORTED, PathSupportProvider::writer);
         }
@@ -64,7 +64,7 @@ public class PathSupportProvider implements MediaSupportProvider {
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         if (Path.class.isAssignableFrom(type.rawType())) {
             return new WriterResponse<>(SupportLevel.SUPPORTED, PathSupportProvider::writer);
         }
@@ -81,7 +81,7 @@ public class PathSupportProvider implements MediaSupportProvider {
                           Path object,
                           OutputStream outputStream,
                           Headers requestHeaders,
-                          HeadersWritable<?> responseHeaders) {
+                          WritableHeaders<?> responseHeaders) {
             write(object, outputStream, responseHeaders);
         }
 
@@ -89,13 +89,13 @@ public class PathSupportProvider implements MediaSupportProvider {
         public void write(GenericType<Path> type,
                           Path object,
                           OutputStream outputStream,
-                          HeadersWritable<?> headers) {
+                          WritableHeaders<?> headers) {
             write(object, outputStream, headers);
         }
 
         private void write(Path toWrite,
                            OutputStream outputStream,
-                           HeadersWritable<?> writableHeaders) {
+                           WritableHeaders<?> writableHeaders) {
 
             if (!writableHeaders.contains(Http.Header.CONTENT_TYPE)) {
                 MediaType mediaType = MediaTypes.detectType(toWrite).orElse(MediaTypes.APPLICATION_OCTET_STREAM);

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/StringSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/StringSupportProvider.java
@@ -26,10 +26,10 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.spi.MediaSupportProvider;
 
 /**
@@ -53,7 +53,7 @@ public class StringSupportProvider implements MediaSupportProvider {
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
         if (type.equals(GenericType.STRING)) {
             return new WriterResponse<>(SupportLevel.SUPPORTED, StringSupportProvider::writer);
         }
@@ -71,7 +71,7 @@ public class StringSupportProvider implements MediaSupportProvider {
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         if (type.equals(GenericType.STRING)) {
             return new WriterResponse<>(SupportLevel.SUPPORTED, StringSupportProvider::writer);
         }
@@ -96,7 +96,7 @@ public class StringSupportProvider implements MediaSupportProvider {
                           String object,
                           OutputStream outputStream,
                           Headers requestHeaders,
-                          HeadersWritable<?> responseHeaders) {
+                          WritableHeaders<?> responseHeaders) {
             write(object, outputStream, responseHeaders);
         }
 
@@ -104,13 +104,13 @@ public class StringSupportProvider implements MediaSupportProvider {
         public void write(GenericType<String> type,
                           String object,
                           OutputStream outputStream,
-                          HeadersWritable<?> headers) {
+                          WritableHeaders<?> headers) {
             write(object, outputStream, headers);
         }
 
         private void write(String toWrite,
                            OutputStream outputStream,
-                           HeadersWritable<?> writableHeaders) {
+                           WritableHeaders<?> writableHeaders) {
             Charset charset;
             if (writableHeaders.contains(Http.Header.CONTENT_TYPE)) {
                 charset = writableHeaders.contentType()

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/spi/MediaSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/spi/MediaSupportProvider.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.EntityReader;
 import io.helidon.nima.http.media.EntityWriter;
 import io.helidon.nima.http.media.MediaContext;
@@ -62,7 +62,7 @@ public interface MediaSupportProvider {
      */
     default <T> WriterResponse<T> writer(GenericType<T> type,
                                          Headers requestHeaders,
-                                         HeadersWritable<?> responseHeaders) {
+                                         WritableHeaders<?> responseHeaders) {
         return WriterResponse.unsupported();
     }
 
@@ -89,7 +89,7 @@ public interface MediaSupportProvider {
      * @param <T>            type
      * @return writer response, whether this type is supported or not
      */
-    default <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    default <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         return WriterResponse.unsupported();
     }
 

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartImpl.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartImpl.java
@@ -23,9 +23,9 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http1HeadersParser;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.MediaContext;
 
 class MultiPartImpl extends MultiPart {
@@ -82,7 +82,7 @@ class MultiPartImpl extends MultiPart {
         String probablyBoundary = dataReader.readAsciiString(newLine);
         if (probablyBoundary.equals(boundary)) {
             dataReader.skip(2); // skip the new line after boundary
-            HeadersWritable<?> headers = Http1HeadersParser.readHeaders(dataReader, 1024, true);
+            WritableHeaders<?> headers = Http1HeadersParser.readHeaders(dataReader, 1024, true);
             if (headers.contains(Header.CONTENT_LENGTH)) {
                 next = new ReadablePartLength(context,
                                               headers,

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartSupportProvider.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartSupportProvider.java
@@ -21,8 +21,8 @@ import java.util.Optional;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.EntityReader;
 import io.helidon.nima.http.media.EntityWriter;
@@ -95,7 +95,7 @@ public class MultiPartSupportProvider implements MediaSupportProvider {
     @Override
     public <T> WriterResponse<T> writer(GenericType<T> type,
                                         Headers requestHeaders,
-                                        HeadersWritable<?> responseHeaders) {
+                                        WritableHeaders<?> responseHeaders) {
         if (unsupportedWrite(type)) {
             return WriterResponse.unsupported();
         }
@@ -163,7 +163,7 @@ public class MultiPartSupportProvider implements MediaSupportProvider {
     }
 
     @Override
-    public <T> WriterResponse<T> writer(GenericType<T> type, HeadersWritable<?> requestHeaders) {
+    public <T> WriterResponse<T> writer(GenericType<T> type, WritableHeaders<?> requestHeaders) {
         if (unsupportedWrite(type)) {
             return WriterResponse.unsupported();
         }

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartWriter.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartWriter.java
@@ -24,9 +24,9 @@ import java.nio.charset.StandardCharsets;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.EntityWriter;
 import io.helidon.nima.http.media.MediaContext;
 
@@ -46,7 +46,7 @@ class MultiPartWriter implements EntityWriter<WriteableMultiPart> {
                       WriteableMultiPart multiPart,
                       OutputStream os,
                       Headers requestHeaders,
-                      HeadersWritable<?> responseHeaders) {
+                      WritableHeaders<?> responseHeaders) {
 
         try (BufferedOutputStream outputStream = new BufferedOutputStream(os, 512)) {
             responseHeaders.set(contentType);
@@ -75,7 +75,7 @@ class MultiPartWriter implements EntityWriter<WriteableMultiPart> {
     public void write(GenericType<WriteableMultiPart> type,
                       WriteableMultiPart multiPart,
                       OutputStream outputStream,
-                      HeadersWritable<?> headers) {
+                      WritableHeaders<?> headers) {
 
         try (outputStream) {
             headers.set(contentType);

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/ReadablePartLength.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/ReadablePartLength.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.MediaContext;
 
 class ReadablePartLength extends ReadablePartAbstract {
@@ -32,7 +32,7 @@ class ReadablePartLength extends ReadablePartAbstract {
     private PartInputStream inputStream;
 
     ReadablePartLength(MediaContext context,
-                       HeadersWritable<?> headers,
+                       WritableHeaders<?> headers,
                        DataReader dataReader,
                        int index,
                        long partLength) {

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/ReadablePartNoLength.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/ReadablePartNoLength.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.MediaContext;
 
 class ReadablePartNoLength extends ReadablePartAbstract {
@@ -34,7 +34,7 @@ class ReadablePartNoLength extends ReadablePartAbstract {
     private PartInputStream inputStream;
 
     ReadablePartNoLength(MediaContext context,
-                         HeadersWritable<?> headers,
+                         WritableHeaders<?> headers,
                          DataReader dataReader,
                          int index,
                          String boundary,

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePart.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePart.java
@@ -22,8 +22,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.nima.http.media.MediaContext;
 
@@ -90,7 +90,7 @@ public interface WriteablePart {
      * Fluent API builder for {@link WriteablePart}.
      */
     class Builder implements io.helidon.common.Builder<Builder, WriteablePart> {
-        private final HeadersWritable<?> headers = HeadersWritable.create();
+        private final WritableHeaders<?> headers = WritableHeaders.create();
 
         private final String partName;
         private String fileName;

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartAbstract.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartAbstract.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -76,7 +76,7 @@ abstract class WriteablePartAbstract implements WriteablePart {
         outputStream.write('\n');
     }
 
-    protected void send(OutputStream outputStream, HeadersWritable<?> headers, byte[] bytes) {
+    protected void send(OutputStream outputStream, WritableHeaders<?> headers, byte[] bytes) {
         headers.set(Http.Header.CONTENT_LENGTH.withValue(true, false, String.valueOf(bytes.length)));
 
         try (outputStream) {
@@ -89,7 +89,7 @@ abstract class WriteablePartAbstract implements WriteablePart {
         }
     }
 
-    void contentType(HeadersWritable<?> headers) {
+    void contentType(WritableHeaders<?> headers) {
         // we support form-data and byte-ranges, falling back to form data if unknown
         if (contentType().test(MediaTypes.MULTIPART_BYTERANGES)) {
             headers.remove(Http.Header.CONTENT_DISPOSITION);

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartBytes.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartBytes.java
@@ -19,7 +19,7 @@ package io.helidon.nima.http.media.multipart;
 import java.io.OutputStream;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.MediaContext;
 
 class WriteablePartBytes extends WriteablePartAbstract {
@@ -32,15 +32,15 @@ class WriteablePartBytes extends WriteablePartAbstract {
 
     @Override
     public void writeServerResponse(MediaContext context, OutputStream outputStream, Headers requestHeaders) {
-        write(outputStream, HeadersWritable.create(headers()));
+        write(outputStream, WritableHeaders.create(headers()));
     }
 
     @Override
     public void writeClientRequest(MediaContext context, OutputStream outputStream) {
-        write(outputStream, HeadersWritable.create(headers()));
+        write(outputStream, WritableHeaders.create(headers()));
     }
 
-    private void write(OutputStream outputStream, HeadersWritable<?> headers) {
+    private void write(OutputStream outputStream, WritableHeaders<?> headers) {
         // we support form-data and byte-ranges, falling back to form data if unknown
         contentType(headers);
         send(outputStream, headers, bytes);

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartObject.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartObject.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.EntityWriter;
 import io.helidon.nima.http.media.MediaContext;
 
@@ -40,7 +40,7 @@ class WriteablePartObject extends WriteablePartAbstract {
 
     @Override
     public void writeServerResponse(MediaContext context, OutputStream outputStream, Headers requestHeaders) {
-        HeadersWritable<?> headers = HeadersWritable.create(headers());
+        WritableHeaders<?> headers = WritableHeaders.create(headers());
         contentType(headers);
 
         // I am making an assumption here, that the object fits into memory, otherwise stream should be used
@@ -57,7 +57,7 @@ class WriteablePartObject extends WriteablePartAbstract {
 
     @Override
     public void writeClientRequest(MediaContext context, OutputStream outputStream) {
-        HeadersWritable<?> headers = HeadersWritable.create(headers());
+        WritableHeaders<?> headers = WritableHeaders.create(headers());
         contentType(headers);
 
         // I am making an assumption here, that the object fits into memory, otherwise stream should be used

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartStream.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/WriteablePartStream.java
@@ -23,7 +23,7 @@ import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.media.MediaContext;
 
 class WriteablePartStream extends WriteablePartAbstract {
@@ -36,15 +36,15 @@ class WriteablePartStream extends WriteablePartAbstract {
 
     @Override
     public void writeServerResponse(MediaContext context, OutputStream outputStream, Headers requestHeaders) {
-        write(outputStream, HeadersWritable.create(headers()));
+        write(outputStream, WritableHeaders.create(headers()));
     }
 
     @Override
     public void writeClientRequest(MediaContext context, OutputStream outputStream) {
-        write(outputStream, HeadersWritable.create(headers()));
+        write(outputStream, WritableHeaders.create(headers()));
     }
 
-    private void write(OutputStream outputStream, HeadersWritable<?> headers) {
+    private void write(OutputStream outputStream, WritableHeaders<?> headers) {
         contentType(headers);
 
         try (outputStream) {

--- a/nima/http2/http2/src/main/java/io/helidon/nima/http2/Http2Headers.java
+++ b/nima/http2/http2/src/main/java/io/helidon/nima/http2/Http2Headers.java
@@ -27,12 +27,12 @@ import java.util.function.Supplier;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.Http.HeaderValue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 
 import static java.lang.System.Logger.Level.DEBUG;
 
@@ -116,7 +116,7 @@ public class Http2Headers {
                                       Http2FrameData... frames) {
 
         if (frames.length == 0) {
-            return create(HeadersServerRequest.create(HeadersWritable.create()),
+            return create(ServerRequestHeaders.create(WritableHeaders.create()),
                           new PseudoHeaders());
         }
 
@@ -135,7 +135,7 @@ public class Http2Headers {
             stream.priority(priority);
         }
 
-        HeadersWritable<?> headers = HeadersWritable.create();
+        WritableHeaders<?> headers = WritableHeaders.create();
 
         BufferData[] buffers = new BufferData[frames.length];
         for (int i = 0; i < frames.length; i++) {
@@ -151,7 +151,7 @@ public class Http2Headers {
                 if (padLength > 0) {
                     data.skip(padLength);
                 }
-                return create(HeadersServerRequest.create(headers), pseudoHeaders);
+                return create(ServerRequestHeaders.create(headers), pseudoHeaders);
             }
 
             if (data.available() == 0) {
@@ -169,10 +169,10 @@ public class Http2Headers {
      * @return new HTTP/2 headers
      */
     public static Http2Headers create(Headers headers) {
-        if (headers instanceof HeadersWritable) {
-            return createFromWritable((HeadersWritable<?>) headers);
+        if (headers instanceof WritableHeaders) {
+            return createFromWritable((WritableHeaders<?>) headers);
         }
-        return createFromWritable(HeadersWritable.create(headers));
+        return createFromWritable(WritableHeaders.create(headers));
     }
 
     /**
@@ -181,7 +181,7 @@ public class Http2Headers {
      * @param writableHeaders header to use
      * @return new HTTP/2 headers
      */
-    public static Http2Headers create(HeadersWritable<?> writableHeaders) {
+    public static Http2Headers create(WritableHeaders<?> writableHeaders) {
         return createFromWritable(writableHeaders);
     }
 
@@ -440,11 +440,11 @@ public class Http2Headers {
         }
     }
 
-    private static Http2Headers create(HeadersServerRequest httpHeaders, PseudoHeaders pseudoHeaders) {
+    private static Http2Headers create(ServerRequestHeaders httpHeaders, PseudoHeaders pseudoHeaders) {
         return new Http2Headers(httpHeaders, pseudoHeaders);
     }
 
-    private static boolean readHeader(HeadersWritable<?> headers,
+    private static boolean readHeader(WritableHeaders<?> headers,
                                       PseudoHeaders pseudoHeaders,
                                       DynamicTable table,
                                       Http2HuffmanDecoder huffman,
@@ -597,7 +597,7 @@ public class Http2Headers {
         setter.accept(value);
     }
 
-    private static Http2Headers createFromWritable(HeadersWritable<?> headers) {
+    private static Http2Headers createFromWritable(WritableHeaders<?> headers) {
         PseudoHeaders pseudoHeaders = new PseudoHeaders();
         removeFromHeadersAddToPseudo(headers, pseudoHeaders::status, STATUS_NAME);
         removeFromHeadersAddToPseudo(headers, pseudoHeaders::path, PATH_NAME);
@@ -644,7 +644,7 @@ public class Http2Headers {
       PRIORITY flag is set.
      */
 
-    private static void removeFromHeadersAddToPseudo(HeadersWritable<?> headers,
+    private static void removeFromHeadersAddToPseudo(WritableHeaders<?> headers,
                                                      Consumer<String> valueConsumer,
                                                      HeaderName pseudoHeader) {
         headers.remove(pseudoHeader, it -> valueConsumer.accept(it.value()));

--- a/nima/http2/http2/src/test/java/io/helidon/nima/http2/Http2HeadersTest.java
+++ b/nima/http2/http2/src/test/java/io/helidon/nima/http2/Http2HeadersTest.java
@@ -20,10 +20,10 @@ import java.util.HexFormat;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http2.Http2Headers.DynamicTable;
 import io.helidon.nima.http2.Http2Headers.HeaderRecord;
 
@@ -163,7 +163,7 @@ class Http2HeadersTest {
     @Test
     void testC_4_toBytes() {
         DynamicTable dynamicTable = DynamicTable.create(Http2Settings.create());
-        HeadersWritable headers = HeadersWritable.create();
+        WritableHeaders headers = WritableHeaders.create();
         Http2Headers http2Headers = Http2Headers.create(headers);
         http2Headers.method(Http.Method.GET);
         http2Headers.scheme("http");

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
@@ -26,10 +26,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.socket.SocketOptions;
 import io.helidon.common.uri.UriQueryWriteable;
 import io.helidon.nima.common.tls.Tls;
@@ -41,7 +41,7 @@ import io.helidon.nima.webclient.UriHelper;
 class ClientRequestImpl implements Http2ClientRequest {
     private static final Map<ConnectionKey, Http2ClientConnectionHandler> CHANNEL_CACHE = new ConcurrentHashMap<>();
 
-    private final HeadersWritable<?> explicitHeaders = HeadersWritable.create();
+    private final WritableHeaders<?> explicitHeaders = WritableHeaders.create();
 
     private final Http2ClientImpl client;
 
@@ -107,7 +107,7 @@ class ClientRequestImpl implements Http2ClientRequest {
     public Http2ClientResponse submit(Object entity) {
         // todo validate request ok
 
-        HeadersWritable<?> headers = HeadersWritable.create(explicitHeaders);
+        WritableHeaders<?> headers = WritableHeaders.create(explicitHeaders);
 
         Http2ClientStream stream = reserveStream();
 
@@ -132,7 +132,7 @@ class ClientRequestImpl implements Http2ClientRequest {
     public Http2ClientResponse outputStream(ClientRequest.OutputStreamHandler streamHandler) {
         // todo validate request ok
 
-        HeadersWritable<?> headers = HeadersWritable.create(explicitHeaders);
+        WritableHeaders<?> headers = WritableHeaders.create(explicitHeaders);
 
         Http2ClientStream stream = reserveStream();
 
@@ -202,7 +202,7 @@ class ClientRequestImpl implements Http2ClientRequest {
         throw new IllegalArgumentException("Only string and byte array supported now");
     }
 
-    private Http2Headers prepareHeaders(HeadersWritable<?> headers) {
+    private Http2Headers prepareHeaders(WritableHeaders<?> headers) {
         Http2Headers http2Headers = Http2Headers.create(headers);
         http2Headers.method(this.method);
         http2Headers.authority(this.uri.authority());

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientResponseImpl.java
@@ -16,20 +16,20 @@
 
 package io.helidon.nima.http2.webclient;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersClientResponse;
 import io.helidon.common.http.Http;
 import io.helidon.nima.http.media.ReadableEntity;
 import io.helidon.nima.http2.Http2Headers;
 
 class ClientResponseImpl implements Http2ClientResponse {
     private final Http.Status responseStatus;
-    private final HeadersClientResponse responseHeaders;
+    private final ClientResponseHeaders responseHeaders;
     private Http2ClientStream stream;
 
     ClientResponseImpl(Http2Headers headers, Http2ClientStream stream) {
         this.responseStatus = headers.status();
-        this.responseHeaders = HeadersClientResponse.create(headers.httpHeaders());
+        this.responseHeaders = ClientResponseHeaders.create(headers.httpHeaders());
         this.stream = stream;
     }
 

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequest.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequest.java
@@ -20,10 +20,10 @@ import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.nima.http.encoding.ContentDecoder;
@@ -40,7 +40,7 @@ class Http2ServerRequest implements RoutingRequest {
     private static final Runnable NO_OP_RUNNABLE = () -> {
     };
     private final Http2Headers http2Headers;
-    private final HeadersServerRequest headers;
+    private final ServerRequestHeaders headers;
     private final ConnectionContext ctx;
     private final HttpPrologue originalPrologue;
     private final int requestId;
@@ -49,7 +49,7 @@ class Http2ServerRequest implements RoutingRequest {
 
     private HttpPrologue prologue;
     private RoutedPath path;
-    private HeadersWritable<?> writable;
+    private WritableHeaders<?> writable;
 
     Http2ServerRequest(ConnectionContext ctx,
                        HttpPrologue prologue,
@@ -60,7 +60,7 @@ class Http2ServerRequest implements RoutingRequest {
         this.ctx = ctx;
         this.originalPrologue = prologue;
         this.http2Headers = headers;
-        this.headers = HeadersServerRequest.create(headers.httpHeaders());
+        this.headers = ServerRequestHeaders.create(headers.httpHeaders());
         this.requestId = requestId;
         this.authority = headers.authority();
 
@@ -111,7 +111,7 @@ class Http2ServerRequest implements RoutingRequest {
     }
 
     @Override
-    public HeadersServerRequest headers() {
+    public ServerRequestHeaders headers() {
         return headers;
     }
 
@@ -138,7 +138,7 @@ class Http2ServerRequest implements RoutingRequest {
     @Override
     public void header(HeaderValue header) {
         if (writable == null) {
-            writable = HeadersWritable.create(headers);
+            writable = WritableHeaders.create(headers);
         }
         writable.set(header);
     }

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequestEntity.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerRequestEntity.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerRequest;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.media.MediaContext;
 import io.helidon.nima.http.media.ReadableEntity;
@@ -31,13 +31,13 @@ import io.helidon.nima.http.media.ReadableEntityBase;
  * Server request entity.
  */
 public final class Http2ServerRequestEntity extends ReadableEntityBase implements ReadableEntity {
-    private final HeadersServerRequest requestHeaders;
+    private final ServerRequestHeaders requestHeaders;
     private final MediaContext mediaContext;
 
     private Http2ServerRequestEntity(Function<InputStream, InputStream> decoder,
                                      Function<Integer, BufferData> readEntityFunction,
                                      Runnable entityProcessedRunnable,
-                                     HeadersServerRequest requestHeaders,
+                                     ServerRequestHeaders requestHeaders,
                                      MediaContext mediaContext) {
         super(decoder, readEntityFunction, entityProcessedRunnable);
 
@@ -59,7 +59,7 @@ public final class Http2ServerRequestEntity extends ReadableEntityBase implement
     public static Http2ServerRequestEntity create(ContentDecoder decoder,
                                                   Function<Integer, BufferData> readEntityFunction,
                                                   Runnable entityProcessedRunnable,
-                                                  HeadersServerRequest requestHeaders,
+                                                  ServerRequestHeaders requestHeaders,
                                                   MediaContext mediaContext) {
         return new Http2ServerRequestEntity(decoder, readEntityFunction, entityProcessedRunnable, requestHeaders, mediaContext);
     }

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
@@ -21,11 +21,11 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.Http.HeaderValues;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.nima.http2.FlowControl;
 import io.helidon.nima.http2.Http2Flag;
 import io.helidon.nima.http2.Http2Flag.DataFlags;
@@ -44,7 +44,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     private final ConnectionContext ctx;
     private final Http2StreamWriter writer;
     private final int streamId;
-    private final HeadersServerResponse headers;
+    private final ServerResponseHeaders headers;
     private final FlowControl flowControl;
 
     private boolean isSent;
@@ -62,7 +62,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         this.writer = writer;
         this.streamId = streamId;
         this.flowControl = flowControl;
-        this.headers = HeadersServerResponse.create();
+        this.headers = ServerResponseHeaders.create();
     }
 
     @Override
@@ -141,7 +141,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
     }
 
     @Override
-    public HeadersServerResponse headers() {
+    public ServerResponseHeaders headers() {
         return headers;
     }
 
@@ -157,7 +157,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
 
     private static class BlockingOutputStream extends OutputStream {
 
-        private final HeadersServerResponse headers;
+        private final ServerResponseHeaders headers;
         private final Http2StreamWriter writer;
         private final int streamId;
         private final FlowControl flowControl;
@@ -169,7 +169,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         private boolean firstByte = true;
         private long bytesWritten;
 
-        private BlockingOutputStream(HeadersServerResponse headers,
+        private BlockingOutputStream(ServerResponseHeaders headers,
                                      Http2StreamWriter writer,
                                      int streamId,
                                      FlowControl flowControl,

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
@@ -25,11 +25,11 @@ import io.helidon.common.HelidonServiceLoader;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.RequestException;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.socket.SocketWriterException;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http2.FlowControl;
@@ -274,7 +274,7 @@ public class Http2Stream implements Runnable, io.helidon.nima.http2.Http2Stream 
                                                                       e.responseHeaders(),
                                                                       e);
 
-            HeadersServerResponse headers = response.headers();
+            ServerResponseHeaders headers = response.headers();
             byte[] message = response.entity().orElse(BufferData.EMPTY_BYTES);
             if (message.length != 0) {
                 headers.set(HeaderValue.create(Header.CONTENT_LENGTH, String.valueOf(message.length)));

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2UpgradeProvider.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2UpgradeProvider.java
@@ -21,10 +21,10 @@ import java.util.Base64;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http2.Http2Headers;
 import io.helidon.nima.http2.Http2Settings;
 import io.helidon.nima.webserver.ConnectionContext;
@@ -51,7 +51,7 @@ public class Http2UpgradeProvider implements Http1UpgradeProvider {
     @Override
     public ServerConnection upgrade(ConnectionContext ctx,
                                     HttpPrologue prologue,
-                                    HeadersWritable<?> headers) {
+                                    WritableHeaders<?> headers) {
         Http2Connection connection = new Http2Connection(ctx);
         if (headers.contains(HTTP2_SETTINGS_HEADER_NAME)) {
             connection.clientSettings(Http2Settings.create(BufferData.create(BASE_64_DECODER.decode(headers.get(

--- a/nima/tests/benchmark/jmh/src/main/java/io/helidon/nima/tests/benchmark/jmh/Http1ParsingJmhTest.java
+++ b/nima/tests/benchmark/jmh/src/main/java/io/helidon/nima/tests/benchmark/jmh/Http1ParsingJmhTest.java
@@ -21,9 +21,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.http1.Http1Headers;
 import io.helidon.nima.webserver.http1.Http1Prologue;
 
@@ -95,7 +95,7 @@ public class Http1ParsingJmhTest {
         Http1Headers headers = new Http1Headers(reader, 4096, false);
 
         HttpPrologue httpPrologue = prologue.readPrologue();
-        HeadersWritable<?> httpHeaders = headers.readHeaders(httpPrologue);
+        WritableHeaders<?> httpHeaders = headers.readHeaders(httpPrologue);
         boolean hasContent = httpHeaders.contains(Header.CONTENT_LENGTH);
         String authority = httpHeaders.get(Header.HOST).value();
 

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/BadRequestTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/BadRequestTest.java
@@ -18,11 +18,11 @@ package io.helidon.nima.tests.integration.server;
 
 import java.util.List;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.DirectHandler;
-import io.helidon.common.http.HeadersClientResponse;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.nima.testing.junit5.webserver.ServerTest;
 import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
@@ -98,7 +98,7 @@ class BadRequestTest {
 
         assertThat(SocketHttpClient.statusFromResponse(response), is(Http.Status.TEMPORARY_REDIRECT_307));
 
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(response);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         assertThat(headers, hasHeader(LOCATION_ERROR_PAGE));
     }
 
@@ -145,7 +145,7 @@ class BadRequestTest {
     private static DirectHandler.TransportResponse badRequestHandler(DirectHandler.TransportRequest request,
                                                                      DirectHandler.EventType eventType,
                                                                      Http.Status httpStatus,
-                                                                     HeadersServerResponse responseHeaders,
+                                                                     ServerResponseHeaders responseHeaders,
                                                                      String message) {
         if (request.path().equals("/redirect")) {
             return DirectHandler.TransportResponse.builder()

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ConfiguredLimitsTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ConfiguredLimitsTest.java
@@ -16,10 +16,10 @@
 
 package io.helidon.nima.tests.integration.server;
 
-import io.helidon.common.http.HeadersServerRequest;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.nima.testing.junit5.webserver.ServerTest;
 import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
 import io.helidon.nima.testing.junit5.webserver.SetUpServer;
@@ -144,7 +144,7 @@ class ConfiguredLimitsTest {
     }
 
     private static void handleRequest(ServerRequest request, ServerResponse response) {
-        HeadersServerRequest headers = request.headers();
+        ServerRequestHeaders headers = request.headers();
         if (headers.contains(CUSTOM_HEADER)) {
             response.send(headers.get(CUSTOM_HEADER).value());
             return;

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/TransferEncodingTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/TransferEncodingTest.java
@@ -16,7 +16,7 @@
 
 package io.helidon.nima.tests.integration.server;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValues;
@@ -78,7 +78,7 @@ class TransferEncodingTest {
     void testEmptyContentLength() {
         String s = socketHttpClient.sendAndReceive("/empty", Http.Method.GET, null);
 
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(HeaderValues.CONTENT_LENGTH_ZERO));
     }
 
@@ -88,7 +88,7 @@ class TransferEncodingTest {
     @Test
     void testEmptyChunked() {
         String s = socketHttpClient.sendAndReceive("/emptychunked", Http.Method.GET, null);
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(HeaderValues.TRANSFER_ENCODING_CHUNKED));
     }
 
@@ -99,7 +99,7 @@ class TransferEncodingTest {
     void testContentLength() {
         String s = socketHttpClient.sendAndReceive("/length", Http.Method.GET, null);
         assertThat(cutPayloadAndCheckHeadersFormat(s), is("It works!"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(CONTENT_LENGTH_NINE));
     }
 
@@ -110,7 +110,7 @@ class TransferEncodingTest {
     void testChunkedEncoding() {
         String s = socketHttpClient.sendAndReceive("/chunked", Http.Method.GET, null);
         assertThat(cutPayloadAndCheckHeadersFormat(s), is("9\nIt works!\n0\n\n"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(HeaderValues.TRANSFER_ENCODING_CHUNKED));
     }
 
@@ -121,7 +121,7 @@ class TransferEncodingTest {
     void testOptimized() {
         String s = socketHttpClient.sendAndReceive("/optimized", Http.Method.GET, null);
         assertThat(cutPayloadAndCheckHeadersFormat(s), is("It works!"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(CONTENT_LENGTH_NINE));
     }
 

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/UriEncodingTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/UriEncodingTest.java
@@ -16,11 +16,11 @@
 
 package io.helidon.nima.tests.integration.server;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
+import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.nima.testing.junit5.webserver.ServerTest;
 import io.helidon.nima.testing.junit5.webserver.SetUpRoute;
-import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.nima.webserver.http.HttpRules;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 @ServerTest
 class UriEncodingTest {
@@ -51,7 +50,7 @@ class UriEncodingTest {
     void testEncodedUrl() {
         String s = socketHttpClient.sendAndReceive("/f%6F%6F", Http.Method.GET, null);
         assertThat(SocketHttpClient.entityFromResponse(s, true), is("It works!"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.HeaderValues.CONNECTION_KEEP_ALIVE));
     }
 
@@ -62,7 +61,7 @@ class UriEncodingTest {
     void testEncodedUrlParams() {
         String s = socketHttpClient.sendAndReceive("/f%6F%6F/b%61%72", Http.Method.GET, null);
         assertThat(SocketHttpClient.entityFromResponse(s, true), is("bar"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.HeaderValues.CONNECTION_KEEP_ALIVE));
     }
 }

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientResponseEntity.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientResponseEntity.java
@@ -21,8 +21,8 @@ import java.util.function.Function;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersClientRequest;
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientRequestHeaders;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.media.MediaContext;
 import io.helidon.nima.http.media.ReadableEntity;
@@ -32,15 +32,15 @@ import io.helidon.nima.http.media.ReadableEntityBase;
  * Client response rentity.
  */
 public final class ClientResponseEntity extends ReadableEntityBase implements ReadableEntity {
-    private final HeadersClientRequest requestHeaders;
-    private final HeadersClientResponse responseHeaders;
+    private final ClientRequestHeaders requestHeaders;
+    private final ClientResponseHeaders responseHeaders;
     private final MediaContext mediaContext;
 
     private ClientResponseEntity(Function<InputStream, InputStream> decoder,
                                  Function<Integer, BufferData> readEntityFunction,
                                  Runnable entityProcessedRunnable,
-                                 HeadersClientRequest requestHeaders,
-                                 HeadersClientResponse responseHeaders,
+                                 ClientRequestHeaders requestHeaders,
+                                 ClientResponseHeaders responseHeaders,
                                  MediaContext mediaContext) {
         super(decoder, readEntityFunction, entityProcessedRunnable);
 
@@ -63,8 +63,8 @@ public final class ClientResponseEntity extends ReadableEntityBase implements Re
     public static ClientResponseEntity create(ContentDecoder decoder,
                                               Function<Integer, BufferData> readEntityFunction,
                                               Runnable entityProcessedRunnable,
-                                              HeadersClientRequest requestHeaders,
-                                              HeadersClientResponse responseHeaders,
+                                              ClientRequestHeaders requestHeaders,
+                                              ClientResponseHeaders responseHeaders,
                                               MediaContext mediaContext) {
         return new ClientResponseEntity(decoder,
                                         readEntityFunction,

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientResponseImpl.java
@@ -22,14 +22,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
+import io.helidon.common.http.ClientRequestHeaders;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersClientRequest;
-import io.helidon.common.http.HeadersClientResponse;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValues;
 import io.helidon.common.http.Http1HeadersParser;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.encoding.ContentEncodingContext;
 import io.helidon.nima.http.media.MediaContext;
@@ -48,8 +48,8 @@ class ClientResponseImpl implements Http1ClientResponse {
     private final AtomicBoolean closed = new AtomicBoolean();
 
     private final Http.Status responseStatus;
-    private final HeadersClientRequest requestHeaders;
-    private final HeadersClientResponse responseHeaders;
+    private final ClientRequestHeaders requestHeaders;
+    private final ClientResponseHeaders responseHeaders;
     private final DataReader reader;
     // todo configurable
     private final ContentEncodingContext encodingSupport = ContentEncodingContext.create();
@@ -61,11 +61,11 @@ class ClientResponseImpl implements Http1ClientResponse {
     private ClientConnection connection;
     private long entityLength;
     private boolean entityFullyRead;
-    private HeadersWritable<?> trailers;
+    private WritableHeaders<?> trailers;
 
     ClientResponseImpl(Http.Status responseStatus,
-                       HeadersClientRequest requestHeaders,
-                       HeadersClientResponse responseHeaders,
+                       ClientRequestHeaders requestHeaders,
+                       ClientResponseHeaders responseHeaders,
                        ClientConnection connection,
                        DataReader reader) {
         this.responseStatus = responseStatus;
@@ -122,8 +122,8 @@ class ClientResponseImpl implements Http1ClientResponse {
         }
     }
 
-    private ReadableEntity entity(HeadersClientRequest requestHeaders,
-                                  HeadersClientResponse responseHeaders) {
+    private ReadableEntity entity(ClientRequestHeaders requestHeaders,
+                                  ClientResponseHeaders responseHeaders) {
         ContentDecoder decoder;
 
         if (encodingSupport.contentDecodingEnabled()) {

--- a/nima/webserver/access-log/src/test/java/io/helidon/nima/webserver/accesslog/AccessLogFilterTest.java
+++ b/nima/webserver/access-log/src/test/java/io/helidon/nima/webserver/accesslog/AccessLogFilterTest.java
@@ -19,10 +19,10 @@ package io.helidon.nima.webserver.accesslog;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriPath;
@@ -147,13 +147,13 @@ class AccessLogFilterTest {
                                                     UriPath.create(PATH),
                                                     UriQuery.empty(),
                                                     UriFragment.empty());
-        HeadersWritable<?> headers = HeadersWritable.create();
+        WritableHeaders<?> headers = WritableHeaders.create();
         headers.set(REFERER_HEADER);
 
         when(pi.host()).thenReturn(REMOTE_IP);
         when(request.remotePeer()).thenReturn(pi);
         when(request.prologue()).thenReturn(prologue);
-        when(request.headers()).thenReturn(HeadersServerRequest.create(headers));
+        when(request.headers()).thenReturn(ServerRequestHeaders.create(headers));
 
         RoutingResponse response = mock(RoutingResponse.class);
         when(response.status()).thenReturn(Http.Status.I_AM_A_TEAPOT_418);

--- a/nima/webserver/cors/src/main/java/io/helidon/nima/webserver/cors/RequestAdapterNima.java
+++ b/nima/webserver/cors/src/main/java/io/helidon/nima/webserver/cors/RequestAdapterNima.java
@@ -18,8 +18,8 @@ package io.helidon.nima.webserver.cors;
 import java.util.List;
 import java.util.Optional;
 
-import io.helidon.common.http.HeadersServerRequest;
 import io.helidon.common.http.Http.HeaderName;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.nima.webserver.http.ServerRequest;
 import io.helidon.nima.webserver.http.ServerResponse;
 
@@ -30,7 +30,7 @@ class RequestAdapterNima implements CorsSupportBase.RequestAdapter<ServerRequest
 
     private final ServerRequest request;
     private final ServerResponse response;
-    private final HeadersServerRequest headers;
+    private final ServerRequestHeaders headers;
 
     RequestAdapterNima(ServerRequest req, ServerResponse res) {
         this.request = req;

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileBasedContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileBasedContentHandler.java
@@ -33,13 +33,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.helidon.common.http.ForbiddenException;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValues;
 import io.helidon.common.http.HttpException;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.webserver.http.ServerRequest;
@@ -74,8 +74,8 @@ abstract class FileBasedContentHandler extends StaticContentHandler {
      * @param responseHeaders an HTTP response headers
      */
     void processContentType(String filename,
-                            HeadersServerRequest requestHeaders,
-                            HeadersServerResponse responseHeaders) {
+                            ServerRequestHeaders requestHeaders,
+                            ServerResponseHeaders responseHeaders) {
         // Try to get Content-Type
         responseHeaders.contentType(detectType(filename, requestHeaders));
     }
@@ -143,7 +143,7 @@ abstract class FileBasedContentHandler extends StaticContentHandler {
         }
     }
 
-    void processContentLength(Path path, HeadersServerResponse headers) {
+    void processContentLength(Path path, ServerResponseHeaders headers) {
         headers.set(Header.CONTENT_LENGTH.withValue(String.valueOf(contentLength(path))));
     }
 
@@ -156,7 +156,7 @@ abstract class FileBasedContentHandler extends StaticContentHandler {
     }
 
     void send(ServerRequest request, ServerResponse response, Path path) throws IOException {
-        HeadersServerRequest headers = request.headers();
+        ServerRequestHeaders headers = request.headers();
         if (headers.contains(Header.RANGE)) {
             long contentLength = contentLength(path);
             List<ByteRangeRequest> ranges = ByteRangeRequest.parse(request,
@@ -216,7 +216,7 @@ abstract class FileBasedContentHandler extends StaticContentHandler {
         return result;
     }
 
-    private MediaType detectType(String fileName, HeadersServerRequest requestHeaders) {
+    private MediaType detectType(String fileName, ServerRequestHeaders requestHeaders) {
         Objects.requireNonNull(fileName);
         Objects.requireNonNull(requestHeaders);
 

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/StaticContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/StaticContentHandler.java
@@ -25,14 +25,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.HttpException;
 import io.helidon.common.http.InternalServerException;
 import io.helidon.common.http.NotFoundException;
 import io.helidon.common.http.RequestException;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.nima.webserver.http.HttpRules;
 import io.helidon.nima.webserver.http.PathMatchers;
@@ -63,7 +63,7 @@ abstract class StaticContentHandler implements StaticContentSupport {
      * @param responseHeaders an HTTP response headers
      * @throws io.helidon.common.http.RequestException if ETag is checked
      */
-    static void processEtag(String etag, HeadersServerRequest requestHeaders, HeadersServerResponse responseHeaders) {
+    static void processEtag(String etag, ServerRequestHeaders requestHeaders, ServerResponseHeaders responseHeaders) {
         if (etag == null || etag.isEmpty()) {
             return;
         }
@@ -111,8 +111,8 @@ abstract class StaticContentHandler implements StaticContentSupport {
      * @throws io.helidon.common.http.RequestException if (un)modify since header is checked
      */
     static void processModifyHeaders(Instant modified,
-                                     HeadersServerRequest requestHeaders,
-                                     HeadersServerResponse responseHeaders) {
+                                     ServerRequestHeaders requestHeaders,
+                                     ServerResponseHeaders responseHeaders) {
         if (modified == null) {
             return;
         }

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
@@ -24,12 +24,11 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpException;
 import io.helidon.common.http.HttpPrologue;
-import io.helidon.common.http.RequestException;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.parameters.Parameters;
 import io.helidon.common.uri.UriFragment;
 import io.helidon.common.uri.UriPath;
@@ -59,44 +58,44 @@ class StaticContentHandlerTest {
 
     @Test
     void etag_InNoneMatch_NotAccept() {
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.get(IF_NONE_MATCH)).thenReturn(IF_NONE_MATCH.withValue("\"ccc\"", "\"ddd\""));
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
         verify(res).set(ETAG.withValue("\"aaa\""));
     }
 
     @Test
     void etag_InNoneMatch_Accept() {
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
         when(req.get(IF_NONE_MATCH)).thenReturn(IF_NONE_MATCH.withValue("\"ccc\"", "W/\"aaa\""));
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Http.Status.NOT_MODIFIED_304);
         verify(res).set(ETAG.withValue("\"aaa\""));
     }
 
     @Test
     void etag_InMatch_NotAccept() {
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(IF_MATCH.withValue("\"ccc\"", "\"ddd\""));
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Http.Status.PRECONDITION_FAILED_412);
         verify(res).set(ETAG.withValue("\"aaa\""));
     }
 
     @Test
     void etag_InMatch_Accept() {
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
         when(req.get(IF_MATCH)).thenReturn(IF_MATCH.withValue("\"ccc\"", "\"aaa\""));
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
         verify(res).set(ETAG.withValue("\"aaa\""));
     }
@@ -104,20 +103,20 @@ class StaticContentHandlerTest {
     @Test
     void ifModifySince_Accept() {
         ZonedDateTime modified = ZonedDateTime.now();
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifModifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifUnmodifiedSince();
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res);
     }
 
     @Test
     void ifModifySince_NotAccept() {
         ZonedDateTime modified = ZonedDateTime.now();
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         Mockito.doReturn(Optional.of(modified)).when(req).ifModifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifUnmodifiedSince();
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res),
                             Http.Status.NOT_MODIFIED_304);
     }
@@ -125,27 +124,27 @@ class StaticContentHandlerTest {
     @Test
     void ifUnmodifySince_Accept() {
         ZonedDateTime modified = ZonedDateTime.now();
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         Mockito.doReturn(Optional.of(modified)).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res);
     }
 
     @Test
     void ifUnmodifySince_NotAccept() {
         ZonedDateTime modified = ZonedDateTime.now();
-        HeadersServerRequest req = mock(HeadersServerRequest.class);
+        ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         Mockito.doReturn(Optional.of(modified.minusSeconds(60))).when(req).ifUnmodifiedSince();
         Mockito.doReturn(Optional.empty()).when(req).ifModifiedSince();
-        HeadersServerResponse res = mock(HeadersServerResponse.class);
+        ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processModifyHeaders(modified.toInstant(), req, res),
                             Http.Status.PRECONDITION_FAILED_412);
     }
 
     @Test
     void redirect() {
-        HeadersServerResponse resh = mock(HeadersServerResponse.class);
+        ServerResponseHeaders resh = mock(ServerResponseHeaders.class);
         ServerResponse res = mock(ServerResponse.class);
         ServerRequest req = mock(ServerRequest.class);
         when(res.headers()).thenReturn(resh);

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/DirectTransportRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/DirectTransportRequest.java
@@ -18,9 +18,9 @@ package io.helidon.nima.webserver.http;
 
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 
 /**
  * Simple request to use with {@link io.helidon.common.http.RequestException}.
@@ -29,12 +29,12 @@ public class DirectTransportRequest implements DirectHandler.TransportRequest {
     private final String version;
     private final String method;
     private final String path;
-    private final HeadersServerRequest headers;
+    private final ServerRequestHeaders headers;
 
     private DirectTransportRequest(String version,
                                    String method,
                                    String path,
-                                   HeadersServerRequest headers) {
+                                   ServerRequestHeaders headers) {
         this.version = version;
         this.method = method;
         this.path = path;
@@ -55,7 +55,7 @@ public class DirectTransportRequest implements DirectHandler.TransportRequest {
         return new DirectTransportRequest(protocolAndVersion,
                                           method,
                                           path,
-                                          HeadersServerRequest.create(HeadersWritable.create()));
+                                          ServerRequestHeaders.create(WritableHeaders.create()));
     }
 
     /**
@@ -69,7 +69,7 @@ public class DirectTransportRequest implements DirectHandler.TransportRequest {
         return new DirectTransportRequest(prologue.protocol() + "/" + prologue.protocolVersion(),
                                           prologue.method().text(),
                                           prologue.uriPath().rawPathNoParams(),
-                                          HeadersServerRequest.create(headers));
+                                          ServerRequestHeaders.create(headers));
     }
 
     @Override
@@ -88,7 +88,7 @@ public class DirectTransportRequest implements DirectHandler.TransportRequest {
     }
 
     @Override
-    public HeadersServerRequest headers() {
+    public ServerRequestHeaders headers() {
         return headers;
     }
 }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/HttpRequest.java
@@ -16,9 +16,9 @@
 
 package io.helidon.nima.webserver.http;
 
-import io.helidon.common.http.HeadersServerRequest;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
@@ -40,7 +40,7 @@ public interface HttpRequest {
      *
      * @return HTTP headers
      */
-    HeadersServerRequest headers();
+    ServerRequestHeaders headers();
 
     /**
      * Path of the request, with methods to get path parameters.

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerRequestEntity.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerRequestEntity.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerRequest;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.media.MediaContext;
 import io.helidon.nima.http.media.ReadableEntity;
@@ -31,13 +31,13 @@ import io.helidon.nima.http.media.ReadableEntityBase;
  * Server request entity.
  */
 public final class ServerRequestEntity extends ReadableEntityBase implements ReadableEntity {
-    private final HeadersServerRequest requestHeaders;
+    private final ServerRequestHeaders requestHeaders;
     private final MediaContext mediaContext;
 
     private ServerRequestEntity(Function<InputStream, InputStream> decoder,
                                 Function<Integer, BufferData> readEntityFunction,
                                 Runnable entityProcessedRunnable,
-                                HeadersServerRequest requestHeaders,
+                                ServerRequestHeaders requestHeaders,
                                 MediaContext mediaContext) {
         super(decoder, readEntityFunction, entityProcessedRunnable);
 
@@ -59,7 +59,7 @@ public final class ServerRequestEntity extends ReadableEntityBase implements Rea
     public static ServerRequestEntity create(ContentDecoder decoder,
                                              Function<Integer, BufferData> readEntityFunction,
                                              Runnable entityProcessedRunnable,
-                                             HeadersServerRequest requestHeaders,
+                                             ServerRequestHeaders requestHeaders,
                                              MediaContext mediaContext) {
         return new ServerRequestEntity(decoder, readEntityFunction, entityProcessedRunnable, requestHeaders, mediaContext);
     }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
@@ -18,9 +18,9 @@ package io.helidon.nima.webserver.http;
 
 import java.io.OutputStream;
 
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderName;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.uri.UriQuery;
 
 /**
@@ -161,7 +161,7 @@ public interface ServerResponse {
      *
      * @return headers
      */
-    HeadersServerResponse headers();
+    ServerResponseHeaders headers();
 
     /**
      * Description of the result of output stream processing.

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponseBase.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponseBase.java
@@ -25,10 +25,10 @@ import java.util.List;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerRequest;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpException;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.common.uri.UriPath;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.nima.http.encoding.ContentEncoder;
@@ -45,7 +45,7 @@ public abstract class ServerResponseBase<T extends ServerResponseBase<T>> implem
     private final ContentEncodingContext contentEncodingContext;
     private final MediaContext mediaContext;
     private final HttpPrologue requestPrologue;
-    private final HeadersServerRequest requestHeaders;
+    private final ServerRequestHeaders requestHeaders;
     private final List<Runnable> whenSent = new ArrayList<>(5);
 
     private Http.Status status;

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Headers.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Headers.java
@@ -18,10 +18,10 @@ package io.helidon.nima.webserver.http1;
 
 import io.helidon.common.buffers.DataReader;
 import io.helidon.common.http.DirectHandler;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http1HeadersParser;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.RequestException;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.http.DirectTransportRequest;
 
 /**
@@ -52,13 +52,13 @@ public final class Http1Headers {
      * @param prologue parsed prologue of this request
      * @return writable headers parsed from the request data
      */
-    public HeadersWritable<?> readHeaders(HttpPrologue prologue) {
+    public WritableHeaders<?> readHeaders(HttpPrologue prologue) {
         try {
             return Http1HeadersParser.readHeaders(reader, maxHeadersSize, validateHeaders);
         } catch (IllegalStateException | IllegalArgumentException e) {
             throw RequestException.builder()
                     .type(DirectHandler.EventType.BAD_REQUEST)
-                    .request(DirectTransportRequest.create(prologue, HeadersWritable.create()))
+                    .request(DirectTransportRequest.create(prologue, WritableHeaders.create()))
                     .message(e.getMessage())
                     .cause(e)
                     .build();

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequest.java
@@ -21,10 +21,10 @@ import java.util.function.Supplier;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.socket.PeerInfo;
 import io.helidon.common.uri.UriQuery;
 import io.helidon.nima.http.encoding.ContentDecoder;
@@ -36,13 +36,13 @@ import io.helidon.nima.webserver.http.RoutingRequest;
  * Http 1 server request base.
  */
 abstract class Http1ServerRequest implements RoutingRequest {
-    private final HeadersServerRequest headers;
+    private final ServerRequestHeaders headers;
     private final ConnectionContext ctx;
     private final HttpPrologue prologue;
     private final int requestId;
 
     private RoutedPath path;
-    private HeadersWritable<?> writable;
+    private WritableHeaders<?> writable;
 
     private HttpPrologue newPrologue;
 
@@ -52,7 +52,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
                        int requestId) {
         this.ctx = ctx;
         this.prologue = prologue;
-        this.headers = HeadersServerRequest.create(headers);
+        this.headers = ServerRequestHeaders.create(headers);
         this.requestId = requestId;
         this.newPrologue = prologue;
     }
@@ -82,7 +82,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
      */
     static Http1ServerRequest create(ConnectionContext ctx,
                                      HttpPrologue prologue,
-                                     HeadersServerRequest headers,
+                                     ServerRequestHeaders headers,
                                      ContentDecoder decoder,
                                      int requestContext,
                                      CountDownLatch entityReadLatch,
@@ -122,8 +122,8 @@ abstract class Http1ServerRequest implements RoutingRequest {
     }
 
     @Override
-    public HeadersServerRequest headers() {
-        return writable == null ? headers : HeadersServerRequest.create(writable);
+    public ServerRequestHeaders headers() {
+        return writable == null ? headers : ServerRequestHeaders.create(writable);
     }
 
     @Override
@@ -149,7 +149,7 @@ abstract class Http1ServerRequest implements RoutingRequest {
     @Override
     public void header(Http.HeaderValue header) {
         if (writable == null) {
-            writable = HeadersWritable.create(headers);
+            writable = WritableHeaders.create(headers);
         }
         writable.set(header);
     }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequestWithEntity.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerRequestWithEntity.java
@@ -21,8 +21,8 @@ import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
 import io.helidon.common.buffers.BufferData;
-import io.helidon.common.http.HeadersServerRequest;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.nima.http.encoding.ContentDecoder;
 import io.helidon.nima.http.media.ReadableEntity;
 import io.helidon.nima.webserver.ConnectionContext;
@@ -33,7 +33,7 @@ final class Http1ServerRequestWithEntity extends Http1ServerRequest {
 
     Http1ServerRequestWithEntity(ConnectionContext ctx,
                                  HttpPrologue prologue,
-                                 HeadersServerRequest headers,
+                                 ServerRequestHeaders headers,
                                  ContentDecoder decoder,
                                  int requestId,
                                  CountDownLatch entityReadLatch,

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -25,13 +25,13 @@ import java.util.function.Supplier;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersServerResponse;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.DateTime;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.Http.HeaderValues;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.ConnectionContext;
 import io.helidon.nima.webserver.http.ServerResponse;
 import io.helidon.nima.webserver.http.ServerResponseBase;
@@ -58,8 +58,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     private final Http1ConnectionListener sendListener;
     private final DataWriter dataWriter;
     private final Http1ServerRequest request;
-    private final HeadersServerResponse headers;
-    private final HeadersWritable<?> trailers = HeadersWritable.create();
+    private final ServerResponseHeaders headers;
+    private final WritableHeaders<?> trailers = WritableHeaders.create();
     private final boolean keepAlive;
 
     private boolean streamingEntity;
@@ -79,11 +79,11 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         this.sendListener = sendListener;
         this.dataWriter = dataWriter;
         this.request = request;
-        this.headers = HeadersServerResponse.create();
+        this.headers = ServerResponseHeaders.create();
         this.keepAlive = keepAlive;
     }
 
-    static void nonEntityBytes(HeadersServerResponse headers,
+    static void nonEntityBytes(ServerResponseHeaders headers,
                                Http.Status status,
                                BufferData buffer,
                                boolean keepAlive) {
@@ -178,7 +178,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     }
 
     @Override
-    public HeadersServerResponse headers() {
+    public ServerResponseHeaders headers() {
         return headers;
     }
 
@@ -232,8 +232,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     }
 
     private static class BlockingOutputStream extends OutputStream {
-        private final HeadersServerResponse headers;
-        private final HeadersWritable<?> trailers;
+        private final ServerResponseHeaders headers;
+        private final WritableHeaders<?> trailers;
         private final Supplier<Http.Status> status;
         private final DataWriter dataWriter;
         private final Runnable responseCloseRunnable;
@@ -252,8 +252,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
         private boolean forcedChunked;
         private long responseBytesTotal;
 
-        private BlockingOutputStream(HeadersServerResponse headers,
-                                     HeadersWritable<?> trailers,
+        private BlockingOutputStream(ServerResponseHeaders headers,
+                                     WritableHeaders<?> trailers,
                                      Supplier<Http.Status> status,
                                      Supplier<String> streamResult,
                                      DataWriter dataWriter,

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/spi/Http1UpgradeProvider.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/spi/Http1UpgradeProvider.java
@@ -16,8 +16,8 @@
 
 package io.helidon.nima.webserver.http1.spi;
 
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.ConnectionContext;
 import io.helidon.nima.webserver.spi.ServerConnection;
 
@@ -41,5 +41,5 @@ public interface Http1UpgradeProvider {
      * @param headers  http headers of the upgrade request
      * @return a new connection to use instead of the original {@link io.helidon.nima.webserver.http1.Http1Connection}
      */
-    ServerConnection upgrade(ConnectionContext ctx, HttpPrologue prologue, HeadersWritable<?> headers);
+    ServerConnection upgrade(ConnectionContext ctx, HttpPrologue prologue, WritableHeaders<?> headers);
 }

--- a/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsConnection.java
+++ b/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsConnection.java
@@ -21,8 +21,8 @@ import java.nio.charset.StandardCharsets;
 
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataReader;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpPrologue;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.CloseConnectionException;
 import io.helidon.nima.webserver.ConnectionContext;
 import io.helidon.nima.webserver.spi.ServerConnection;
@@ -35,7 +35,7 @@ class WsConnection implements ServerConnection, WsSession {
 
     private final ConnectionContext ctx;
     private final HttpPrologue prologue;
-    private final HeadersWritable<?> headers;
+    private final WritableHeaders<?> headers;
     private final String wsKey;
     private final WsListener listener;
 
@@ -48,7 +48,7 @@ class WsConnection implements ServerConnection, WsSession {
 
     WsConnection(ConnectionContext ctx,
                  HttpPrologue prologue,
-                 HeadersWritable<?> headers,
+                 WritableHeaders<?> headers,
                  String wsKey,
                  WebSocket wsRoute) {
         this.ctx = ctx;

--- a/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsUpgradeProvider.java
+++ b/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsUpgradeProvider.java
@@ -27,12 +27,12 @@ import java.util.Set;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.buffers.DataWriter;
 import io.helidon.common.http.DirectHandler;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.RequestException;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.nima.webserver.ConnectionContext;
 import io.helidon.nima.webserver.http1.spi.Http1UpgradeProvider;
 import io.helidon.nima.webserver.spi.ServerConnection;
@@ -88,7 +88,7 @@ public class WsUpgradeProvider implements Http1UpgradeProvider {
     }
 
     @Override
-    public ServerConnection upgrade(ConnectionContext ctx, HttpPrologue prologue, HeadersWritable<?> headers) {
+    public ServerConnection upgrade(ConnectionContext ctx, HttpPrologue prologue, WritableHeaders<?> headers) {
         String wsKey;
         if (headers.contains(WS_KEY)) {
             wsKey = headers.get(WS_KEY).value();

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyReaderContext.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyReaderContext.java
@@ -27,8 +27,8 @@ import java.util.concurrent.Flow.Publisher;
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.reactive.Single;
 
@@ -77,7 +77,7 @@ public final class MessageBodyReaderContext extends MessageBodyContext implement
      */
     private MessageBodyReaderContext() {
         super(null, null);
-        this.headers = HeadersWritable.create();
+        this.headers = WritableHeaders.create();
         this.contentType = Optional.empty();
         this.readers = new MessageBodyOperators<>();
         this.sreaders = new MessageBodyOperators<>();

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyWriterContext.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyWriterContext.java
@@ -28,10 +28,10 @@ import java.util.function.Predicate;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.mapper.Mapper;
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.reactive.Multi;
@@ -52,7 +52,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
-    private final HeadersWritable<?> headers;
+    private final WritableHeaders<?> headers;
     private final List<HttpMediaType> acceptedTypes;
     private final MessageBodyOperators<MessageBodyWriter<?>> writers;
     private final MessageBodyOperators<MessageBodyStreamWriter<?>> swriters;
@@ -66,7 +66,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     private MessageBodyWriterContext(MessageBodyWriterContext parent,
                                      EventListener eventListener,
-                                     HeadersWritable<?> headers,
+                                     WritableHeaders<?> headers,
                                      List<HttpMediaType> acceptedTypes) {
 
         super(parent, eventListener);
@@ -90,7 +90,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      * Create a new standalone (non parented) context.
      * @param headers backing headers, may not be {@code null}
      */
-    private MessageBodyWriterContext(HeadersWritable<?> headers) {
+    private MessageBodyWriterContext(WritableHeaders<?> headers) {
         super(null, null);
         Objects.requireNonNull(headers, "headers cannot be null!");
         this.headers = headers;
@@ -104,7 +104,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     private MessageBodyWriterContext() {
         super(null, null);
-        this.headers = HeadersWritable.create();
+        this.headers = WritableHeaders.create();
         this.writers = new MessageBodyOperators<>();
         this.swriters = new MessageBodyOperators<>();
         this.acceptedTypes = List.of();
@@ -114,7 +114,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
         this.charsetCached = true;
     }
 
-    private MessageBodyWriterContext(MessageBodyWriterContext writerContext, HeadersWritable<?> headers) {
+    private MessageBodyWriterContext(MessageBodyWriterContext writerContext, WritableHeaders<?> headers) {
         super(writerContext);
         Objects.requireNonNull(headers, "headers cannot be null!");
         this.headers = headers;
@@ -140,7 +140,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     public static MessageBodyWriterContext create(MediaContext mediaContext,
                                                   EventListener eventListener,
-                                                  HeadersWritable<?> headers,
+                                                  WritableHeaders<?> headers,
                                                   List<HttpMediaType> acceptedTypes) {
 
         if (mediaContext == null) {
@@ -160,7 +160,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      * @return MessageBodyWriterContext
      */
     public static MessageBodyWriterContext create(MessageBodyWriterContext parent, EventListener eventListener,
-                                                  HeadersWritable<?> headers, List<HttpMediaType> acceptedTypes) {
+                                                  WritableHeaders<?> headers, List<HttpMediaType> acceptedTypes) {
 
         return new MessageBodyWriterContext(parent, eventListener, headers, acceptedTypes);
     }
@@ -170,7 +170,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      * @param headers headers
      * @return MessageBodyWriterContext
      */
-    public static MessageBodyWriterContext create(HeadersWritable<?> headers) {
+    public static MessageBodyWriterContext create(WritableHeaders<?> headers) {
         return new MessageBodyWriterContext(headers);
     }
 
@@ -191,7 +191,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      * @param headers headers
      * @return MessageBodyWriterContext
      */
-    public static MessageBodyWriterContext create(MessageBodyWriterContext parent, HeadersWritable<?> headers) {
+    public static MessageBodyWriterContext create(MessageBodyWriterContext parent, WritableHeaders<?> headers) {
         return new MessageBodyWriterContext(parent, headers);
     }
 
@@ -202,7 +202,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      * @return MessageBodyWriterContext
      */
     public static MessageBodyWriterContext create() {
-        return new MessageBodyWriterContext(HeadersWritable.create());
+        return new MessageBodyWriterContext(WritableHeaders.create());
     }
 
     @Override
@@ -330,7 +330,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      *
      * @return Parameters, never {@code null}
      */
-    public HeadersWritable<?> headers() {
+    public WritableHeaders<?> headers() {
         return headers;
     }
 

--- a/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentCharsetTest.java
+++ b/reactive/media/common/src/test/java/io/helidon/reactive/media/common/ContentCharsetTest.java
@@ -20,8 +20,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Optional;
 
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +79,6 @@ public class ContentCharsetTest {
             contentType = Optional.of(HttpMediaType.create(contentTypeValue));
         }
         return MessageBodyReaderContext.create((MediaContext) null, null,
-                                               HeadersWritable.create(), contentType);
+                                               WritableHeaders.create(), contentType);
     }
 }

--- a/reactive/media/jsonp/src/test/java/io/helidon/reactive/media/jsonp/JsonpStreamWriterTest.java
+++ b/reactive/media/jsonp/src/test/java/io/helidon/reactive/media/jsonp/JsonpStreamWriterTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.reactive.Multi;
 import io.helidon.reactive.media.common.MessageBodyOperator;
 import io.helidon.reactive.media.common.MessageBodyWriterContext;
@@ -49,7 +49,7 @@ public class JsonpStreamWriterTest {
     private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
     private static final JsonReaderFactory JSON_PARSER = Json.createReaderFactory(Map.of());
 
-    private static final MessageBodyWriterContext CONTEXT = MessageBodyWriterContext.create(HeadersWritable.create());
+    private static final MessageBodyWriterContext CONTEXT = MessageBodyWriterContext.create(WritableHeaders.create());
     private static final JsonpBodyStreamWriter WRITER = (JsonpBodyStreamWriter) JsonpSupport.streamWriter();
     private static final GenericType<JsonObject> JSON_OBJECT = GenericType.create(JsonObject.class);
     private static final GenericType<JsonArray> JSON_ARRAY = GenericType.create(JsonArray.class);

--- a/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/ReadableBodyPartHeaders.java
+++ b/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/ReadableBodyPartHeaders.java
@@ -21,9 +21,9 @@ import java.util.function.Supplier;
 
 import io.helidon.common.http.ContentDisposition;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 
 /**
  * Readable body part headers.
@@ -117,7 +117,7 @@ public final class ReadableBodyPartHeaders implements BodyPartHeaders {
         /**
          * The headers map.
          */
-        private final HeadersWritable<?> headers = HeadersWritable.create();
+        private final WritableHeaders<?> headers = WritableHeaders.create();
 
         /**
          * Force the use of {@link ReadableBodyPartHeaders#builder() }.

--- a/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/WriteableBodyPart.java
+++ b/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/WriteableBodyPart.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Flow.Publisher;
 
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersWritable;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.reactive.Single;
 import io.helidon.common.reactive.SubscriptionHelper;
 import io.helidon.reactive.media.common.MessageBodyWriterContext;
@@ -188,7 +188,7 @@ public final class WriteableBodyPart implements BodyPart {
 
         private final Object entity;
         private final GenericType<Object> type;
-        private final HeadersWritable<?> headers;
+        private final WritableHeaders<?> headers;
         private Publisher<DataChunk> publisher;
 
         EntityBodyPartContent(Object entity, WriteableBodyPartHeaders headers) {
@@ -218,10 +218,10 @@ public final class WriteableBodyPart implements BodyPart {
 
         private final Publisher<T> stream;
         private final GenericType<T> type;
-        private final HeadersWritable<?> headers;
+        private final WritableHeaders<?> headers;
         private Publisher<DataChunk> publisher;
 
-        EntityStreamBodyPartContent(Publisher<T> stream, GenericType<T> type, HeadersWritable<?> headers) {
+        EntityStreamBodyPartContent(Publisher<T> stream, GenericType<T> type, WritableHeaders<?> headers) {
             this.stream = Objects.requireNonNull(stream, "entity cannot be null!");
             this.type = Objects.requireNonNull(type, "type cannot be null!");
             this.headers = Objects.requireNonNull(headers, "headers cannot be null");

--- a/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/WriteableBodyPartHeaders.java
+++ b/reactive/media/multipart/src/main/java/io/helidon/reactive/media/multipart/WriteableBodyPartHeaders.java
@@ -21,19 +21,19 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.helidon.common.http.ContentDisposition;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaTypes;
 
 /**
  * Writeable body part headers.
  */
-public final class WriteableBodyPartHeaders implements BodyPartHeaders, HeadersWritable<WriteableBodyPartHeaders> {
+public final class WriteableBodyPartHeaders implements BodyPartHeaders, WritableHeaders<WriteableBodyPartHeaders> {
 
-    private final HeadersWritable<?> delegate;
+    private final WritableHeaders<?> delegate;
 
-    private WriteableBodyPartHeaders(HeadersWritable<?> delegate) {
+    private WriteableBodyPartHeaders(WritableHeaders<?> delegate) {
         this.delegate = delegate;
     }
 
@@ -53,7 +53,7 @@ public final class WriteableBodyPartHeaders implements BodyPartHeaders, HeadersW
      * @return WriteableBodyPartHeaders
      */
     public static WriteableBodyPartHeaders create() {
-        return new WriteableBodyPartHeaders(HeadersWritable.create());
+        return new WriteableBodyPartHeaders(WritableHeaders.create());
     }
 
     @Override
@@ -160,7 +160,7 @@ public final class WriteableBodyPartHeaders implements BodyPartHeaders, HeadersW
         /**
          * The headers map.
          */
-        private final HeadersWritable<?> headers = HeadersWritable.create();
+        private final WritableHeaders<?> headers = WritableHeaders.create();
         private String name;
         private String fileName;
 

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeaders.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeaders.java
@@ -19,8 +19,8 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import io.helidon.common.http.ClientRequestHeaders;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersClientRequest;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
 
@@ -28,7 +28,7 @@ import io.helidon.common.http.HttpMediaType;
  * Headers that can be modified (until request is sent) for
  * outbound request.
  */
-public interface WebClientRequestHeaders extends HeadersClientRequest {
+public interface WebClientRequestHeaders extends ClientRequestHeaders {
 
     /**
      * Remove a header if set.

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeadersImpl.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeadersImpl.java
@@ -29,12 +29,12 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import io.helidon.common.http.ClientRequestHeaders;
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersClientRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.media.type.MediaType;
 
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
@@ -47,7 +47,7 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     private static final DateTimeFormatter FORMATTER = Http.DateTime.RFC_1123_DATE_TIME.withZone(ZoneId.of("GMT"));
 
-    private final HeadersClientRequest headers = HeadersClientRequest.create(HeadersWritable.create());
+    private final ClientRequestHeaders headers = ClientRequestHeaders.create(WritableHeaders.create());
 
     WebClientRequestHeadersImpl() {
     }

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseHeaders.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseHeaders.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
 import io.helidon.common.http.SetCookie;
@@ -29,7 +29,7 @@ import io.helidon.common.http.SetCookie;
 /**
  * Headers that may be available on response from server.
  */
-public interface WebClientResponseHeaders extends HeadersClientResponse {
+public interface WebClientResponseHeaders extends ClientResponseHeaders {
 
     /**
      * Returns {@link SetCookie} header of the response.

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseImpl.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseImpl.java
@@ -21,9 +21,9 @@ import java.util.Optional;
 import java.util.concurrent.Flow;
 
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.reactive.Single;
 import io.helidon.reactive.media.common.MessageBodyReadableContent;
 import io.helidon.reactive.media.common.MessageBodyReaderContext;
@@ -97,7 +97,7 @@ final class WebClientResponseImpl implements WebClientResponse {
      */
     static class Builder implements io.helidon.common.Builder<Builder, WebClientResponseImpl> {
 
-        private final HeadersWritable<?> headers = HeadersWritable.create();
+        private final WritableHeaders<?> headers = WritableHeaders.create();
 
         private Flow.Publisher<DataChunk> publisher;
         private Http.Status status = Http.Status.INTERNAL_SERVER_ERROR_500;

--- a/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestRequestHeaders.java
+++ b/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestRequestHeaders.java
@@ -21,16 +21,16 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.reactive.webserver.RequestHeaders;
 
-class TestRequestHeaders implements RequestHeaders, HeadersWritable<TestRequestHeaders> {
-    private final HeadersWritable<?> delegate;
+class TestRequestHeaders implements RequestHeaders, WritableHeaders<TestRequestHeaders> {
+    private final WritableHeaders<?> delegate;
 
     TestRequestHeaders() {
-        this.delegate = HeadersWritable.create();
+        this.delegate = WritableHeaders.create();
     }
 
     @Override

--- a/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestResponse.java
+++ b/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestResponse.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.reactive.webserver.WebServer;
 
 /**
@@ -34,7 +34,7 @@ import io.helidon.reactive.webserver.WebServer;
 public class TestResponse {
 
     private final Http.Status status;
-    private final HeadersWritable<?> headers;
+    private final WritableHeaders<?> headers;
     // todo Needs much better solution.
     private final TestClient.TestBareResponse bareResponse;
 
@@ -49,7 +49,7 @@ public class TestResponse {
                  Map<String, List<String>> headers,
                  TestClient.TestBareResponse bareResponse) {
         this.status = status;
-        this.headers = HeadersWritable.create();
+        this.headers = WritableHeaders.create();
         headers.forEach((key, value) -> this.headers.set(Http.Header.create(key), value));
         this.bareResponse = bareResponse;
     }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
@@ -35,10 +35,10 @@ import io.helidon.common.context.Contexts;
 import io.helidon.common.http.BadRequestException;
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.DirectHandler.TransportResponse;
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersServerResponse;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.ServerResponseHeaders;
+import io.helidon.common.http.WritableHeaders;
 import io.helidon.logging.common.HelidonMdc;
 import io.helidon.reactive.webserver.ByteBufRequestChunk.DataChunkHoldingQueue;
 import io.helidon.reactive.webserver.ReferenceHoldingQueue.IndirectReference;
@@ -509,7 +509,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 .handle(new DirectHandlerRequest(request),
                         DirectHandler.EventType.BAD_REQUEST,
                         Http.Status.BAD_REQUEST_400,
-                        HeadersServerResponse.create(),
+                        ServerResponseHeaders.create(),
                         t);
 
         FullHttpResponse response = toNettyResponse(handlerResponse);
@@ -532,7 +532,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
                 .handle(new DirectHandlerRequest(request),
                         DirectHandler.EventType.PAYLOAD_TOO_LARGE,
                         Http.Status.REQUEST_ENTITY_TOO_LARGE_413,
-                        HeadersServerResponse.create(),
+                        ServerResponseHeaders.create(),
                         "");
 
         FullHttpResponse response = toNettyResponse(transportResponse);
@@ -548,7 +548,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
     private FullHttpResponse toNettyResponse(TransportResponse handlerResponse) {
         Optional<byte[]> entity = handlerResponse.entity();
         Http.Status status = handlerResponse.status();
-        HeadersServerResponse headers = handlerResponse.headers();
+        ServerResponseHeaders headers = handlerResponse.headers();
 
         HttpResponseStatus nettyStatus = HttpResponseStatus.valueOf(status.code(), status.reasonPhrase());
 
@@ -595,17 +595,17 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         private final String protocolVersion;
         private final String uri;
         private final String method;
-        private final HeadersServerRequest headers;
+        private final ServerRequestHeaders headers;
 
         private DirectHandlerRequest(HttpRequest request) {
             protocolVersion = request.protocolVersion().text();
             uri = request.uri();
             method = request.method().name();
-            HeadersWritable<?> result = HeadersWritable.create();
+            WritableHeaders<?> result = WritableHeaders.create();
             for (String name : request.headers().names()) {
                 result.add(Http.HeaderValue.create(Http.Header.create(name), request.headers().getAll(name)));
             }
-            headers = HeadersServerRequest.create(result);
+            headers = ServerRequestHeaders.create(result);
         }
 
         @Override
@@ -624,7 +624,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
         }
 
         @Override
-        public HeadersServerRequest headers() {
+        public ServerRequestHeaders headers() {
             return headers;
         }
     }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/HashResponseHeaders.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/HashResponseHeaders.java
@@ -31,9 +31,9 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import io.helidon.common.LazyValue;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.http.SetCookie;
 import io.helidon.common.reactive.Single;
 
@@ -51,7 +51,7 @@ class HashResponseHeaders implements ResponseHeaders {
     private volatile Http.Status httpStatus;
     private final CompletionSupport completable;
     private final CompletableFuture<ResponseHeaders> completionStage = new CompletableFuture<>();
-    private final HeadersServerResponse headers = HeadersServerResponse.create();
+    private final ServerResponseHeaders headers = ServerResponseHeaders.create();
 
     /**
      * Creates a new instance.
@@ -154,43 +154,43 @@ class HashResponseHeaders implements ResponseHeaders {
     }
 
     @Override
-    public HeadersServerResponse addCookie(SetCookie cookie) {
+    public ServerResponseHeaders addCookie(SetCookie cookie) {
         completable.runIfNotCompleted(() -> headers.addCookie(cookie), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse clearCookie(String name) {
+    public ServerResponseHeaders clearCookie(String name) {
         completable.runIfNotCompleted(() -> headers.clearCookie(name), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse setIfAbsent(Http.HeaderValue header) {
+    public ServerResponseHeaders setIfAbsent(Http.HeaderValue header) {
         completable.runIfNotCompleted(() -> headers.setIfAbsent(header), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse add(Http.HeaderValue header) {
+    public ServerResponseHeaders add(Http.HeaderValue header) {
         completable.runIfNotCompleted(() -> headers.add(header), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse remove(Http.HeaderName name) {
+    public ServerResponseHeaders remove(Http.HeaderName name) {
         completable.runIfNotCompleted(() -> headers.remove(name), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse remove(Http.HeaderName name, Consumer<Http.HeaderValue> removedConsumer) {
+    public ServerResponseHeaders remove(Http.HeaderName name, Consumer<Http.HeaderValue> removedConsumer) {
         completable.runIfNotCompleted(() -> headers.remove(name, removedConsumer), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }
 
     @Override
-    public HeadersServerResponse set(Http.HeaderValue header) {
+    public ServerResponseHeaders set(Http.HeaderValue header) {
         completable.runIfNotCompleted(() -> headers.set(header), COMPLETED_EXCEPTION_MESSAGE);
         return this;
     }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyRequestHeaders.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyRequestHeaders.java
@@ -20,22 +20,22 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
 
-import io.helidon.common.http.HeadersServerRequest;
-import io.helidon.common.http.HeadersWritable;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.HttpMediaType;
+import io.helidon.common.http.ServerRequestHeaders;
+import io.helidon.common.http.WritableHeaders;
 
 import io.netty.handler.codec.http.HttpHeaders;
 
 class NettyRequestHeaders implements RequestHeaders {
-    private final HeadersServerRequest delegate;
+    private final ServerRequestHeaders delegate;
 
     NettyRequestHeaders(HttpHeaders nettyHeaders) {
-        HeadersWritable<?> hw = HeadersWritable.create();
+        WritableHeaders<?> hw = WritableHeaders.create();
         for (String name : nettyHeaders.names()) {
             hw.set(Http.HeaderValue.create(Http.Header.create(name), nettyHeaders.getAll(name)));
         }
-        this.delegate = HeadersServerRequest.create(hw);
+        this.delegate = ServerRequestHeaders.create(hw);
     }
 
     @Override

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/RequestHeaders.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/RequestHeaders.java
@@ -16,7 +16,7 @@
 
 package io.helidon.reactive.webserver;
 
-import io.helidon.common.http.HeadersServerRequest;
+import io.helidon.common.http.ServerRequestHeaders;
 
 /**
  * Extends {@link io.helidon.common.http.Headers} interface by adding HTTP request headers oriented convenient methods.
@@ -24,5 +24,5 @@ import io.helidon.common.http.HeadersServerRequest;
  *
  * @see io.helidon.common.http.Http.Header
  */
-public interface RequestHeaders extends HeadersServerRequest {
+public interface RequestHeaders extends ServerRequestHeaders {
 }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ResponseHeaders.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ResponseHeaders.java
@@ -18,11 +18,11 @@ package io.helidon.reactive.webserver;
 
 import java.util.function.Consumer;
 
-import io.helidon.common.http.HeadersServerResponse;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.reactive.Single;
 
 /**
- * Extends {@link io.helidon.common.http.HeadersServerResponse} interface by adding HTTP response headers oriented constants and
+ * Extends {@link io.helidon.common.http.ServerResponseHeaders} interface by adding HTTP response headers oriented constants and
  * convenient methods.
  * Use constants located in {@link io.helidon.common.http.Http.Header} as standard header names.
  *
@@ -34,7 +34,7 @@ import io.helidon.common.reactive.Single;
  *
  * @see io.helidon.common.http.Http.Header
  */
-public interface ResponseHeaders extends HeadersServerResponse {
+public interface ResponseHeaders extends ServerResponseHeaders {
     /**
      * Register a {@link Consumer} which is executed just before headers are send. {@code Consumer} can made 'last minute
      * changes' in headers.

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionTest.java
@@ -21,7 +21,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.logging.Logger;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.reactive.webclient.WebClient;
@@ -102,7 +102,7 @@ class CompressionTest {
                                         Http.Method.GET, null,
                                         requestHeaders);
 
-            HeadersClientResponse responseHeaders = SocketHttpClient.headersFromResponse(s);
+            ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
             assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "gzip")));
         }
     }
@@ -122,7 +122,7 @@ class CompressionTest {
                                         Http.Method.GET, null,
                                         requestHeaders);
 
-            HeadersClientResponse responseHeaders = SocketHttpClient.headersFromResponse(s);
+            ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
             assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "deflate")));
         }
     }

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionV2ApiTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionV2ApiTest.java
@@ -21,7 +21,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.logging.Logger;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.reactive.webclient.WebClient;
@@ -106,7 +106,7 @@ class CompressionV2ApiTest {
                                         Http.Method.GET, null,
                                         requestHeaders);
 
-            HeadersClientResponse responseHeaders = SocketHttpClient.headersFromResponse(s);
+            ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
             assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "gzip")));
         }
     }
@@ -126,7 +126,7 @@ class CompressionV2ApiTest {
                                         Http.Method.GET, null,
                                         requestHeaders);
 
-            HeadersClientResponse responseHeaders = SocketHttpClient.headersFromResponse(s);
+            ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
             assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "deflate")));
         }
     }

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893Test.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893Test.java
@@ -19,11 +19,11 @@ package io.helidon.reactive.webserver;
 import java.time.Duration;
 import java.util.List;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.DirectHandler.TransportResponse;
-import io.helidon.common.http.HeadersClientResponse;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.reactive.webclient.WebClient;
@@ -89,7 +89,7 @@ class Gh1893Test {
     private static TransportResponse badRequestHandler(DirectHandler.TransportRequest request,
                                                        DirectHandler.EventType eventType,
                                                        Http.Status defaultStatus,
-                                                       HeadersServerResponse headers,
+                                                       ServerResponseHeaders headers,
                                                        String message) {
         if (request.path().equals("/redirect")) {
             return TransportResponse.builder()
@@ -154,7 +154,7 @@ class Gh1893Test {
 
         assertThat(SocketHttpClient.statusFromResponse(response), is(Http.Status.TEMPORARY_REDIRECT_307));
 
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(response);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         assertThat(headers, HttpHeaderMatcher.hasHeader(Http.HeaderValue.create(Http.Header.LOCATION, "/errorPage")));
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893V2ApiTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893V2ApiTest.java
@@ -19,11 +19,11 @@ package io.helidon.reactive.webserver;
 import java.time.Duration;
 import java.util.List;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.DirectHandler.TransportResponse;
-import io.helidon.common.http.HeadersClientResponse;
-import io.helidon.common.http.HeadersServerResponse;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.testing.http.junit5.HttpHeaderMatcher;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 import io.helidon.reactive.webclient.WebClient;
@@ -89,7 +89,7 @@ class Gh1893V2ApiTest {
     private static TransportResponse badRequestHandler(DirectHandler.TransportRequest request,
                                                        DirectHandler.EventType eventType,
                                                        Http.Status defaultStatus,
-                                                       HeadersServerResponse headers,
+                                                       ServerResponseHeaders headers,
                                                        String message) {
         if (request.path().equals("/redirect")) {
             return TransportResponse.builder()
@@ -154,7 +154,7 @@ class Gh1893V2ApiTest {
 
         assertThat(SocketHttpClient.statusFromResponse(response), is(Http.Status.TEMPORARY_REDIRECT_307));
 
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(response);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         assertThat(headers, HttpHeaderMatcher.hasHeader(Http.HeaderValue.create(Http.Header.LOCATION, "/errorPage")));
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/PlainTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/PlainTest.java
@@ -29,8 +29,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersClientResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
@@ -161,7 +161,7 @@ class PlainTest {
     @Test
     void getTest() {
         String s = client.sendAndReceive(Http.Method.GET, null);
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.HeaderValues.CONNECTION_KEEP_ALIVE));
         assertThat(SocketHttpClient.entityFromResponse(s, false), is("9\nIt works!\n0\n\n"));
     }
@@ -420,7 +420,7 @@ class PlainTest {
                                          Http.Method.GET,
                                          null,
                                          List.of("Connection: close"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, noHeader(Http.Header.CONNECTION));
         assertThat(headers, hasHeader(TRANSFER_ENCODING_CHUNKED));
 
@@ -433,7 +433,7 @@ class PlainTest {
                                          Http.Method.GET,
                                          null,
                                          List.of("Connection: close"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, noHeader(Http.Header.CONNECTION));
         assertThat(SocketHttpClient.entityFromResponse(s, false), is("9\nIt works!\n0\n\n"));
     }
@@ -445,7 +445,7 @@ class PlainTest {
                                          null,
                                          List.of("Connection: close"));
         assertThat(s, containsString("400 Bad Request"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.Header.CONTENT_TYPE));
         assertThat(headers, hasHeader(Http.Header.CONTENT_LENGTH));
     }
@@ -457,7 +457,7 @@ class PlainTest {
                                          null,
                                          List.of("Content-Type: %", "Connection: close"));
         assertThat(s, containsString("400 Bad Request"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.Header.CONTENT_TYPE));
         assertThat(headers, hasHeader(Http.Header.CONTENT_LENGTH));
     }

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/PlainV2ApiTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/PlainV2ApiTest.java
@@ -29,8 +29,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.DataChunk;
-import io.helidon.common.http.HeadersClientResponse;
 import io.helidon.common.http.Http;
 import io.helidon.common.reactive.Multi;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
@@ -160,7 +160,7 @@ class PlainV2ApiTest {
     @Test
     void getTest() {
         String s = client.sendAndReceive(Http.Method.GET, null);
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.HeaderValues.CONNECTION_KEEP_ALIVE));
         assertThat(SocketHttpClient.entityFromResponse(s, false), is("9\nIt works!\n0\n\n"));
     }
@@ -419,7 +419,7 @@ class PlainV2ApiTest {
                                          Http.Method.GET,
                                          null,
                                          List.of("Connection: close"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, noHeader(Http.Header.CONNECTION));
         assertThat(headers, hasHeader(TRANSFER_ENCODING_CHUNKED));
 
@@ -432,7 +432,7 @@ class PlainV2ApiTest {
                                          Http.Method.GET,
                                          null,
                                          List.of("Connection: close"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, noHeader(Http.Header.CONNECTION));
         assertThat(SocketHttpClient.entityFromResponse(s, false), is("9\nIt works!\n0\n\n"));
     }
@@ -444,7 +444,7 @@ class PlainV2ApiTest {
                                          null,
                                          List.of("Connection: close"));
         assertThat(s, containsString("400 Bad Request"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.Header.CONTENT_TYPE));
         assertThat(headers, hasHeader(Http.Header.CONTENT_LENGTH));
     }
@@ -456,7 +456,7 @@ class PlainV2ApiTest {
                                          null,
                                          List.of("Content-Type: %", "Connection: close"));
         assertThat(s, containsString("400 Bad Request"));
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(s);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(s);
         assertThat(headers, hasHeader(Http.Header.CONTENT_TYPE));
         assertThat(headers, hasHeader(Http.Header.CONTENT_LENGTH));
     }

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/TestNettyRejectRequest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/TestNettyRejectRequest.java
@@ -18,7 +18,7 @@ package io.helidon.reactive.webserver;
 import java.time.Duration;
 import java.util.List;
 
-import io.helidon.common.http.HeadersClientResponse;
+import io.helidon.common.http.ClientResponseHeaders;
 import io.helidon.common.http.Http;
 import io.helidon.common.testing.http.junit5.SocketHttpClient;
 
@@ -30,7 +30,6 @@ import static io.helidon.common.testing.http.junit5.HttpHeaderMatcher.hasHeader;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 
 class TestNettyRejectRequest {
     private static final Duration TIMEOUT = Duration.ofSeconds(10);
@@ -72,7 +71,7 @@ class TestNettyRejectRequest {
                                                 null,
                                                 List.of("Accept: text/plain", "Bad=Header: anything"));
 
-        HeadersClientResponse headers = SocketHttpClient.headersFromResponse(response);
+        ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
         Http.Status status = SocketHttpClient.statusFromResponse(response);
         String entity = SocketHttpClient.entityFromResponse(response, false);
 


### PR DESCRIPTION
Resolves #4856 

Renames HeadersServerRequest to ServerRequestHeaders (and similar)