### PR TITLE
Fix the structure of the table in the section "Traced spans" (#4792)

### DIFF
--- a/docs/includes/tracing/common-spans.adoc
+++ b/docs/includes/tracing/common-spans.adoc
@@ -42,7 +42,7 @@ is used.
 
 Some of these spans `log` to the span. These log events can be (in most cases) configured:
 
-[cols="2,2,2,4", role="flex, sm10"]
+[cols="2,2,2,2,4", role="flex, sm10"]
 |===
 |span name          |log name               |configurable   |enabled by default |description
 


### PR DESCRIPTION
Fixes #4792

The table looks good. Width can be 2 or more.

<img width="1032" alt="Screenshot 2022-09-08 at 22 34 34" src="https://user-images.githubusercontent.com/4740207/189212152-584111a9-4641-4236-9363-a6abe8797f4f.png">
