### PR TITLE
Use Header.create() for both header names and header values.

### DIFF
--- a/common/http/src/main/java/io/helidon/common/http/ClientRequestHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ClientRequestHeaders.java
@@ -54,7 +54,7 @@ public interface ClientRequestHeaders extends ServerRequestHeaders,
             HttpMediaType mediaType = accepted[i];
             values[i] = mediaType.text();
         }
-        set(Http.HeaderValue.create(Http.Header.ACCEPT, values));
+        set(Http.Header.create(Http.Header.ACCEPT, values));
         return this;
     }
 }

--- a/common/http/src/main/java/io/helidon/common/http/Http1HeadersParser.java
+++ b/common/http/src/main/java/io/helidon/common/http/Http1HeadersParser.java
@@ -64,7 +64,7 @@ public final class Http1HeadersParser {
             reader.skip(2);
             maxLength -= eol + 1;
 
-            headers.add(Http.HeaderValue.create(header, value));
+            headers.add(Http.Header.create(header, value));
             if (maxLength < 0) {
                 throw new IllegalStateException("Header size exceeded");
             }

--- a/common/http/src/main/java/io/helidon/common/http/ServerRequestHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerRequestHeaders.java
@@ -36,7 +36,7 @@ public interface ServerRequestHeaders extends Headers {
      *
      * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8163921">JDK-8163921</a>
      */
-    HeaderValue HUC_ACCEPT_DEFAULT = HeaderValue.create(Http.Header.ACCEPT,
+    HeaderValue HUC_ACCEPT_DEFAULT = Http.Header.create(Http.Header.ACCEPT,
                                                         "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2");
 
     /**

--- a/common/http/src/main/java/io/helidon/common/http/ServerResponseHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerResponseHeaders.java
@@ -23,7 +23,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import io.helidon.common.http.Http.Header;
-import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.media.type.MediaType;
 
 import static io.helidon.common.http.Http.Header.EXPIRES;
@@ -68,8 +67,8 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
             HttpMediaType acceptableMediaType = acceptableMediaTypes[i];
             values[i] = acceptableMediaType.text();
         }
-        return add(HeaderValue.create(Header.ACCEPT_PATCH,
-                                      values));
+        return add(Header.create(Header.ACCEPT_PATCH,
+                                 values));
     }
 
     /**
@@ -85,8 +84,8 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
             MediaType acceptableMediaType = acceptableMediaTypes[i];
             values[i] = acceptableMediaType.text();
         }
-        return add(HeaderValue.create(Header.ACCEPT_PATCH,
-                                      values));
+        return add(Header.create(Header.ACCEPT_PATCH,
+                                 values));
     }
 
     /**
@@ -141,7 +140,7 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
      */
     default ServerResponseHeaders lastModified(Instant modified) {
         ZonedDateTime dt = ZonedDateTime.ofInstant(modified, ZoneId.systemDefault());
-        return set(HeaderValue.create(LAST_MODIFIED, true, false, dt.format(Http.DateTime.RFC_1123_DATE_TIME)));
+        return set(Header.create(LAST_MODIFIED, true, false, dt.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 
     /**
@@ -153,7 +152,7 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
      * @return this instance
      */
     default ServerResponseHeaders lastModified(ZonedDateTime modified) {
-        return set(HeaderValue.create(LAST_MODIFIED, true, false, modified.format(Http.DateTime.RFC_1123_DATE_TIME)));
+        return set(Header.create(LAST_MODIFIED, true, false, modified.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 
     /**
@@ -165,7 +164,7 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
      * @return updated headers
      */
     default ServerResponseHeaders location(URI location) {
-        return set(HeaderValue.create(LOCATION, true, false, location.toASCIIString()));
+        return set(Header.create(LOCATION, true, false, location.toASCIIString()));
     }
 
     /**
@@ -177,7 +176,7 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
      * @return updated headers
      */
     default ServerResponseHeaders expires(ZonedDateTime dateTime) {
-        return set(HeaderValue.create(EXPIRES, dateTime.format(Http.DateTime.RFC_1123_DATE_TIME)));
+        return set(Header.create(EXPIRES, dateTime.format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 
     /**
@@ -189,7 +188,7 @@ public interface ServerResponseHeaders extends ClientResponseHeaders,
      * @return updated headers
      */
     default ServerResponseHeaders expires(Instant dateTime) {
-        return set(HeaderValue.create(EXPIRES, ZonedDateTime.ofInstant(dateTime, ZoneId.systemDefault())
+        return set(Header.create(EXPIRES, ZonedDateTime.ofInstant(dateTime, ZoneId.systemDefault())
                 .format(Http.DateTime.RFC_1123_DATE_TIME)));
     }
 }

--- a/common/http/src/main/java/io/helidon/common/http/ServerResponseHeadersImpl.java
+++ b/common/http/src/main/java/io/helidon/common/http/ServerResponseHeadersImpl.java
@@ -35,7 +35,7 @@ class ServerResponseHeadersImpl extends HeadersImpl<ServerResponseHeaders> imple
 
     @Override
     public ServerResponseHeaders addCookie(SetCookie cookie) {
-        add(Http.HeaderValue.create(Http.Header.SET_COOKIE, cookie.toString()));
+        add(Http.Header.create(Http.Header.SET_COOKIE, cookie.toString()));
         return this;
     }
 
@@ -67,7 +67,7 @@ class ServerResponseHeadersImpl extends HeadersImpl<ServerResponseHeaders> imple
                     newValues = values;
                 }
 
-                set(Http.HeaderValue.create(Http.Header.SET_COOKIE, newValues));
+                set(Http.Header.create(Http.Header.SET_COOKIE, newValues));
             });
         } else {
             addCookie(expiredCookie);

--- a/common/http/src/main/java/io/helidon/common/http/WritableHeaders.java
+++ b/common/http/src/main/java/io/helidon/common/http/WritableHeaders.java
@@ -72,7 +72,7 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B add(HeaderName header, String... value) {
-        return add(HeaderValue.create(header, value));
+        return add(Http.Header.create(header, value));
     }
 
     /**
@@ -100,7 +100,7 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B contentType(MediaType contentType) {
-        return set(HeaderValue.create(HeaderEnum.CONTENT_TYPE, contentType.text()));
+        return set(Http.Header.create(HeaderEnum.CONTENT_TYPE, contentType.text()));
     }
 
     /**
@@ -110,7 +110,7 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B contentType(HttpMediaType contentType) {
-        return set(HeaderValue.create(HeaderEnum.CONTENT_TYPE, contentType.text()));
+        return set(Http.Header.create(HeaderEnum.CONTENT_TYPE, contentType.text()));
     }
 
     /**
@@ -132,7 +132,7 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B set(HeaderName name, String... values) {
-        return set(HeaderValue.create(name, true, false, values));
+        return set(Http.Header.create(name, true, false, values));
     }
 
     /**
@@ -146,7 +146,7 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B set(HeaderName name, List<String> values) {
-        return set(HeaderValue.create(name, values));
+        return set(Http.Header.create(name, values));
     }
 
     /**
@@ -159,10 +159,10 @@ public interface WritableHeaders<B extends WritableHeaders<B>> extends Headers {
      * @return this instance
      */
     default B contentLength(long length) {
-        return set(HeaderValue.create(HeaderEnum.CONTENT_LENGTH,
-                                     true,
-                                     false,
-                                     String.valueOf(length)));
+        return set(Http.Header.create(HeaderEnum.CONTENT_LENGTH,
+                                      true,
+                                      false,
+                                      String.valueOf(length)));
     }
 
     /**

--- a/common/http/src/test/java/io/helidon/common/http/CookieParserTest.java
+++ b/common/http/src/test/java/io/helidon/common/http/CookieParserTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.common.http;
 
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.parameters.Parameters;
 
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class CookieParserTest {
     @Test
     public void rfc2965() throws Exception {
         String header = "$version=1; foo=bar; $Domain=google.com, aaa=bbb, c=cool; $Domain=google.com; $Path=\"/foo\"";
-        Parameters p = CookieParser.parse(COOKIE.withValue(header));
+        Parameters p = CookieParser.parse(Header.create(COOKIE, header));
         assertThat(p, notNullValue());
         assertThat(p.all("foo"), contains("bar"));
         assertThat(p.all("aaa"), contains("bbb"));
@@ -42,7 +43,7 @@ class CookieParserTest {
 
     @Test
     public void unquote() throws Exception {
-        Parameters p = CookieParser.parse(COOKIE.withValue("foo=\"bar\"; aaa=bbb; c=\"what_the_hell\"; aaa=\"ccc\""));
+        Parameters p = CookieParser.parse(Header.create(COOKIE, "foo=\"bar\"; aaa=bbb; c=\"what_the_hell\"; aaa=\"ccc\""));
         assertThat(p, notNullValue());
         assertThat(p.all("foo"), contains("bar"));
         assertThat(p.all("aaa"), contains("bbb", "ccc"));
@@ -56,7 +57,7 @@ class CookieParserTest {
 
     @Test
     void testMultiValueSingleHeader() {
-        Parameters cookies = CookieParser.parse(COOKIE.withValue("foo=bar; aaa=bbb; c=here; aaa=ccc"));
+        Parameters cookies = CookieParser.parse(Header.create(COOKIE, "foo=bar; aaa=bbb; c=here; aaa=ccc"));
         assertThat(cookies, notNullValue());
         assertThat(cookies.all("foo"), contains("bar"));
         assertThat(cookies.all("aaa"), contains("bbb", "ccc"));
@@ -65,7 +66,7 @@ class CookieParserTest {
 
     @Test
     void testMultiValueMultiHeader() {
-        Parameters cookies = CookieParser.parse(COOKIE.withValue("foo=bar; aaa=bbb; c=here", "aaa=ccc"));
+        Parameters cookies = CookieParser.parse(Header.create(COOKIE, "foo=bar; aaa=bbb; c=here", "aaa=ccc"));
         assertThat(cookies, notNullValue());
         assertThat(cookies.all("foo"), contains("bar"));
         assertThat(cookies.all("aaa"), contains("bbb", "ccc"));

--- a/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
+++ b/common/testing/http-junit5/src/main/java/io/helidon/common/testing/http/junit5/HttpHeaderMatcher.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderName;
 
 import org.hamcrest.Description;
@@ -57,7 +58,8 @@ public final class HttpHeaderMatcher {
      * </pre>
      *
      * @param name header name
-     * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the provided header regardless of its value(s)
+     * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the provided header regardless of its
+     *         value(s)
      */
     public static Matcher<Headers> hasHeader(HeaderName name) {
         return new HasHeaderMatcher(name);
@@ -73,10 +75,27 @@ public final class HttpHeaderMatcher {
      * </pre>
      *
      * @param header http header with values
-     * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the provided header regardless of its value(s)
+     * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the provided header
      */
     public static Matcher<Headers> hasHeader(Http.HeaderValue header) {
         return new HasValueMatcher(header);
+    }
+
+    /**
+     * A matcher for an {@link io.helidon.common.http.Headers} that checks that the header is present and has the defined
+     * value(s).
+     * <p>
+     * Usage example:
+     * <pre>
+     *     assertThat(httpHeaders, hasHeader(HeaderValues.REDIRECT, "/location"));
+     * </pre>
+     *
+     * @param name  http header name
+     * @param value value(s) of the header
+     * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the provided header
+     */
+    public static Matcher<Headers> hasHeader(Http.HeaderName name, String... value) {
+        return new HasValueMatcher(Header.create(name, value));
     }
 
     /**
@@ -105,8 +124,8 @@ public final class HttpHeaderMatcher {
      *     assertThat(httpHeaders, hasHeaderValue(HeaderNames.CONNECTION, startsWith("c")));
      * </pre>
      *
-     * @param name          header name
-     * @param valueMatcher  matcher to validate the value is OK
+     * @param name         header name
+     * @param valueMatcher matcher to validate the value is OK
      * @return matcher validating the {@link io.helidon.common.http.Headers} does contain the expected value
      */
     public static Matcher<Headers> hasHeaderValue(HeaderName name, Matcher<String> valueMatcher) {

--- a/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/Main.java
+++ b/examples/media/multipart/src/main/java/io/helidon/examples/media/multipart/Main.java
@@ -28,7 +28,7 @@ import io.helidon.reactive.webserver.staticcontent.StaticContentSupport;
  * This application provides a simple file upload service with a UI to exercise multipart.
  */
 public final class Main {
-    private static final Http.HeaderValue REDIRECT_LOCATION = Http.HeaderValue.createCached(Http.Header.LOCATION, "/ui");
+    private static final Http.HeaderValue REDIRECT_LOCATION = Http.Header.createCached(Http.Header.LOCATION, "/ui");
 
     private Main() {
     }

--- a/examples/nima/echo/src/main/java/io/helidon/examples/nima/echo/EchoClient.java
+++ b/examples/nima/echo/src/main/java/io/helidon/examples/nima/echo/EchoClient.java
@@ -17,7 +17,7 @@
 package io.helidon.examples.nima.echo;
 
 import io.helidon.common.http.Headers;
-import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.nima.webclient.WebClient;
 import io.helidon.nima.webclient.http1.Http1Client;
@@ -28,8 +28,8 @@ import io.helidon.nima.webclient.http1.Http1ClientResponse;
  * A client that invokes the echo server.
  */
 public class EchoClient {
-    private static final HeaderValue HEADER = Http.Header.create("MY-HEADER").withValue("header-value");
-    private static final HeaderValue HEADERS = Http.Header.create("MY-HEADERS").withValue("ha", "hb", "hc");
+    private static final HeaderValue HEADER = Header.create(Header.create("MY-HEADER"), "header-value");
+    private static final HeaderValue HEADERS = Header.create(Header.create("MY-HEADERS"), "ha", "hb", "hc");
 
     private EchoClient() {
     }

--- a/examples/nima/media/src/main/java/io/helidon/examples/nima/media/FileService.java
+++ b/examples/nima/media/src/main/java/io/helidon/examples/nima/media/FileService.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 
 import io.helidon.common.http.ContentDisposition;
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.ServerResponseHeaders;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.nima.http.media.multipart.MultiPart;
@@ -47,7 +48,7 @@ import static io.helidon.common.http.Http.Status.NOT_FOUND_404;
  * File service.
  */
 final class FileService implements HttpService {
-    private static final Http.HeaderValue UI_LOCATION = Http.Header.LOCATION.withValue("/ui");
+    private static final Http.HeaderValue UI_LOCATION = Header.createCached(Header.LOCATION, "/ui");
     private final JsonBuilderFactory jsonFactory;
     private final Path storage;
 

--- a/examples/nima/media/src/main/java/io/helidon/examples/nima/media/MediaMain.java
+++ b/examples/nima/media/src/main/java/io/helidon/examples/nima/media/MediaMain.java
@@ -17,6 +17,7 @@
 package io.helidon.examples.nima.media;
 
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.nima.webserver.WebServer;
 import io.helidon.nima.webserver.http.HttpRules;
 import io.helidon.nima.webserver.staticcontent.StaticContentSupport;
@@ -25,7 +26,7 @@ import io.helidon.nima.webserver.staticcontent.StaticContentSupport;
  * This application provides a simple file upload service with a UI to exercise multipart.
  */
 public class MediaMain {
-    private static final Http.HeaderValue UI_LOCATION = Http.Header.LOCATION.withValue("/ui");
+    private static final Http.HeaderValue UI_LOCATION = Header.createCached(Header.LOCATION, "/ui");
 
     private MediaMain() {
     }

--- a/examples/webserver/static-content/src/main/java/io/helidon/reactive/webserver/examples/staticcontent/Main.java
+++ b/examples/webserver/static-content/src/main/java/io/helidon/reactive/webserver/examples/staticcontent/Main.java
@@ -27,7 +27,7 @@ import io.helidon.reactive.webserver.staticcontent.StaticContentSupport;
  * on the WEB page.
  */
 public class Main {
-    private static final Http.HeaderValue UI_REDIRECT = Http.HeaderValue.createCached(Http.Header.LOCATION, "/ui");
+    private static final Http.HeaderValue UI_REDIRECT = Http.Header.createCached(Http.Header.LOCATION, "/ui");
 
     private Main() {
     }

--- a/examples/webserver/tutorial/src/main/java/io/helidon/reactive/webserver/examples/tutorial/CommentService.java
+++ b/examples/webserver/tutorial/src/main/java/io/helidon/reactive/webserver/examples/tutorial/CommentService.java
@@ -160,8 +160,8 @@ public class CommentService implements Service {
     }
 
     private static final class CommentWriter implements MessageBodyWriter<List<Comment>> {
-        private static final Http.HeaderValue CONTENT_TYPE_UTF_8 = Http.HeaderValue.createCached(Http.Header.CONTENT_TYPE,
-                                                                                           HttpMediaType.PLAINTEXT_UTF_8.text());
+        private static final Http.HeaderValue CONTENT_TYPE_UTF_8 = Http.Header.createCached(Http.Header.CONTENT_TYPE,
+                                                                                            HttpMediaType.PLAINTEXT_UTF_8.text());
 
         @Override
         public PredicateResult accept(GenericType<?> type, MessageBodyWriterContext context) {

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcProtocolHandler.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
-import io.helidon.common.http.Http.HeaderName;
 import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.WritableHeaders;
@@ -48,9 +47,8 @@ import io.grpc.Status;
 
 class GrpcProtocolHandler<REQ, RES> implements Http2SubProtocolProvider.SubProtocolHandler {
     private static final System.Logger LOGGER = System.getLogger(GrpcProtocolHandler.class.getName());
-    private static final HeaderValue GRPC_CONTENT_TYPE = Header.CONTENT_TYPE.withValue("application/grpc");
-    private static final HeaderName GRPC_ENCODING = Header.create("grpc-encoding");
-    private static final HeaderValue GRPC_ENCODING_IDENTITY = GRPC_ENCODING.withValue("identity");
+    private static final HeaderValue GRPC_CONTENT_TYPE = Header.createCached(Header.CONTENT_TYPE, "application/grpc");
+    private static final HeaderValue GRPC_ENCODING_IDENTITY = Header.createCached("grpc-encoding", "identity");
 
     private final HttpPrologue prologue;
     private final Http2Headers headers;

--- a/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcStatus.java
+++ b/nima/grpc/webserver/src/main/java/io/helidon/nima/grpc/webserver/GrpcStatus.java
@@ -37,11 +37,11 @@ public final class GrpcStatus {
     /**
      * The operation completed successfully.
      */
-    public static final HeaderValue OK = STATUS_NAME.withValue(Status.Code.OK.value());
+    public static final HeaderValue OK = Header.createCached(STATUS_NAME, Status.Code.OK.value());
     /**
      * The operation was cancelled (typically by the caller).
      */
-    public static final HeaderValue CANCELLED = STATUS_NAME.withValue(Status.Code.CANCELLED.value());
+    public static final HeaderValue CANCELLED = Header.createCached(STATUS_NAME, Status.Code.CANCELLED.value());
     /**
      * Unknown error.  An example of where this error may be returned is
      * if a Status value received from another address space belongs to
@@ -49,14 +49,14 @@ public final class GrpcStatus {
      * errors raised by APIs that do not return enough error information
      * may be converted to this error.
      */
-    public static final HeaderValue UNKNOWN = STATUS_NAME.withValue(Status.Code.UNKNOWN.value());
+    public static final HeaderValue UNKNOWN = Header.createCached(STATUS_NAME, Status.Code.UNKNOWN.value());
     /**
      * Client specified an invalid argument.  Note that this differs
      * from FAILED_PRECONDITION.  INVALID_ARGUMENT indicates arguments
      * that are problematic regardless of the state of the system
      * (e.g., a malformed file name).
      */
-    public static final HeaderValue INVALID_ARGUMENT = STATUS_NAME.withValue(Status.Code.INVALID_ARGUMENT.value());
+    public static final HeaderValue INVALID_ARGUMENT = Header.createCached(STATUS_NAME, Status.Code.INVALID_ARGUMENT.value());
     /**
      * Deadline expired before operation could complete.  For operations
      * that change the state of the system, this error may be returned
@@ -64,15 +64,15 @@ public final class GrpcStatus {
      * successful response from a server could have been delayed long
      * enough for the deadline to expire.
      */
-    public static final HeaderValue DEADLINE_EXCEEDED = STATUS_NAME.withValue(Status.Code.DEADLINE_EXCEEDED.value());
+    public static final HeaderValue DEADLINE_EXCEEDED = Header.createCached(STATUS_NAME, Status.Code.DEADLINE_EXCEEDED.value());
     /**
      * Some requested entity (e.g., file or directory) was not found.
      */
-    public static final HeaderValue NOT_FOUND = STATUS_NAME.withValue(Status.Code.NOT_FOUND.value());
+    public static final HeaderValue NOT_FOUND = Header.createCached(STATUS_NAME, Status.Code.NOT_FOUND.value());
     /**
      * Some entity that we attempted to create (e.g., file or directory) already exists.
      */
-    public static final HeaderValue ALREADY_EXISTS = STATUS_NAME.withValue(Status.Code.ALREADY_EXISTS.value());
+    public static final HeaderValue ALREADY_EXISTS = Header.createCached(STATUS_NAME, Status.Code.ALREADY_EXISTS.value());
     /**
      * The caller does not have permission to execute the specified
      * operation.  PERMISSION_DENIED must not be used for rejections
@@ -81,12 +81,12 @@ public final class GrpcStatus {
      * used if the caller cannot be identified (use UNAUTHENTICATED
      * instead for those errors).
      */
-    public static final HeaderValue PERMISSION_DENIED = STATUS_NAME.withValue(Status.Code.PERMISSION_DENIED.value());
+    public static final HeaderValue PERMISSION_DENIED = Header.createCached(STATUS_NAME, Status.Code.PERMISSION_DENIED.value());
     /**
      * Some resource has been exhausted, perhaps a per-user quota, or
      * perhaps the entire file system is out of space.
      */
-    public static final HeaderValue RESOURCE_EXHAUSTED = STATUS_NAME.withValue(Status.Code.RESOURCE_EXHAUSTED.value());
+    public static final HeaderValue RESOURCE_EXHAUSTED = Header.createCached(STATUS_NAME, Status.Code.RESOURCE_EXHAUSTED.value());
     /**
      * Operation was rejected because the system is not in a state
      * required for the operation's execution.  For example, directory
@@ -104,7 +104,8 @@ public final class GrpcStatus {
      * should be returned since the client should not retry unless
      * they have first fixed up the directory by deleting files from it.
      */
-    public static final HeaderValue FAILED_PRECONDITION = STATUS_NAME.withValue(Status.Code.FAILED_PRECONDITION.value());
+    public static final HeaderValue FAILED_PRECONDITION = Header.createCached(STATUS_NAME,
+                                                                              Status.Code.FAILED_PRECONDITION.value());
     /**
      * The operation was aborted, typically due to a concurrency issue
      * like sequencer check failures, transaction aborts, etc.
@@ -112,7 +113,7 @@ public final class GrpcStatus {
      * <p>See litmus test above for deciding between FAILED_PRECONDITION,
      * ABORTED, and UNAVAILABLE.
      */
-    public static final HeaderValue ABORTED = STATUS_NAME.withValue(Status.Code.ABORTED.value());
+    public static final HeaderValue ABORTED = Header.createCached(STATUS_NAME, Status.Code.ABORTED.value());
     /**
      * Operation was attempted past the valid range.  E.g., seeking or
      * reading past end of file.
@@ -129,17 +130,17 @@ public final class GrpcStatus {
      * so that callers who are iterating through
      * a space can easily look for an OUT_OF_RANGE error to detect when they are done.
      */
-    public static final HeaderValue OUT_OF_RANGE = STATUS_NAME.withValue(Status.Code.OUT_OF_RANGE.value());
+    public static final HeaderValue OUT_OF_RANGE = Header.createCached(STATUS_NAME, Status.Code.OUT_OF_RANGE.value());
     /**
      * Operation is not implemented or not supported/enabled in this service.
      */
-    public static final HeaderValue UNIMPLEMENTED = STATUS_NAME.withValue(Status.Code.UNIMPLEMENTED.value());
+    public static final HeaderValue UNIMPLEMENTED = Header.createCached(STATUS_NAME, Status.Code.UNIMPLEMENTED.value());
     /**
      * Internal errors.  Means some invariants expected by underlying
      * system has been broken.  If you see one of these errors,
      * something is very broken.
      */
-    public static final HeaderValue INTERNAL = STATUS_NAME.withValue(Status.Code.INTERNAL.value());
+    public static final HeaderValue INTERNAL = Header.createCached(STATUS_NAME, Status.Code.INTERNAL.value());
     /**
      * The service is currently unavailable.  This is a most likely a
      * transient condition and may be corrected by retrying with
@@ -149,16 +150,16 @@ public final class GrpcStatus {
      * <p>See litmus test above for deciding between FAILED_PRECONDITION,
      * ABORTED, and UNAVAILABLE.
      */
-    public static final HeaderValue UNAVAILABLE = STATUS_NAME.withValue(Status.Code.UNAVAILABLE.value());
+    public static final HeaderValue UNAVAILABLE = Header.createCached(STATUS_NAME, Status.Code.UNAVAILABLE.value());
     /**
      * Unrecoverable data loss or corruption.
      */
-    public static final HeaderValue DATA_LOSS = STATUS_NAME.withValue(Status.Code.DATA_LOSS.value());
+    public static final HeaderValue DATA_LOSS = Header.createCached(STATUS_NAME, Status.Code.DATA_LOSS.value());
     /**
      * The request does not have valid authentication credentials for the
      * operation.
      */
-    public static final HeaderValue UNAUTHENTICATED = STATUS_NAME.withValue(Status.Code.UNAUTHENTICATED.value());
+    public static final HeaderValue UNAUTHENTICATED = Header.createCached(STATUS_NAME, Status.Code.UNAUTHENTICATED.value());
 
     private GrpcStatus() {
     }

--- a/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
+++ b/nima/http/encoding/deflate/src/main/java/io/helidon/nima/http/encoding/deflate/DeflateEncodingProvider.java
@@ -33,10 +33,10 @@ import io.helidon.nima.http.encoding.spi.ContentEncodingProvider;
  */
 public class DeflateEncodingProvider implements ContentEncodingProvider {
     private static final Http.HeaderValue CONTENT_ENCODING_DEFLATE =
-            Http.HeaderValue.createCached(Http.Header.CONTENT_ENCODING,
-                                          false,
-                                          false,
-                                          "deflate");
+            Http.Header.createCached(Http.Header.CONTENT_ENCODING,
+                                     false,
+                                     false,
+                                     "deflate");
 
     @Override
     public Set<String> ids() {

--- a/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
+++ b/nima/http/encoding/gzip/src/main/java/io/helidon/nima/http/encoding/gzip/GzipEncodingProvider.java
@@ -38,7 +38,7 @@ import static io.helidon.common.http.Http.Header.CONTENT_LENGTH;
  * Support for gzip content encoding.
  */
 public class GzipEncodingProvider implements ContentEncodingProvider, Weighted {
-    private static final HeaderValue CONTENT_ENCODING_GZIP = HeaderValue.createCached(Http.Header.CONTENT_ENCODING,
+    private static final HeaderValue CONTENT_ENCODING_GZIP = Http.Header.createCached(Http.Header.CONTENT_ENCODING,
                                                                                       false,
                                                                                       false,
                                                                                       "gzip");

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/FormParamsSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/FormParamsSupportProvider.java
@@ -220,7 +220,7 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
 
     private static class FormParamsUrlWriter extends FormParamsWriter {
         private static final HeaderValue CONTENT_TYPE_URL_ENCODED =
-                HeaderValue.createCached(Http.Header.CONTENT_TYPE,
+                Http.Header.createCached(Http.Header.CONTENT_TYPE,
                                          HttpMediaType.create(MediaTypes.APPLICATION_FORM_URLENCODED)
                                                  .withCharset("utf-8")
                                                  .text());
@@ -235,7 +235,7 @@ public class FormParamsSupportProvider implements MediaSupportProvider {
 
     private static class FormParamsPlaintextWriter extends FormParamsWriter {
         private static final HeaderValue CONTENT_TYPE_TEXT =
-                HeaderValue.createCached(Http.Header.CONTENT_TYPE,
+                Http.Header.createCached(Http.Header.CONTENT_TYPE,
                                          HttpMediaType.create(MediaTypes.TEXT_PLAIN)
                                                  .withCharset("utf-8")
                                                  .text());

--- a/nima/http/media/media/src/main/java/io/helidon/nima/http/media/StringSupportProvider.java
+++ b/nima/http/media/media/src/main/java/io/helidon/nima/http/media/StringSupportProvider.java
@@ -88,7 +88,7 @@ public class StringSupportProvider implements MediaSupportProvider {
 
     private static final class StringWriter implements EntityWriter<String> {
 
-        private static final HeaderValue HEADER_PLAIN_TEXT = HeaderValue.createCached(Http.Header.CONTENT_TYPE,
+        private static final HeaderValue HEADER_PLAIN_TEXT = Http.Header.createCached(Http.Header.CONTENT_TYPE,
                                                                                       HttpMediaType.PLAINTEXT_UTF_8.text());
 
         @Override

--- a/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartWriter.java
+++ b/nima/http/media/multipart/src/main/java/io/helidon/nima/http/media/multipart/MultiPartWriter.java
@@ -37,7 +37,7 @@ class MultiPartWriter implements EntityWriter<WriteableMultiPart> {
 
     MultiPartWriter(MediaContext context, HttpMediaType mediaType, String boundary) {
         this.context = context;
-        this.contentType = Http.Header.CONTENT_TYPE.withValue(false, false, mediaType.text());
+        this.contentType = Http.Header.create(Http.Header.CONTENT_TYPE, false, false, mediaType.text());
         this.boundaryPrefix = ("--" + boundary).getBytes(StandardCharsets.UTF_8);
     }
 

--- a/nima/http2/http2/src/main/java/io/helidon/nima/http2/Http2Headers.java
+++ b/nima/http2/http2/src/main/java/io/helidon/nima/http2/Http2Headers.java
@@ -551,10 +551,10 @@ public class Http2Headers {
             }
 
             if (!isPseudoHeader) {
-                headers.add(HeaderValue.create(headerName,
-                                               !approach.addToIndex,
-                                               approach.neverIndex,
-                                               value));
+                headers.add(Header.create(headerName,
+                                          !approach.addToIndex,
+                                          approach.neverIndex,
+                                          value));
             }
             return isPseudoHeader;
         }

--- a/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
+++ b/nima/http2/webclient/src/main/java/io/helidon/nima/http2/webclient/ClientRequestImpl.java
@@ -117,7 +117,7 @@ class ClientRequestImpl implements Http2ClientRequest {
         } else {
             entityBytes = entityBytes(entity);
         }
-        headers.setIfAbsent(HeaderValue.create(Header.CONTENT_LENGTH, String.valueOf(entityBytes.length)));
+        headers.setIfAbsent(Header.create(Header.CONTENT_LENGTH, String.valueOf(entityBytes.length)));
 
         Http2Headers http2Headers = prepareHeaders(headers);
         stream.write(http2Headers, entityBytes.length == 0);

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2ServerResponse.java
@@ -85,11 +85,11 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         // handle content encoding
         byte[] bytes = entityBytes(entityBytes);
 
-        headers.setIfAbsent(HeaderValue.create(Header.CONTENT_LENGTH,
-                                               true,
-                                               false,
-                                               String.valueOf(bytes.length)));
-        headers.setIfAbsent(HeaderValue.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
+        headers.setIfAbsent(Header.create(Header.CONTENT_LENGTH,
+                                          true,
+                                          false,
+                                          String.valueOf(bytes.length)));
+        headers.setIfAbsent(Header.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
 
         Http2Headers http2Headers = Http2Headers.create(headers);
         http2Headers.status(status());
@@ -242,13 +242,13 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
                 headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
                 contentLength = 0;
             } else {
-                headers.set(HeaderValue.create(Header.CONTENT_LENGTH,
-                                               true,
-                                               false,
-                                               String.valueOf(firstBuffer.available())));
+                headers.set(Header.create(Header.CONTENT_LENGTH,
+                                          true,
+                                          false,
+                                          String.valueOf(firstBuffer.available())));
                 contentLength = firstBuffer.available();
             }
-            headers.setIfAbsent(HeaderValue.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
+            headers.setIfAbsent(Header.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
 
             Http2Headers http2Headers = Http2Headers.create(headers);
             http2Headers.status(status);
@@ -278,7 +278,7 @@ class Http2ServerResponse extends ServerResponseBase<Http2ServerResponse> {
         }
 
         private void sendHeadersAndPrepare() {
-            headers.setIfAbsent(HeaderValue.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
+            headers.setIfAbsent(Header.create(Header.DATE, true, false, Http.DateTime.rfc1123String()));
 
             Http2Headers http2Headers = Http2Headers.create(headers);
             http2Headers.validateResponse();

--- a/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
+++ b/nima/http2/webserver/src/main/java/io/helidon/nima/http2/webserver/Http2Stream.java
@@ -26,7 +26,6 @@ import io.helidon.common.buffers.BufferData;
 import io.helidon.common.http.DirectHandler;
 import io.helidon.common.http.Headers;
 import io.helidon.common.http.Http.Header;
-import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.RequestException;
 import io.helidon.common.http.ServerResponseHeaders;
@@ -277,7 +276,7 @@ public class Http2Stream implements Runnable, io.helidon.nima.http2.Http2Stream 
             ServerResponseHeaders headers = response.headers();
             byte[] message = response.entity().orElse(BufferData.EMPTY_BYTES);
             if (message.length != 0) {
-                headers.set(HeaderValue.create(Header.CONTENT_LENGTH, String.valueOf(message.length)));
+                headers.set(Header.create(Header.CONTENT_LENGTH, String.valueOf(message.length)));
             }
             Http2Headers http2Headers = Http2Headers.create(headers);
             if (message.length == 0) {

--- a/nima/tests/benchmark/h2/src/main/java/io/helidon/nima/tests/benchmark/h2/Main.java
+++ b/nima/tests/benchmark/h2/src/main/java/io/helidon/nima/tests/benchmark/h2/Main.java
@@ -89,10 +89,10 @@ public class Main {
     }
 
     private static class PlaintextHandler implements Handler {
-        private static final HeaderValue CONTENT_TYPE = HeaderValue.createCached(Header.CONTENT_TYPE,
-                                                                                 "text/plain; charset=UTF-8");
-        private static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH, "13");
-        private static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "NIMA");
+        private static final HeaderValue CONTENT_TYPE = Header.createCached(Header.CONTENT_TYPE,
+                                                                            "text/plain; charset=UTF-8");
+        private static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH, "13");
+        private static final HeaderValue SERVER = Header.createCached(Header.SERVER, "NIMA");
 
         private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
 

--- a/nima/tests/benchmark/jmh/src/main/java/io/helidon/nima/tests/benchmark/jmh/HttpJmhTest.java
+++ b/nima/tests/benchmark/jmh/src/main/java/io/helidon/nima/tests/benchmark/jmh/HttpJmhTest.java
@@ -43,10 +43,10 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
 public class HttpJmhTest {
-    private static final HeaderValue CONTENT_TYPE = HeaderValue.createCached(Header.CONTENT_TYPE,
-                                                                             "text/plain; charset=UTF-8");
-    private static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH, "13");
-    private static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+    private static final HeaderValue CONTENT_TYPE = Header.createCached(Header.CONTENT_TYPE,
+                                                                        "text/plain; charset=UTF-8");
+    private static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH, "13");
+    private static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
     private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     private WebServer server;
     private int serverPort;

--- a/nima/tests/benchmark/techempower/src/main/java/io/helidon/nima/tests/benchmark/techempower/TechEmpowerMain.java
+++ b/nima/tests/benchmark/techempower/src/main/java/io/helidon/nima/tests/benchmark/techempower/TechEmpowerMain.java
@@ -78,10 +78,10 @@ public final class TechEmpowerMain {
     }
 
     static class PlaintextHandler implements Handler {
-        static final HeaderValue CONTENT_TYPE = HeaderValue.createCached(Header.CONTENT_TYPE,
-                                                                         "text/plain; charset=UTF-8");
-        static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH, "13");
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue CONTENT_TYPE = Header.createCached(Header.CONTENT_TYPE,
+                                                                    "text/plain; charset=UTF-8");
+        static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH, "13");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
 
         private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
 
@@ -95,11 +95,11 @@ public final class TechEmpowerMain {
     }
 
     static class JsonHandler implements Handler {
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
         private static final String MESSAGE = "Hello, World!";
         private static final int JSON_LENGTH = serializeMsg(new Message(MESSAGE)).length;
-        static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH,
-                                                                           String.valueOf(JSON_LENGTH));
+        static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH,
+                                                                      String.valueOf(JSON_LENGTH));
 
         @Override
         public void handle(ServerRequest req, ServerResponse res) {
@@ -115,15 +115,15 @@ public final class TechEmpowerMain {
     }
 
     static class JsonKHandler implements Handler {
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
         private final HeaderValue contentLength;
         private final String message;
 
         JsonKHandler(int kilobytes) {
             this.message = "a".repeat(1024 * kilobytes);
             int length = serializeMsg(new Message(message)).length;
-            this.contentLength = HeaderValue.createCached(Header.CONTENT_LENGTH,
-                                                          String.valueOf(length));
+            this.contentLength = Header.createCached(Header.CONTENT_LENGTH,
+                                                     String.valueOf(length));
         }
 
         @Override

--- a/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/GetTest.java
+++ b/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/GetTest.java
@@ -55,7 +55,8 @@ class GetTest {
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
     private static final HeaderName REQUEST_HEADER_NAME = Header.create(REQUEST_HEADER_NAME_STRING);
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create(RESPONSE_HEADER_NAME_STRING);
-    private static final HeaderValue RESPONSE_HEADER_VALUE = RESPONSE_HEADER_NAME.withValue(RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.createCached(RESPONSE_HEADER_NAME,
+                                                                                 RESPONSE_HEADER_VALUE_STRING);
 
     static {
         Random random = new Random();

--- a/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/Http2ClientTest.java
+++ b/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/Http2ClientTest.java
@@ -46,7 +46,7 @@ class Http2ClientTest {
     public static final String MESSAGE = "Hello World!";
     private static final String TEST_HEADER_NAME = "custom_header";
     private static final String TEST_HEADER_VALUE = "as!fd";
-    private static final HeaderValue TEST_HEADER = HeaderValue.create(Header.create(TEST_HEADER_NAME), TEST_HEADER_VALUE);
+    private static final HeaderValue TEST_HEADER = Header.create(Header.create(TEST_HEADER_NAME), TEST_HEADER_VALUE);
 
     private final Http1Client http1Client;
     private final Http2Client tlsClient;

--- a/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/PostTest.java
+++ b/nima/tests/integration/http2/client/src/test/java/io/helidon/nima/tests/integration/http2/client/PostTest.java
@@ -54,11 +54,11 @@ class PostTest {
     private static final byte[] BYTES = new byte[256];
     private static final HeaderName REQUEST_HEADER_NAME = Header.create("X-REquEst-HEADeR");
     private static final String REQUEST_HEADER_VALUE_STRING = "some nice value";
-    private static final HeaderValue REQUEST_HEADER_VALUE = REQUEST_HEADER_NAME.withValue(REQUEST_HEADER_VALUE_STRING);
+    private static final HeaderValue REQUEST_HEADER_VALUE = Header.createCached(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create("X-REsponSE-HeADER");
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
-    private static final HeaderValue RESPONSE_HEADER_VALUE = HeaderValue.create(RESPONSE_HEADER_NAME,
-                                                                                RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.create(RESPONSE_HEADER_NAME,
+                                                                           RESPONSE_HEADER_VALUE_STRING);
 
     private static WebServer server;
     private static Http2ClientRequest request;

--- a/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/GetTest.java
+++ b/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/GetTest.java
@@ -50,8 +50,8 @@ class GetTest {
     private static final String REQUEST_HEADER_VALUE = "some nice value";
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create("X-REsponSE-HeADER");
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
-    private static final HeaderValue RESPONSE_HEADER_VALUE = HeaderValue.create(RESPONSE_HEADER_NAME,
-                                                                                RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.create(RESPONSE_HEADER_NAME,
+                                                                           RESPONSE_HEADER_VALUE_STRING);
 
     static {
         Random random = new Random();

--- a/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/Http2ServerTest.java
+++ b/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/Http2ServerTest.java
@@ -53,7 +53,7 @@ class Http2ServerTest {
     public static final String MESSAGE = "Hello World!";
     private static final String TEST_HEADER_NAME = "custom_header";
     private static final String TEST_HEADER_VALUE = "as!fd";
-    private static final HeaderValue TEST_HEADER = HeaderValue.create(Header.create(TEST_HEADER_NAME), TEST_HEADER_VALUE);
+    private static final HeaderValue TEST_HEADER = Header.create(Header.create(TEST_HEADER_NAME), TEST_HEADER_VALUE);
     private final int plainPort;
     private final int tlsPort;
     private final Http1Client http1Client;

--- a/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/PostTest.java
+++ b/nima/tests/integration/http2/server/src/test/java/io/helidon/nima/tests/integration/http2/webserver/PostTest.java
@@ -50,11 +50,11 @@ class PostTest {
     private static final byte[] BYTES = new byte[256];
     private static final HeaderName REQUEST_HEADER_NAME = Header.create("X-REquEst-HEADeR");
     private static final String REQUEST_HEADER_VALUE_STRING = "some nice value";
-    private static final HeaderValue REQUEST_HEADER_VALUE = HeaderValue.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
+    private static final HeaderValue REQUEST_HEADER_VALUE = Header.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create("X-REsponSE-HeADER");
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
-    private static final HeaderValue RESPONSE_HEADER_VALUE = HeaderValue.create(RESPONSE_HEADER_NAME,
-                                                                                RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.create(RESPONSE_HEADER_NAME,
+                                                                           RESPONSE_HEADER_VALUE_STRING);
 
     static {
         Random random = new Random();

--- a/nima/tests/integration/media/string/src/test/java/io/helidon/nima/tests/integration/media/string/StringTest.java
+++ b/nima/tests/integration/media/string/src/test/java/io/helidon/nima/tests/integration/media/string/StringTest.java
@@ -39,8 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class StringTest {
     private static final HttpMediaType TEXT_ISO_8859_2 = HttpMediaType.create(MediaTypes.TEXT_PLAIN)
             .withCharset("ISO-8859-2");
-    private static final HeaderValue ISO_8859_CONTENT_TYPE = HeaderValue.create(Header.CONTENT_TYPE,
-                                                                                TEXT_ISO_8859_2.text());
+    private static final HeaderValue ISO_8859_CONTENT_TYPE = Header.create(Header.CONTENT_TYPE,
+                                                                           TEXT_ISO_8859_2.text());
     private static final String UTF_8_TEXT = "český řízný text";
 
     private final Http1Client client;

--- a/nima/tests/integration/webserver/access-log/src/test/java/io/helidon/nima/tests/integration/server/accesslog/AccessLogTest.java
+++ b/nima/tests/integration/webserver/access-log/src/test/java/io/helidon/nima/tests/integration/server/accesslog/AccessLogTest.java
@@ -81,7 +81,7 @@ class AccessLogTest {
         assertThat(response.status(), is(Http.Status.NOT_FOUND_404));
 
         response = client.get("/access")
-                .header(Http.HeaderValue.create(Http.Header.CONTENT_LENGTH, "47a"))
+                .header(Http.Header.create(Http.Header.CONTENT_LENGTH, "47a"))
                 .request();
 
         assertThat(response.status(), is(Http.Status.BAD_REQUEST_400));

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/BadRequestTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/BadRequestTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class BadRequestTest {
     public static final String CUSTOM_REASON_PHRASE = "Custom-bad-request";
     public static final String CUSTOM_ENTITY = "There we go";
-    private static final Http.HeaderValue LOCATION_ERROR_PAGE = Http.HeaderValue.create(Header.LOCATION, "/errorPage");
+    private static final Http.HeaderValue LOCATION_ERROR_PAGE = Header.create(Header.LOCATION, "/errorPage");
 
     private final Http1Client client;
     private final SocketHttpClient socketClient;

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ConfiguredLimitsTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ConfiguredLimitsTest.java
@@ -126,7 +126,7 @@ class ConfiguredLimitsTest {
         String headerValue = "m".repeat(size);
 
         try (Http1ClientResponse response = client.get("any")
-                .header(CUSTOM_HEADER.withValue(headerValue))
+                .header(Header.create(CUSTOM_HEADER, headerValue))
                 .request()) {
             if (success) {
                 assertThat("Header of size " + size + " should have passed",

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/FormParamsSupportTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/FormParamsSupportTest.java
@@ -62,7 +62,7 @@ class FormParamsSupportTest {
     void urlEncodedTest() {
         String result = client.method(Http.Method.PUT)
                 .path("/params")
-                .header(Header.CONTENT_TYPE.withValue(MediaTypes.APPLICATION_FORM_URLENCODED.fullType()))
+                .header(Header.CONTENT_TYPE, MediaTypes.APPLICATION_FORM_URLENCODED.text())
                 .submit("key1=val+1&key2=val2_1&key2=val2_2")
                 .as(String.class);
 

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/GetTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/GetTest.java
@@ -48,11 +48,12 @@ class GetTest {
     private static final byte[] BYTES = new byte[256];
     private static final HeaderName REQUEST_HEADER_NAME = Header.create("X-REquEst-HEADeR");
     private static final String REQUEST_HEADER_VALUE_STRING = "some nice value";
-    private static final HeaderValue REQUEST_HEADER_VALUE = HeaderValue.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
+    private static final HeaderValue REQUEST_HEADER_VALUE = Header.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create("X-REsponSE-HeADER");
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
-    private static final HeaderValue RESPONSE_HEADER_VALUE = HeaderValue.create(RESPONSE_HEADER_NAME,
-                                                                                RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.create(RESPONSE_HEADER_NAME,
+                                                                           RESPONSE_HEADER_VALUE_STRING);
+    public static final HeaderValue CONTENT_LENGTH_5 = Header.create(CONTENT_LENGTH, "5");
 
     static {
         Random random = new Random();
@@ -83,7 +84,7 @@ class GetTest {
             String entity = response.entity().as(String.class);
             assertThat(entity, is("Hello"));
             Headers headers = response.headers();
-            assertThat(headers, hasHeader(CONTENT_LENGTH.withValue("5")));
+            assertThat(headers, hasHeader(CONTENT_LENGTH_5));
             assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
         }
     }
@@ -97,7 +98,7 @@ class GetTest {
             byte[] entity = response.entity().as(byte[].class);
             assertThat(entity, is(BYTES));
             Headers headers = response.headers();
-            assertThat(headers, hasHeader(CONTENT_LENGTH.withValue(String.valueOf(BYTES.length))));
+            assertThat(headers, hasHeader(Header.create(CONTENT_LENGTH, String.valueOf(BYTES.length))));
             assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
         }
     }
@@ -131,7 +132,7 @@ class GetTest {
 
             assertThat("Should contain echoed request header", headers, hasHeader(REQUEST_HEADER_VALUE));
             assertThat("Should contain configured response header", headers, hasHeader(RESPONSE_HEADER_VALUE));
-            assertThat(headers, hasHeader(CONTENT_LENGTH.withValue("5")));
+            assertThat(headers, hasHeader(CONTENT_LENGTH_5));
             assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
         }
     }
@@ -145,7 +146,7 @@ class GetTest {
             String entity = response.entity().as(String.class);
             assertThat(entity, is("Hello"));
             Headers headers = response.headers();
-            assertThat(headers, hasHeader(CONTENT_LENGTH.withValue("5")));
+            assertThat(headers, hasHeader(CONTENT_LENGTH_5));
             assertThat(headers, hasHeader(HeaderValues.CONNECTION_CLOSE));
         }
     }

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MaxPayloadSizeTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MaxPayloadSizeTest.java
@@ -77,7 +77,7 @@ class MaxPayloadSizeTest {
     @Test
     void testContentLengthExceeded() {
         try (Http1ClientResponse response = client.method(Http.Method.POST)
-                .header(Header.CONTENT_LENGTH.withValue("512"))
+                .header(Header.CONTENT_LENGTH, "512")
                 .path("/maxpayload")
                 .header(HeaderValues.CONTENT_TYPE_OCTET_STREAM)
                 .request()) {

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MultiPortTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/MultiPortTest.java
@@ -147,11 +147,11 @@ class MultiPortTest {
                     router.addRouting(HttpRouting.builder()
                                               .any((req, res) -> {
                                                   res.status(Http.Status.MOVED_PERMANENTLY_301)
-                                                          .header(Header.LOCATION.withValue(
+                                                          .header(Header.LOCATION,
                                                                   String.format("http://%s:%s%s",
                                                                                 host(req.authority()),
                                                                                 server.port(),
-                                                                                req.path().absolute().rawPathNoParams())))
+                                                                                req.path().absolute().rawPathNoParams()))
                                                           .send();
                                               }));
                 })
@@ -163,7 +163,7 @@ class MultiPortTest {
                 .request()) {
             assertThat(response.status(), is(Http.Status.MOVED_PERMANENTLY_301));
             assertThat(response.headers(),
-                       hasHeader(Header.LOCATION.withValue("http://localhost:" + server.port() + "/foo")));
+                       hasHeader(Header.create(Header.LOCATION, "http://localhost:" + server.port() + "/foo")));
         }
     }
 

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/PostTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/PostTest.java
@@ -51,11 +51,11 @@ class PostTest {
     private static final byte[] BYTES = new byte[256];
     private static final HeaderName REQUEST_HEADER_NAME = Header.create("X-REquEst-HEADeR");
     private static final String REQUEST_HEADER_VALUE_STRING = "some nice value";
-    private static final HeaderValue REQUEST_HEADER_VALUE = HeaderValue.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
+    private static final HeaderValue REQUEST_HEADER_VALUE = Header.create(REQUEST_HEADER_NAME, REQUEST_HEADER_VALUE_STRING);
     private static final HeaderName RESPONSE_HEADER_NAME = Header.create("X-REsponSE-HeADER");
     private static final String RESPONSE_HEADER_VALUE_STRING = "another nice value";
-    private static final HeaderValue RESPONSE_HEADER_VALUE = HeaderValue.create(RESPONSE_HEADER_NAME,
-                                                                                RESPONSE_HEADER_VALUE_STRING);
+    private static final HeaderValue RESPONSE_HEADER_VALUE = Header.create(RESPONSE_HEADER_NAME,
+                                                                           RESPONSE_HEADER_VALUE_STRING);
 
     static {
         Random random = new Random();
@@ -89,7 +89,7 @@ class PostTest {
             assertThat(entity, is("Hello"));
             headers = response.headers();
         }
-        assertThat(headers, hasHeader(CONTENT_LENGTH.withValue("5")));
+        assertThat(headers, hasHeader(Header.create(CONTENT_LENGTH, "5")));
         assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
     }
 
@@ -105,7 +105,7 @@ class PostTest {
             assertThat(entity, is(BYTES));
             headers = response.headers();
         }
-        assertThat(headers, hasHeader(CONTENT_LENGTH.withValue(String.valueOf(BYTES.length))));
+        assertThat(headers, hasHeader(Header.create(CONTENT_LENGTH, String.valueOf(BYTES.length))));
         assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
     }
 
@@ -142,7 +142,7 @@ class PostTest {
             assertThat(entity, is("Hello"));
             headers = response.headers();
         }
-        assertThat(headers, hasHeader(CONTENT_LENGTH.withValue("5")));
+        assertThat(headers, hasHeader(Header.create(CONTENT_LENGTH, "5")));
         assertThat(headers, hasHeader(HeaderValues.CONNECTION_KEEP_ALIVE));
         assertThat(headers, hasHeader(REQUEST_HEADER_VALUE));
         assertThat(headers, hasHeader(RESPONSE_HEADER_VALUE));

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ReroutingAndNextingTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/ReroutingAndNextingTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @ServerTest
 class ReroutingAndNextingTest {
-    private static final HeaderValue NEXTED_HEADER = Header.create("NEXTED").withValue("yes");
+    private static final HeaderValue NEXTED_HEADER = Header.create(Header.create("NEXTED"), "yes");
 
     private final Http1Client client;
 

--- a/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/TransferEncodingTest.java
+++ b/nima/tests/integration/webserver/webserver/src/test/java/io/helidon/nima/tests/integration/server/TransferEncodingTest.java
@@ -39,7 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @ServerTest
 class TransferEncodingTest {
-    private static final Http.HeaderValue CONTENT_LENGTH_NINE = Http.HeaderValue.create(Header.CONTENT_LENGTH, "9");
+    private static final Http.HeaderValue CONTENT_LENGTH_NINE = Header.create(Header.CONTENT_LENGTH, "9");
     private final SocketHttpClient socketHttpClient;
 
     TransferEncodingTest(SocketHttpClient socketHttpClient) {
@@ -50,7 +50,7 @@ class TransferEncodingTest {
     static void routing(HttpRules rules) {
         rules.get("/length", (req, res) -> {
                     String payload = "It works!";
-                    res.headers().add(Header.CONTENT_LENGTH.withValue(payload.length()));
+                    res.contentLength(payload.length());
                     res.send(payload);
                 })
                 .get("/chunked", (req, res) -> {

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/ClientRequest.java
@@ -77,6 +77,17 @@ public interface ClientRequest<B extends ClientRequest<B, R>, R extends ClientRe
     B header(Http.HeaderValue header);
 
     /**
+     * Set an HTTP header.
+     *
+     * @param name  header name
+     * @param value header value
+     * @return updated request
+     */
+    default B header(Http.HeaderName name, String value) {
+        return header(Http.Header.create(name, true, false, value));
+    }
+
+    /**
      * Replace a placeholder in URI with an actual value.
      *
      * @param name  name of parameter

--- a/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
+++ b/nima/webclient/webclient/src/main/java/io/helidon/nima/webclient/http1/ClientRequestImpl.java
@@ -154,7 +154,7 @@ class ClientRequestImpl implements Http1ClientRequest {
         // I have a valid connection
         prologue(writeBuffer);
 
-        headers.setIfAbsent(HeaderValue.create(Header.HOST, uri.authority()));
+        headers.setIfAbsent(Header.create(Header.HOST, uri.authority()));
 
         byte[] entityBytes;
         if (entity == BufferData.EMPTY_BYTES) {
@@ -163,7 +163,7 @@ class ClientRequestImpl implements Http1ClientRequest {
             entityBytes = entityBytes(entity, headers);
         }
 
-        headers.setIfAbsent(HeaderValue.create(Header.CONTENT_LENGTH, String.valueOf(entityBytes.length)));
+        headers.setIfAbsent(Header.create(Header.CONTENT_LENGTH, String.valueOf(entityBytes.length)));
 
         writeHeaders(headers, writeBuffer);
         if (entityBytes.length > 0) {
@@ -189,7 +189,7 @@ class ClientRequestImpl implements Http1ClientRequest {
         writeBuffer.clear();
         prologue(writeBuffer);
 
-        headers.setIfAbsent(HeaderValue.create(Header.HOST, uri.authority()));
+        headers.setIfAbsent(Header.create(Header.HOST, uri.authority()));
         // hardcoded chunked encoding, as we have an output stream
         // todo we may optimize small amounts
         boolean chunked = false;

--- a/nima/webserver/access-log/src/test/java/io/helidon/nima/webserver/accesslog/AccessLogFilterTest.java
+++ b/nima/webserver/access-log/src/test/java/io/helidon/nima/webserver/accesslog/AccessLogFilterTest.java
@@ -20,6 +20,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.ServerRequestHeaders;
 import io.helidon.common.http.WritableHeaders;
@@ -52,7 +53,7 @@ class AccessLogFilterTest {
     private static final int STATUS_CODE = Http.Status.I_AM_A_TEAPOT_418.code();
     private static final String CONTENT_LENGTH = "0";
     private static final long TIME_TAKEN_MICROS = 1140000;
-    private static final Http.HeaderValue REFERER_HEADER = Http.Header.REFERER.withValue("first", "second");
+    private static final Http.HeaderValue REFERER_HEADER = Header.create(Header.REFERER, "first", "second");
 
     @Test
     void testHelidonFormat() {

--- a/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/AbstractCorsTest.java
+++ b/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/AbstractCorsTest.java
@@ -72,16 +72,16 @@ abstract class AbstractCorsTest extends CorsRouting {
     void test1PreFlightAllowedHeaders1() {
         try (Http1ClientResponse response = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_1))
-                .header(ORIGIN.withValue("http://foo.bar"))
-                .header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"))
-                .header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo"))
+                .header(ORIGIN, "http://foo.bar")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
+                .header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo")
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_HEADERS.withValue("X-foo")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE.withValue("3600")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_HEADERS, "X-foo"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE, "3600"));
         }
     }
 
@@ -89,18 +89,18 @@ abstract class AbstractCorsTest extends CorsRouting {
     void test1PreFlightAllowedHeaders2() {
         try (Http1ClientResponse response = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_1))
-                .header(ORIGIN.withValue("http://foo.bar"))
-                .header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"))
-                .header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar"))
+                .header(ORIGIN, "http://foo.bar")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
+                .header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar")
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_HEADERS));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).values(), containsString("X-foo"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).values(), containsString("X-bar"));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE.withValue("3600")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE, "3600"));
         }
     }
 
@@ -109,8 +109,8 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http.Status status;
         try (Http1ClientResponse response = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2))
-                .header(ORIGIN.withValue("http://not.allowed"))
-                .header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"))
+                .header(ORIGIN, "http://not.allowed")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
                 .request()) {
 
             status = response.status();
@@ -124,15 +124,15 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2));
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
 
         try (Http1ClientResponse response = request.request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS.withValue("true")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_ALLOW_HEADERS));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_ALLOW_HEADERS));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
@@ -144,8 +144,8 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2));
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("POST"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "POST");
 
         Http.Status status;
         try (Http1ClientResponse response = request.request()) {
@@ -160,9 +160,9 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2));
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
-        request.header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar, X-oops"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        request.header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar, X-oops");
 
         try (Http1ClientResponse response = request.request()) {
             Http.Status status = response.status();
@@ -176,9 +176,9 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(contextRoot(), SERVICE_2));
 
-        request.header(ORIGIN.withValue(fooOrigin()));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
-        request.header(ACCESS_CONTROL_REQUEST_HEADERS.withValue(fooHeader()));
+        request.header(ORIGIN, fooOrigin());
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        request.header(ACCESS_CONTROL_REQUEST_HEADERS, fooHeader());
 
         try (Http1ClientResponse response = request.request()) {
 
@@ -200,16 +200,16 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2));
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
-        request.header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        request.header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar");
 
         try (Http1ClientResponse response = request.request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS.withValue("true")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-foo"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-bar"));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
@@ -221,17 +221,17 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(SERVICE_2));
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
-        request.header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar"));
-        request.header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
+        request.header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar");
+        request.header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar");
 
         try (Http1ClientResponse response = request.request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS.withValue("true")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-foo"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).value(), containsString("X-bar"));
             assertThat(response.headers(), noHeader(ACCESS_CONTROL_MAX_AGE));
@@ -244,13 +244,13 @@ abstract class AbstractCorsTest extends CorsRouting {
                 .uri(TestUtil.path(SERVICE_1))
                 .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
+        request.header(ORIGIN, "http://foo.bar");
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
 
         try (ClientResponse response = request.submit("")) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("*")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "*"));
         }
     }
 
@@ -260,13 +260,13 @@ abstract class AbstractCorsTest extends CorsRouting {
                 .uri(TestUtil.path(SERVICE_2))
                 .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
+        request.header(ORIGIN, "http://foo.bar");
 
         try (ClientResponse response = request.submit("")) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS.withValue("true")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
         }
     }
 
@@ -275,7 +275,7 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().get(TestUtil.path(SERVICE_2) + "/notfound")
                 .header(HeaderValues.CONTENT_TYPE_TEXT_PLAIN);
 
-        request.header(ORIGIN.withValue("http://foo.bar"));
+        request.header(ORIGIN, "http://foo.bar");
 
         try (ClientResponse response = request.request()) {
 
@@ -288,8 +288,8 @@ abstract class AbstractCorsTest extends CorsRouting {
         Http1ClientRequest request = client().method(Http.Method.OPTIONS)
                 .uri(TestUtil.path(contextRoot(), SERVICE_1));
 
-        request.header(ORIGIN.withValue(fooOrigin()));
-        request.header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"));
+        request.header(ORIGIN, fooOrigin());
+        request.header(ACCESS_CONTROL_REQUEST_METHOD, "PUT");
 
         return request.request();
     }

--- a/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/CorsTest.java
+++ b/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/CorsTest.java
@@ -66,10 +66,10 @@ class CorsTest extends AbstractCorsTest {
         ClientResponse response = runTest1PreFlightAllowedOrigin();
 
         assertThat(response.status(), is(Http.Status.OK_200));
-        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue(origin)));
-        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin));
+        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
         assertThat(response.headers(), noHeader(ACCESS_CONTROL_ALLOW_HEADERS));
-        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE.withValue("3600")));
+        assertThat(response.headers(), hasHeader(ACCESS_CONTROL_MAX_AGE, "3600"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).allValues().size(), is(1));
     }
 }

--- a/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/TestDefaultCorsSupport.java
+++ b/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/TestDefaultCorsSupport.java
@@ -84,12 +84,12 @@ class TestDefaultCorsSupport {
                     .build();
 
             try (ClientResponse response = client.get("/greet")
-                    .header(Header.ORIGIN.withValue("http://foo.com"))
-                    .header(Header.HOST.withValue("bar.com"))
+                    .header(Header.ORIGIN, "http://foo.com")
+                    .header(Header.HOST, "bar.com")
                     .request()) {
 
                 Headers headers = response.headers();
-                assertThat(headers, hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("*")));
+                assertThat(headers, hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "*"));
             }
         } finally {
             if (server != null) {
@@ -111,8 +111,8 @@ class TestDefaultCorsSupport {
                     .build();
 
             try (ClientResponse response = client.get("/greet")
-                    .header(Header.ORIGIN.withValue("http://foo.com"))
-                    .header(Header.HOST.withValue("bar.com"))
+                    .header(Header.ORIGIN, "http://foo.com")
+                    .header(Header.HOST, "bar.com")
                     .request()) {
 
                 assertThat(response.headers(), noHeader(ACCESS_CONTROL_ALLOW_ORIGIN));

--- a/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/TestHandlerRegistration.java
+++ b/nima/webserver/cors/src/test/java/io/helidon/nima/webserver/cors/TestHandlerRegistration.java
@@ -48,14 +48,14 @@ class TestHandlerRegistration extends CorsRouting {
     void test4PreFlightAllowedHeaders2() {
         try (ClientResponse response = client.method(Http.Method.OPTIONS)
                 .uri(CORS4_CONTEXT_ROOT)
-                .header(ORIGIN.withValue("http://foo.bar"))
-                .header(ACCESS_CONTROL_REQUEST_METHOD.withValue("PUT"))
-                .header(ACCESS_CONTROL_REQUEST_HEADERS.withValue("X-foo, X-bar"))
+                .header(ORIGIN, "http://foo.bar")
+                .header(ACCESS_CONTROL_REQUEST_METHOD, "PUT")
+                .header(ACCESS_CONTROL_REQUEST_HEADERS, "X-foo, X-bar")
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN.withValue("http://foo.bar")));
-            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS.withValue("PUT")));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "http://foo.bar"));
+            assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_METHODS, "PUT"));
             assertThat(response.headers(), hasHeader(ACCESS_CONTROL_ALLOW_HEADERS));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).values(), containsString("X-foo"));
             assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).values(), containsString("X-bar"));

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/ByteRangeRequest.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/ByteRangeRequest.java
@@ -73,16 +73,16 @@ record ByteRangeRequest(long fileLength, long offset, long length) {
         // Content-Range: bytes 0-1023/146515
         // Content-Length: 1024
         long last = (offset + length) - 1;
-        response.header(Header.CONTENT_RANGE.withValue(true,
+        response.header(Header.create(Header.CONTENT_RANGE, true,
                                                        false,
                                                        "bytes " + offset + "-" + last + "/" + fileLength));
-        response.header(Header.CONTENT_LENGTH.withValue(true, false, String.valueOf(length)));
+        response.contentLength(length);
         response.status(Http.Status.PARTIAL_CONTENT_206);
     }
 
     private static ByteRangeRequest create(ServerRequest req, ServerResponse res, long offset, long last, long fileLength) {
         if (offset >= fileLength || last < offset) {
-            res.header(Header.CONTENT_RANGE.withValue("*/" + fileLength));
+            res.header(Header.CONTENT_RANGE, "*/" + fileLength);
             throw new HttpException("Wrong range", Http.Status.REQUESTED_RANGE_NOT_SATISFIABLE_416, true);
         }
 

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileBasedContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/FileBasedContentHandler.java
@@ -144,7 +144,7 @@ abstract class FileBasedContentHandler extends StaticContentHandler {
     }
 
     void processContentLength(Path path, ServerResponseHeaders headers) {
-        headers.set(Header.CONTENT_LENGTH.withValue(String.valueOf(contentLength(path))));
+        headers.set(Header.create(Header.CONTENT_LENGTH, contentLength(path)));
     }
 
     long contentLength(Path path) {

--- a/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/StaticContentHandler.java
+++ b/nima/webserver/static-content/src/main/java/io/helidon/nima/webserver/staticcontent/StaticContentHandler.java
@@ -69,7 +69,7 @@ abstract class StaticContentHandler implements StaticContentSupport {
         }
         etag = unquoteETag(etag);
         // Put ETag into the response
-        responseHeaders.set(Header.ETAG.withValue('"' + etag + '"'));
+        responseHeaders.set(Header.ETAG, '"' + etag + '"');
         // Process If-None-Match header
         if (requestHeaders.contains(Header.IF_NONE_MATCH)) {
             List<String> ifNoneMatches = requestHeaders.get(Header.IF_NONE_MATCH).allValues();
@@ -163,7 +163,7 @@ abstract class StaticContentHandler implements StaticContentSupport {
         }
 
         response.status(Http.Status.MOVED_PERMANENTLY_301);
-        response.header(Header.LOCATION.withValue(locationWithQuery));
+        response.header(Header.LOCATION, locationWithQuery);
         response.send();
     }
 

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/ByteRangeRequestTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/ByteRangeRequestTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class ByteRangeRequestTest {
     @Test
     void testFromUntilEnd() {
-        HeaderValue header = Header.RANGE.withValue("bytes=49-");
+        HeaderValue header = Header.create(Header.RANGE, "bytes=49-");
         ServerRequest req = Mockito.mock(ServerRequest.class);
         ServerResponse res = Mockito.mock(ServerResponse.class);
 
@@ -48,7 +48,7 @@ class ByteRangeRequestTest {
 
     @Test
     void testFromUntil() {
-        HeaderValue header = Header.RANGE.withValue("bytes=49-49");
+        HeaderValue header = Header.create(Header.RANGE, "bytes=49-49");
         ServerRequest req = Mockito.mock(ServerRequest.class);
         ServerResponse res = Mockito.mock(ServerResponse.class);
 
@@ -63,7 +63,7 @@ class ByteRangeRequestTest {
 
     @Test
     void testLast() {
-        HeaderValue header = Header.RANGE.withValue("bytes=-1");
+        HeaderValue header = Header.create(Header.RANGE, "bytes=-1");
         ServerRequest req = Mockito.mock(ServerRequest.class);
         ServerResponse res = Mockito.mock(ServerResponse.class);
 
@@ -78,7 +78,7 @@ class ByteRangeRequestTest {
 
     @Test
     void testMultiRangeMultiValue() {
-        HeaderValue header = Header.RANGE.withValue("bytes=-1", "bytes=47-48", "bytes=0-");
+        HeaderValue header = Header.create(Header.RANGE, "bytes=-1", "bytes=47-48", "bytes=0-");
         ServerRequest req = Mockito.mock(ServerRequest.class);
         ServerResponse res = Mockito.mock(ServerResponse.class);
 
@@ -103,7 +103,7 @@ class ByteRangeRequestTest {
 
     @Test
     void testMultiRangeSingleValue() {
-        HeaderValue header = Header.RANGE.withValue("bytes=-1, bytes=47-48, s bytes=0-");
+        HeaderValue header = Header.create(Header.RANGE, "bytes=-1, bytes=47-48, s bytes=0-");
         ServerRequest req = Mockito.mock(ServerRequest.class);
         ServerResponse res = Mockito.mock(ServerResponse.class);
 

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.http.Http;
+import io.helidon.common.http.Http.Header;
 import io.helidon.common.http.HttpException;
 import io.helidon.common.http.HttpPrologue;
 import io.helidon.common.http.ServerRequestHeaders;
@@ -55,16 +56,17 @@ import static org.mockito.Mockito.when;
  * Tests {@link StaticContentHandler}.
  */
 class StaticContentHandlerTest {
+    private static final String ETAG_VALUE = "\"aaa\"";
 
     @Test
     void etag_InNoneMatch_NotAccept() {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.get(IF_NONE_MATCH)).thenReturn(IF_NONE_MATCH.withValue("\"ccc\"", "\"ddd\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(Header.create(IF_NONE_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
-        verify(res).set(ETAG.withValue("\"aaa\""));
+        verify(res).set(ETAG, ETAG_VALUE);
     }
 
     @Test
@@ -72,10 +74,10 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(true);
         when(req.contains(IF_MATCH)).thenReturn(false);
-        when(req.get(IF_NONE_MATCH)).thenReturn(IF_NONE_MATCH.withValue("\"ccc\"", "W/\"aaa\""));
+        when(req.get(IF_NONE_MATCH)).thenReturn(Header.create(IF_NONE_MATCH, "\"ccc\"", "W/\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Http.Status.NOT_MODIFIED_304);
-        verify(res).set(ETAG.withValue("\"aaa\""));
+        verify(res).set(ETAG, ETAG_VALUE);
     }
 
     @Test
@@ -83,10 +85,10 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(IF_MATCH.withValue("\"ccc\"", "\"ddd\""));
+        when(req.get(IF_MATCH)).thenReturn(Header.create(IF_MATCH, "\"ccc\"", "\"ddd\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         assertHttpException(() -> StaticContentHandler.processEtag("aaa", req, res), Http.Status.PRECONDITION_FAILED_412);
-        verify(res).set(ETAG.withValue("\"aaa\""));
+        verify(res).set(ETAG, ETAG_VALUE);
     }
 
     @Test
@@ -94,10 +96,10 @@ class StaticContentHandlerTest {
         ServerRequestHeaders req = mock(ServerRequestHeaders.class);
         when(req.contains(IF_NONE_MATCH)).thenReturn(false);
         when(req.contains(IF_MATCH)).thenReturn(true);
-        when(req.get(IF_MATCH)).thenReturn(IF_MATCH.withValue("\"ccc\"", "\"aaa\""));
+        when(req.get(IF_MATCH)).thenReturn(Header.create(IF_MATCH, "\"ccc\"", "\"aaa\""));
         ServerResponseHeaders res = mock(ServerResponseHeaders.class);
         StaticContentHandler.processEtag("aaa", req, res);
-        verify(res).set(ETAG.withValue("\"aaa\""));
+        verify(res).set(ETAG, ETAG_VALUE);
     }
 
     @Test
@@ -150,7 +152,7 @@ class StaticContentHandlerTest {
         when(res.headers()).thenReturn(resh);
         StaticContentHandler.redirect(req, res, "/foo/");
         verify(res).status(Http.Status.MOVED_PERMANENTLY_301);
-        verify(res).header(LOCATION.withValue("/foo/"));
+        verify(res).header(LOCATION, "/foo/");
         verify(res).send();
     }
 

--- a/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentTest.java
+++ b/nima/webserver/static-content/src/test/java/io/helidon/nima/webserver/staticcontent/StaticContentTest.java
@@ -49,7 +49,7 @@ class StaticContentTest {
                 .request()) {
 
             assertThat(response.status(), is(Http.Status.OK_200));
-            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(Header.CONTENT_TYPE.withValue("image/x-icon")));
+            assertThat(response.headers(), HttpHeaderMatcher.hasHeader(Header.CONTENT_TYPE, "image/x-icon"));
         }
     }
 }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http/ServerResponse.java
@@ -44,7 +44,7 @@ public interface ServerResponse {
 
     /**
      * Set a header. If the values are constant, please use
-     * {@link Http.HeaderValue#create(HeaderName, String...)} and store the header
+     * {@link io.helidon.common.http.Http.Header#create(io.helidon.common.http.Http.HeaderName, String...)} and store the header
      * in a constant field and call {@link #header(Http.HeaderValue)}.
      *
      * @param name   header name
@@ -52,7 +52,7 @@ public interface ServerResponse {
      * @return this instance
      */
     default ServerResponse header(HeaderName name, String... values) {
-        return header(Http.HeaderValue.create(name, values));
+        return header(Http.Header.create(name, values));
     }
 
     /**
@@ -66,7 +66,7 @@ public interface ServerResponse {
      * @return this instance
      */
     default ServerResponse header(String name, String... values) {
-        return header(Http.HeaderValue.create(Http.Header.create(name), values));
+        return header(Http.Header.create(Http.Header.create(name), values));
     }
 
     /**
@@ -172,4 +172,13 @@ public interface ServerResponse {
      * @param result result description
      */
     void streamResult(String result);
+
+    /**
+     * Configure a content length header for this response.
+     *
+     * @param length content length
+     */
+    default void contentLength(long length) {
+        header(Http.Header.create(Http.Header.CONTENT_LENGTH, true, false, String.valueOf(length)));
+    }
 }

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1Connection.java
@@ -353,7 +353,7 @@ public class Http1Connection implements ServerConnection {
         }
         byte[] message = response.entity().orElse(BufferData.EMPTY_BYTES);
         if (message.length != 0) {
-            headers.set(Http.HeaderValue.create(Http.Header.CONTENT_LENGTH, String.valueOf(message.length)));
+            headers.set(Http.Header.create(Http.Header.CONTENT_LENGTH, String.valueOf(message.length)));
         }
         Http1ServerResponse.nonEntityBytes(headers, response.status(), buffer, response.keepAlive());
         if (message.length != 0) {

--- a/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
+++ b/nima/webserver/webserver/src/main/java/io/helidon/nima/webserver/http1/Http1ServerResponse.java
@@ -51,7 +51,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
     private static final HeaderName STREAM_STATUS_NAME = Http.Header.create("stream-status");
     private static final HeaderName STREAM_RESULT_NAME = Http.Header.create("stream-result");
     private static final HeaderValue STREAM_TRAILERS =
-            HeaderValue.create(Http.Header.TRAILER, STREAM_STATUS_NAME.defaultCase()
+            Http.Header.create(Http.Header.TRAILER, STREAM_STATUS_NAME.defaultCase()
                     + "," + STREAM_RESULT_NAME.defaultCase());
 
     private final ConnectionContext ctx;
@@ -213,7 +213,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
         headers.setIfAbsent(HeaderValues.CONNECTION_KEEP_ALIVE);
         if (!headers.contains(Http.Header.CONTENT_LENGTH)) {
-            headers.set(HeaderValue.create(Http.Header.CONTENT_LENGTH, String.valueOf(bytes.length)));
+            headers.set(Http.Header.create(Http.Header.CONTENT_LENGTH, String.valueOf(bytes.length)));
         }
 
         sendListener.headers(ctx, headers);
@@ -313,8 +313,8 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
 
             if (isChunked || forcedChunked) {
                 // not optimized, we need to write trailers
-                trailers.set(STREAM_STATUS_NAME.withValue(status.get().code()));
-                trailers.set(STREAM_RESULT_NAME.withValue(streamResult.get()));
+                trailers.set(STREAM_STATUS_NAME, String.valueOf(status.get().code()));
+                trailers.set(STREAM_RESULT_NAME, streamResult.get());
                 BufferData buffer = BufferData.growing(128);
                 writeHeaders(trailers, buffer);
                 buffer.write('\r');        // "\r\n" - empty line after headers
@@ -383,7 +383,7 @@ class Http1ServerResponse extends ServerResponseBase<Http1ServerResponse> {
                 headers.set(HeaderValues.CONTENT_LENGTH_ZERO);
                 contentLength = 0;
             } else {
-                headers.set(HeaderValue.create(Http.Header.CONTENT_LENGTH, String.valueOf(firstBuffer.available())));
+                headers.set(Http.Header.create(Http.Header.CONTENT_LENGTH, String.valueOf(firstBuffer.available())));
                 contentLength = firstBuffer.available();
             }
             isChunked = false;

--- a/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsUpgradeProvider.java
+++ b/nima/websocket/webserver/src/main/java/io/helidon/nima/websocket/webserver/WsUpgradeProvider.java
@@ -55,7 +55,7 @@ public class WsUpgradeProvider implements Http1UpgradeProvider {
             + "Sec-WebSocket-Accept: ";
     private static final String SWITCHING_PROTOCOLS_SUFFIX = "\r\n\r\n";
     private static final String SUPPORTED_VERSION = "13";
-    private static final Http.HeaderValue SUPPORTED_VERSION_HEADER = Http.HeaderValue.create(WS_VERSION, SUPPORTED_VERSION);
+    private static final Http.HeaderValue SUPPORTED_VERSION_HEADER = Header.create(WS_VERSION, SUPPORTED_VERSION);
 
     private final Set<String> origins;
     private final boolean anyOrigin;

--- a/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyWriterContext.java
+++ b/reactive/media/common/src/main/java/io/helidon/reactive/media/common/MessageBodyWriterContext.java
@@ -29,7 +29,6 @@ import java.util.function.Predicate;
 import io.helidon.common.GenericType;
 import io.helidon.common.http.DataChunk;
 import io.helidon.common.http.Http;
-import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
 import io.helidon.common.http.WritableHeaders;
 import io.helidon.common.mapper.Mapper;
@@ -367,7 +366,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     public void contentType(HttpMediaType contentType) {
         Objects.requireNonNull(contentType);
-        headers.setIfAbsent(HeaderValue.create(Http.Header.CONTENT_TYPE, false, false, contentType.text()));
+        headers.setIfAbsent(Http.Header.create(Http.Header.CONTENT_TYPE, false, false, contentType.text()));
     }
 
     /**
@@ -379,7 +378,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     public void contentType(MediaType mediaType) {
         Objects.requireNonNull(mediaType);
-        headers.setIfAbsent(HeaderValue.create(Http.Header.CONTENT_TYPE, false, false, mediaType.fullType()));
+        headers.setIfAbsent(Http.Header.create(Http.Header.CONTENT_TYPE, false, false, mediaType.fullType()));
     }
 
     /**
@@ -391,7 +390,7 @@ public final class MessageBodyWriterContext extends MessageBodyContext implement
      */
     public void contentLength(long contentLength) {
         if (contentLength >= 0) {
-            headers.setIfAbsent(HeaderValue.create(Http.Header.CONTENT_LENGTH, true, false,
+            headers.setIfAbsent(Http.Header.create(Http.Header.CONTENT_LENGTH, true, false,
                                                    String.valueOf(contentLength)));
         }
     }

--- a/reactive/tests/benchmark/techempower/src/main/java/io/helidon/reactive/tests/benchmark/techempower/TechEmpowerMain.java
+++ b/reactive/tests/benchmark/techempower/src/main/java/io/helidon/reactive/tests/benchmark/techempower/TechEmpowerMain.java
@@ -79,10 +79,10 @@ public final class TechEmpowerMain {
     }
 
     static class PlaintextHandler implements Handler {
-        static final HeaderValue CONTENT_TYPE = HeaderValue.createCached(Header.CONTENT_TYPE,
-                                                                         "text/plain; charset=UTF-8");
-        static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH, "13");
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue CONTENT_TYPE = Header.createCached(Header.CONTENT_TYPE,
+                                                                    "text/plain; charset=UTF-8");
+        static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH, "13");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
 
         private static final byte[] RESPONSE_BYTES = "Hello, World!".getBytes(StandardCharsets.UTF_8);
 
@@ -96,11 +96,11 @@ public final class TechEmpowerMain {
     }
 
     static class JsonHandler implements Handler {
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
         private static final String MESSAGE = "Hello, World!";
         private static final int JSON_LENGTH = serializeMsg(new Message(MESSAGE)).length;
-        static final HeaderValue CONTENT_LENGTH = HeaderValue.createCached(Header.CONTENT_LENGTH,
-                                                                           String.valueOf(JSON_LENGTH));
+        static final HeaderValue CONTENT_LENGTH = Header.createCached(Header.CONTENT_LENGTH,
+                                                                      String.valueOf(JSON_LENGTH));
 
         @Override
         public void accept(ServerRequest req, ServerResponse res) {
@@ -116,15 +116,15 @@ public final class TechEmpowerMain {
     }
 
     static class JsonKHandler implements Handler {
-        static final HeaderValue SERVER = HeaderValue.createCached(Header.SERVER, "Nima");
+        static final HeaderValue SERVER = Header.createCached(Header.SERVER, "Nima");
         private final HeaderValue contentLength;
         private final String message;
 
         JsonKHandler(int kilobytes) {
             this.message = "a".repeat(1024 * kilobytes);
             int length = serializeMsg(new Message(message)).length;
-            this.contentLength = HeaderValue.createCached(Header.CONTENT_LENGTH,
-                                                          String.valueOf(length));
+            this.contentLength = Header.createCached(Header.CONTENT_LENGTH,
+                                                     String.valueOf(length));
         }
 
         @Override

--- a/reactive/webclient/tracing/src/main/java/io/helidon/reactive/webclient/tracing/WebClientTracing.java
+++ b/reactive/webclient/tracing/src/main/java/io/helidon/reactive/webclient/tracing/WebClientTracing.java
@@ -115,12 +115,12 @@ public final class WebClientTracing implements WebClientService {
 
         @Override
         public void setIfAbsent(String key, String... values) {
-            headers.setIfAbsent(Http.HeaderValue.create(Http.Header.create(key), values));
+            headers.setIfAbsent(Http.Header.create(Http.Header.create(key), values));
         }
 
         @Override
         public void set(String key, String... values) {
-            headers.set(Http.HeaderValue.create(Http.Header.create(key), values));
+            headers.set(Http.Header.create(Http.Header.create(key), values));
         }
 
         @Override

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClient.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClient.java
@@ -319,7 +319,7 @@ public interface WebClient {
          */
         @Deprecated(forRemoval = true)
         public Builder addHeader(String header, String... value) {
-            configuration.defaultHeader(Http.HeaderValue.create(Http.Header.create(header), value));
+            configuration.defaultHeader(Http.Header.create(Http.Header.create(header), value));
             return this;
         }
 
@@ -331,7 +331,7 @@ public interface WebClient {
          * @return updated builder instance
          */
         public Builder addHeader(Http.HeaderName header, String... value) {
-            configuration.defaultHeader(Http.HeaderValue.create(header, value));
+            configuration.defaultHeader(Http.Header.create(header, value));
             return this;
         }
 

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientConfiguration.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientConfiguration.java
@@ -738,10 +738,10 @@ class WebClientConfiguration {
             configHeaders.asNodeList()
                     .ifPresent(headers -> headers
                             .forEach(header ->
-                                             defaultHeader(HeaderValue.create(Header.create(header.get("name")
+                                             defaultHeader(Header.create(Header.create(header.get("name")
                                                                                                     .asString()
                                                                                                     .get()),
-                                                                                header.get("value")
+                                                                         header.get("value")
                                                                                         .asList(String.class)
                                                                                         .get()))));
         }

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestBuilder.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestBuilder.java
@@ -201,7 +201,7 @@ public interface WebClientRequestBuilder {
      * @return updated builder
      */
     default WebClientRequestBuilder addHeader(Http.HeaderName name, String... values) {
-        headers().add(Http.HeaderValue.create(name, values));
+        headers().add(Http.Header.create(name, values));
         return this;
     }
 
@@ -213,7 +213,7 @@ public interface WebClientRequestBuilder {
      * @return updated builder
      */
     default WebClientRequestBuilder addHeader(Http.HeaderName name, List<String> values) {
-        headers().add(Http.HeaderValue.create(name, values));
+        headers().add(Http.Header.create(name, values));
         return this;
     }
 

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeaders.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeaders.java
@@ -194,7 +194,7 @@ public interface WebClientRequestHeaders extends ClientRequestHeaders {
      * @return updated headers
      */
     default WebClientRequestHeaders add(Http.HeaderName key, String... values) {
-        add(Http.HeaderValue.create(key, values));
+        add(Http.Header.create(key, values));
         return this;
     }
 

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeadersImpl.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientRequestHeadersImpl.java
@@ -66,7 +66,7 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public WebClientRequestHeaders addCookie(String name, String value) {
-        headers.add(HeaderValue.create(Http.Header.COOKIE, ClientCookieEncoder.STRICT.encode(new DefaultCookie(name, value))));
+        headers.add(Http.Header.create(Http.Header.COOKIE, ClientCookieEncoder.STRICT.encode(new DefaultCookie(name, value))));
         return this;
     }
 
@@ -84,13 +84,13 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public WebClientRequestHeaders addAccept(HttpMediaType mediaType) {
-        headers.add(HeaderValue.create(Http.Header.ACCEPT, mediaType.text()));
+        headers.add(Http.Header.create(Http.Header.ACCEPT, mediaType.text()));
         return this;
     }
 
     @Override
     public WebClientRequestHeaders ifModifiedSince(ZonedDateTime time) {
-        headers.set(HeaderValue.create(Http.Header.IF_MODIFIED_SINCE,
+        headers.set(Http.Header.create(Http.Header.IF_MODIFIED_SINCE,
                                        true,
                                        false,
                                        time.format(FORMATTER)));
@@ -99,7 +99,7 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public WebClientRequestHeaders ifUnmodifiedSince(ZonedDateTime time) {
-        headers.set(HeaderValue.create(Http.Header.IF_UNMODIFIED_SINCE,
+        headers.set(Http.Header.create(Http.Header.IF_UNMODIFIED_SINCE,
                                        true,
                                        false,
                                        time.format(FORMATTER)));
@@ -108,25 +108,25 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public WebClientRequestHeaders ifNoneMatch(String... etags) {
-        headers.set(HeaderValue.create(Http.Header.IF_NONE_MATCH, processEtags(etags)));
+        headers.set(Http.Header.create(Http.Header.IF_NONE_MATCH, processEtags(etags)));
         return this;
     }
 
     @Override
     public WebClientRequestHeaders ifMatch(String... etags) {
-        headers.set(HeaderValue.create(Http.Header.IF_MATCH, processEtags(etags)));
+        headers.set(Http.Header.create(Http.Header.IF_MATCH, processEtags(etags)));
         return this;
     }
 
     @Override
     public WebClientRequestHeaders ifRange(ZonedDateTime time) {
-        headers.set(HeaderValue.create(Http.Header.IF_RANGE, time.format(FORMATTER)));
+        headers.set(Http.Header.create(Http.Header.IF_RANGE, time.format(FORMATTER)));
         return this;
     }
 
     @Override
     public WebClientRequestHeaders ifRange(String etag) {
-        headers.set(HeaderValue.create(Http.Header.IF_RANGE, processEtags(etag)));
+        headers.set(Http.Header.create(Http.Header.IF_RANGE, processEtags(etag)));
         return this;
     }
 
@@ -271,7 +271,7 @@ class WebClientRequestHeadersImpl implements WebClientRequestHeaders {
 
     @Override
     public WebClientRequestHeaders add(String key, String... values) {
-        headers.add(HeaderValue.create(Http.Header.create(key), values));
+        headers.add(Http.Header.create(Http.Header.create(key), values));
         return this;
     }
 

--- a/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseImpl.java
+++ b/reactive/webclient/webclient/src/main/java/io/helidon/reactive/webclient/WebClientResponseImpl.java
@@ -163,7 +163,7 @@ final class WebClientResponseImpl implements WebClientResponse {
          * @return updated builder instance
          */
         Builder addHeader(String name, List<String> values) {
-            this.headers.set(Http.HeaderValue.create(Http.Header.create(name), values));
+            this.headers.set(Http.Header.create(Http.Header.create(name), values));
             return this;
         }
 

--- a/reactive/webclient/webclient/src/test/java/io/helidon/reactive/webclient/ClientRequestHeadersImplTest.java
+++ b/reactive/webclient/webclient/src/test/java/io/helidon/reactive/webclient/ClientRequestHeadersImplTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import io.helidon.common.http.Http.Header;
-import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
 import io.helidon.common.media.type.MediaTypes;
 
@@ -62,7 +61,7 @@ class ClientRequestHeadersImplTest {
         List<HttpMediaType> expectedTypes = List.of(HttpMediaType.PLAINTEXT_UTF_8, HttpMediaType.JSON_UTF_8);
 
         clientRequestHeaders.addAccept(HttpMediaType.PLAINTEXT_UTF_8);
-        clientRequestHeaders.add(HeaderValue.create(Header.ACCEPT, HttpMediaType.JSON_UTF_8.text()));
+        clientRequestHeaders.add(Header.create(Header.ACCEPT, HttpMediaType.JSON_UTF_8.text()));
 
         assertThat(clientRequestHeaders.acceptedTypes(), is(expectedTypes));
     }
@@ -101,7 +100,7 @@ class ClientRequestHeadersImplTest {
 
         clientRequestHeaders.ifModifiedSince(ifModifiedSince);
 
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_MODIFIED_SINCE, template)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_MODIFIED_SINCE, template)));
         assertThat(clientRequestHeaders.ifModifiedSince(), is(Optional.of(zonedDateTemplate)));
     }
 
@@ -117,7 +116,7 @@ class ClientRequestHeadersImplTest {
 
         clientRequestHeaders.ifUnmodifiedSince(ifUnmodifiedSince);
 
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_UNMODIFIED_SINCE, template)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_UNMODIFIED_SINCE, template)));
         assertThat(clientRequestHeaders.ifUnmodifiedSince(), is(Optional.of(zonedDateTemplate)));
     }
 
@@ -131,11 +130,11 @@ class ClientRequestHeadersImplTest {
 
         clientRequestHeaders.ifNoneMatch(unquotedTemplate.toArray(new String[0]));
         assertThat(clientRequestHeaders.ifNoneMatch(), is(unquotedTemplate));
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_NONE_MATCH, quotedTemplate)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_NONE_MATCH, quotedTemplate)));
 
         clientRequestHeaders.ifNoneMatch(star.toArray(new String[0]));
         assertThat(clientRequestHeaders.ifNoneMatch(), is(star));
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_NONE_MATCH, star)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_NONE_MATCH, star)));
     }
 
     @Test
@@ -148,11 +147,11 @@ class ClientRequestHeadersImplTest {
 
         clientRequestHeaders.ifMatch(unquotedTemplate.toArray(new String[0]));
         assertThat(clientRequestHeaders.ifMatch(), is(unquotedTemplate));
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_MATCH, quotedTemplate)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_MATCH, quotedTemplate)));
 
         clientRequestHeaders.ifMatch(star.toArray(new String[0]));
         assertThat(clientRequestHeaders.ifMatch(), is(star));
-        assertThat(clientRequestHeaders, hasHeader(HeaderValue.create(IF_MATCH, star)));
+        assertThat(clientRequestHeaders, hasHeader(Header.create(IF_MATCH, star)));
     }
 
     @Test

--- a/reactive/webclient/webclient/src/test/java/io/helidon/reactive/webclient/ConfigurationTest.java
+++ b/reactive/webclient/webclient/src/test/java/io/helidon/reactive/webclient/ConfigurationTest.java
@@ -55,7 +55,7 @@ class ConfigurationTest {
                 .followRedirects(true)
                 .maxRedirects(10)
                 .userAgent("HelidonTest")
-                .defaultHeader(Http.HeaderValue.create(Http.Header.ACCEPT, List.of("application/json", "text/plain")))
+                .defaultHeader(Http.Header.create(Http.Header.ACCEPT, List.of("application/json", "text/plain")))
                 .build();
         validateConfiguration(wcc);
     }

--- a/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestRequest.java
+++ b/reactive/webserver/test-support/src/main/java/io/helidon/reactive/webserver/testsupport/TestRequest.java
@@ -91,7 +91,7 @@ public class TestRequest {
     public TestRequest header(Http.HeaderName name, String value) {
         Objects.requireNonNull(name, "Parameter 'name' is null!");
         Objects.requireNonNull(name, "Parameter 'value' is null!");
-        headers.setIfAbsent(Http.HeaderValue.create(name, value));
+        headers.setIfAbsent(Http.Header.create(name, value));
         return this;
     }
 

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ForwardingHandler.java
@@ -603,7 +603,7 @@ public class ForwardingHandler extends SimpleChannelInboundHandler<Object> {
             method = request.method().name();
             WritableHeaders<?> result = WritableHeaders.create();
             for (String name : request.headers().names()) {
-                result.add(Http.HeaderValue.create(Http.Header.create(name), request.headers().getAll(name)));
+                result.add(Http.Header.create(Http.Header.create(name), request.headers().getAll(name)));
             }
             headers = ServerRequestHeaders.create(result);
         }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyRequestHeaders.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/NettyRequestHeaders.java
@@ -33,7 +33,7 @@ class NettyRequestHeaders implements RequestHeaders {
     NettyRequestHeaders(HttpHeaders nettyHeaders) {
         WritableHeaders<?> hw = WritableHeaders.create();
         for (String name : nettyHeaders.names()) {
-            hw.set(Http.HeaderValue.create(Http.Header.create(name), nettyHeaders.getAll(name)));
+            hw.set(Http.Header.create(Http.Header.create(name), nettyHeaders.getAll(name)));
         }
         this.delegate = ServerRequestHeaders.create(hw);
     }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/Response.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/Response.java
@@ -419,7 +419,7 @@ abstract class Response implements ServerResponse {
             if (headers != null && !sent) {
                 status(500);
                 //We are not using CombinedHttpHeaders
-                headers().add(Http.HeaderValue.create(Http.Header.TRAILER, STREAM_STATUS + "," + STREAM_RESULT));
+                headers().add(Http.Header.create(Http.Header.TRAILER, STREAM_STATUS + "," + STREAM_RESULT));
                 sent = true;
                 headers.send();
             }

--- a/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ServerResponse.java
+++ b/reactive/webserver/webserver/src/main/java/io/helidon/reactive/webserver/ServerResponse.java
@@ -148,7 +148,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      */
     @Deprecated
     default ServerResponse addHeader(String name, List<String> values) {
-        headers().add(Http.HeaderValue.create(Http.Header.create(name), values));
+        headers().add(Http.Header.create(Http.Header.create(name), values));
         return this;
     }
 
@@ -163,7 +163,7 @@ public interface ServerResponse extends MessageBodyFilters, MessageBodyWriters {
      * @see Http.Header header names constants
      */
     default ServerResponse addHeader(Http.HeaderName name, String... values) {
-        headers().add(Http.HeaderValue.create(name, values));
+        headers().add(Http.Header.create(name, values));
         return this;
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionTest.java
@@ -103,7 +103,7 @@ class CompressionTest {
                                         requestHeaders);
 
             ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
-            assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "gzip")));
+            assertThat(responseHeaders, hasHeader(Http.Header.create(Http.Header.CONTENT_ENCODING, "gzip")));
         }
     }
 
@@ -123,7 +123,7 @@ class CompressionTest {
                                         requestHeaders);
 
             ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
-            assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "deflate")));
+            assertThat(responseHeaders, hasHeader(Http.Header.create(Http.Header.CONTENT_ENCODING, "deflate")));
         }
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionV2ApiTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/CompressionV2ApiTest.java
@@ -107,7 +107,7 @@ class CompressionV2ApiTest {
                                         requestHeaders);
 
             ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
-            assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "gzip")));
+            assertThat(responseHeaders, hasHeader(Http.Header.create(Http.Header.CONTENT_ENCODING, "gzip")));
         }
     }
 
@@ -127,7 +127,7 @@ class CompressionV2ApiTest {
                                         requestHeaders);
 
             ClientResponseHeaders responseHeaders = SocketHttpClient.headersFromResponse(s);
-            assertThat(responseHeaders, hasHeader(Http.HeaderValue.create(Http.Header.CONTENT_ENCODING, "deflate")));
+            assertThat(responseHeaders, hasHeader(Http.Header.create(Http.Header.CONTENT_ENCODING, "deflate")));
         }
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893Test.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893Test.java
@@ -155,7 +155,7 @@ class Gh1893Test {
         assertThat(SocketHttpClient.statusFromResponse(response), is(Http.Status.TEMPORARY_REDIRECT_307));
 
         ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
-        assertThat(headers, HttpHeaderMatcher.hasHeader(Http.HeaderValue.create(Http.Header.LOCATION, "/errorPage")));
+        assertThat(headers, HttpHeaderMatcher.hasHeader(Http.Header.create(Http.Header.LOCATION, "/errorPage")));
     }
 
     @Test

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893V2ApiTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/Gh1893V2ApiTest.java
@@ -155,7 +155,7 @@ class Gh1893V2ApiTest {
         assertThat(SocketHttpClient.statusFromResponse(response), is(Http.Status.TEMPORARY_REDIRECT_307));
 
         ClientResponseHeaders headers = SocketHttpClient.headersFromResponse(response);
-        assertThat(headers, HttpHeaderMatcher.hasHeader(Http.HeaderValue.create(Http.Header.LOCATION, "/errorPage")));
+        assertThat(headers, HttpHeaderMatcher.hasHeader(Http.Header.create(Http.Header.LOCATION, "/errorPage")));
     }
 
     @Test

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/HashResponseHeadersTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/HashResponseHeadersTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.http.Http;
 import io.helidon.common.http.Http.Header;
-import io.helidon.common.http.Http.HeaderValue;
 import io.helidon.common.http.HttpMediaType;
 import io.helidon.common.http.SetCookie;
 import io.helidon.common.media.type.MediaTypes;
@@ -152,14 +151,14 @@ class HashResponseHeadersTest {
     void immutableWhenCompleted() throws Exception {
         HashResponseHeaders h = new HashResponseHeaders(mockBareResponse());
         h.set(HEADER_A, "b");
-        h.add(HeaderValue.create(HEADER_A, "b"));
-        h.setIfAbsent(HeaderValue.create(HEADER_A, "b"));
+        h.add(Header.create(HEADER_A, "b"));
+        h.setIfAbsent(Header.create(HEADER_A, "b"));
         h.remove(HEADER_A);
 
         h.send().toCompletableFuture().get();
         assertException(() -> h.set(HEADER_A, "b"), AlreadyCompletedException.class);
-        assertException(() -> h.add(HeaderValue.create(HEADER_A, "b")), AlreadyCompletedException.class);
-        assertException(() -> h.setIfAbsent(HeaderValue.create(HEADER_A, "b")), AlreadyCompletedException.class);
+        assertException(() -> h.add(Header.create(HEADER_A, "b")), AlreadyCompletedException.class);
+        assertException(() -> h.setIfAbsent(Header.create(HEADER_A, "b")), AlreadyCompletedException.class);
         assertException(() -> h.remove(HEADER_A), AlreadyCompletedException.class);
     }
 

--- a/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/KeepAliveTest.java
+++ b/reactive/webserver/webserver/src/test/java/io/helidon/reactive/webserver/KeepAliveTest.java
@@ -119,7 +119,7 @@ public class KeepAliveTest {
             assertThat(res.status().code(), is(expectedStatus));
             if (expectedConnectionHeader != null) {
                 assertThat(res.headers(),
-                           hasHeader(Http.HeaderValue.create(Http.Header.CONNECTION, expectedConnectionHeader.toString())));
+                           hasHeader(Http.Header.create(Http.Header.CONNECTION, expectedConnectionHeader.toString())));
             } else {
                 assertThat(res.headers(), noHeader(Http.Header.CONNECTION));
             }

--- a/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
+++ b/security/integration/webserver/src/main/java/io/helidon/security/integration/webserver/SecurityHandler.java
@@ -443,7 +443,7 @@ public final class SecurityHandler implements Handler {
         clientBuilder.explicitProvider(explicitAuthenticator.orElse(null)).submit().thenAccept(response -> {
             // copy headers to be returned with the current response
             response.responseHeaders()
-                    .forEach((key, value) -> res.headers().set(Http.HeaderValue.create(Http.Header.create(key), value)));
+                    .forEach((key, value) -> res.headers().set(Http.Header.create(Http.Header.create(key), value)));
 
             switch (response.status()) {
             case SUCCESS:


### PR DESCRIPTION
 Remove HeaderName.withValue() and its usages.

Resolves #4861 