### PR TITLE
Fixed race condition in the OCI Metrics integration test between retrieval of metrics from registry and asserting that from expected results

### DIFF
--- a/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
+++ b/integrations/oci/metrics/cdi/src/main/java/io/helidon/integrations/oci/metrics/cdi/OciMetricsCdiExtension.java
@@ -37,7 +37,8 @@ import static javax.interceptor.Interceptor.Priority.LIBRARY_BEFORE;
  */
 public class OciMetricsCdiExtension implements Extension {
 
-    void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 10) @Initialized(ApplicationScoped.class) Object adv) {
+    // Make Priority higher than MetricsCdiExtension so this will only start after MetricsCdiExtension has completed.
+    void registerOciMetrics(@Observes @Priority(LIBRARY_BEFORE + 20) @Initialized(ApplicationScoped.class) Object adv) {
         org.eclipse.microprofile.config.Config config = ConfigProvider.getConfig();
         Config helidonConfig = MpConfig.toHelidonConfig(config).get("ocimetrics");
 


### PR DESCRIPTION
To fix the issue, here are the list of changes made:

1. Used CountDownLatches to signal when to start testing, for example, test only after results has been retrieved.
2. Make OciMetricsCdiExtension Priority higher than MetricsCdiExtension so that it will only start after MetricsCdiExtension has completed.